### PR TITLE
feat(domain): enforce Tier 1 hard invariants (MGG-199)

### DIFF
--- a/src/Application/Commands/Transaction/Create/CreateTransactionCommandHandler.cs
+++ b/src/Application/Commands/Transaction/Create/CreateTransactionCommandHandler.cs
@@ -1,13 +1,50 @@
 using Application.Interfaces.Services;
+using Domain.Aggregates;
+using FluentValidation;
+using FluentValidation.Results;
 using MediatR;
 
 namespace Application.Commands.Transaction.Create;
 
-public class CreateTransactionCommandHandler(ITransactionService transactionService) : IRequestHandler<CreateTransactionCommand, List<Domain.Core.Transaction>>
+public class CreateTransactionCommandHandler(
+	ITransactionService transactionService,
+	IReceiptService receiptService,
+	IReceiptItemService receiptItemService,
+	IAdjustmentService adjustmentService) : IRequestHandler<CreateTransactionCommand, List<Domain.Core.Transaction>>
 {
 	public async Task<List<Domain.Core.Transaction>> Handle(CreateTransactionCommand request, CancellationToken cancellationToken)
 	{
-		List<Domain.Core.Transaction> createdEntities = await transactionService.CreateAsync([.. request.Transactions], request.AccountId, request.ReceiptId, cancellationToken);
-		return createdEntities;
+		Task<Domain.Core.Receipt?> receiptTask = receiptService.GetByIdAsync(request.ReceiptId, cancellationToken);
+		Task<List<Domain.Core.ReceiptItem>?> itemsTask = receiptItemService.GetByReceiptIdAsync(request.ReceiptId, cancellationToken);
+		Task<List<Domain.Core.Adjustment>?> adjustmentsTask = adjustmentService.GetByReceiptIdAsync(request.ReceiptId, cancellationToken);
+		Task<List<Domain.Core.Transaction>?> existingTransactionsTask = transactionService.GetByReceiptIdAsync(request.ReceiptId, cancellationToken);
+
+		await Task.WhenAll(receiptTask, itemsTask, adjustmentsTask, existingTransactionsTask);
+
+		Domain.Core.Receipt receipt = receiptTask.Result
+			?? throw new InvalidOperationException("Receipt not found");
+
+		ReceiptWithItems receiptWithItems = new()
+		{
+			Receipt = receipt,
+			Items = itemsTask.Result ?? [],
+			Adjustments = adjustmentsTask.Result ?? []
+		};
+
+		decimal existingTotal = existingTransactionsTask.Result?.Sum(t => t.Amount.Amount) ?? 0;
+		decimal newTotal = request.Transactions.Sum(t => t.Amount.Amount);
+		decimal proposedTotal = existingTotal + newTotal;
+
+		if (proposedTotal != receiptWithItems.ExpectedTotal.Amount)
+		{
+			throw new ValidationException(
+			[
+				new ValidationFailure("Transactions",
+					string.Format(Trip.BalanceEquationViolation,
+						receiptWithItems.ExpectedTotal.Amount, proposedTotal))
+			]);
+		}
+
+		return await transactionService.CreateAsync([.. request.Transactions], request.AccountId, request.ReceiptId, cancellationToken);
 	}
 }

--- a/src/Application/Commands/Transaction/Update/UpdateTransactionCommandHandler.cs
+++ b/src/Application/Commands/Transaction/Update/UpdateTransactionCommandHandler.cs
@@ -1,12 +1,53 @@
 using Application.Interfaces.Services;
+using Domain.Aggregates;
+using FluentValidation;
+using FluentValidation.Results;
 using MediatR;
 
 namespace Application.Commands.Transaction.Update;
 
