### PR TITLE
refactor(shared): remove TotalAmount from ReceiptItemVM, calculate in mapper (MGG-13)

### DIFF
--- a/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
+++ b/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
@@ -10,12 +10,27 @@ namespace API.Mapping.Core;
 public partial class ReceiptItemMapper
 {
 	[MapProperty(nameof(ReceiptItem.UnitPrice.Amount), nameof(ReceiptItemVM.UnitPrice))]
-	[MapProperty(nameof(ReceiptItem.TotalAmount.Amount), nameof(ReceiptItemVM.TotalAmount))]
+	[MapperIgnoreSource(nameof(ReceiptItem.TotalAmount))]
 	public partial ReceiptItemVM ToViewModel(ReceiptItem source);
 
-	private Money MapUnitPrice(decimal? unitPrice) => new(unitPrice ?? 0, Currency.USD);
-	private Money MapTotalAmount(decimal? totalAmount) => new(totalAmount ?? 0, Currency.USD);
 	private Guid MapId(Guid? id) => id ?? Guid.Empty;
 
-	public partial ReceiptItem ToDomain(ReceiptItemVM source);
+	public ReceiptItem ToDomain(ReceiptItemVM source)
+	{
+		decimal quantity = source.Quantity ?? 0;
+		decimal unitPrice = source.UnitPrice ?? 0;
+		Money unitPriceMoney = new(unitPrice, Currency.USD);
+		Money totalAmount = new(Math.Floor(quantity * unitPrice * 100) / 100, Currency.USD);
+
+		return new ReceiptItem(
+			source.Id ?? Guid.Empty,
+			source.ReceiptItemCode ?? string.Empty,
+			source.Description ?? string.Empty,
+			quantity,
+			unitPriceMoney,
+			totalAmount,
+			source.Category ?? string.Empty,
+			source.Subcategory ?? string.Empty
+		);
+	}
 }

--- a/src/Presentation/Shared/Validators/ReceiptItemValidator.cs
+++ b/src/Presentation/Shared/Validators/ReceiptItemValidator.cs
@@ -9,7 +9,6 @@ public class ReceiptItemValidator : AbstractValidator<ReceiptItemVM>
 	public const string DescriptionIsRequired = "Description is required.";
 	public const string CategoryIsRequired = "Category is required.";
 	public const string SubcategoryIsRequired = "Subcategory is required.";
-	public const string TotalAmountErrorMessage = "Total amount must be equal to the product of Quantity and Unit Price.";
 
 	public ReceiptItemValidator()
 	{
@@ -28,9 +27,5 @@ public class ReceiptItemValidator : AbstractValidator<ReceiptItemVM>
 		RuleFor(x => x.Subcategory)
 			.NotEmpty()
 			.WithMessage(SubcategoryIsRequired);
-
-		RuleFor(x => x.TotalAmount)
-			.Equal(x => Math.Floor((x.Quantity ?? 0) * (x.UnitPrice ?? 0) * 100) / 100)
-			.WithMessage(TotalAmountErrorMessage);
 	}
 }

--- a/src/Presentation/Shared/ViewModels/Core/ReceiptItemVM.cs
+++ b/src/Presentation/Shared/ViewModels/Core/ReceiptItemVM.cs
@@ -7,7 +7,6 @@ public class ReceiptItemVM
 	public string? Description { get; set; }
 	public decimal? Quantity { get; set; }
 	public decimal? UnitPrice { get; set; }
-	public decimal? TotalAmount { get; set; } // TODO: Remove this property and calculate it in the mapper instead
 	public string? Category { get; set; }
 	public string? Subcategory { get; set; }
 }

--- a/tests/Presentation.Shared.Tests/Validators/ReceiptItemValidatorTests.cs
+++ b/tests/Presentation.Shared.Tests/Validators/ReceiptItemValidatorTests.cs
@@ -17,7 +17,6 @@ public class ReceiptItemValidatorTests
 			Description = "Test Item",
 			Quantity = 1,
 			UnitPrice = 100,
-			TotalAmount = 100,
 			Category = "Test Category",
 			Subcategory = "Test Subcategory"
 		};
@@ -39,7 +38,6 @@ public class ReceiptItemValidatorTests
 			Description = "Test Item",
 			Quantity = 1,
 			UnitPrice = 100,
-			TotalAmount = 100,
 			Category = "Test Category",
 			Subcategory = "Test Subcategory"
 		};
@@ -62,7 +60,6 @@ public class ReceiptItemValidatorTests
 			Description = string.Empty,
 			Quantity = 1,
 			UnitPrice = 100,
-			TotalAmount = 100,
 			Category = "Test Category",
 			Subcategory = "Test Subcategory"
 		};
@@ -85,7 +82,6 @@ public class ReceiptItemValidatorTests
 			Description = "Test Item",
 			Quantity = 1,
 			UnitPrice = 100,
-			TotalAmount = 100,
 			Category = string.Empty,
 			Subcategory = "Test Subcategory"
 		};
@@ -108,7 +104,6 @@ public class ReceiptItemValidatorTests
 			Description = "Test Item",
 			Quantity = 1,
 			UnitPrice = 100,
-			TotalAmount = 100,
 			Category = "Test Category",
 			Subcategory = string.Empty
 		};
