### PR TITLE
Publish code coverage to PR comments

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +42,27 @@ jobs:
         run: dotnet build Receipts.slnx --no-restore -p:TreatWarningsAsErrors=true
 
       - name: Test
-        run: dotnet test Receipts.slnx --no-build --verbosity normal
+        run: >-
+          dotnet test Receipts.slnx
+          --no-build
+          --verbosity normal
+          --collect:"XPlat Code Coverage"
+          --settings scripts/tests/coverlet.runsettings
+          --results-directory TestResults
+
+      - name: Merge coverage reports
+        if: always()
+        uses: danielpalme/ReportGenerator-GitHub-Action@5
+        with:
+          reports: TestResults/**/coverage.cobertura.xml
+          targetdir: TestResults/merged
+          reporttypes: Cobertura;MarkdownSummaryGithub
+
+      - name: Post coverage to PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: TestResults/merged/SummaryGithub.md
 
   lint:
     name: Code Formatting


### PR DESCRIPTION
## Summary
- Wire `coverlet` coverage collection into the CI test step using the existing `.runsettings`
- Merge per-project Cobertura reports with `ReportGenerator-GitHub-Action`
- Post a markdown coverage summary as a sticky PR comment via `marocchino/sticky-pull-request-comment`
- Add `pull-requests: write` permission to the `build` job

## Test plan
- [ ] CI produces `coverage.cobertura.xml` files under `TestResults/`
- [ ] ReportGenerator merges them into `TestResults/merged/SummaryGithub.md`
- [ ] A coverage summary comment appears on this PR
- [ ] On push to master (no PR), the comment step is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)