### PR TITLE
fix(client): suppress keyboard shortcuts when a dialog is open (MGG-174)

### DIFF
--- a/src/client/src/hooks/useKeyboardShortcut.ts
+++ b/src/client/src/hooks/useKeyboardShortcut.ts
@@ -17,6 +17,7 @@ export function useKeyboardShortcut({
     if (!enabled) return;
 
     function onKeyDown(e: KeyboardEvent) {
+      if (document.querySelector("[role=dialog]")) return;
       const modifierOk = ctrlOrMeta ? e.metaKey || e.ctrlKey : true;
       if (modifierOk && e.key.toLowerCase() === key.toLowerCase()) {
         e.preventDefault();


### PR DESCRIPTION
## Summary

- Add a `[role=dialog]` check in `useKeyboardShortcut` to suppress global shortcuts when any dialog is active
- Prevents Ctrl+K from opening the command palette on top of an already-open dialog (e.g., Create Account)

## Test plan

- [ ] Open any CRUD dialog (e.g., click "New Account")
- [ ] Press Ctrl+K — nothing happens (command palette stays closed)
- [ ] Close the dialog, press Ctrl+K — command palette opens normally
- [ ] Open ShortcutsHelp modal (`?`), press Ctrl+K — nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)