### PR TITLE
feat(api): wire up FluentValidation + MediatR validation pipeline (MGG-197)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="8.2.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="14.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <ProjectReference Include="..\Common\Common.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />

--- a/src/Application/Behaviors/ValidationBehavior.cs
+++ b/src/Application/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using MediatR;
+
+namespace Application.Behaviors;
+
+public class ValidationBehavior<TRequest, TResponse>(IEnumerable<IValidator<TRequest>> validators)
+	: IPipelineBehavior<TRequest, TResponse>
+	where TRequest : notnull
+{
+	public async Task<TResponse> Handle(
+		TRequest request,
+		RequestHandlerDelegate<TResponse> next,
+		CancellationToken cancellationToken)
+	{
+		if (!validators.Any())
+		{
+			return await next(cancellationToken);
+		}
+
+		FluentValidation.Results.ValidationResult[] results = await Task.WhenAll(
+			validators.Select(v => v.ValidateAsync(new ValidationContext<TRequest>(request), cancellationToken)));
+
+		List<FluentValidation.Results.ValidationFailure> failures = results
+			.SelectMany(r => r.Errors)
+			.Where(f => f is not null)
+			.ToList();
+
+		if (failures.Count > 0)
+		{
+			throw new ValidationException(failures);
+		}
+
+		return await next(cancellationToken);
+	}
+}

--- a/src/Application/Services/ApplicationService.cs
+++ b/src/Application/Services/ApplicationService.cs
@@ -1,3 +1,4 @@
+using Application.Behaviors;
 using Application.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +13,7 @@ public static class ApplicationService
 		{
 			cfg.RegisterServicesFromAssembly(typeof(ICommand<>).Assembly);
 			cfg.RegisterServicesFromAssembly(typeof(IQuery<>).Assembly);
+			cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
 		});
 
 		return services;

--- a/src/Presentation/API/API.csproj
+++ b/src/Presentation/API/API.csproj
@@ -27,6 +27,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentValidation" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Riok.Mapperly" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.AspNetCore" />

--- a/src/Presentation/API/Configuration/ApplicationConfiguration.cs
+++ b/src/Presentation/API/Configuration/ApplicationConfiguration.cs
@@ -1,5 +1,9 @@
+using API.Filters;
 using API.Hubs;
+using API.Middleware;
 using API.Services;
+using API.Validators;
+using FluentValidation;
 
 namespace API.Configuration;
 
