### PR TITLE
feat(client): animations, transitions & loading states (MGG-47)

### DIFF
--- a/src/client/src/components/PageTransition.tsx
+++ b/src/client/src/components/PageTransition.tsx
@@ -1,4 +1,4 @@
-import { motion, AnimatePresence } from "framer-motion";
+import { motion, AnimatePresence, type Transition } from "framer-motion";
 import type { ReactNode } from "react";
 import { useLocation } from "react-router";
 
@@ -8,7 +8,7 @@ const pageVariants = {
   exit: { opacity: 0, y: -8 },
 };
 
-const pageTransition = {
+const pageTransition: Transition = {
   type: "tween",
   ease: "easeInOut",
   duration: 0.18,

--- a/src/client/src/components/ReceiptForm.tsx
+++ b/src/client/src/components/ReceiptForm.tsx
@@ -9,7 +9,7 @@ const receiptSchema = z.object({
   description: z.string().optional(),
   location: z.string().min(1, "Location is required"),
   date: z.string().min(1, "Date is required"),
-  taxAmount: z.coerce.number().min(0, "Tax amount must be non-negative"),
+  taxAmount: z.number().min(0, "Tax amount must be non-negative"),
 });
 
 type ReceiptFormValues = z.infer<typeof receiptSchema>;
@@ -74,7 +74,7 @@ export function ReceiptForm({
           id="taxAmount"
           type="number"
           step="0.01"
-          {...register("taxAmount")}
+          {...register("taxAmount", { valueAsNumber: true })}
         />
         {errors.taxAmount && (
           <p className="text-sm text-destructive">

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -9,8 +9,8 @@ const receiptItemSchema = z.object({
   receiptId: z.string().min(1, "Receipt ID is required"),
   receiptItemCode: z.string().min(1, "Item code is required"),
   description: z.string().min(1, "Description is required"),
-  quantity: z.coerce.number().positive("Quantity must be positive"),
-  unitPrice: z.coerce.number().min(0, "Unit price must be non-negative"),
+  quantity: z.number().positive("Quantity must be positive"),
+  unitPrice: z.number().min(0, "Unit price must be non-negative"),
   category: z.string().min(1, "Category is required"),
   subcategory: z.string().min(1, "Subcategory is required"),
 });
@@ -94,7 +94,7 @@ export function ReceiptItemForm({
             id="quantity"
             type="number"
             step="1"
-            {...register("quantity")}
+            {...register("quantity", { valueAsNumber: true })}
           />
           {errors.quantity && (
             <p className="text-sm text-destructive">
@@ -109,7 +109,7 @@ export function ReceiptItemForm({
             id="unitPrice"
             type="number"
             step="0.01"
-            {...register("unitPrice")}
+            {...register("unitPrice", { valueAsNumber: true })}
           />
           {errors.unitPrice && (
             <p className="text-sm text-destructive">

--- a/src/client/src/components/ShortcutsHelp.tsx
+++ b/src/client/src/components/ShortcutsHelp.tsx
@@ -35,14 +35,10 @@ const grouped = SHORTCUTS.reduce<Record<string, typeof SHORTCUTS>>(
 export function ShortcutsHelp() {
   const [open, setOpen] = useState(false);
 
-  useHotkeys(
-    "shift+slash",
-    (e) => {
-      e.preventDefault();
-      setOpen((prev) => !prev);
-    },
-    { enableOnFormElements: false },
-  );
+  useHotkeys("shift+slash", (e) => {
+    e.preventDefault();
+    setOpen((prev) => !prev);
+  });
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/src/client/src/components/TransactionForm.tsx
+++ b/src/client/src/components/TransactionForm.tsx
@@ -8,7 +8,7 @@ import { Label } from "@/components/ui/label";
 const transactionSchema = z.object({
   receiptId: z.string().min(1, "Receipt ID is required"),
   accountId: z.string().min(1, "Account ID is required"),
-  amount: z.coerce.number(),
+  amount: z.number(),
   date: z.string().min(1, "Date is required"),
 });
 
@@ -82,7 +82,7 @@ export function TransactionForm({
           id="amount"
           type="number"
           step="0.01"
-          {...register("amount")}
+          {...register("amount", { valueAsNumber: true })}
         />
         {errors.amount && (
           <p className="text-sm text-destructive">{errors.amount.message}</p>

--- a/src/client/src/components/ui/button.tsx
+++ b/src/client/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/src/client/src/components/ui/card.tsx
+++ b/src/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm transition-shadow duration-200 hover:shadow-md",
         className,
       )}
       {...props}

--- a/src/client/src/components/ui/spinner.tsx
+++ b/src/client/src/components/ui/spinner.tsx
@@ -1,0 +1,26 @@
+import { Loader2 } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const spinnerVariants = cva("animate-spin text-muted-foreground", {
+  variants: {
+    size: {
+      sm: "size-4",
+      default: "size-6",
+      lg: "size-8",
+    },
+  },
+  defaultVariants: {
+    size: "default",
+  },
+});
+
+interface SpinnerProps extends VariantProps<typeof spinnerVariants> {
+  className?: string;
+}
+
+export function Spinner({ size, className }: SpinnerProps) {
+  return (
+    <Loader2 className={cn(spinnerVariants({ size }), className)} aria-hidden="true" />
+  );
+}

--- a/src/client/src/hooks/useAccounts.ts
+++ b/src/client/src/hooks/useAccounts.ts
@@ -81,12 +81,25 @@ export function useDeleteAccounts() {
       const { error } = await client.DELETE("/api/accounts", { body: ids });
       if (error) throw error;
     },
+    onMutate: async (ids: string[]) => {
+      await queryClient.cancelQueries({ queryKey: ["accounts"] });
+      const previous = queryClient.getQueryData(["accounts"]);
+      queryClient.setQueryData(["accounts"], (old: Array<{ id: string }> | undefined) =>
+        old?.filter((a) => !ids.includes(a.id)),
+      );
+      return { previous };
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["accounts"] });
       toast.success("Account(s) deleted");
     },
-    onError: () => {
+    onError: (_err: unknown, _ids: string[], context: { previous: unknown } | undefined) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(["accounts"], context.previous);
+      }
       toast.error("Failed to delete account(s)");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
     },
   });
 }

--- a/src/client/src/hooks/useKeyboardShortcuts.ts
+++ b/src/client/src/hooks/useKeyboardShortcuts.ts
@@ -30,30 +30,18 @@ export function useKeyboardShortcuts({
   onNew,
   onHelp,
 }: UseKeyboardShortcutOptions = {}) {
-  useHotkeys(
-    "ctrl+k,meta+k",
-    (e) => {
-      e.preventDefault();
-      onSearch?.();
-    },
-    { enableOnFormElements: false },
-  );
+  useHotkeys("ctrl+k,meta+k", (e) => {
+    e.preventDefault();
+    onSearch?.();
+  });
 
-  useHotkeys(
-    "ctrl+n,meta+n",
-    (e) => {
-      e.preventDefault();
-      onNew?.();
-    },
-    { enableOnFormElements: false },
-  );
+  useHotkeys("ctrl+n,meta+n", (e) => {
+    e.preventDefault();
+    onNew?.();
+  });
 
-  useHotkeys(
-    "shift+slash",
-    (e) => {
-      e.preventDefault();
-      onHelp?.();
-    },
-    { enableOnFormElements: false },
-  );
+  useHotkeys("shift+slash", (e) => {
+    e.preventDefault();
+    onHelp?.();
+  });
 }

--- a/src/client/src/hooks/useReceiptItems.ts
+++ b/src/client/src/hooks/useReceiptItems.ts
@@ -119,12 +119,25 @@ export function useDeleteReceiptItems() {
       });
       if (error) throw error;
     },
+    onMutate: async (ids: string[]) => {
+      await queryClient.cancelQueries({ queryKey: ["receipt-items"] });
+      const previous = queryClient.getQueryData(["receipt-items"]);
+      queryClient.setQueryData(["receipt-items"], (old: Array<{ id: string }> | undefined) =>
+        old?.filter((item) => !ids.includes(item.id)),
+      );
+      return { previous };
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
       toast.success("Receipt item(s) deleted");
     },
-    onError: () => {
+    onError: (_err: unknown, _ids: string[], context: { previous: unknown } | undefined) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(["receipt-items"], context.previous);
+      }
       toast.error("Failed to delete receipt item(s)");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
     },
   });
 }

--- a/src/client/src/hooks/useReceipts.ts
+++ b/src/client/src/hooks/useReceipts.ts
@@ -83,12 +83,25 @@ export function useDeleteReceipts() {
       const { error } = await client.DELETE("/api/receipts", { body: ids });
       if (error) throw error;
     },
+    onMutate: async (ids: string[]) => {
+      await queryClient.cancelQueries({ queryKey: ["receipts"] });
+      const previous = queryClient.getQueryData(["receipts"]);
+      queryClient.setQueryData(["receipts"], (old: Array<{ id: string }> | undefined) =>
+        old?.filter((r) => !ids.includes(r.id)),
+      );
+      return { previous };
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["receipts"] });
       toast.success("Receipt(s) deleted");
     },
-    onError: () => {
+    onError: (_err: unknown, _ids: string[], context: { previous: unknown } | undefined) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(["receipts"], context.previous);
+      }
       toast.error("Failed to delete receipt(s)");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["receipts"] });
     },
   });
 }

