### PR TITLE
Rewrite Snyk-to-Linear integration (MGG-104)

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -60,6 +60,8 @@ jobs:
   security:
     name: Vulnerability Scan
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
 
     steps:
       - uses: actions/checkout@v4
@@ -81,13 +83,23 @@ jobs:
             exit 1
           fi
 
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/dotnet@master
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run Snyk Code analysis
+        uses: snyk/actions/node@master
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --severity-threshold=medium --sarif-file-output=snyk.sarif --json-file-output=snyk-results.json
+          command: code test
+          args: --severity-threshold=medium --sarif-file-output=snyk.sarif
 
       - name: Upload Snyk results to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
@@ -96,13 +108,11 @@ jobs:
           sarif_file: snyk.sarif
         continue-on-error: true
 
-      - name: Create Linear issues for vulnerabilities
-        if: env.LINEAR_API_KEY != ''
-        run: node scripts/create-linear-issues.mjs snyk-results.json
+      - name: Sync Snyk findings to Linear
+        if: always()
+        run: node scripts/create-linear-issues.mjs snyk.sarif
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
-          LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
         continue-on-error: true
 
   api-compat:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "mggarofalo-mgg-88-generate-net-requestresponse-dtos-from-openapi-spec",
+  "name": "mggarofalo-mgg-106-rewrite-create-linear-issuesmjs-with-dedup-lifecycle",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "devDependencies": {
+        "@linear/sdk": "^75.0.0",
         "@stoplight/spectral-cli": "^6.15.0",
         "js-yaml": "^4.1.0"
       }
