### PR TITLE
fix(client): prevent Enter key from propagating into edit dialog (MGG-173)

### DIFF
--- a/src/client/src/hooks/useListKeyboardNav.ts
+++ b/src/client/src/hooks/useListKeyboardNav.ts
@@ -65,12 +65,16 @@ export function useListKeyboardNav<T>({
     [items.length, scrollToRow],
   );
 
-  // Enter — open focused item
+  // Enter — open focused item (deferred so the keydown event doesn't
+  // propagate into the newly-mounted dialog and trigger an immediate submit)
   useHotkeys(
     "Enter",
-    () => {
+    (e) => {
       if (focusedIndex >= 0 && focusedIndex < items.length && onOpen) {
-        onOpen(items[focusedIndex]);
+        e.preventDefault();
+        e.stopPropagation();
+        const item = items[focusedIndex];
+        setTimeout(() => onOpen(item), 0);
       }
     },
     {


### PR DESCRIPTION
## Summary

- Defer `onOpen` callback via `setTimeout(..., 0)` so the Enter keydown event finishes propagating before the edit dialog mounts
- Add `preventDefault` and `stopPropagation` to the Enter handler to prevent the event from reaching the dialog's form

## Test plan

- [ ] Navigate to Accounts page with data
- [ ] Press `j` to focus a row, then press `Enter`
- [ ] Edit dialog opens and **stays open** for editing
- [ ] No "Updated" toast appears until the user explicitly submits
- [ ] Repeat on Receipts, Receipt Items, and Transactions pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)