### PR TITLE
fix(client): replace Ctrl+Shift+N with Shift+N for new item shortcut (MGG-172)

### DIFF
--- a/src/client/src/hooks/useGlobalShortcuts.ts
+++ b/src/client/src/hooks/useGlobalShortcuts.ts
@@ -15,9 +15,9 @@ export function useGlobalShortcuts() {
 
   // Ctrl+K is handled by GlobalSearchDialog via useKeyboardShortcut
 
-  // Ctrl+Shift+N — Dispatch new-item event
+  // Shift+N — Dispatch new-item event
   useHotkeys(
-    "mod+shift+n",
+    "shift+n",
     () => {
       window.dispatchEvent(new CustomEvent("shortcut:new-item"));
     },

--- a/src/client/src/lib/shortcut-registry.ts
+++ b/src/client/src/lib/shortcut-registry.ts
@@ -11,7 +11,7 @@ export const shortcuts: ShortcutDefinition[] = [
   { keys: "?", label: "Show keyboard shortcuts", category: "Global" },
   { keys: "Ctrl+K", label: "Open command palette", category: "Global" },
   {
-    keys: "Ctrl+Shift+N",
+    keys: "Shift+N",
     label: "Create new item (context-aware)",
     category: "Global",
   },


### PR DESCRIPTION
## Summary

- Replace `mod+shift+n` (Ctrl+Shift+N) with `shift+n` (Shift+N) for the "new item" shortcut
- Ctrl+Shift+N is reserved by Chrome/Edge (incognito window) and macOS browsers, so the event never reaches the app
- Update `shortcut-registry.ts` display text to match

## Test plan

- [ ] Press Shift+N on any CRUD page — create dialog opens
- [ ] Press Shift+N while focused in a form input — nothing happens (`enableOnFormTags: false`)
- [ ] Press `?` — help modal shows "Shift+N" for new item shortcut
- [ ] Ctrl+Shift+N no longer triggers any app behavior (browser handles it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)