### PR TITLE
Phase 3: Aspire Developer Experience (MGG-109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,10 @@ project.lock.json
 project.fragment.lock.json
 artifacts/
 
-# VS Code
-.vscode/
+# VS Code (track shared dev config, ignore user-specific settings)
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
 
 *_i.c
 *_p.c

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Aspire AppHost",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-apphost",
+      "program": "${workspaceFolder}/src/Receipts.AppHost/bin/Debug/net10.0/Receipts.AppHost.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/src/Receipts.AppHost",
+      "stopAtEntry": false,
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "Login to the dashboard at (https?://\\S+)",
+        "uriFormat": "%s"
+      }
+    },
+    {
+      "name": "Attach to API",
+      "type": "coreclr",
+      "request": "attach",
+      "processName": "API"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug All (AppHost + API)",
+      "configurations": ["Launch Aspire AppHost", "Attach to API"],
+      "preLaunchTask": "build-all",
+      "stopAll": true
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build-apphost",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/src/Receipts.AppHost/Receipts.AppHost.csproj"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": "build",
+      "presentation": {
+        "reveal": "silent"
+      }
+    },
+    {
+      "label": "build-all",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/Receipts.slnx"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always"
+      }
+    }
+  ]
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,144 @@
+# Development Guide
+
+Local development uses **.NET Aspire** to orchestrate all services — API, PostgreSQL, and PgAdmin — with a single F5 press in VS Code.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| [.NET 10 SDK](https://dot.net) | 10.0+ | Build and run the API |
+| [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Any | PostgreSQL container (Aspire manages it) |
+| [Node.js](https://nodejs.org) | 18+ | OpenAPI spec linting and drift detection |
+| [VS Code](https://code.visualstudio.com) | Any | Recommended IDE |
+| [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) | Any | VS Code C# support |
+
+> **Docker is required** — Aspire provisions PostgreSQL as a container automatically. You don't need to manage the database manually.
+
+## Initial Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/mggarofalo/Receipts.git
+cd Receipts
+
+# Restore .NET packages and install tools (also installs Husky pre-commit hooks)
+dotnet restore Receipts.slnx
+
+# Install Node dependencies (OpenAPI linting tools)
+npm install
+```
+
+## F5 Debugging (Recommended)
+
+1. Open the repository root in VS Code
+2. Press **F5** (or **Run → Start Debugging**)
+3. Select **"Launch Aspire AppHost"** if prompted
+4. Wait ~30 seconds for all services to start
+
+VS Code will automatically open the **Aspire Dashboard** in your browser.
+
+### What Starts
+
+| Service | URL | Description |
+|---------|-----|-------------|
+| Aspire Dashboard | http://localhost:15888 | Observability — logs, traces, metrics |
+| API (HTTP) | http://localhost:5000 | REST API |
+| API (HTTPS) | https://localhost:5001 | REST API (HTTPS) |
+| API Docs (Scalar) | http://localhost:5000/scalar | Interactive API documentation |
+| PgAdmin | auto-assigned | PostgreSQL admin UI |
+
+### Debug Configurations
+
+- **Launch Aspire AppHost** — Starts the entire stack (API + DB + Dashboard)
+- **Attach to API** — Attach debugger to a running API process for breakpoints
+- **Debug All (AppHost + API)** — Launch AppHost and immediately attach the debugger to the API
+
+## Aspire Dashboard
+
+The dashboard provides full observability without any external tooling:
+
+| View | What You See |
+|------|-------------|
+| **Resources** | All running services with health status |
+| **Traces** | Distributed request traces across API → DB |
+| **Metrics** | Request rates, response times, runtime stats |
+| **Logs** | Structured logs from all services, searchable |
+| **Console** | Raw stdout/stderr from each service |
+
+### Database Tracing
+
+EF Core queries are automatically traced and visible in the Traces view. Each HTTP request shows the full span tree including SQL statements executed against PostgreSQL.
+
+## Running Without Aspire
+
+If you prefer to run the API directly (without Docker/Aspire):
+
+```bash
+# Set database environment variables
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5432
+export POSTGRES_USER=postgres
+export POSTGRES_PASSWORD=yourpassword
+export POSTGRES_DB=receiptsdb
+
+# Run the API
+dotnet run --project src/Presentation/API/API.csproj
+```
+
+EF Core migrations run automatically on startup when the database is configured.
+
+## Build and Test
+
+```bash
+# Build entire solution
+dotnet build Receipts.slnx
+
+# Run all tests
+dotnet test Receipts.slnx
+
+# Run tests for a specific project
+dotnet test tests/Application.Tests/Application.Tests.csproj
+```
+
+## Pre-commit Hooks
+
+Every `git commit` runs the full quality pipeline automatically:
+
+1. **OpenAPI spec lint** — `npx spectral lint openapi/spec.yaml`
+2. **Code format check** — `dotnet format --verify-no-changes`
+3. **Build with warnings-as-errors** — also regenerates `openapi/generated/API.json`
+4. **Semantic drift check** — compares spec vs generated output for structural differences
+5. **Tests** — `dotnet test --no-build`
+
+To skip hooks temporarily (use sparingly):
+```bash
+git commit --no-verify -m "message"
+```
+
+## OpenAPI Spec-First Workflow
+
+All API changes follow a spec-first workflow:
+
+1. Edit `openapi/spec.yaml` — this is the single source of truth
+2. `npm run lint:spec` — validate the spec
+3. `dotnet build` — regenerates DTOs and the built output
+4. `npm run check:drift` — verify spec and implementation stay in sync
+
+See [AGENTS.md](AGENTS.md) for the full workflow details.
+
+## Troubleshooting
+
+### Port conflicts
+If ports 5000/5001 are in use, Aspire will pick alternative ports. Check the Dashboard Resources view for the actual URLs.
+
+### Docker not running
+Aspire requires Docker to provision the PostgreSQL container. Start Docker Desktop before pressing F5.
+
+### Database connection issues
+The API waits for PostgreSQL to be healthy before starting (`.WaitFor(db)` in AppHost). If the API starts before the database is ready, Aspire restarts it automatically.
+
+### Pre-commit hook failures
+- **Spec lint fails** — fix the OpenAPI spec error reported by Spectral
+- **Format fails** — run `dotnet format Receipts.slnx` to auto-fix
+- **Drift check fails** — the spec and generated API are out of sync; update the spec or the implementation to match
+- **Tests fail** — fix the failing tests before committing

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,29 +1,29 @@
 <!-- https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management -->
-
 <Project>
-	<ItemGroup>
-		<PackageVersion Include="Riok.Mapperly" Version="4.2.0" />
-		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
-		<PackageVersion Include="FluentAssertions" Version="8.2.0" />
-		<PackageVersion Include="FluentValidation" Version="12.1.1" />
-		<PackageVersion Include="MediatR" Version="14.0.0" />
-		<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
-		<PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageVersion Include="Moq" Version="4.20.72" />
-		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-		<PackageVersion Include="NSwag.MSBuild" Version="14.6.3" />
-		<PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
-		<PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
-		<PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-		<PackageVersion Include="Serilog" Version="4.3.0" />
-		<PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.3" />
-		<PackageVersion Include="Scalar.AspNetCore" Version="2.12.39" />
-		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-		<PackageVersion Include="xunit" Version="2.9.3" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="Riok.Mapperly" Version="4.2.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="FluentAssertions" Version="8.2.0" />
+    <PackageVersion Include="FluentValidation" Version="12.1.1" />
+    <PackageVersion Include="MediatR" Version="14.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageVersion Include="NSwag.MSBuild" Version="14.6.3" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.3" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.39" />
+    <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ A receipt management API built with .NET 10 and Clean Architecture. Tracks accou
 | CQRS | MediatR 14 |
 | Mapping | Mapperly (compile-time, zero-reflection) |
 | Validation | FluentValidation |
-| Logging | Serilog |
+| Logging | Serilog + OpenTelemetry |
 | Real-time | SignalR |
 | API Docs | Microsoft.AspNetCore.OpenApi + Scalar |
+| Local Dev | .NET Aspire (orchestration + observability) |
 | Testing | xUnit + FluentAssertions + Moq |
 
 ## Architecture
@@ -67,39 +68,24 @@ tests/
 ## Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download)
-- [PostgreSQL](https://www.postgresql.org/download/) (any recent version)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (for local dev — Aspire provisions PostgreSQL as a container)
+- [Node.js 18+](https://nodejs.org) (for OpenAPI tooling)
 
 ## Getting Started
 
-1. **Clone and restore**
+See **[DEVELOPMENT.md](DEVELOPMENT.md)** for the full local development guide including F5 debugging with Aspire, the Aspire Dashboard, and troubleshooting.
 
-   ```bash
-   git clone https://github.com/mggarofalo/Receipts.git
-   cd Receipts
-   dotnet restore Receipts.slnx
-   ```
+**Quick start:**
 
-2. **Configure the database**
+```bash
+git clone https://github.com/mggarofalo/Receipts.git
+cd Receipts
+dotnet restore Receipts.slnx
+npm install
+# Then press F5 in VS Code
+```
 
-   Set the following environment variables (or edit `src/Presentation/API/appsettings.Development.json`):
-
-   | Variable | Default |
-   |---|---|
-   | `POSTGRES_HOST` | `localhost` |
-   | `POSTGRES_PORT` | `5432` |
-   | `POSTGRES_USER` | `postgres` |
-   | `POSTGRES_PASSWORD` | `postgres` |
-   | `POSTGRES_DB` | `receipts` |
-
-3. **Run the API**
-
-   ```bash
-   dotnet run --project src/Presentation/API/API.csproj
-   ```
-
-   The API starts at `https://localhost:5001` with Swagger UI at `/swagger`.
-
-   EF Core migrations run automatically on startup.
+Aspire orchestrates the entire stack (API + PostgreSQL + Dashboard) automatically. No manual database setup needed.
 
 ## Development
 

--- a/Receipts.slnx
+++ b/Receipts.slnx
@@ -4,6 +4,8 @@
     <Project Path="src/Common/Common.csproj" />
     <Project Path="src/Domain/Domain.csproj" />
     <Project Path="src/Infrastructure/Infrastructure.csproj" />
+    <Project Path="src/Receipts.AppHost/Receipts.AppHost.csproj" />
+    <Project Path="src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj" />
   </Folder>
   <Folder Name="/src/Presentation/">
     <Project Path="src/Presentation/API/API.csproj" />

--- a/src/Common/ConfigurationVariables.cs
+++ b/src/Common/ConfigurationVariables.cs
@@ -7,5 +7,8 @@ public static class ConfigurationVariables
 	public const string PostgresUser = "POSTGRES_USER";
 	public const string PostgresPassword = "POSTGRES_PASSWORD";
 	public const string PostgresDb = "POSTGRES_DB";
+
+	// Aspire-injected connection string name (set via WithReference(db) in AppHost)
+	public const string AspireConnectionStringName = "receiptsdb";
 }
 

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -15,7 +15,7 @@ public static class InfrastructureService
 	public static bool IsDatabaseConfigured(IConfiguration configuration)
 	{
 		// Aspire-injected connection string takes precedence
-		if (!string.IsNullOrEmpty(configuration.GetConnectionString(ConfigurationVariables.AspireConnectionStringName)))
+		if (!string.IsNullOrEmpty(configuration[$"ConnectionStrings:{ConfigurationVariables.AspireConnectionStringName}"]))
 		{
 			return true;
 		}
@@ -31,7 +31,7 @@ public static class InfrastructureService
 	private static string GetConnectionString(IConfiguration configuration)
 	{
 		// Aspire-injected connection string (set by WithReference(db) in AppHost)
-		string? aspireConnectionString = configuration.GetConnectionString(ConfigurationVariables.AspireConnectionStringName);
+		string? aspireConnectionString = configuration[$"ConnectionStrings:{ConfigurationVariables.AspireConnectionStringName}"];
 		if (!string.IsNullOrEmpty(aspireConnectionString))
 		{
 			return aspireConnectionString;

--- a/src/Presentation/API/API.csproj
+++ b/src/Presentation/API/API.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\Domain\Domain.csproj" />
     <ProjectReference Include="..\..\Application\Application.csproj" />
 	<ProjectReference Include="..\..\Infrastructure\Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Receipts.ServiceDefaults\Receipts.ServiceDefaults.csproj" />
   </ItemGroup>
 
   <Target Name="NSwag" BeforeTargets="CoreCompile"

--- a/src/Presentation/API/API.csproj
+++ b/src/Presentation/API/API.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" />
     <ProjectReference Include="..\..\Common\Common.csproj" />
     <ProjectReference Include="..\..\Domain\Domain.csproj" />
     <ProjectReference Include="..\..\Application\Application.csproj" />
@@ -31,9 +32,7 @@
     <ProjectReference Include="..\..\Receipts.ServiceDefaults\Receipts.ServiceDefaults.csproj" />
   </ItemGroup>
 
-  <Target Name="NSwag" BeforeTargets="CoreCompile"
-          Inputs="$(MSBuildProjectDirectory)\..\..\..\openapi\spec.yaml"
-          Outputs="$(MSBuildProjectDirectory)\Generated\Dtos.g.cs">
+  <Target Name="NSwag" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectDirectory)\..\..\..\openapi\spec.yaml" Outputs="$(MSBuildProjectDirectory)\Generated\Dtos.g.cs">
     <Message Text="Regenerating DTOs from OpenAPI spec..." Importance="high" />
     <Exec Command="$(NSwagExe_Net90) run $(MSBuildProjectDirectory)\..\..\..\nswag.json" EnvironmentVariables="DOTNET_ROLL_FORWARD=Major" />
   </Target>

--- a/src/Presentation/API/Program.cs
+++ b/src/Presentation/API/Program.cs
@@ -7,6 +7,7 @@ using Infrastructure.Services;
 
 // Create builder
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
 builder.AddApplicationConfiguration();
 
 // Register services
@@ -32,6 +33,9 @@ if (Infrastructure.Services.InfrastructureService.IsDatabaseConfigured(builder.C
 	using IServiceScope scope = app.Services.CreateScope();
 	await scope.ServiceProvider.GetRequiredService<IDatabaseMigratorService>().MigrateAsync();
 }
+
+// Map Aspire health check endpoints (/health, /alive)
+app.MapDefaultEndpoints();
 
 // Map controllers
 app.MapControllers();

--- a/src/Presentation/API/Services/LoggingService.cs
+++ b/src/Presentation/API/Services/LoggingService.cs
@@ -1,4 +1,5 @@
 using Serilog;
+using Serilog.Sinks.OpenTelemetry;
 
 namespace API.Services;
 
@@ -20,6 +21,21 @@ public static class LoggingService
 			loggerConfiguration
 				.WriteTo.Console()
 				.MinimumLevel.Information();
+		}
+
+		// Forward logs to Aspire Dashboard via OTLP when running under Aspire
+		string? otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+		if (!string.IsNullOrEmpty(otlpEndpoint))
+		{
+			loggerConfiguration.WriteTo.OpenTelemetry(options =>
+			{
+				options.Endpoint = otlpEndpoint;
+				options.Protocol = OtlpProtocol.Grpc;
+				options.ResourceAttributes = new Dictionary<string, object>
+				{
+					["service.name"] = builder.Environment.ApplicationName
+				};
+			});
 		}
 
 		Log.Logger = loggerConfiguration.CreateLogger();

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -1,0 +1,3 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.Build().Run();

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -1,3 +1,7 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.Build().Run();
+IResourceBuilder<ProjectResource> api = builder.AddProject<Projects.API>("api")
+	.WithHttpEndpoint(port: 5000, name: "http")
+	.WithHttpsEndpoint(port: 5001, name: "https");
+
+await builder.Build().RunAsync();

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -1,6 +1,14 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
+IResourceBuilder<PostgresServerResource> postgres = builder.AddPostgres("postgres")
+	.WithDataVolume()
+	.WithPgAdmin();
+
+IResourceBuilder<PostgresDatabaseResource> db = postgres.AddDatabase("receiptsdb");
+
 IResourceBuilder<ProjectResource> api = builder.AddProject<Projects.API>("api")
+	.WithReference(db)
+	.WaitFor(db)
 	.WithHttpEndpoint(port: 5000, name: "http")
 	.WithHttpsEndpoint(port: 5001, name: "https");
 

--- a/src/Receipts.AppHost/Properties/launchSettings.json
+++ b/src/Receipts.AppHost/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17054;http://localhost:15082",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21157",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:23005",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22204"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15082",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19272",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18266",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20275"
+      }
+    }
+  }
+}

--- a/src/Receipts.AppHost/Receipts.AppHost.csproj
+++ b/src/Receipts.AppHost/Receipts.AppHost.csproj
@@ -8,4 +8,8 @@
     <UserSecretsId>b5ec2e0d-4615-427e-9fdc-7c109cb3902a</UserSecretsId>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Presentation\API\API.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Receipts.AppHost/Receipts.AppHost.csproj
+++ b/src/Receipts.AppHost/Receipts.AppHost.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="..\Presentation\API\API.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Receipts.AppHost/Receipts.AppHost.csproj
+++ b/src/Receipts.AppHost/Receipts.AppHost.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Aspire.AppHost.Sdk/13.1.1">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>b5ec2e0d-4615-427e-9fdc-7c109cb3902a</UserSecretsId>
+  </PropertyGroup>
+
+</Project>

--- a/src/Receipts.AppHost/appsettings.Development.json
+++ b/src/Receipts.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Receipts.AppHost/appsettings.json
+++ b/src/Receipts.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/src/Receipts.AppHost/appsettings.json
+++ b/src/Receipts.AppHost/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "Dashboard": {
+    "Frontend": {
+      "BrowserToken": ""
+    }
   }
 }