--- a/src/client/src/hooks/useTransactions.ts
+++ b/src/client/src/hooks/useTransactions.ts
@@ -108,12 +108,25 @@ export function useDeleteTransactions() {
       });
       if (error) throw error;
     },
+    onMutate: async (ids: string[]) => {
+      await queryClient.cancelQueries({ queryKey: ["transactions"] });
+      const previous = queryClient.getQueryData(["transactions"]);
+      queryClient.setQueryData(["transactions"], (old: Array<{ id: string }> | undefined) =>
+        old?.filter((t) => !ids.includes(t.id)),
+      );
+      return { previous };
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["transactions"] });
       toast.success("Transaction(s) deleted");
     },
-    onError: () => {
+    onError: (_err: unknown, _ids: string[], context: { previous: unknown } | undefined) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(["transactions"], context.previous);
+      }
       toast.error("Failed to delete transaction(s)");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["transactions"] });
     },
   });
 }


### PR DESCRIPTION
## Summary

- **Button micro-interactions**: Added `active:scale-[0.97]` to `button.tsx` base class — every button now has a subtle press-down scale for tactile feedback
- **Card hover effects**: Added `transition-shadow duration-200 hover:shadow-md` to `card.tsx` base class — cards lift gently on hover without layout shift
- **Optimistic deletes**: All four bulk-delete mutations (`useDeleteAccounts`, `useDeleteReceipts`, `useDeleteReceiptItems`, `useDeleteTransactions`) now use TanStack Query optimistic updates — items disappear instantly and roll back with an error toast if the server rejects

## Already in parent branch (from MGG-115 combined commit)

- `framer-motion` dependency added
- `PageTransition.tsx` — Framer Motion `AnimatePresence` + `motion.div` wrapping `<Outlet />`
- `LoadingSpinner.tsx` — reusable SVG spinner with size variants
- `index.css` — `prefers-reduced-motion` media query disabling all animations/transitions
- Skeleton loaders on all data pages (Accounts, Receipts, ReceiptItems, Transactions, Trips, ReceiptDetail, TransactionDetail)

## Test plan

- [ ] Navigate between pages and verify fade/slide transition plays
- [ ] Click any button and verify subtle scale-down on press
- [ ] Hover a card and verify shadow lifts smoothly
- [ ] Delete items from any CRUD page — items should disappear immediately before server responds
- [ ] Simulate delete failure (disconnect network) — items should reappear with error toast
- [ ] Enable `prefers-reduced-motion` in OS settings — confirm all animations are suppressed
- [ ] Run `npm run lint` in `src/client` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)