### PR TITLE
chore(infra): upgrade CodeQL action from v3 to v4

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -102,7 +102,7 @@ jobs:
           args: --severity-threshold=medium --sarif-file-output=snyk.sarif
 
       - name: Upload Snyk results to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: snyk.sarif


### PR DESCRIPTION
## Summary
- Upgrades `github/codeql-action/upload-sarif` from v3 to v4 in the CI workflow
- CodeQL Action v3 is being deprecated ([changelog](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/)); v4 runs on Node.js 24

## Test plan
- [x] CI passes with the updated action version
- [x] Snyk SARIF upload to GitHub Code Scanning still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)