@@ -17,6 +18,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@jsep-plugin/assignment": {
@@ -56,6 +67,19 @@
       },
       "peerDependencies": {
         "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@linear/sdk": {
+      "version": "75.0.0",
+      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-75.0.0.tgz",
+      "integrity": "sha512-gf/xmbiWc4cLHjoeOGCNVTglpy+M+ENHpP3bvU57wxD17s7j8zJGXp4wOStnRcQYR0FT+n/76fPp+XR3ZtEjDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1656,6 +1680,17 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "check:breaking": "node scripts/check-breaking.mjs"
   },
   "devDependencies": {
+    "@linear/sdk": "^75.0.0",
     "@stoplight/spectral-cli": "^6.15.0",
     "js-yaml": "^4.1.0"
   }

--- a/scripts/create-linear-issues.mjs
+++ b/scripts/create-linear-issues.mjs
@@ -1,131 +1,287 @@
 #!/usr/bin/env node
 
 /**
- * Script to create Linear issues from Snyk vulnerability findings
- * Usage: node scripts/create-linear-issues.mjs <snyk-json-file>
+ * Syncs Snyk SARIF findings to Linear issues with fingerprint-based deduplication
+ * and a two-scan confirmation lifecycle for auto-closing resolved vulnerabilities.
  *
- * Required environment variables:
- * - LINEAR_TEAM_ID: Linear team ID
- * - LINEAR_PROJECT_ID: Linear project ID
+ * Usage: node scripts/create-linear-issues.mjs <sarif-file>
+ *
+ * Required env vars:
+ *   LINEAR_API_KEY — Linear personal API key
+ *
+ * Auto-provided by GitHub Actions:
+ *   GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID
  */
 
-import { readFileSync } from 'fs';
-import { execSync } from 'child_process';
+import { readFileSync } from "node:fs";
+import { LinearClient } from "@linear/sdk";
 
-// Configuration from environment variables
-const TEAM_ID = process.env.LINEAR_TEAM_ID;
-const PROJECT_ID = process.env.LINEAR_PROJECT_ID;
+// --- Workspace constants (stable IDs, not secrets) ---
+const TEAM_ID = "a4aff05d-41e6-45dc-b670-cdb485fef765";
+const PROJECT_ID = "06199e4e-d3a8-4f98-9edf-e1e02efb6cee";
 
-// Severity mapping to Linear priority
-const SEVERITY_TO_PRIORITY = {
-  critical: 1, // Urgent
-  high: 2,     // High
-  medium: 3,   // Medium
-  low: 4       // Low
-};
+// Label IDs
+const LABEL_SECURITY = "ee5f0431-4384-4c19-b83d-45ed2a34c9c4";
+const LABEL_BACKEND = "f5657ea9-462c-42f3-bb3b-1885eb43a3e3";
+const LABEL_INFRA = "3a0c50c8-5ad3-4f3a-9d42-4bce3f4bde9c";
+const LABEL_SNYK = "ac0e5039-260b-42db-a3bd-8d23a9034895";
+const LABEL_RESOLVED = "46afab2a-f987-40ab-a3f5-47809eaa7c70";
 
-function parseSnykResults(jsonFile) {
+// State IDs
+const STATE_BACKLOG = "601c0945-c05f-4602-ab32-9267a1dc0090";
+const STATE_DONE = "5cd41ab3-b7b2-4788-b15e-2b40afa4f837";
+
+// Fingerprint metadata marker regex
+const FINGERPRINT_RE = /<!-- snyk:fingerprint:(.+?) -->/;
+
+// --- SARIF parsing ---
+
+/**
+ * Maps SARIF level + priority score to Linear priority.
+ * SARIF uses error/warning/note — NOT critical/high/medium.
+ */
+function mapPriority(level, priorityScore) {
+  if (level === "error") return priorityScore >= 700 ? 1 : 2;
+  if (level === "warning") return 3;
+  return 4; // note, none, or unknown
+}
+
+/**
+ * Parses a SARIF file and returns a Map<fingerprint, Finding>.
+ * Skips results that lack a snyk/asset/finding/v1 fingerprint.
+ */
+function parseSarifResults(filePath) {
+  const findings = new Map();
+
+  let sarif;
   try {
-    const data = readFileSync(jsonFile, 'utf8');
-    const results = JSON.parse(data);
+    sarif = JSON.parse(readFileSync(filePath, "utf8"));
+  } catch (err) {
+    console.error(`Failed to read/parse SARIF file: ${err.message}`);
+    return findings;
+  }
 
-    const vulnerabilities = [];
+  const runs = sarif.runs ?? [];
+  for (const run of runs) {
+    for (const result of run.results ?? []) {
+      const props = result.properties ?? {};
+      const findingMeta = props["snyk/asset/finding/v1"];
+      const fingerprint = findingMeta?.fingerprint;
 
-    // Snyk JSON structure varies, but typically has vulnerabilities array
-    if (results.vulnerabilities) {
-      for (const vuln of results.vulnerabilities) {
-        if (['critical', 'high', 'medium'].includes(vuln.severity)) {
-          vulnerabilities.push({
-            title: `${vuln.packageName}: ${vuln.title}`,
-            description: `
-**Severity:** ${vuln.severity}
-**Package:** ${vuln.packageName} ${vuln.version}
-**Vulnerability:** ${vuln.title}
-**CVE:** ${vuln.identifiers?.CVE?.join(', ') || 'N/A'}
-**CVSS Score:** ${vuln.cvssScore || 'N/A'}
-
-**Description:**
-${vuln.description}
-
-**Remediation:**
-${vuln.remediation || 'No remediation available'}
-
-**References:**
-${vuln.references?.map(ref => `- ${ref.url}`).join('\n') || 'None'}
-            `,
-            severity: vuln.severity,
-            package: vuln.packageName,
-            cve: vuln.identifiers?.CVE?.[0] || null
-          });
-        }
+      if (!fingerprint) {
+        console.warn(
+          `Skipping result without fingerprint: ${result.ruleId ?? "unknown rule"}`,
+        );
+        continue;
       }
-    }
 
-    return vulnerabilities;
-  } catch (error) {
-    console.error('Error parsing Snyk results:', error);
-    return [];
-  }
-}
-
-function createLinearIssue(vulnerability) {
-  const title = `[Security] ${vulnerability.title}`;
-  const description = vulnerability.description;
-  const priority = SEVERITY_TO_PRIORITY[vulnerability.severity] || 3;
-
-  // Using Linear MCP to create issue
-  // This assumes Linear MCP is available and configured
-  const linearCommand = `linear issue create --team "${TEAM_ID}" --project "${PROJECT_ID}" --title "${title}" --description "${description}" --priority ${priority} --label "security" --label "backend"`;
-
-  try {
-    console.log(`Creating Linear issue: ${title}`);
-    const result = execSync(linearCommand, { encoding: 'utf8' });
-    console.log('Issue created:', result);
-    return true;
-  } catch (error) {
-    console.error('Failed to create Linear issue:', error);
-    return false;
-  }
-}
-
-function main() {
-  // Validate required environment variables
-  if (!TEAM_ID) {
-    console.error('Error: LINEAR_TEAM_ID environment variable is required');
-    process.exit(1);
-  }
-  if (!PROJECT_ID) {
-    console.error('Error: LINEAR_PROJECT_ID environment variable is required');
-    process.exit(1);
-  }
-
-  const jsonFile = process.argv[2];
-
-  if (!jsonFile) {
-    console.error('Usage: node scripts/create-linear-issues.mjs <snyk-json-file>');
-    process.exit(1);
-  }
-
-  console.log('Parsing Snyk results from:', jsonFile);
-  const vulnerabilities = parseSnykResults(jsonFile);
-
-  if (vulnerabilities.length === 0) {
-    console.log('No critical/high/medium vulnerabilities found.');
-    return;
-  }
-
-  console.log(`Found ${vulnerabilities.length} vulnerabilities to report.`);
-
-  let created = 0;
-  for (const vuln of vulnerabilities) {
-    if (createLinearIssue(vuln)) {
-      created++;
+      const location = result.locations?.[0]?.physicalLocation;
+      findings.set(fingerprint, {
+        fingerprint,
+        ruleId: result.ruleId ?? "unknown",
+        level: result.level ?? "warning",
+        priorityScore: props.priorityScore ?? 0,
+        message: result.message?.text ?? "Security vulnerability detected",
+        filePath: location?.artifactLocation?.uri ?? "unknown",
+        startLine: location?.region?.startLine ?? 0,
+      });
     }
   }
 
-  console.log(`Created ${created} Linear issues.`);
+  return findings;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
+// --- Linear helpers ---
+
+function truncate(str, max) {
+  return str.length > max ? str.slice(0, max - 1) + "\u2026" : str;
 }
+
+function buildDescription(finding) {
+  const runUrl = buildRunUrl();
+  const lines = [
+    `**Severity:** ${finding.level} (score: ${finding.priorityScore})`,
+    `**File:** \`${finding.filePath}:${finding.startLine}\``,
+    `**Rule:** ${finding.ruleId}`,
+    "",
+    finding.message,
+  ];
+  if (runUrl) {
+    lines.push("", `**CI Run:** ${runUrl}`);
+  }
+  lines.push("", `<!-- snyk:fingerprint:${finding.fingerprint} -->`);
+  return lines.join("\n");
+}
+
+function buildRunUrl() {
+  const server = process.env.GITHUB_SERVER_URL;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const runId = process.env.GITHUB_RUN_ID;
+  if (server && repo && runId) return `${server}/${repo}/actions/runs/${runId}`;
+  return null;
+}
+
+/**
+ * Fetches all open issues with the `snyk` label and returns
+ * a Map<fingerprint, LinearIssue>.
+ */
+async function fetchOpenSnykIssues(client) {
+  const issueMap = new Map();
+
+  const issues = await client.issues({
+    filter: {
+      team: { id: { eq: TEAM_ID } },
+      labels: { name: { eq: "snyk" } },
+      state: { type: { nin: ["completed", "canceled"] } },
+    },
+    first: 250,
+  });
+
+  for (const issue of issues.nodes) {
+    const match = issue.description?.match(FINGERPRINT_RE);
+    if (match) {
+      issueMap.set(match[1], issue);
+    }
+  }
+
+  return issueMap;
+}
+
+async function getIssueLabelIds(issue) {
+  const labels = await issue.labels();
+  return labels.nodes.map((l) => l.id);
+}
+
+// --- Core logic ---
+
+async function createIssue(client, finding) {
+  await client.createIssue({
+    teamId: TEAM_ID,
+    projectId: PROJECT_ID,
+    stateId: STATE_BACKLOG,
+    title: `[Snyk] ${finding.ruleId}: ${truncate(finding.message, 80)}`,
+    description: buildDescription(finding),
+    priority: mapPriority(finding.level, finding.priorityScore),
+    labelIds: [LABEL_SECURITY, LABEL_BACKEND, LABEL_INFRA, LABEL_SNYK],
+  });
+}
+
+async function handleReappearance(client, issue) {
+  const labelIds = await getIssueLabelIds(issue);
+  const filtered = labelIds.filter((id) => id !== LABEL_RESOLVED);
+
+  await client.updateIssue(issue.id, { labelIds: filtered });
+  await client.createComment({
+    issueId: issue.id,
+    body: "This vulnerability has reappeared in the latest Snyk scan. Removing `resolved-by-scan` label.",
+  });
+}
+
+async function markResolving(client, issue) {
+  const labelIds = await getIssueLabelIds(issue);
+  await client.updateIssue(issue.id, {
+    labelIds: [...labelIds, LABEL_RESOLVED],
+  });
+  await client.createComment({
+    issueId: issue.id,
+    body: "This vulnerability is no longer detected by Snyk. Marking as `resolved-by-scan` \u2014 will auto-close if still absent in the next scan.",
+  });
+}
+
+async function confirmResolved(client, issue) {
+  await client.updateIssue(issue.id, { stateId: STATE_DONE });
+  await client.createComment({
+    issueId: issue.id,
+    body: "Vulnerability confirmed resolved (absent for two consecutive scans). Auto-closing.",
+  });
+}
+
+// --- Main ---
+
+async function main() {
+  const apiKey = process.env.LINEAR_API_KEY;
+  if (!apiKey) {
+    console.error("LINEAR_API_KEY is required");
+    process.exit(0); // don't fail the build
+  }
+
+  const sarifPath = process.argv[2];
+  if (!sarifPath) {
+    console.error("Usage: node scripts/create-linear-issues.mjs <sarif-file>");
+    process.exit(0);
+  }
+
+  const client = new LinearClient({ apiKey });
+  const findings = parseSarifResults(sarifPath);
+  console.log(`Parsed ${findings.size} findings from SARIF`);
+
+  const openIssues = await fetchOpenSnykIssues(client);
+  console.log(`Found ${openIssues.size} open snyk-labeled issues in Linear`);
+
+  const stats = { new: 0, tracked: 0, resolving: 0, closed: 0, recurred: 0 };
+
+  // Process each finding
+  for (const [fingerprint, finding] of findings) {
+    const existing = openIssues.get(fingerprint);
+
+    if (!existing) {
+      try {
+        await createIssue(client, finding);
+        stats.new++;
+        console.log(`  NEW: ${finding.ruleId} in ${finding.filePath}`);
+      } catch (err) {
+        console.error(
+          `  Failed to create issue for ${finding.ruleId}: ${err.message}`,
+        );
+      }
+      continue;
+    }
+
+    // Existing issue — check if it was marked as resolving and has come back
+    try {
+      const labelIds = await getIssueLabelIds(existing);
+      if (labelIds.includes(LABEL_RESOLVED)) {
+        await handleReappearance(client, existing);
+        stats.recurred++;
+        console.log(`  RECURRED: ${finding.ruleId}`);
+      } else {
+        stats.tracked++;
+      }
+    } catch (err) {
+      console.error(
+        `  Failed to check/update ${existing.identifier}: ${err.message}`,
+      );
+    }
+  }
+
+  // Reconcile: find open issues whose fingerprints are no longer in the scan
+  for (const [fingerprint, issue] of openIssues) {
+    if (findings.has(fingerprint)) continue;
+
+    try {
+      const labelIds = await getIssueLabelIds(issue);
+      if (labelIds.includes(LABEL_RESOLVED)) {
+        await confirmResolved(client, issue);
+        stats.closed++;
+        console.log(`  CLOSED: ${issue.identifier} (confirmed resolved)`);
+      } else {
+        await markResolving(client, issue);
+        stats.resolving++;
+        console.log(`  RESOLVING: ${issue.identifier}`);
+      }
+    } catch (err) {
+      console.error(
+        `  Failed to reconcile ${issue.identifier}: ${err.message}`,
+      );
+    }
+  }
+
+  console.log(
+    `\nSummary: ${stats.new} new | ${stats.tracked} tracked | ${stats.resolving} resolving | ${stats.closed} closed | ${stats.recurred} recurred`,
+  );
+}
+
+main().catch((err) => {
+  console.error(`Unexpected error: ${err.message}`);
+  process.exit(0); // never fail the build
+});


### PR DESCRIPTION
## Summary

- **Rewrote `scripts/create-linear-issues.mjs`** with `@linear/sdk`, fingerprint-based deduplication, and a two-scan resolution lifecycle that auto-closes vulnerabilities no longer detected by Snyk
- **Cleaned up the CI security job** to use the official `snyk/actions/node` action with `code test` command, proper Node.js setup, and removed unnecessary secret env vars (team/project IDs are now hardcoded constants)
- **Fixed SARIF severity mapping** — the old script mapped `critical/high/medium` but SARIF uses `error/warning/note`

## Test plan

- [ ] CI security job runs successfully with Snyk + SARIF upload
- [ ] Linear sync step creates issues with fingerprint metadata comments
- [ ] Running twice with same SARIF creates 0 duplicates (dedup works)
- [ ] Removing a finding from SARIF adds `resolved-by-scan` label
- [ ] Second removal confirms resolution and auto-closes the issue
- [ ] Re-adding a finding removes `resolved-by-scan` label and comments

Closes MGG-106, MGG-107
Relates to MGG-104

🤖 Generated with [Claude Code](https://claude.com/claude-code)