--- a/src/Receipts.ServiceDefaults/Extensions.cs
+++ b/src/Receipts.ServiceDefaults/Extensions.cs
@@ -1,0 +1,127 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    private const string HealthEndpointPath = "/health";
+    private const string AlivenessEndpointPath = "/alive";
+
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation(tracing =>
+                        // Exclude health check requests from tracing
+                        tracing.Filter = context =>
+                            !context.Request.Path.StartsWithSegments(HealthEndpointPath)
+                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
+                    )
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks(HealthEndpointPath);
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/src/Receipts.ServiceDefaults/Extensions.cs
+++ b/src/Receipts.ServiceDefaults/Extensions.cs
@@ -70,7 +70,8 @@ public static class Extensions
                     )
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
-                    .AddHttpClientInstrumentation();
+                    .AddHttpClientInstrumentation()
+                    .AddEntityFrameworkCoreInstrumentation();
             });
 
         builder.AddOpenTelemetryExporters();

--- a/src/Receipts.ServiceDefaults/Extensions.cs
+++ b/src/Receipts.ServiceDefaults/Extensions.cs
@@ -15,114 +15,114 @@ namespace Microsoft.Extensions.Hosting;
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
-    private const string HealthEndpointPath = "/health";
-    private const string AlivenessEndpointPath = "/alive";
+	private const string HealthEndpointPath = "/health";
+	private const string AlivenessEndpointPath = "/alive";
 