-public class UpdateTransactionCommandHandler(ITransactionService transactionService) : IRequestHandler<UpdateTransactionCommand, bool>
+public class UpdateTransactionCommandHandler(
+	ITransactionService transactionService,
+	IReceiptService receiptService,
+	IReceiptItemService receiptItemService,
+	IAdjustmentService adjustmentService) : IRequestHandler<UpdateTransactionCommand, bool>
 {
 	public async Task<bool> Handle(UpdateTransactionCommand request, CancellationToken cancellationToken)
 	{
+		Task<Domain.Core.Receipt?> receiptTask = receiptService.GetByIdAsync(request.ReceiptId, cancellationToken);
+		Task<List<Domain.Core.ReceiptItem>?> itemsTask = receiptItemService.GetByReceiptIdAsync(request.ReceiptId, cancellationToken);
+		Task<List<Domain.Core.Adjustment>?> adjustmentsTask = adjustmentService.GetByReceiptIdAsync(request.ReceiptId, cancellationToken);
+		Task<List<Domain.Core.Transaction>?> existingTransactionsTask = transactionService.GetByReceiptIdAsync(request.ReceiptId, cancellationToken);
+
+		await Task.WhenAll(receiptTask, itemsTask, adjustmentsTask, existingTransactionsTask);
+
+		Domain.Core.Receipt receipt = receiptTask.Result
+			?? throw new InvalidOperationException("Receipt not found");
+
+		ReceiptWithItems receiptWithItems = new()
+		{
+			Receipt = receipt,
+			Items = itemsTask.Result ?? [],
+			Adjustments = adjustmentsTask.Result ?? []
+		};
+
+		HashSet<Guid> updatedIds = [.. request.Transactions.Select(t => t.Id)];
+		decimal unchangedTotal = existingTransactionsTask.Result?
+			.Where(t => !updatedIds.Contains(t.Id))
+			.Sum(t => t.Amount.Amount) ?? 0;
+		decimal updatedTotal = request.Transactions.Sum(t => t.Amount.Amount);
+		decimal proposedTotal = unchangedTotal + updatedTotal;
+
+		if (proposedTotal != receiptWithItems.ExpectedTotal.Amount)
+		{
+			throw new ValidationException(
+			[
+				new ValidationFailure("Transactions",
+					string.Format(Trip.BalanceEquationViolation,
+						receiptWithItems.ExpectedTotal.Amount, proposedTotal))
+			]);
+		}
+
 		await transactionService.UpdateAsync([.. request.Transactions], request.AccountId, request.ReceiptId, cancellationToken);
 		return true;
 	}

--- a/src/Domain/Aggregates/Trip.cs
+++ b/src/Domain/Aggregates/Trip.cs
@@ -2,8 +2,22 @@ namespace Domain.Aggregates;
 
 public class Trip
 {
+	public const string BalanceEquationViolation = "Balance equation violated: expected total ({0:C}) does not equal transaction total ({1:C})";
+
 	public required ReceiptWithItems Receipt { get; set; }
 	public required List<TransactionAccount> Transactions { get; set; }
 
 	public Money TransactionTotal => Transactions.Aggregate(Money.Zero, (sum, ta) => sum + ta.Transaction.Amount);
+
+	public List<string> Validate()
+	{
+		List<string> errors = [];
+
+		if (Transactions.Count > 0 && Receipt.ExpectedTotal.Amount != TransactionTotal.Amount)
+		{
+			errors.Add(string.Format(BalanceEquationViolation, Receipt.ExpectedTotal.Amount, TransactionTotal.Amount));
+		}
+
+		return errors;
+	}
 }

--- a/src/Domain/Core/ReceiptItem.cs
+++ b/src/Domain/Core/ReceiptItem.cs
@@ -24,6 +24,8 @@ public class ReceiptItem
 	public const string CategoryCannotBeEmpty = "Category cannot be empty";
 	public const string SubcategoryCannotBeEmpty = "Subcategory cannot be empty";
 	public const string FlatPricingModeQuantityMustBeOne = "Quantity must be 1 when pricing mode is flat.";
+	public const string UnitPriceMustBePositive = "Unit price must be positive";
+	public const string TotalAmountExceedsTolerance = "Total amount must be within $0.01 of quantity times unit price";
 
 	public ReceiptItem(Guid id, string receiptItemCode, string description, decimal quantity, Money unitPrice, Money totalAmount, string category, string subcategory, PricingMode pricingMode = PricingMode.Quantity)
 	{
@@ -40,6 +42,17 @@ public class ReceiptItem
 		if (quantity <= 0)
 		{
 			throw new ArgumentException(QuantityMustBePositive, nameof(quantity));
+		}
+
+		if (unitPrice.Amount <= 0)
+		{
+			throw new ArgumentException(UnitPriceMustBePositive, nameof(unitPrice));
+		}
+
+		decimal expectedTotal = Math.Floor(quantity * unitPrice.Amount * 100) / 100;
+		if (Math.Abs(totalAmount.Amount - expectedTotal) > 0.01m)
+		{
+			throw new ArgumentException(TotalAmountExceedsTolerance, nameof(totalAmount));
 		}
 
 		if (string.IsNullOrWhiteSpace(category))

--- a/src/Presentation/API/Validators/CreateReceiptItemRequestValidator.cs
+++ b/src/Presentation/API/Validators/CreateReceiptItemRequestValidator.cs
@@ -1,0 +1,16 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class CreateReceiptItemRequestValidator : AbstractValidator<CreateReceiptItemRequest>
+{
+	public const string UnitPriceMustBePositive = "Unit price must be positive.";
+
+	public CreateReceiptItemRequestValidator()
+	{
+		RuleFor(x => x.UnitPrice)
+			.GreaterThan(0)
+			.WithMessage(UnitPriceMustBePositive);
+	}
+}

--- a/src/Presentation/API/Validators/UpdateReceiptItemRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateReceiptItemRequestValidator.cs
@@ -1,0 +1,16 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class UpdateReceiptItemRequestValidator : AbstractValidator<UpdateReceiptItemRequest>
+{
+	public const string UnitPriceMustBePositive = "Unit price must be positive.";
+
+	public UpdateReceiptItemRequestValidator()
+	{
+		RuleFor(x => x.UnitPrice)
+			.GreaterThan(0)
+			.WithMessage(UnitPriceMustBePositive);
+	}
+}

--- a/tests/Application.Tests/Commands/Transaction/CreateTransactionCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Transaction/CreateTransactionCommandHandlerTests.cs
@@ -1,28 +1,118 @@
 using Application.Commands.Transaction.Create;
 using Application.Interfaces.Services;
+using Common;
+using Domain;
 using FluentAssertions;
+using FluentValidation;
 using Moq;
-using SampleData.Domain.Core;
 
 namespace Application.Tests.Commands.Transaction;
 
 public class CreateTransactionCommandHandlerTests
 {
-	[Fact]
-	public async Task CreateTransactionCommandHandler_WithValidCommand_ReturnsCreatedTransactions()
+	private readonly Mock<ITransactionService> _transactionService = new();
+	private readonly Mock<IReceiptService> _receiptService = new();
+	private readonly Mock<IReceiptItemService> _receiptItemService = new();
+	private readonly Mock<IAdjustmentService> _adjustmentService = new();
+
+	private CreateTransactionCommandHandler CreateHandler() =>
+		new(_transactionService.Object, _receiptService.Object,
+			_receiptItemService.Object, _adjustmentService.Object);
+
+	private void SetupBalancedData(Guid receiptId, List<Domain.Core.Transaction> transactions)
 	{
-		Mock<ITransactionService> mockService = new();
-		CreateTransactionCommandHandler handler = new(mockService.Object);
+		// Receipt: TaxAmount = $10
+		Domain.Core.Receipt receipt = new(Guid.NewGuid(), "Test", DateOnly.FromDateTime(DateTime.Now), new Money(10), "desc");
 
-		List<Domain.Core.Transaction> input = TransactionGenerator.GenerateList(2);
+		// Item: qty=1, unitPrice=$5, totalAmount=$5 → Subtotal = $5
+		Domain.Core.ReceiptItem item = new(Guid.NewGuid(), "CODE", "Item", 1, new Money(5), new Money(5), "Cat", "Sub", PricingMode.Quantity);
 
-		mockService.Setup(r => r
-			.CreateAsync(It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(input);
+		// ExpectedTotal = Subtotal($5) + TaxAmount($10) + Adjustments($0) = $15
 
-		CreateTransactionCommand command = new(input, Guid.NewGuid(), Guid.NewGuid());
+		_receiptService.Setup(s => s.GetByIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(receipt);
+		_receiptItemService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([item]);
+		_adjustmentService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+		_transactionService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+		_transactionService.Setup(s => s.CreateAsync(
+				It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(transactions);
+	}
+
+	[Fact]
+	public async Task Handle_BalancedTransactions_ReturnsCreatedTransactions()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		// Single transaction matching ExpectedTotal of $15
+		List<Domain.Core.Transaction> input =
+		[
+			new(Guid.NewGuid(), new Money(15), DateOnly.FromDateTime(DateTime.Now))
+		];
+		SetupBalancedData(receiptId, input);
+
+		CreateTransactionCommandHandler handler = CreateHandler();
+		CreateTransactionCommand command = new(input, receiptId, Guid.NewGuid());
+
+		// Act
 		List<Domain.Core.Transaction> result = await handler.Handle(command, CancellationToken.None);
 
-		result.Should().HaveCount(input.Count);
+		// Assert
+		result.Should().HaveCount(1);
+		result[0].Amount.Amount.Should().Be(15);
+	}
+
+	[Fact]
+	public async Task Handle_UnbalancedTransactions_ThrowsValidationException()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		// Transaction $100 does not match ExpectedTotal of $15
+		List<Domain.Core.Transaction> input =
+		[
+			new(Guid.NewGuid(), new Money(100), DateOnly.FromDateTime(DateTime.Now))
+		];
+		SetupBalancedData(receiptId, input);
+
+		CreateTransactionCommandHandler handler = CreateHandler();
+		CreateTransactionCommand command = new(input, receiptId, Guid.NewGuid());
+
+		// Act
+		Func<Task> act = () => handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<ValidationException>();
+	}
+
+	[Fact]
+	public async Task Handle_ReceiptNotFound_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		_receiptService.Setup(s => s.GetByIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Domain.Core.Receipt?)null);
+		_receiptItemService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+		_adjustmentService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+		_transactionService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+
+		List<Domain.Core.Transaction> input =
+		[
+			new(Guid.NewGuid(), new Money(15), DateOnly.FromDateTime(DateTime.Now))
+		];
+
+		CreateTransactionCommandHandler handler = CreateHandler();
+		CreateTransactionCommand command = new(input, receiptId, Guid.NewGuid());
+
+		// Act
+		Func<Task> act = () => handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
 	}
 }

--- a/tests/Application.Tests/Commands/Transaction/UpdateTransactionCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Transaction/UpdateTransactionCommandHandlerTests.cs
@@ -1,27 +1,116 @@
 using Application.Commands.Transaction.Update;
 using Application.Interfaces.Services;
+using Common;
+using Domain;
+using FluentAssertions;
+using FluentValidation;
 using Moq;
-using SampleData.Domain.Core;
 
 namespace Application.Tests.Commands.Transaction;
 
 public class UpdateTransactionCommandHandlerTests
 {
-	[Fact]
-	public async Task UpdateTransactionCommandHandler_WithValidCommand_ReturnsTrueAndCallsUpdateAndSaveChanges()
+	private readonly Mock<ITransactionService> _transactionService = new();
+	private readonly Mock<IReceiptService> _receiptService = new();
+	private readonly Mock<IReceiptItemService> _receiptItemService = new();
+	private readonly Mock<IAdjustmentService> _adjustmentService = new();
+
+	private UpdateTransactionCommandHandler CreateHandler() =>
+		new(_transactionService.Object, _receiptService.Object,
+			_receiptItemService.Object, _adjustmentService.Object);
+
+	private void SetupBalancedData(Guid receiptId, List<Domain.Core.Transaction> existingTransactions)
 	{
-		Mock<ITransactionService> mockService = new();
-		UpdateTransactionCommandHandler handler = new(mockService.Object);
+		// Receipt: TaxAmount = $10
+		Domain.Core.Receipt receipt = new(Guid.NewGuid(), "Test", DateOnly.FromDateTime(DateTime.Now), new Money(10), "desc");
 
-		List<Domain.Core.Transaction> input = TransactionGenerator.GenerateList(2);
+		// Item: qty=1, unitPrice=$5, totalAmount=$5 → Subtotal = $5
+		Domain.Core.ReceiptItem item = new(Guid.NewGuid(), "CODE", "Item", 1, new Money(5), new Money(5), "Cat", "Sub", PricingMode.Quantity);
 
-		mockService.Setup(r => r
-			.UpdateAsync(It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+		// ExpectedTotal = Subtotal($5) + TaxAmount($10) + Adjustments($0) = $15
+
+		_receiptService.Setup(s => s.GetByIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(receipt);
+		_receiptItemService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([item]);
+		_adjustmentService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+		_transactionService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(existingTransactions);
+		_transactionService.Setup(s => s.UpdateAsync(
+				It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
 			.Returns(Task.CompletedTask);
+	}
 
-		UpdateTransactionCommand command = new(input, Guid.NewGuid(), Guid.NewGuid());
+	[Fact]
+	public async Task Handle_BalancedTransactions_ReturnsTrue()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		Guid txId = Guid.NewGuid();
+		// Existing transaction matches what we're updating (same ID)
+		Domain.Core.Transaction existing = new(txId, new Money(15), DateOnly.FromDateTime(DateTime.Now));
+		SetupBalancedData(receiptId, [existing]);
+
+		// Update with same amount → still balanced at $15
+		List<Domain.Core.Transaction> updated = [new(txId, new Money(15), DateOnly.FromDateTime(DateTime.Now))];
+
+		UpdateTransactionCommandHandler handler = CreateHandler();
+		UpdateTransactionCommand command = new(updated, receiptId, Guid.NewGuid());
+
+		// Act
 		bool result = await handler.Handle(command, CancellationToken.None);
 
-		Assert.True(result);
+		// Assert
+		result.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Handle_UnbalancedTransactions_ThrowsValidationException()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		Guid txId = Guid.NewGuid();
+		Domain.Core.Transaction existing = new(txId, new Money(15), DateOnly.FromDateTime(DateTime.Now));
+		SetupBalancedData(receiptId, [existing]);
+
+		// Update to $100 → unbalanced (ExpectedTotal is $15)
+		List<Domain.Core.Transaction> updated = [new(txId, new Money(100), DateOnly.FromDateTime(DateTime.Now))];
+
+		UpdateTransactionCommandHandler handler = CreateHandler();
+		UpdateTransactionCommand command = new(updated, receiptId, Guid.NewGuid());
+
+		// Act
+		Func<Task> act = () => handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<ValidationException>();
+	}
+
+	[Fact]
+	public async Task Handle_ReceiptNotFound_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		_receiptService.Setup(s => s.GetByIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Domain.Core.Receipt?)null);
+		_receiptItemService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+		_adjustmentService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+		_transactionService.Setup(s => s.GetByReceiptIdAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+
+		Guid txId = Guid.NewGuid();
+		List<Domain.Core.Transaction> updated = [new(txId, new Money(15), DateOnly.FromDateTime(DateTime.Now))];
+
+		UpdateTransactionCommandHandler handler = CreateHandler();
+		UpdateTransactionCommand command = new(updated, receiptId, Guid.NewGuid());
+
+		// Act
+		Func<Task> act = () => handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
 	}
 }


### PR DESCRIPTION
## Summary
- Add domain constructor guards: UnitPrice must be positive, TotalAmount within ±$0.01 tolerance of qty × unitPrice
- Add `Trip.Validate()` method enforcing the balance equation (ExpectedTotal == TransactionTotal)
- Add FluentValidation validators for `CreateReceiptItemRequest` and `UpdateReceiptItemRequest`
- Add mutation-time balance validation in `CreateTransactionCommandHandler` and `UpdateTransactionCommandHandler` — rejects transactions that would break the balance equation
- Update transaction handler tests with balanced/unbalanced/receipt-not-found scenarios

## Test plan
- [x] All 666 existing tests pass (no regressions from ReceiptItem constructor tightening)
- [x] New handler tests verify balanced transactions succeed
- [x] New handler tests verify unbalanced transactions throw `ValidationException`
- [x] New handler tests verify missing receipt throws `InvalidOperationException`
- [x] `dotnet format --verify-no-changes` passes
- [x] Pre-commit hooks pass (lint, format, build, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)