### PR TITLE
feat(client): add CurrencyInput component (MGG-182)

### DIFF
--- a/src/client/src/components/GlobalSearchDialog.tsx
+++ b/src/client/src/components/GlobalSearchDialog.tsx
@@ -18,6 +18,7 @@ import {
   CommandSeparator,
 } from "@/components/ui/command";
 import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
+import { formatCurrency } from "@/lib/format";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useReceipts } from "@/hooks/useReceipts";
 import { useReceiptItems } from "@/hooks/useReceiptItems";
@@ -46,13 +47,6 @@ interface TransactionResponse {
   id: string;
   amount: number;
   date: string;
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(amount);
 }
 
 interface GlobalSearchDialogProps {

--- a/src/client/src/components/ReceiptForm.tsx
+++ b/src/client/src/components/ReceiptForm.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { CurrencyInput } from "@/components/ui/currency-input";
 import {
   Form,
   FormControl,
@@ -105,12 +106,7 @@ export function ReceiptForm({
             <FormItem>
               <FormLabel>Tax Amount</FormLabel>
               <FormControl>
-                <Input
-                  type="number"
-                  step="0.01"
-                  {...field}
-                  onChange={(e) => field.onChange(e.target.valueAsNumber)}
-                />
+                <CurrencyInput {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -8,6 +8,7 @@ import { receiptToOption } from "@/lib/combobox-options";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Combobox } from "@/components/ui/combobox";
+import { CurrencyInput } from "@/components/ui/currency-input";
 import {
   Form,
   FormControl,
@@ -154,12 +155,7 @@ export function ReceiptItemForm({
               <FormItem>
                 <FormLabel>Unit Price</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    step="0.01"
-                    {...field}
-                    onChange={(e) => field.onChange(e.target.valueAsNumber)}
-                  />
+                  <CurrencyInput {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/src/client/src/components/TransactionForm.tsx
+++ b/src/client/src/components/TransactionForm.tsx
@@ -9,6 +9,7 @@ import { receiptToOption, accountToOption } from "@/lib/combobox-options";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Combobox } from "@/components/ui/combobox";
+import { CurrencyInput } from "@/components/ui/currency-input";
 import {
   Form,
   FormControl,
@@ -131,12 +132,7 @@ export function TransactionForm({
             <FormItem>
               <FormLabel>Amount</FormLabel>
               <FormControl>
-                <Input
-                  type="number"
-                  step="0.01"
-                  {...field}
-                  onChange={(e) => field.onChange(e.target.valueAsNumber)}
-                />
+                <CurrencyInput {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/client/src/components/ui/currency-input.tsx
+++ b/src/client/src/components/ui/currency-input.tsx
@@ -1,0 +1,91 @@
+import { useState, useRef, type ComponentProps } from "react";
+import { cn } from "@/lib/utils";
+import { formatDecimal, parseCurrencyInput } from "@/lib/format";
+
+interface CurrencyInputProps
+  extends Omit<ComponentProps<"input">, "type" | "value" | "onChange"> {
+  value: number;
+  onChange: (value: number) => void;
+  onBlur?: () => void;
+  symbol?: string;
+}
+
+export function CurrencyInput({
+  value,
+  onChange,
+  onBlur,
+  symbol = "$",
+  className,
+  ...props
+}: CurrencyInputProps) {
+  const [text, setText] = useState(() => formatDecimal(value));
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [focused, setFocused] = useState(false);
+
+  // When not focused, derive display value from the prop directly
+  const displayValue = focused ? text : formatDecimal(value);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const raw = parseCurrencyInput(e.target.value);
+    const parts = raw.split(".");
+    if (parts.length > 1 && parts[1].length > 2) return;
+    setText(raw);
+    const num = parseFloat(raw);
+    if (!isNaN(num)) {
+      onChange(num);
+    } else if (raw === "" || raw === ".") {
+      onChange(0);
+    }
+  }
+
+  function handleFocus() {
+    setFocused(true);
+    setText(formatDecimal(value));
+    setTimeout(() => inputRef.current?.select(), 0);
+  }
+
+  function handleBlur() {
+    setFocused(false);
+    const num = parseFloat(text);
+    const final = isNaN(num) ? 0 : num;
+    setText(formatDecimal(final));
+    onChange(final);
+    onBlur?.();
+  }
+
+  function handlePaste(e: React.ClipboardEvent<HTMLInputElement>) {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData("text");
+    const cleaned = parseCurrencyInput(pasted);
+    const parts = cleaned.split(".");
+    const limited =
+      parts.length > 1 ? `${parts[0]}.${parts[1].slice(0, 2)}` : cleaned;
+    setText(limited);
+    const num = parseFloat(limited);
+    onChange(isNaN(num) ? 0 : num);
+  }
+
+  return (
+    <div className="relative">
+      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">
+        {symbol}
+      </span>
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode="decimal"
+        value={displayValue}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onPaste={handlePaste}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "pl-7 text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/src/client/src/lib/format.ts
+++ b/src/client/src/lib/format.ts
@@ -1,0 +1,14 @@
+export function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(amount);
+}
+
+export function formatDecimal(value: number, decimals = 2): string {
+  return value.toFixed(decimals);
+}
+
+export function parseCurrencyInput(raw: string): string {
+  return raw.replace(/[^0-9.]/g, "").replace(/(\..*)\./g, "$1");
+}

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -23,13 +23,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(amount);
-}
+import { formatCurrency } from "@/lib/format";
 
 function ReceiptDetail() {
   usePageTitle("Receipt Detail");

--- a/src/client/src/pages/ReceiptItems.tsx
+++ b/src/client/src/pages/ReceiptItems.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { formatCurrency } from "@/lib/format";
 
 interface ReceiptItemResponse {
   id: string;
@@ -49,13 +50,6 @@ interface ReceiptItemResponse {
   unitPrice: number;
   category: string;
   subcategory: string;
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(amount);
 }
 
 const SEARCH_CONFIG: FuseSearchConfig<ReceiptItemResponse> = {

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { formatCurrency } from "@/lib/format";
 
 interface ReceiptResponse {
   id: string;
@@ -45,13 +46,6 @@ interface ReceiptResponse {
   location: string;
   date: string;
   taxAmount: number;
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(amount);
 }
 
 const SEARCH_CONFIG: FuseSearchConfig<ReceiptResponse> = {

--- a/src/client/src/pages/TransactionDetail.tsx
+++ b/src/client/src/pages/TransactionDetail.tsx
@@ -27,13 +27,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(amount);
-}
+import { formatCurrency } from "@/lib/format";
 
 type LookupMode = "receipt" | "transaction";
 

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { formatCurrency } from "@/lib/format";
 
 interface TransactionResponse {
   id: string;
@@ -45,13 +46,6 @@ interface TransactionResponse {
   accountId: string;
   amount: number;
   date: string;
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(amount);
 }
 
 const SEARCH_CONFIG: FuseSearchConfig<TransactionResponse> = {

--- a/src/client/src/pages/Trips.tsx
+++ b/src/client/src/pages/Trips.tsx
@@ -24,13 +24,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { CardSkeleton } from "@/components/ui/card-skeleton";
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(amount);
-}
+import { formatCurrency } from "@/lib/format";
 
 function Trips() {
   usePageTitle("Trips");


### PR DESCRIPTION
## Summary
- Adds a reusable `CurrencyInput` component for monetary fields
- Extracts shared `formatCurrency` utility to `src/lib/format.ts`
- Replaces raw number inputs with `CurrencyInput` in ReceiptForm, ReceiptItemForm, TransactionForm
- Updates display formatting in Receipts, ReceiptItems, ReceiptDetail, TransactionDetail, Transactions, Trips pages

## Test plan
- [ ] Verify currency inputs render with `$` prefix and proper formatting
- [ ] Verify form submission sends correct numeric values
- [ ] Verify display pages show formatted currency values

🤖 Generated with [Claude Code](https://claude.com/claude-code)