@@ -23,7 +27,12 @@ public static class ApplicationConfiguration
 
 	public static IServiceCollection AddApplicationServices(this IServiceCollection services)
 	{
-		services.AddControllers()
+		services.AddValidatorsFromAssemblyContaining<CreateReceiptRequestValidator>();
+
+		services.AddControllers(options =>
+			{
+				options.Filters.Add<FluentValidationActionFilter>();
+			})
 			.AddJsonOptions(options =>
 			{
 				options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
@@ -34,6 +43,7 @@ public static class ApplicationConfiguration
 
 	public static WebApplication UseApplicationServices(this WebApplication app)
 	{
+		app.UseMiddleware<ValidationExceptionMiddleware>();
 		app.UseHttpsRedirection();
 		app.UseRouting();
 

--- a/src/Presentation/API/Filters/FluentValidationActionFilter.cs
+++ b/src/Presentation/API/Filters/FluentValidationActionFilter.cs
@@ -1,0 +1,36 @@
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace API.Filters;
+
+public class FluentValidationActionFilter(IServiceProvider serviceProvider) : IAsyncActionFilter
+{
+	public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+	{
+		foreach (object? argument in context.ActionArguments.Values)
+		{
+			if (argument is null)
+			{
+				continue;
+			}
+
+			Type validatorType = typeof(IValidator<>).MakeGenericType(argument.GetType());
+
+			if (serviceProvider.GetService(validatorType) is not IValidator validator)
+			{
+				continue;
+			}
+
+			IValidationContext validationContext = new ValidationContext<object>(argument);
+			ValidationResult result = await validator.ValidateAsync(validationContext);
+
+			if (!result.IsValid)
+			{
+				throw new ValidationException(result.Errors);
+			}
+		}
+
+		await next();
+	}
+}

--- a/src/Presentation/API/Middleware/ValidationExceptionMiddleware.cs
+++ b/src/Presentation/API/Middleware/ValidationExceptionMiddleware.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Middleware;
+
+public class ValidationExceptionMiddleware(RequestDelegate next)
+{
+	public async Task InvokeAsync(HttpContext context)
+	{
+		try
+		{
+			await next(context);
+		}
+		catch (ValidationException ex)
+		{
+			context.Response.StatusCode = StatusCodes.Status400BadRequest;
+
+			Dictionary<string, string[]> errors = ex.Errors
+				.GroupBy(e => e.PropertyName)
+				.ToDictionary(
+					g => g.Key,
+					g => g.Select(e => e.ErrorMessage).ToArray());
+
+			ValidationProblemDetails problemDetails = new(errors)
+			{
+				Status = StatusCodes.Status400BadRequest,
+				Title = "One or more validation errors occurred.",
+				Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+			};
+
+			await context.Response.WriteAsJsonAsync(
+				problemDetails,
+				options: null,
+				contentType: "application/problem+json");
+		}
+	}
+}

--- a/tests/Application.Tests/Application.Tests.csproj
+++ b/tests/Application.Tests/Application.Tests.csproj
@@ -23,6 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 

--- a/tests/Application.Tests/Behaviors/ValidationBehaviorTests.cs
+++ b/tests/Application.Tests/Behaviors/ValidationBehaviorTests.cs
@@ -1,0 +1,110 @@
+using Application.Behaviors;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using MediatR;
+
+namespace Application.Tests.Behaviors;
+
+public class ValidationBehaviorTests
+{
+	public record TestRequest(string Name) : IRequest<string>;
+
+	public class PassingValidator : AbstractValidator<TestRequest>
+	{
+	}
+
+	public class FailingNameRequiredValidator : AbstractValidator<TestRequest>
+	{
+		public FailingNameRequiredValidator()
+		{
+			RuleFor(x => x.Name).NotEmpty().WithMessage("Name is required");
+		}
+	}
+
+	public class FailingNameLengthValidator : AbstractValidator<TestRequest>
+	{
+		public FailingNameLengthValidator()
+		{
+			RuleFor(x => x.Name).MinimumLength(3).WithMessage("Name must be at least 3 characters");
+		}
+	}
+
+	[Fact]
+	public async Task Handle_NoValidators_CallsNext()
+	{
+		// Arrange
+		List<IValidator<TestRequest>> validators = [];
+		ValidationBehavior<TestRequest, string> behavior = new(validators);
+		TestRequest request = new("test");
+
+		// Act
+		string result = await behavior.Handle(
+			request,
+			_ => Task.FromResult("ok"),
+			CancellationToken.None);
+
+		// Assert
+		result.Should().Be("ok");
+	}
+
+	[Fact]
+	public async Task Handle_ValidRequest_CallsNext()
+	{
+		// Arrange
+		List<IValidator<TestRequest>> validators = [new PassingValidator()];
+		ValidationBehavior<TestRequest, string> behavior = new(validators);
+		TestRequest request = new("test");
+
+		// Act
+		string result = await behavior.Handle(
+			request,
+			_ => Task.FromResult("ok"),
+			CancellationToken.None);
+
+		// Assert
+		result.Should().Be("ok");
+	}
+
+	[Fact]
+	public async Task Handle_InvalidRequest_ThrowsValidationException()
+	{
+		// Arrange
+		List<IValidator<TestRequest>> validators = [new FailingNameRequiredValidator()];
+		ValidationBehavior<TestRequest, string> behavior = new(validators);
+		TestRequest request = new("");
+
+		// Act
+		Func<Task> act = () => behavior.Handle(
+			request,
+			_ => Task.FromResult("ok"),
+			CancellationToken.None);
+
+		// Assert
+		ValidationException exception = (await act.Should().ThrowAsync<ValidationException>()).Which;
+		exception.Errors.Should().ContainSingle(e => e.PropertyName == "Name");
+	}
+
+	[Fact]
+	public async Task Handle_MultipleValidators_AggregatesErrors()
+	{
+		// Arrange
+		List<IValidator<TestRequest>> validators =
+		[
+			new FailingNameRequiredValidator(),
+			new FailingNameLengthValidator()
+		];
+		ValidationBehavior<TestRequest, string> behavior = new(validators);
+		TestRequest request = new("");
+
+		// Act
+		Func<Task> act = () => behavior.Handle(
+			request,
+			_ => Task.FromResult("ok"),
+			CancellationToken.None);
+
+		// Assert
+		ValidationException exception = (await act.Should().ThrowAsync<ValidationException>()).Which;
+		exception.Errors.Should().HaveCount(2);
+	}
+}

--- a/tests/Presentation.API.Tests/Filters/FluentValidationActionFilterTests.cs
+++ b/tests/Presentation.API.Tests/Filters/FluentValidationActionFilterTests.cs
@@ -1,0 +1,135 @@
+using API.Filters;
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Presentation.API.Tests.Filters;
+
+public class FluentValidationActionFilterTests
+{
+	public record TestModel(string Name);
+
+	public class PassingValidator : AbstractValidator<TestModel>
+	{
+	}
+
+	public class FailingValidator : AbstractValidator<TestModel>
+	{
+		public FailingValidator()
+		{
+			RuleFor(x => x.Name).NotEmpty().WithMessage("Name is required");
+		}
+	}
+
+	private static ActionExecutingContext CreateContext(Dictionary<string, object?> arguments)
+	{
+		DefaultHttpContext httpContext = new();
+		ActionContext actionContext = new(httpContext, new RouteData(), new ActionDescriptor());
+		return new ActionExecutingContext(
+			actionContext,
+			[],
+			arguments,
+			new object());
+	}
+
+	[Fact]
+	public async Task OnActionExecutionAsync_NoValidator_CallsNext()
+	{
+		// Arrange
+		ServiceCollection services = new();
+		ServiceProvider provider = services.BuildServiceProvider();
+		FluentValidationActionFilter filter = new(provider);
+		ActionExecutingContext context = CreateContext(new Dictionary<string, object?>
+		{
+			["model"] = new TestModel("test")
+		});
+		bool nextCalled = false;
+
+		// Act
+		await filter.OnActionExecutionAsync(context, () =>
+		{
+			nextCalled = true;
+			return Task.FromResult<ActionExecutedContext>(null!);
+		});
+
+		// Assert
+		nextCalled.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task OnActionExecutionAsync_ValidModel_CallsNext()
+	{
+		// Arrange
+		ServiceCollection services = new();
+		services.AddSingleton<IValidator<TestModel>, PassingValidator>();
+		ServiceProvider provider = services.BuildServiceProvider();
+
+		FluentValidationActionFilter filter = new(provider);
+		ActionExecutingContext context = CreateContext(new Dictionary<string, object?>
+		{
+			["model"] = new TestModel("test")
+		});
+		bool nextCalled = false;
+
+		// Act
+		await filter.OnActionExecutionAsync(context, () =>
+		{
+			nextCalled = true;
+			return Task.FromResult<ActionExecutedContext>(null!);
+		});
+
+		// Assert
+		nextCalled.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task OnActionExecutionAsync_InvalidModel_ThrowsValidationException()
+	{
+		// Arrange
+		ServiceCollection services = new();
+		services.AddSingleton<IValidator<TestModel>, FailingValidator>();
+		ServiceProvider provider = services.BuildServiceProvider();
+
+		FluentValidationActionFilter filter = new(provider);
+		ActionExecutingContext context = CreateContext(new Dictionary<string, object?>
+		{
+			["model"] = new TestModel("")
+		});
+
+		// Act
+		Func<Task> act = () => filter.OnActionExecutionAsync(context, () =>
+			Task.FromResult<ActionExecutedContext>(null!));
+
+		// Assert
+		await act.Should().ThrowAsync<ValidationException>();
+	}
+
+	[Fact]
+	public async Task OnActionExecutionAsync_NullArgument_SkipsValidation()
+	{
+		// Arrange
+		ServiceCollection services = new();
+		ServiceProvider provider = services.BuildServiceProvider();
+		FluentValidationActionFilter filter = new(provider);
+		ActionExecutingContext context = CreateContext(new Dictionary<string, object?>
+		{
+			["model"] = null
+		});
+		bool nextCalled = false;
+
+		// Act
+		await filter.OnActionExecutionAsync(context, () =>
+		{
+			nextCalled = true;
+			return Task.FromResult<ActionExecutedContext>(null!);
+		});
+
+		// Assert
+		nextCalled.Should().BeTrue();
+	}
+}

--- a/tests/Presentation.API.Tests/Middleware/ValidationExceptionMiddlewareTests.cs
+++ b/tests/Presentation.API.Tests/Middleware/ValidationExceptionMiddlewareTests.cs
@@ -1,0 +1,85 @@
+using API.Middleware;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
+
+namespace Presentation.API.Tests.Middleware;
+
+public class ValidationExceptionMiddlewareTests
+{
+	[Fact]
+	public async Task InvokeAsync_NoException_PassesThrough()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+		ValidationExceptionMiddleware middleware = new(_ => Task.CompletedTask);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(200);
+	}
+
+	[Fact]
+	public async Task InvokeAsync_ValidationException_Returns400ProblemDetails()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+
+		List<ValidationFailure> failures =
+		[
+			new("Name", "Name is required"),
+			new("Name", "Name must be at least 3 characters"),
+			new("Email", "Email is invalid")
+		];
+
+		ValidationExceptionMiddleware middleware = new(_ =>
+			throw new ValidationException(failures));
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(400);
+		context.Response.ContentType.Should().Be("application/problem+json");
+
+		context.Response.Body.Position = 0;
+		using StreamReader reader = new(context.Response.Body);
+		string body = await reader.ReadToEndAsync();
+
+		ValidationProblemDetails? problemDetails = JsonSerializer.Deserialize<ValidationProblemDetails>(
+			body,
+			new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+		problemDetails.Should().NotBeNull();
+		problemDetails!.Status.Should().Be(400);
+		problemDetails.Title.Should().Be("One or more validation errors occurred.");
+		problemDetails.Errors.Should().ContainKey("Name");
+		problemDetails.Errors["Name"].Should().HaveCount(2);
+		problemDetails.Errors.Should().ContainKey("Email");
+		problemDetails.Errors["Email"].Should().HaveCount(1);
+	}
+
+	[Fact]
+	public async Task InvokeAsync_OtherException_Rethrows()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+
+		ValidationExceptionMiddleware middleware = new(_ =>
+			throw new InvalidOperationException("Something else"));
+
+		// Act
+		Func<Task> act = () => middleware.InvokeAsync(context);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+	}
+}


### PR DESCRIPTION
## Summary

- Wire up the 5 existing FluentValidation validators (CreateReceipt, CreateTransaction, CreateUser, UpdateUser, AdminResetPassword) that were previously orphaned in DI
- Add `ValidationBehavior<TRequest, TResponse>` MediatR pipeline behavior in the Application layer for command/query validation
- Add `FluentValidationActionFilter` for controller-level DTO validation so existing validators fire before controller actions
- Add `ValidationExceptionMiddleware` that catches `ValidationException` anywhere in the pipeline and returns structured 400 ProblemDetails with per-field error details
- Register validators via `AddValidatorsFromAssemblyContaining<>()` and behavior via `AddOpenBehavior()`

## Test plan

- [x] Build succeeds with 0 warnings
- [x] All 662 tests pass (11 new tests for ValidationBehavior, FluentValidationActionFilter, and ValidationExceptionMiddleware)
- [x] `dotnet format --verify-no-changes` passes
- [x] Pre-commit hooks pass (spec lint, format, build, tests, drift check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)