### PR TITLE
docs: update documentation for Phase 7 correctness hardening (MGG-203)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,7 @@ This is a .NET 10 Clean Architecture solution for a receipt management applicati
   - `Core/` - Entity classes (Account, Receipt, ReceiptItem, Transaction, Category, Subcategory, ItemTemplate)
   - `Aggregates/` - Composite domain objects (ReceiptWithItems, TransactionAccount, Trip)
 - **Application** - Business logic using CQRS pattern with MediatR
+  - `Behaviors/` - MediatR pipeline behaviors (e.g., `ValidationBehavior`)
   - `Commands/{Entity}/Create|Update|Delete/` - Command + Handler pairs for write operations
   - `Queries/Core/{Entity}/` - Query + Handler pairs for read operations
   - `Queries/Aggregates/` - Complex queries joining multiple entities
@@ -33,6 +34,7 @@ This is a .NET 10 Clean Architecture solution for a receipt management applicati
 
 - **CQRS**: Commands and Queries are separate with dedicated handlers
 - **Mediator Pattern**: MediatR dispatches commands/queries to handlers
+- **Validation Pipeline**: `ValidationBehavior<TRequest, TResponse>` intercepts MediatR requests and runs registered `IValidator<T>` instances before handlers execute. `FluentValidationActionFilter` validates controller DTOs. `ValidationExceptionMiddleware` catches `ValidationException` and returns 400 ProblemDetails.
 - **Repository Pattern**: Infrastructure repositories abstract EF Core
 - **Mapping**: Mapperly handles Domain <-> Entity (Infrastructure) and Domain <-> generated DTOs (API)
 - **Service Registration**: Each layer has a static extension method (`RegisterApplicationServices`, `RegisterInfrastructureServices`) for DI setup

