### PR TITLE
Add receipt/transaction pages and PWA support

### DIFF
--- a/src/Presentation/Client/Pages/Receipts/ReceiptCreate.razor
+++ b/src/Presentation/Client/Pages/Receipts/ReceiptCreate.razor
@@ -1,0 +1,20 @@
+@page "/receipts/create"
+@using Client.Interfaces.Services.Core
+@namespace Client.Pages.Receipts
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
+@inject IReceiptService ReceiptService
+
+<MudText Typo="Typo.h4" Class="mb-4">Create New Receipt</MudText>
+
+<MudForm @ref="form" @bind-IsValid="@success">
+    <MudTextField T="string" Label="Description" @bind-Value="_receipt.Description" />
+    <MudTextField T="string" Label="Location" Required="true" @bind-Value="_receipt.Location" RequiredError=@ReceiptValidator.LocationIsRequired />
+    <DateOnlyPicker @bind-Value="_receipt.Date" Label="Date" />
+    <MudNumericField T="decimal" Label="Tax Amount" @bind-Value="_receipt.TaxAmount" />
+
+    <div class="d-flex justify-space-between mt-6">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!success)" OnClick="@SubmitReceipt">Create Receipt</MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="@(() => NavigationManager.NavigateTo("/receipts"))">Cancel</MudButton>
+    </div>
+</MudForm>

