### PR TITLE
Add Linear MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "linear-server": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.linear.app/sse"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "linear-server": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.linear.app/sse"]
+      "args": ["-y", "mcp-remote", "https://mcp.linear.app/mcp"]
     }
   }
 }


### PR DESCRIPTION
Configure the official Linear remote MCP server using mcp-remote
bridge in .mcp.json, matching the existing linear-server permission
entries in .claude/settings.local.json.

https://claude.ai/code/session_018Kz9cSZP9cwVXmyf6ANKWs