### PR TITLE
fix: remove duplicate Aspire HTTP/HTTPS endpoint declarations

### DIFF
--- a/src/Presentation/API/Properties/launchSettings.json
+++ b/src/Presentation/API/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 				"POSTGRES_PORT": "5432",
 				"POSTGRES_USER": "postgres",
 				"POSTGRES_PASSWORD": "admin",
-				"POSTGRES_DB": "receipts",
+				"POSTGRES_DB": "receipts"
 			}
 		}
 	}

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -8,8 +8,6 @@ IResourceBuilder<PostgresDatabaseResource> db = postgres.AddDatabase("receiptsdb
 
 IResourceBuilder<ProjectResource> api = builder.AddProject<Projects.API>("api")
 	.WithReference(db)
-	.WaitFor(db)
-	.WithHttpEndpoint(port: 5000, name: "http")
-	.WithHttpsEndpoint(port: 5001, name: "https");
+	.WaitFor(db);
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
## Summary

- Aspire auto-creates `http`/`https` endpoints by reading `applicationUrl` in the API's `launchSettings.json`
- `AppHost.cs` was additionally calling `.WithHttpEndpoint()` and `.WithHttpsEndpoint()`, causing a `DistributedApplicationException` on startup due to duplicate endpoint names
- Removed the redundant explicit endpoint declarations; Aspire picks them up from `launchSettings.json` automatically

## Test plan

- [ ] Run the Aspire AppHost and confirm it starts without the duplicate endpoint exception
- [ ] Verify the API is reachable on ports 5000 (http) and 5001 (https)

🤖 Generated with [Claude Code](https://claude.com/claude-code)