--- a/src/Presentation/Client/Pages/Receipts/ReceiptCreate.razor.cs
+++ b/src/Presentation/Client/Pages/Receipts/ReceiptCreate.razor.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Shared.ViewModels.Core;
+using Shared.Validators;
+using FluentValidation.Results;
+using Client.Common;
+
+namespace Client.Pages.Receipts;
+
+public partial class ReceiptCreate
+{
+    private MudForm? form;
+    private readonly ReceiptVM _receipt = new();
+    private bool success;
+
+    private async Task SubmitReceipt()
+    {
+        try
+        {
+            if (!await ValidateForm())
+            {
+                return;
+            }
+
+            if (!await ValidateReceipt())
+            {
+                return;
+            }
+
+            await ReceiptService.CreateReceiptsAsync([_receipt]);
+            Snackbar.ShowSuccessMessage("Receipt created successfully");
+            NavigateToReceipts();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.ShowErrorMessage(ex.Message);
+        }
+    }
+
+    private async Task<bool> ValidateForm()
+    {
+        if (form is null)
+        {
+            Snackbar.ShowErrorMessage("Form is null");
+            return false;
+        }
+
+        await form.Validate();
+
+        return form.IsValid;
+    }
+
+    private async Task<bool> ValidateReceipt()
+    {
+        ReceiptValidator validator = new();
+        ValidationResult validationResult = await validator.ValidateAsync(_receipt);
+
+        if (!validationResult.IsValid)
+        {
+            Snackbar.ShowValidationErrors(validationResult);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void NavigateToReceipts()
+    {
+        NavigationManager.NavigateTo("/receipts");
+    }
+}

--- a/src/Presentation/Client/Pages/Receipts/ReceiptEdit.razor
+++ b/src/Presentation/Client/Pages/Receipts/ReceiptEdit.razor
@@ -1,0 +1,20 @@
+@page "/receipts/edit/{Id:guid}"
+@using Client.Interfaces.Services.Core
+@namespace Client.Pages.Receipts
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
+@inject IReceiptService ReceiptService
+
+<MudText Typo="Typo.h4" Class="mb-4">@(Id == null ? "Create New Receipt" : "Edit Receipt")</MudText>
+
+<MudForm @ref="form" @bind-IsValid="@success">
+    <MudTextField T="string" Label="Description" @bind-Value="_receipt.Description" />
+    <MudTextField T="string" Label="Location" Required="true" @bind-Value="_receipt.Location" RequiredError=@ReceiptValidator.LocationIsRequired />
+    <DateOnlyPicker @bind-Value="_receipt.Date" Label="Date" />
+    <MudNumericField T="decimal" Label="Tax Amount" @bind-Value="_receipt.TaxAmount" />
+
+    <div class="d-flex justify-space-between mt-6">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!success)" OnClick="@SubmitReceipt">@(Id == null ? "Create Receipt" : "Update Receipt")</MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="@(() => NavigationManager.NavigateTo("/receipts"))">Cancel</MudButton>
+    </div>
+</MudForm>

--- a/src/Presentation/Client/Pages/Receipts/ReceiptEdit.razor.cs
+++ b/src/Presentation/Client/Pages/Receipts/ReceiptEdit.razor.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Shared.ViewModels.Core;
+using Shared.Validators;
+using FluentValidation.Results;
+using Client.Common;
+
+namespace Client.Pages.Receipts;
+
+public partial class ReceiptEdit
+{
+    [Parameter]
+    public Guid? Id { get; set; }
+
+    private MudForm? form;
+    private ReceiptVM _receipt = new();
+    private bool success;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Id.HasValue)
+        {
+            ReceiptVM? result = await ReceiptService.GetReceiptByIdAsync(Id.Value);
+
+            if (result == null)
+            {
+                Snackbar.ShowErrorMessage("Receipt not found");
+                NavigateToReceipts();
+                return;
+            }
+
+            _receipt = result;
+        }
+    }
+
+    private async Task SubmitReceipt()
+    {
+        try
+        {
+            if (!await ValidateForm())
+            {
+                return;
+            }
+
+            if (!await ValidateReceipt())
+            {
+                return;
+            }
+
+            if (Id.HasValue)
+            {
+                _receipt.Id = Id.Value;
+                await ReceiptService.UpdateReceiptsAsync([_receipt]);
+                Snackbar.ShowSuccessMessage("Receipt updated successfully");
+            }
+            else
+            {
+                await ReceiptService.CreateReceiptsAsync([_receipt]);
+                Snackbar.ShowSuccessMessage("Receipt created successfully");
+            }
+
+            NavigateToReceipts();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.ShowErrorMessage(ex.Message);
+        }
+    }
+
+    private async Task<bool> ValidateForm()
+    {
+        if (form is null)
+        {
+            Snackbar.ShowErrorMessage("Form is null");
+            return false;
+        }
+
+        await form.Validate();
+
+        return form.IsValid;
+    }
+
+    private async Task<bool> ValidateReceipt()
+    {
+        ReceiptValidator validator = new();
+        ValidationResult validationResult = await validator.ValidateAsync(_receipt);
+
+        if (!validationResult.IsValid)
+        {
+            Snackbar.ShowValidationErrors(validationResult);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void NavigateToReceipts()
+    {
+        NavigationManager.NavigateTo("/receipts");
+    }
+}

--- a/src/Presentation/Client/Pages/Receipts/ReceiptsList.razor
+++ b/src/Presentation/Client/Pages/Receipts/ReceiptsList.razor
@@ -1,0 +1,39 @@
+@page "/receipts"
+@using Client.Interfaces.Services.Core
+@namespace Client.Pages.Receipts
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
+@inject IReceiptService ReceiptService
+@inject IDialogService DialogService
+
+<MudText Typo="Typo.h4" Class="mb-4">Receipts List</MudText>
+
+<MudTable Items="@receipts" Dense="true" Hover="true" Bordered="true" Striped="true" Filter="new Func<ReceiptVM,bool>(FilterFunc)">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Receipts</MudText>
+        <MudSpacer />
+        <MudTextField @bind-Value="searchString" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh>Description</MudTh>
+        <MudTh>Location</MudTh>
+        <MudTh>Date</MudTh>
+        <MudTh>Tax</MudTh>
+        <MudTh>Actions</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Description">@context.Description</MudTd>
+        <MudTd DataLabel="Location">@context.Location</MudTd>
+        <MudTd DataLabel="Date">@context.Date?.ToString("yyyy-MM-dd")</MudTd>
+        <MudTd DataLabel="Tax">@context.TaxAmount</MudTd>
+        <MudTd>
+            <MudButton @onclick="() => EditReceipt(context)" Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small">Edit</MudButton>
+            <MudButton @onclick="() => DeleteReceipt(context)" Color="Color.Error" Variant="Variant.Filled" Size="Size.Small">Delete</MudButton>
+        </MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+<MudButton @onclick="AddReceipt" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mt-4">Add Receipt</MudButton>

--- a/src/Presentation/Client/Pages/Receipts/ReceiptsList.razor.cs
+++ b/src/Presentation/Client/Pages/Receipts/ReceiptsList.razor.cs
@@ -1,0 +1,83 @@
+using Client.Common;
+using Microsoft.AspNetCore.Components;
+using Shared.ViewModels.Core;
+
+namespace Client.Pages.Receipts;
+
+public partial class ReceiptsList
+{
+    private List<ReceiptVM> receipts = [];
+    private string searchString = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadReceipts();
+    }
+
+    private async Task LoadReceipts()
+    {
+        List<ReceiptVM>? result = await ReceiptService.GetAllReceiptsAsync();
+
+        if (result == null)
+        {
+            Snackbar.ShowErrorMessage("An error occurred while retrieving receipts. Please try again.");
+            receipts = [];
+        }
+        else
+        {
+            receipts = result;
+        }
+    }
+
+    private void AddReceipt()
+    {
+        NavigationManager.NavigateTo("/receipts/create");
+    }
+
+    private void EditReceipt(ReceiptVM receipt)
+    {
+        NavigationManager.NavigateTo($"/receipts/edit/{receipt.Id}");
+    }
+
+    private async Task DeleteReceipt(ReceiptVM receipt)
+    {
+        bool? confirm = await DialogService.ShowMessageBox(
+            "Confirm Delete",
+            "Are you sure you want to delete this receipt?",
+            yesText: "Delete", cancelText: "Cancel");
+
+        if (confirm == true)
+        {
+            try
+            {
+                await ReceiptService.DeleteReceiptsAsync([receipt.Id!.Value]);
+                await LoadReceipts();
+                Snackbar.ShowSuccessMessage("Receipt deleted successfully");
+            }
+            catch (Exception ex)
+            {
+                Snackbar.ShowErrorMessage(ex.Message);
+            }
+        }
+    }
+
+    private bool FilterFunc(ReceiptVM receipt)
+    {
+        if (string.IsNullOrWhiteSpace(searchString))
+        {
+            return true;
+        }
+
+        if (receipt.Description != null && receipt.Description.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (receipt.Location != null && receipt.Location.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Presentation/Client/Pages/Transactions/TransactionCreate.razor
+++ b/src/Presentation/Client/Pages/Transactions/TransactionCreate.razor
@@ -1,0 +1,18 @@
+@page "/transactions/create"
+@using Client.Interfaces.Services.Core
+@namespace Client.Pages.Transactions
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
+@inject ITransactionService TransactionService
+
+<MudText Typo="Typo.h4" Class="mb-4">Create New Transaction</MudText>
+
+<MudForm @ref="form" @bind-IsValid="@success">
+    <MudNumericField T="decimal" Label="Amount" Required="true" @bind-Value="_transaction.Amount" RequiredError=@TransactionValidator.AmountMustBeNonZero />
+    <DateOnlyPicker @bind-Value="_transaction.Date" Label="Date" />
+
+    <div class="d-flex justify-space-between mt-6">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!success)" OnClick="@SubmitTransaction">Create Transaction</MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="@(() => NavigationManager.NavigateTo("/transactions"))">Cancel</MudButton>
+    </div>
+</MudForm>

--- a/src/Presentation/Client/Pages/Transactions/TransactionCreate.razor.cs
+++ b/src/Presentation/Client/Pages/Transactions/TransactionCreate.razor.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Shared.ViewModels.Core;
+using Shared.Validators;
+using FluentValidation.Results;
+using Client.Common;
+
+namespace Client.Pages.Transactions;
+
+public partial class TransactionCreate
+{
+    private MudForm? form;
+    private readonly TransactionVM _transaction = new();
+    private bool success;
+
+    private async Task SubmitTransaction()
+    {
+        try
+        {
+            if (!await ValidateForm())
+            {
+                return;
+            }
+
+            if (!await ValidateTransaction())
+            {
+                return;
+            }
+
+            await TransactionService.CreateTransactionsAsync([_transaction]);
+            Snackbar.ShowSuccessMessage("Transaction created successfully");
+            NavigateToTransactions();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.ShowErrorMessage(ex.Message);
+        }
+    }
+
+    private async Task<bool> ValidateForm()
+    {
+        if (form is null)
+        {
+            Snackbar.ShowErrorMessage("Form is null");
+            return false;
+        }
+
+        await form.Validate();
+
+        return form.IsValid;
+    }
+
+    private async Task<bool> ValidateTransaction()
+    {
+        TransactionValidator validator = new();
+        ValidationResult validationResult = await validator.ValidateAsync(_transaction);
+
+        if (!validationResult.IsValid)
+        {
+            Snackbar.ShowValidationErrors(validationResult);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void NavigateToTransactions()
+    {
+        NavigationManager.NavigateTo("/transactions");
+    }
+}

--- a/src/Presentation/Client/Pages/Transactions/TransactionEdit.razor
+++ b/src/Presentation/Client/Pages/Transactions/TransactionEdit.razor
@@ -1,0 +1,18 @@
+@page "/transactions/edit/{Id:guid}"
+@using Client.Interfaces.Services.Core
+@namespace Client.Pages.Transactions
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
+@inject ITransactionService TransactionService
+
+<MudText Typo="Typo.h4" Class="mb-4">@(Id == null ? "Create New Transaction" : "Edit Transaction")</MudText>
+
+<MudForm @ref="form" @bind-IsValid="@success">
+    <MudNumericField T="decimal" Label="Amount" Required="true" @bind-Value="_transaction.Amount" RequiredError=@TransactionValidator.AmountMustBeNonZero />
+    <DateOnlyPicker @bind-Value="_transaction.Date" Label="Date" />
+
+    <div class="d-flex justify-space-between mt-6">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!success)" OnClick="@SubmitTransaction">@(Id == null ? "Create Transaction" : "Update Transaction")</MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="@(() => NavigationManager.NavigateTo("/transactions"))">Cancel</MudButton>
+    </div>
+</MudForm>

--- a/src/Presentation/Client/Pages/Transactions/TransactionEdit.razor.cs
+++ b/src/Presentation/Client/Pages/Transactions/TransactionEdit.razor.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Shared.ViewModels.Core;
+using Shared.Validators;
+using FluentValidation.Results;
+using Client.Common;
+
+namespace Client.Pages.Transactions;
+
+public partial class TransactionEdit
+{
+    [Parameter]
+    public Guid? Id { get; set; }
+
+    private MudForm? form;
+    private TransactionVM _transaction = new();
+    private bool success;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Id.HasValue)
+        {
+            TransactionVM? result = await TransactionService.GetTransactionByIdAsync(Id.Value);
+
+            if (result == null)
+            {
+                Snackbar.ShowErrorMessage("Transaction not found");
+                NavigateToTransactions();
+                return;
+            }
+
+            _transaction = result;
+        }
+    }
+
+    private async Task SubmitTransaction()
+    {
+        try
+        {
+            if (!await ValidateForm())
+            {
+                return;
+            }
+
+            if (!await ValidateTransaction())
+            {
+                return;
+            }
+
+            if (Id.HasValue)
+            {
+                _transaction.Id = Id.Value;
+                await TransactionService.UpdateTransactionsAsync([_transaction]);
+                Snackbar.ShowSuccessMessage("Transaction updated successfully");
+            }
+            else
+            {
+                await TransactionService.CreateTransactionsAsync([_transaction]);
+                Snackbar.ShowSuccessMessage("Transaction created successfully");
+            }
+
+            NavigateToTransactions();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.ShowErrorMessage(ex.Message);
+        }
+    }
+
+    private async Task<bool> ValidateForm()
+    {
+        if (form is null)
+        {
+            Snackbar.ShowErrorMessage("Form is null");
+            return false;
+        }
+
+        await form.Validate();
+
+        return form.IsValid;
+    }
+
+    private async Task<bool> ValidateTransaction()
+    {
+        TransactionValidator validator = new();
+        ValidationResult validationResult = await validator.ValidateAsync(_transaction);
+
+        if (!validationResult.IsValid)
+        {
+            Snackbar.ShowValidationErrors(validationResult);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void NavigateToTransactions()
+    {
+        NavigationManager.NavigateTo("/transactions");
+    }
+}

--- a/src/Presentation/Client/Pages/Transactions/TransactionsList.razor
+++ b/src/Presentation/Client/Pages/Transactions/TransactionsList.razor
@@ -1,0 +1,35 @@
+@page "/transactions"
+@using Client.Interfaces.Services.Core
+@namespace Client.Pages.Transactions
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
+@inject ITransactionService TransactionService
+@inject IDialogService DialogService
+
+<MudText Typo="Typo.h4" Class="mb-4">Transactions List</MudText>
+
+<MudTable Items="@transactions" Dense="true" Hover="true" Bordered="true" Striped="true" Filter="new Func<TransactionVM,bool>(FilterFunc)">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Transactions</MudText>
+        <MudSpacer />
+        <MudTextField @bind-Value="searchString" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh>Amount</MudTh>
+        <MudTh>Date</MudTh>
+        <MudTh>Actions</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Amount">@context.Amount</MudTd>
+        <MudTd DataLabel="Date">@context.Date?.ToString("yyyy-MM-dd")</MudTd>
+        <MudTd>
+            <MudButton @onclick="() => EditTransaction(context)" Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small">Edit</MudButton>
+            <MudButton @onclick="() => DeleteTransaction(context)" Color="Color.Error" Variant="Variant.Filled" Size="Size.Small">Delete</MudButton>
+        </MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+<MudButton @onclick="AddTransaction" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mt-4">Add Transaction</MudButton>

--- a/src/Presentation/Client/Pages/Transactions/TransactionsList.razor.cs
+++ b/src/Presentation/Client/Pages/Transactions/TransactionsList.razor.cs
@@ -1,0 +1,83 @@
+using Client.Common;
+using Microsoft.AspNetCore.Components;
+using Shared.ViewModels.Core;
+
+namespace Client.Pages.Transactions;
+
+public partial class TransactionsList
+{
+    private List<TransactionVM> transactions = [];
+    private string searchString = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadTransactions();
+    }
+
+    private async Task LoadTransactions()
+    {
+        List<TransactionVM>? result = await TransactionService.GetAllTransactionsAsync();
+
+        if (result == null)
+        {
+            Snackbar.ShowErrorMessage("An error occurred while retrieving transactions. Please try again.");
+            transactions = [];
+        }
+        else
+        {
+            transactions = result;
+        }
+    }
+
+    private void AddTransaction()
+    {
+        NavigationManager.NavigateTo("/transactions/create");
+    }
+
+    private void EditTransaction(TransactionVM transaction)
+    {
+        NavigationManager.NavigateTo($"/transactions/edit/{transaction.Id}");
+    }
+
+    private async Task DeleteTransaction(TransactionVM transaction)
+    {
+        bool? confirm = await DialogService.ShowMessageBox(
+            "Confirm Delete",
+            "Are you sure you want to delete this transaction?",
+            yesText: "Delete", cancelText: "Cancel");
+
+        if (confirm == true)
+        {
+            try
+            {
+                await TransactionService.DeleteTransactionsAsync([transaction.Id!.Value]);
+                await LoadTransactions();
+                Snackbar.ShowSuccessMessage("Transaction deleted successfully");
+            }
+            catch (Exception ex)
+            {
+                Snackbar.ShowErrorMessage(ex.Message);
+            }
+        }
+    }
+
+    private bool FilterFunc(TransactionVM transaction)
+    {
+        if (string.IsNullOrWhiteSpace(searchString))
+        {
+            return true;
+        }
+
+        if (transaction.Amount.HasValue && transaction.Amount.Value.ToString().Contains(searchString, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (transaction.Date.HasValue && transaction.Date.Value.ToString("yyyy-MM-dd").Contains(searchString, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Presentation/Client/wwwroot/index.html
+++ b/src/Presentation/Client/wwwroot/index.html
@@ -8,9 +8,11 @@
 	<base href="/" />
 	<link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
 	<link rel="stylesheet" href="css/app.css" />
-	<link rel="icon" type="image/png" href="favicon.png" />
-	<link href="Client.styles.css" rel="stylesheet" />
-	<link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+        <link rel="icon" type="image/png" href="favicon.png" />
+        <link rel="manifest" href="manifest.json" />
+        <meta name="theme-color" content="#0277bd" />
+        <link href="Client.styles.css" rel="stylesheet" />
+        <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
 </head>
 
 <body>
@@ -27,8 +29,13 @@
 		<a href="" class="reload">Reload</a>
 		<a class="dismiss">🗙</a>
 	</div>
-	<script src="_framework/blazor.webassembly.js"></script>
-	<script src="_content/MudBlazor/MudBlazor.min.js"></script>
+        <script src="_framework/blazor.webassembly.js"></script>
+        <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+        <script>
+            if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.register('service-worker.js');
+            }
+        </script>
 </body>
 
 </html>

--- a/src/Presentation/Client/wwwroot/manifest.json
+++ b/src/Presentation/Client/wwwroot/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Receipt Manager",
+  "short_name": "Receipts",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0277bd",
+  "icons": [
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-192.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/Presentation/Client/wwwroot/service-worker.js
+++ b/src/Presentation/Client/wwwroot/service-worker.js
@@ -1,0 +1,31 @@
+const CACHE_NAME = 'receipt-cache-v1';
+const OFFLINE_URL = 'index.html';
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll([
+      '/',
+      OFFLINE_URL,
+      'manifest.json',
+      'icon-192.png'
+    ]))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then(cached => cached || fetch(event.request).catch(() => caches.match(OFFLINE_URL)))
+  );
+});


### PR DESCRIPTION
## Summary
- implement UI pages to create, edit and list receipts
- implement UI pages to create, edit and list transactions
- enable basic PWA support with manifest and service worker
- update `index.html` to register the service worker

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6840f45d763c832d91b6294f4ae4c232