--- a/docs/design/phase7-correctness-hardening.md
+++ b/docs/design/phase7-correctness-hardening.md
@@ -1,0 +1,115 @@
+# Design Document: Phase 7 — Correctness Hardening
+
+## Introduction
+
+Phase 7 enforces cross-entity business invariants that the API currently lacks. Before this phase, individual fields were validated (non-empty strings, positive quantities, future dates), but no aggregate-level rules existed. A receipt where items total $98 but transactions sum to $103 would be silently accepted.
+
+## Objectives
+
+- Enforce the balance equation across receipts, items, adjustments, and transactions
+- Add typed adjustments to model tips, discounts, coupons, and rounding
+- Surface soft warnings for suspicious but technically valid data
+- Connect existing FluentValidation validators to the request pipeline
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Aggregate model | Proper aggregate root — `Trip` gets `Validate()` + computed properties | Domain objects should enforce their own invariants |
+| Rounding tolerance | Fixed ±$0.01 per line item | Avoids false positives from floating-point math |
+| Reconciliation | Typed `Adjustment` entity with `AdjustmentType` enum | Explains the gap between item subtotal + tax and transaction total |
+| Balance timing | Enforce on mutation (write-time validation) | Catches errors at the source, not during reads |
+| Adjustment signing | Signed values — positive = paid more, negative = paid less | Tip is +$5.00, Coupon is -$3.00. Simplifies the balance equation. |
+
+## Balance Equation
+
+```
+sum(item.TotalAmount) + Receipt.TaxAmount + sum(adjustment.Amount) == sum(transaction.Amount)
+```
+
+Where:
+- `item.TotalAmount` = `quantity × unitPrice` (calculated server-side, floored to 2dp)
+- `adjustment.Amount` is signed (positive for tips, negative for discounts)
+- All amounts use the `Money` value object (`decimal Amount` + `Currency Currency`)
+
+## Architecture
+
+### Adjustment Entity
+
+A new `Adjustment` domain entity captures receipt-level monetary adjustments:
+
+```csharp
+public class Adjustment
+{
+    public Guid Id { get; set; }
+    public Guid ReceiptId { get; set; }
+    public AdjustmentType Type { get; set; }  // Tip, Discount, Rounding, etc.
+    public Money Amount { get; set; }          // Signed: +tip, -coupon
+    public string? Description { get; set; }   // Required when Type == Other
+}
+```
+
+**AdjustmentType enum:** `Tip`, `Discount`, `Rounding`, `LoyaltyRedemption`, `Coupon`, `StoreCredit`, `Other`
+
+Constructor invariants:
+- Amount must be non-zero
+- Description is required when type is `Other`
+
+### Evolved Aggregates
+
+**ReceiptWithItems** gained computed properties:
+
+```csharp
+public class ReceiptWithItems
+{
+    public required Receipt Receipt { get; set; }
+    public required List<ReceiptItem> Items { get; set; }
+    public required List<Adjustment> Adjustments { get; set; }
+
+    public Money Subtotal => Items.Aggregate(Money.Zero, (sum, item) => sum + item.TotalAmount);
+    public Money AdjustmentTotal => Adjustments.Aggregate(Money.Zero, (sum, adj) => sum + adj.Amount);
+    public Money ExpectedTotal => Subtotal + Receipt.TaxAmount + AdjustmentTotal;
+}
+```
+
+**Trip** gained a computed `TransactionTotal`:
+
+```csharp
+public Money TransactionTotal => Transactions.Aggregate(
+    Money.Zero, (sum, ta) => sum + ta.Transaction.Amount);
+```
+
+### Validation Pipeline
+
+FluentValidation validators are connected to the request pipeline at two levels:
+
+1. **MediatR Pipeline Behavior** (`ValidationBehavior<TRequest, TResponse>`): Intercepts MediatR commands/queries and runs any registered `IValidator<TRequest>` before the handler executes. Aggregates errors from multiple validators.
+
+2. **Controller Action Filter** (`FluentValidationActionFilter`): Validates controller action parameters (request DTOs) against registered validators before the action method runs. This is how the existing 5 validators (CreateReceipt, CreateTransaction, CreateUser, UpdateUser, AdminResetPassword) fire.
+
+3. **Exception Middleware** (`ValidationExceptionMiddleware`): Catches `ValidationException` from anywhere in the pipeline and returns a structured 400 ProblemDetails response with per-field error details.
+
+### Validation Tiers
+
+**Tier 1 — Hard invariants (reject if violated):**
+
+- Balance equation: `ExpectedTotal == TransactionTotal` (within tolerance)
+- Non-negative prices: `UnitPrice > 0`
+- Line-item totals: Within ±$0.01 of `quantity × unitPrice`
+
+**Tier 2 — Soft invariants (warn, don't reject):**
+
+- Tax reasonableness: `TaxAmount / Subtotal` within 0–25%
+- Adjustment reasonableness: `|AdjustmentTotal| < 10%` of Subtotal
+- Date consistency: Transaction dates on or after receipt date
+
+Soft warnings are returned as a `warnings` array in the response, not as validation errors.
+
+## Execution Waves
+
+| Wave | Issues | Dependency |
+|------|--------|------------|
+| 1 | MGG-197 (validation pipeline), MGG-198 (adjustment entity), MGG-203 (docs) | None |
+| 2 | MGG-199 (hard invariants), MGG-200 (soft warnings) | Wave 1 |
+| 3 | MGG-201 (frontend adjustment management) | MGG-198, MGG-200 |
+| 4 | MGG-202 (comprehensive tests) | Waves 2 + 3 |

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -54,10 +54,10 @@ All active issues are assigned to a milestone. Milestones are ordered and repres
 | **Phase 2: Backend DTO Generation** | Replace ViewModels with spec-generated DTOs | **COMPLETE** |
 | **Phase 3: Aspire Developer Experience** | Local dev orchestration with .NET Aspire | Immediately |
 | **Phase 4: React Frontend** | Build React/Vite SPA | Phase 0 done (setup), Phase 1 done (codegen) |
-| **Phase 5: Docker Deployment** | Containerize and deploy to Raspberry Pi | Phase 4 MVP done |
-| **Phase 6: Correctness Hardening** | Business invariants, receipt coherence validation | Phase 2 done (stable API model) |
-| **Phase 7: Security Automation** | Snyk-to-Linear integration | Phase 2 done |
-| **Phase 8: Test Coverage** | Code coverage collection, CI reporting, enforcement gate, agent test-writing loop | Phase 3 MVP done |
+| **Phase 5: Test Coverage** | Code coverage collection, CI reporting, enforcement gate, agent test-writing loop | Phase 3 MVP done |
+| **Phase 6: Docker Deployment** | Containerize and deploy to Raspberry Pi | Phase 4 MVP done |
+| **Phase 7: Correctness Hardening** | Business invariants, receipt coherence validation | Phase 2 done (stable API model) |
+| **Phase 8: Security Automation** | Snyk-to-Linear integration | Phase 2 done |
 
 ## Priority Semantics
 
@@ -110,19 +110,19 @@ Epics are parent issues that group related work.
 | **MGG-115** UX Polish & Enhancements | MGG-37, 44, 45, 46, 47 | No — follow-up |
 | **MGG-116** Frontend Quality & Documentation | MGG-49, 50 | No — follow-up |
 
-### Phase 5: Docker Deployment
+### Phase 5: Test Coverage
+
+| Epic | Children | MVP? |
+|------|----------|------|
+| **MGG-121** Test Coverage Pipeline | MGG-122, 123, 124, 125, 126, 127 | All MVP |
+
+### Phase 6: Docker Deployment
 
 | Epic | Children | MVP? |
 |------|----------|------|
 | **MGG-117** Container Architecture & CI | MGG-52, 53, 54, 55, 57 | Yes |
 | **MGG-118** Production Operations | MGG-58, 59, 61, 62, 63, 64 | Mixed (58, 59 MVP) |
 | **MGG-119** Deployment Security & Documentation | MGG-56, 60, 65, 70 | No — follow-up |
-
-### Phase 8: Test Coverage
-
-| Epic | Children | MVP? |
-|------|----------|------|
-| **MGG-121** Test Coverage Pipeline | MGG-122, 123, 124, 125, 126, 127 | All MVP |
 
 Dependency chain:
 ```
@@ -133,6 +133,26 @@ MGG-33  (React app) ──────> MGG-126
 
 MGG-122 ──> MGG-125 (agent loop: .NET)
 MGG-126 ──> MGG-127 (agent loop: React)
+```
+
+### Phase 7: Correctness Hardening
+
+| Epic | Children | MVP? |
+|------|----------|------|
+| **MGG-94** Correctness Hardening | MGG-197, 198, 199, 200, 201, 202, 203 | All MVP |
+
+Dependency chain:
+```
+MGG-197 (validation pipeline) ──┐
+                                 ├──> MGG-199 (hard invariants) ──┐
+MGG-198 (adjustment entity) ────┤                                  ├──> MGG-202 (tests)
+                                 ├──> MGG-200 (soft invariants) ──┤
+                                 │         │                       │
+                                 │         └──> MGG-201 (frontend) ┘
+                                 │              ▲
+                                 └──────────────┘
+
+MGG-203 (docs) — no dependencies, anytime
 ```
 
 ### Retired Epics
@@ -158,7 +178,7 @@ Phase 4 critical path:
   MGG-34 ──> MGG-35 (Frontend auth UI)
   MGG-34 ──> MGG-66, 67, 68 (Data safety)
 
-Phase 5 gate:
+Phase 6 gate:
   MGG-111 + MGG-112 + MGG-113 (Phase 4 MVP) ──blocks──> MGG-117 (Containers)
   MGG-117 ──blocks──> MGG-118 (Operations)
   MGG-117 ──blocks──> MGG-119 (Security & Docs)


### PR DESCRIPTION
## Summary

- Create `docs/design/phase7-correctness-hardening.md` capturing all Phase 7 design decisions: aggregate model, balance equation, typed adjustments, validation tiers, and execution waves
- Update `docs/architecture.md` with the ValidationBehavior pipeline pattern and Application layer `Behaviors/` directory
- Update `docs/linear.md` with Phase 7 epic structure, dependency chain, and corrected phase numbering

## Test plan

- [x] No code changes — docs only
- [x] Pre-commit hooks pass (spec lint, format, build, tests, drift check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)