-    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
-    {
-        builder.ConfigureOpenTelemetry();
+	public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+	{
+		builder.ConfigureOpenTelemetry();
 
-        builder.AddDefaultHealthChecks();
+		builder.AddDefaultHealthChecks();
 
-        builder.Services.AddServiceDiscovery();
+		builder.Services.AddServiceDiscovery();
 
-        builder.Services.ConfigureHttpClientDefaults(http =>
-        {
-            // Turn on resilience by default
-            http.AddStandardResilienceHandler();
+		builder.Services.ConfigureHttpClientDefaults(http =>
+		{
+			// Turn on resilience by default
+			http.AddStandardResilienceHandler();
 
-            // Turn on service discovery by default
-            http.AddServiceDiscovery();
-        });
+			// Turn on service discovery by default
+			http.AddServiceDiscovery();
+		});
 
-        // Uncomment the following to restrict the allowed schemes for service discovery.
-        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
-        // {
-        //     options.AllowedSchemes = ["https"];
-        // });
+		// Uncomment the following to restrict the allowed schemes for service discovery.
+		// builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+		// {
+		//     options.AllowedSchemes = ["https"];
+		// });
 
-        return builder;
-    }
+		return builder;
+	}
 
-    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
-    {
-        builder.Logging.AddOpenTelemetry(logging =>
-        {
-            logging.IncludeFormattedMessage = true;
-            logging.IncludeScopes = true;
-        });
+	public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+	{
+		builder.Logging.AddOpenTelemetry(logging =>
+		{
+			logging.IncludeFormattedMessage = true;
+			logging.IncludeScopes = true;
+		});
 
-        builder.Services.AddOpenTelemetry()
-            .WithMetrics(metrics =>
-            {
-                metrics.AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
-            })
-            .WithTracing(tracing =>
-            {
-                tracing.AddSource(builder.Environment.ApplicationName)
-                    .AddAspNetCoreInstrumentation(tracing =>
-                        // Exclude health check requests from tracing
-                        tracing.Filter = context =>
-                            !context.Request.Path.StartsWithSegments(HealthEndpointPath)
-                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
-                    )
-                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
-                    //.AddGrpcClientInstrumentation()
-                    .AddHttpClientInstrumentation()
-                    .AddEntityFrameworkCoreInstrumentation();
-            });
+		builder.Services.AddOpenTelemetry()
+			.WithMetrics(metrics =>
+			{
+				metrics.AddAspNetCoreInstrumentation()
+					.AddHttpClientInstrumentation()
+					.AddRuntimeInstrumentation();
+			})
+			.WithTracing(tracing =>
+			{
+				tracing.AddSource(builder.Environment.ApplicationName)
+					.AddAspNetCoreInstrumentation(tracing =>
+						// Exclude health check requests from tracing
+						tracing.Filter = context =>
+							!context.Request.Path.StartsWithSegments(HealthEndpointPath)
+							&& !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
+					)
+					// Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+					//.AddGrpcClientInstrumentation()
+					.AddHttpClientInstrumentation()
+					.AddEntityFrameworkCoreInstrumentation();
+			});
 
-        builder.AddOpenTelemetryExporters();
+		builder.AddOpenTelemetryExporters();
 
-        return builder;
-    }
+		return builder;
+	}
 