@@ -119,59 +114,6 @@ public class ReceiptItemValidatorTests
 		// Assert
 		Assert.False(result.IsValid);
 		Assert.Contains(result.Errors, e => e.ErrorMessage == ReceiptItemValidator.SubcategoryIsRequired);
-	}
-
-	[Theory]
-	[InlineData(1, 100, 100)]
-	[InlineData(2, 50, 100)]
-	[InlineData(3, 33.33, 99.99)]
-	[InlineData(3.423, 1.99, 6.81)]
-	[InlineData(3.422, 1.99, 6.80)]
-	public void Should_Pass_When_TotalAmountIsEqualQuantityUnitPrice(decimal quantity, decimal unitPrice, decimal totalAmount)
-	{
-		// Arrange
-		ReceiptItemVM receiptItem = new()
-		{
-			ReceiptItemCode = "ITEM123",
-			Description = "Test Item",
-			Quantity = quantity,
-			UnitPrice = unitPrice,
-			TotalAmount = totalAmount,
-			Category = "Test Category",
-			Subcategory = "Test Subcategory"
-		};
-
-		// Act
-		FluentValidation.Results.ValidationResult result = _validator.Validate(receiptItem);
-
-		// Assert
-		Assert.True(result.IsValid);
-	}
-
-	[Theory]
-	[InlineData(1, 100, 105)]
-	[InlineData(2, 50, 105)]
-	[InlineData(3, 33.33, 100)]
-	public void Should_Fail_When_TotalAmountIsNotEqualQuantityUnitPrice(decimal quantity, decimal unitPrice, decimal totalAmount)
-	{
-		// Arrange
-		ReceiptItemVM receiptItem = new()
-		{
-			ReceiptItemCode = "ITEM123",
-			Description = "Test Item",
-			Quantity = quantity,
-			UnitPrice = unitPrice,
-			TotalAmount = totalAmount,
-			Category = "Test Category",
-			Subcategory = "Test Subcategory"
-		};
-
-		// Act
-		FluentValidation.Results.ValidationResult result = _validator.Validate(receiptItem);
-
-		// Assert
-		Assert.False(result.IsValid);
-		Assert.Contains(result.Errors, e => e.ErrorMessage == ReceiptItemValidator.TotalAmountErrorMessage);
 	}
 
 	[Fact]

--- a/tests/Presentation.Shared.Tests/ViewModels/Core/ReceiptItemVMTests.cs
+++ b/tests/Presentation.Shared.Tests/ViewModels/Core/ReceiptItemVMTests.cs
@@ -13,7 +13,6 @@ public class ReceiptItemVMTests
 		string description = "Test Item";
 		decimal quantity = 2.0m;
 		decimal unitPrice = 5.0m;
-		decimal totalAmount = 10.0m;
 		string category = "Test Category";
 		string subcategory = "Test Subcategory";
 
@@ -25,7 +24,6 @@ public class ReceiptItemVMTests
 			Description = description,
 			Quantity = quantity,
 			UnitPrice = unitPrice,
-			TotalAmount = totalAmount,
 			Category = category,
 			Subcategory = subcategory
 		};
@@ -36,7 +34,6 @@ public class ReceiptItemVMTests
 		Assert.Equal(description, receiptItemVM.Description);
 		Assert.Equal(quantity, receiptItemVM.Quantity);
 		Assert.Equal(unitPrice, receiptItemVM.UnitPrice);
-		Assert.Equal(totalAmount, receiptItemVM.TotalAmount);
 		Assert.Equal(category, receiptItemVM.Category);
 		Assert.Equal(subcategory, receiptItemVM.Subcategory);
 	}
@@ -49,7 +46,6 @@ public class ReceiptItemVMTests
 		string description = "Test Item";
 		decimal quantity = 2.0m;
 		decimal unitPrice = 5.0m;
-		decimal totalAmount = 10.0m;
 		string category = "Test Category";
 		string subcategory = "Test Subcategory";
 
@@ -60,7 +56,6 @@ public class ReceiptItemVMTests
 			Description = description,
 			Quantity = quantity,
 			UnitPrice = unitPrice,
-			TotalAmount = totalAmount,
 			Category = category,
 			Subcategory = subcategory
 		};

--- a/tests/SampleData/ViewModels/Core/ReceiptItemVMGenerator.cs
+++ b/tests/SampleData/ViewModels/Core/ReceiptItemVMGenerator.cs
@@ -13,7 +13,6 @@ public static class ReceiptItemVMGenerator
 			Description = "Test Item",
 			Quantity = 1,
 			UnitPrice = 5m,
-			TotalAmount = 5m,
 			Category = "Test Category",
 			Subcategory = "Test Subcategory"
 		};


### PR DESCRIPTION
TotalAmount is now computed as Quantity * UnitPrice in the API mapper
during VM-to-domain conversion instead of being a stored ViewModel
property. This eliminates redundant data and ensures consistency.

- Remove TotalAmount property from ReceiptItemVM
- Make ToDomain a manual method in API ReceiptItemMapper with calculation
- Ignore TotalAmount source in ToViewModel mapping
- Remove TotalAmount validation rule from ReceiptItemValidator
- Remove TotalAmount-specific validator tests
- Update ViewModel tests and sample data generators

https://claude.ai/code/session_01MQceqDsLJF1PUwH8vs5Wu8