-    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
-    {
-        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+	private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+	{
+		var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
 
-        if (useOtlpExporter)
-        {
-            builder.Services.AddOpenTelemetry().UseOtlpExporter();
-        }
+		if (useOtlpExporter)
+		{
+			builder.Services.AddOpenTelemetry().UseOtlpExporter();
+		}
 
-        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
-        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
-        //{
-        //    builder.Services.AddOpenTelemetry()
-        //       .UseAzureMonitor();
-        //}
+		// Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+		//if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+		//{
+		//    builder.Services.AddOpenTelemetry()
+		//       .UseAzureMonitor();
+		//}
 
-        return builder;
-    }
+		return builder;
+	}
 
-    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
-    {
-        builder.Services.AddHealthChecks()
-            // Add a default liveness check to ensure app is responsive
-            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+	public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+	{
+		builder.Services.AddHealthChecks()
+			// Add a default liveness check to ensure app is responsive
+			.AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
 
-        return builder;
-    }
+		return builder;
+	}
 
-    public static WebApplication MapDefaultEndpoints(this WebApplication app)
-    {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-        if (app.Environment.IsDevelopment())
-        {
-            // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks(HealthEndpointPath);
+	public static WebApplication MapDefaultEndpoints(this WebApplication app)
+	{
+		// Adding health checks endpoints to applications in non-development environments has security implications.
+		// See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+		if (app.Environment.IsDevelopment())
+		{
+			// All health checks must pass for app to be considered ready to accept traffic after starting
+			app.MapHealthChecks(HealthEndpointPath);
 
-            // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
-            {
-                Predicate = r => r.Tags.Contains("live")
-            });
-        }
+			// Only health checks tagged with the "live" tag must pass for app to be considered alive
+			app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+			{
+				Predicate = r => r.Tags.Contains("live")
+			});
+		}
 
-        return app;
-    }
+		return app;
+	}
 }

--- a/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
+++ b/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
   </ItemGroup>

--- a/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
+++ b/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Implements the **Core Aspire Orchestration** epic (MGG-109) — "F5 and everything starts" local dev experience using .NET Aspire.

- **MGG-72** — Bootstrap `Receipts.AppHost` and `Receipts.ServiceDefaults` projects
- **MGG-73** — Wire API service into AppHost; add `AddServiceDefaults()` to API for OpenTelemetry, health checks, service discovery
- **MGG-74** — Add PostgreSQL resource to AppHost with data persistence; update `InfrastructureService` to accept Aspire-injected connection string with fallback to individual `POSTGRES_*` env vars
- **MGG-76** — Add `.vscode/launch.json` and `tasks.json` for F5 debugging; update `.gitignore` to track shared VS Code config
- **MGG-77** — Add EF Core distributed tracing (Aspire Dashboard shows DB query spans); forward Serilog logs to Aspire Dashboard via OTLP
- **MGG-80** — Create `DEVELOPMENT.md` developer guide; update README

## What This Enables

Press **F5** in VS Code → entire stack starts (API on 5000/5001, PostgreSQL container, PgAdmin, Aspire Dashboard). No manual database setup required.

## Test plan

- [ ] Confirm `dotnet build Receipts.slnx` passes (CI will verify)
- [ ] Confirm all tests pass (CI will verify)
- [ ] Optionally: start AppHost locally and verify Aspire Dashboard shows API + postgres resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)