### PR TITLE
feat(client): adjustment CRUD, validation warnings, balance display (MGG-201)

### DIFF
--- a/src/client/src/components/AdjustmentForm.tsx
+++ b/src/client/src/components/AdjustmentForm.tsx
@@ -1,0 +1,180 @@
+import { useRef } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod/v4";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useFormShortcuts } from "@/hooks/useFormShortcuts";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Spinner } from "@/components/ui/spinner";
+
+const ADJUSTMENT_TYPES = [
+  { value: "tip", label: "Tip" },
+  { value: "discount", label: "Discount" },
+  { value: "rounding", label: "Rounding" },
+  { value: "loyaltyRedemption", label: "Loyalty Redemption" },
+  { value: "coupon", label: "Coupon" },
+  { value: "storeCredit", label: "Store Credit" },
+  { value: "other", label: "Other" },
+] as const;
+
+const adjustmentSchema = z
+  .object({
+    type: z.string().min(1, "Type is required"),
+    amount: z.number({ error: "Amount is required" }),
+    description: z.string().optional(),
+  })
+  .refine((data) => data.type !== "other" || (data.description && data.description.trim().length > 0), {
+    message: "Description is required when type is 'other'",
+    path: ["description"],
+  });
+
+export type AdjustmentFormValues = z.output<typeof adjustmentSchema>;
+
+interface AdjustmentFormProps {
+  mode: "create" | "edit";
+  defaultValues?: Partial<AdjustmentFormValues>;
+  onSubmit: (values: AdjustmentFormValues) => void;
+  onCancel: () => void;
+  isSubmitting?: boolean;
+  serverErrors?: Record<string, string>;
+}
+
+export function AdjustmentForm({
+  mode,
+  defaultValues,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  serverErrors,
+}: AdjustmentFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  useFormShortcuts({ formRef });
+
+  const form = useForm<AdjustmentFormValues>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: zodResolver(adjustmentSchema) as any,
+    defaultValues: {
+      type: "",
+      amount: 0,
+      description: "",
+      ...defaultValues,
+    },
+  });
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const watchedType = form.watch("type");
+
+  return (
+    <Form {...form}>
+      <form
+        ref={formRef}
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4"
+      >
+        <FormField
+          control={form.control}
+          name="type"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Type</FormLabel>
+              <FormControl>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select adjustment type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ADJUSTMENT_TYPES.map((t) => (
+                      <SelectItem key={t.value} value={t.value}>
+                        {t.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+              {serverErrors?.type && (
+                <p className="text-sm font-medium text-destructive">
+                  {serverErrors.type}
+                </p>
+              )}
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="amount"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Amount</FormLabel>
+              <FormControl>
+                <CurrencyInput {...field} />
+              </FormControl>
+              <FormMessage />
+              {serverErrors?.amount && (
+                <p className="text-sm font-medium text-destructive">
+                  {serverErrors.amount}
+                </p>
+              )}
+            </FormItem>
+          )}
+        />
+
+        {watchedType === "other" && (
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Describe this adjustment..."
+                    aria-required="true"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+                {serverErrors?.description && (
+                  <p className="text-sm font-medium text-destructive">
+                    {serverErrors.description}
+                  </p>
+                )}
+              </FormItem>
+            )}
+          />
+        )}
+
+        <div className="flex justify-end gap-2 pt-4">
+          <Button type="button" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting && <Spinner size="sm" />}
+            {isSubmitting
+              ? "Saving..."
+              : mode === "create"
+                ? "Add Adjustment"
+                : "Update Adjustment"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/client/src/components/AdjustmentsCard.tsx
+++ b/src/client/src/components/AdjustmentsCard.tsx
@@ -1,0 +1,306 @@
+import { useState } from "react";
+import {
+  useCreateAdjustment,
+  useUpdateAdjustment,
+  useDeleteAdjustments,
+} from "@/hooks/useAdjustments";
+import {
+  AdjustmentForm,
+  type AdjustmentFormValues,
+} from "@/components/AdjustmentForm";
+import {
+  parseProblemDetails,
+  extractFieldErrors,
+} from "@/lib/problem-details";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatCurrency } from "@/lib/format";
+
+interface AdjustmentRow {
+  id: string;
+  receiptId: string;
+  type: string;
+  amount: number;
+  description?: string | null;
+}
+
+interface AdjustmentsCardProps {
+  receiptId: string;
+  adjustments: AdjustmentRow[];
+  adjustmentTotal: number;
+}
+
+export function AdjustmentsCard({
+  receiptId,
+  adjustments,
+  adjustmentTotal,
+}: AdjustmentsCardProps) {
+  const createAdjustment = useCreateAdjustment();
+  const updateAdjustment = useUpdateAdjustment();
+  const deleteAdjustments = useDeleteAdjustments();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editAdj, setEditAdj] = useState<AdjustmentRow | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [selectedAdjs, setSelectedAdjs] = useState<Set<string>>(new Set());
+  const [serverErrors, setServerErrors] = useState<Record<string, string>>({});
+
+  function handleCreate(values: AdjustmentFormValues) {
+    setServerErrors({});
+    createAdjustment.mutate(
+      {
+        receiptId,
+        body: {
+          type: values.type,
+          amount: values.amount,
+          description: values.description || null,
+        },
+      },
+      {
+        onSuccess: () => setCreateOpen(false),
+        onError: (error) => {
+          const problem = parseProblemDetails(error);
+          if (problem) setServerErrors(extractFieldErrors(problem));
+        },
+      },
+    );
+  }
+
+  function handleUpdate(values: AdjustmentFormValues) {
+    if (!editAdj) return;
+    setServerErrors({});
+    updateAdjustment.mutate(
+      {
+        receiptId,
+        body: {
+          id: editAdj.id,
+          type: values.type,
+          amount: values.amount,
+          description: values.description || null,
+        },
+      },
+      {
+        onSuccess: () => setEditAdj(null),
+        onError: (error) => {
+          const problem = parseProblemDetails(error);
+          if (problem) setServerErrors(extractFieldErrors(problem));
+        },
+      },
+    );
+  }
+
+  function toggleSelect(id: string) {
+    setSelectedAdjs((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Adjustments ({adjustments.length})</CardTitle>
+            <div className="flex gap-2">
+              {selectedAdjs.size > 0 && (
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  Delete ({selectedAdjs.size})
+                </Button>
+              )}
+              <Button size="sm" onClick={() => { setServerErrors({}); setCreateOpen(true); }}>
+                Add Adjustment
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {adjustments.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No adjustments for this receipt.
+            </p>
+          ) : (
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-12">
+                      <input
+                        type="checkbox"
+                        aria-label="Select all adjustments"
+                        checked={
+                          selectedAdjs.size === adjustments.length &&
+                          adjustments.length > 0
+                        }
+                        onChange={() => {
+                          if (selectedAdjs.size === adjustments.length) {
+                            setSelectedAdjs(new Set());
+                          } else {
+                            setSelectedAdjs(new Set(adjustments.map((a) => a.id)));
+                          }
+                        }}
+                        className="h-4 w-4 rounded border-gray-300"
+                      />
+                    </TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                    <TableHead className="w-24">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {adjustments.map((adj) => (
+                    <TableRow key={adj.id}>
+                      <TableCell>
+                        <input
+                          type="checkbox"
+                          aria-label={`Select ${adj.type} adjustment`}
+                          checked={selectedAdjs.has(adj.id)}
+                          onChange={() => toggleSelect(adj.id)}
+                          className="h-4 w-4 rounded border-gray-300"
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline">{adj.type}</Badge>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {adj.description ?? "\u2014"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(adj.amount)}
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setServerErrors({});
+                            setEditAdj(adj);
+                          }}
+                        >
+                          Edit
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+                <TableFooter>
+                  <TableRow>
+                    <TableCell colSpan={3} className="text-right font-medium">
+                      Adjustment Total
+                    </TableCell>
+                    <TableCell className="text-right font-bold">
+                      {formatCurrency(adjustmentTotal)}
+                    </TableCell>
+                    <TableCell />
+                  </TableRow>
+                </TableFooter>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Create Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Adjustment</DialogTitle>
+          </DialogHeader>
+          <AdjustmentForm
+            mode="create"
+            isSubmitting={createAdjustment.isPending}
+            serverErrors={serverErrors}
+            onCancel={() => setCreateOpen(false)}
+            onSubmit={handleCreate}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog
+        open={editAdj !== null}
+        onOpenChange={(open) => !open && setEditAdj(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Adjustment</DialogTitle>
+          </DialogHeader>
+          {editAdj && (
+            <AdjustmentForm
+              mode="edit"
+              defaultValues={{
+                type: editAdj.type,
+                amount: editAdj.amount,
+                description: editAdj.description ?? "",
+              }}
+              isSubmitting={updateAdjustment.isPending}
+              serverErrors={serverErrors}
+              onCancel={() => setEditAdj(null)}
+              onSubmit={handleUpdate}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Adjustments</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete {selectedAdjs.size} adjustment(s)?
+            This action can be undone by restoring.
+          </p>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteAdjustments.isPending}
+              onClick={() => {
+                const ids = [...selectedAdjs];
+                setSelectedAdjs(new Set());
+                setDeleteOpen(false);
+                deleteAdjustments.mutate(ids);
+              }}
+            >
+              {deleteAdjustments.isPending && <Spinner size="sm" />}
+              {deleteAdjustments.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/client/src/components/BalanceSummaryCard.tsx
+++ b/src/client/src/components/BalanceSummaryCard.tsx
@@ -1,0 +1,68 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { formatCurrency } from "@/lib/format";
+
+interface BalanceSummaryCardProps {
+  subtotal: number;
+  taxAmount: number;
+  adjustmentTotal: number;
+  expectedTotal: number;
+  transactionsTotal?: number;
+  showBalance?: boolean;
+}
+
+export function BalanceSummaryCard({
+  subtotal,
+  taxAmount,
+  adjustmentTotal,
+  expectedTotal,
+  transactionsTotal,
+  showBalance = false,
+}: BalanceSummaryCardProps) {
+  const isBalanced =
+    transactionsTotal != null
+      ? Math.abs(expectedTotal - transactionsTotal) < 0.005
+      : true;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Balance Summary</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm sm:grid-cols-4">
+          <div>
+            <p className="text-muted-foreground">Subtotal</p>
+            <p className="text-lg font-semibold">{formatCurrency(subtotal)}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">Tax</p>
+            <p className="text-lg font-semibold">{formatCurrency(taxAmount)}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">Adjustments</p>
+            <p className="text-lg font-semibold">{formatCurrency(adjustmentTotal)}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">Expected Total</p>
+            <p className="text-lg font-semibold">{formatCurrency(expectedTotal)}</p>
+          </div>
+        </div>
+        {showBalance && transactionsTotal != null && (
+          <div className="mt-4 flex items-center gap-2 text-sm">
+            <span className="text-muted-foreground">Transactions Total:</span>
+            <span className="font-semibold">{formatCurrency(transactionsTotal)}</span>
+            <Badge variant={isBalanced ? "default" : "destructive"}>
+              {isBalanced ? "Balanced" : "Unbalanced"}
+            </Badge>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/client/src/components/ReceiptItemsCard.tsx
+++ b/src/client/src/components/ReceiptItemsCard.tsx
@@ -1,0 +1,110 @@
+import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatCurrency } from "@/lib/format";
+
+interface ReceiptItem {
+  id: string;
+  receiptItemCode: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  category: string;
+  subcategory: string;
+}
+
+interface ReceiptItemsCardProps {
+  items: ReceiptItem[];
+  subtotal: number;
+}
+
+export function ReceiptItemsCard({ items, subtotal }: ReceiptItemsCardProps) {
+  const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
+    items,
+    getId: (item) => item.id,
+    enabled: items.length > 0,
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Items ({items.length})</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No items for this receipt.
+          </p>
+        ) : (
+          <div className="rounded-md border" ref={tableRef}>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Code</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead className="text-right">Qty</TableHead>
+                  <TableHead className="text-right">Unit Price</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Subcategory</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((item, index) => (
+                  <TableRow
+                    key={item.id}
+                    className={`cursor-pointer ${focusedId === item.id ? "bg-accent" : ""}`}
+                    onClick={(e) => {
+                      if ((e.target as HTMLElement).closest("button, input, a, [role='button']")) return;
+                      setFocusedIndex(index);
+                    }}
+                  >
+                    <TableCell className="font-mono">
+                      {item.receiptItemCode}
+                    </TableCell>
+                    <TableCell>{item.description}</TableCell>
+                    <TableCell className="text-right">
+                      {item.quantity}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatCurrency(item.unitPrice)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatCurrency(item.quantity * item.unitPrice)}
+                    </TableCell>
+                    <TableCell>{item.category}</TableCell>
+                    <TableCell>{item.subcategory}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+              <TableFooter>
+                <TableRow>
+                  <TableCell colSpan={4} className="text-right font-medium">
+                    Subtotal
+                  </TableCell>
+                  <TableCell className="text-right font-bold">
+                    {formatCurrency(subtotal)}
+                  </TableCell>
+                  <TableCell colSpan={2} />
+                </TableRow>
+              </TableFooter>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/client/src/components/ValidationWarnings.tsx
+++ b/src/client/src/components/ValidationWarnings.tsx
@@ -1,0 +1,34 @@
+import { AlertTriangle, Info } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+interface ValidationWarning {
+  property: string;
+  message: string;
+  severity?: number;
+}
+
+interface ValidationWarningsProps {
+  warnings: ValidationWarning[];
+}
+
+export function ValidationWarnings({ warnings }: ValidationWarningsProps) {
+  if (warnings.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {warnings.map((w, i) => (
+        <Alert key={`${w.property}-${i}`} variant="default" className="border-amber-500/50 bg-amber-500/5">
+          {w.severity === 1 ? (
+            <AlertTriangle className="h-4 w-4 text-amber-500" />
+          ) : (
+            <Info className="h-4 w-4 text-blue-500" />
+          )}
+          <AlertTitle className="text-sm">
+            {w.severity === 1 ? "Warning" : "Info"}: {w.property}
+          </AlertTitle>
+          <AlertDescription>{w.message}</AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  );
+}

--- a/src/client/src/hooks/useAdjustments.ts
+++ b/src/client/src/hooks/useAdjustments.ts
@@ -1,0 +1,179 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+import { toast } from "sonner";
+
+export function useAdjustments() {
+  return useQuery({
+    queryKey: ["adjustments"],
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/adjustments");
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useAdjustment(id: string | null) {
+  return useQuery({
+    queryKey: ["adjustments", id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/adjustments/{id}", {
+        params: { path: { id: id! } },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useAdjustmentsByReceiptId(receiptId: string | null) {
+  return useQuery({
+    queryKey: ["adjustments", "by-receipt", receiptId],
+    enabled: !!receiptId,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/adjustments/by-receipt-id/{receiptId}",
+        { params: { path: { receiptId: receiptId! } } },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useCreateAdjustment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      receiptId,
+      body,
+    }: {
+      receiptId: string;
+      body: {
+        type: string;
+        amount: number;
+        description?: string | null;
+      };
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/adjustments/{receiptId}",
+        { params: { path: { receiptId } }, body },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["adjustments"] });
+      queryClient.invalidateQueries({ queryKey: ["receipts-with-items"] });
+      queryClient.invalidateQueries({ queryKey: ["trips"] });
+      toast.success("Adjustment created");
+    },
+    onError: () => {
+      toast.error("Failed to create adjustment");
+    },
+  });
+}
+
+export function useUpdateAdjustment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      receiptId,
+      body,
+    }: {
+      receiptId: string;
+      body: {
+        id: string;
+        type: string;
+        amount: number;
+        description?: string | null;
+      };
+    }) => {
+      const { error } = await client.PUT("/api/adjustments/{receiptId}", {
+        params: { path: { receiptId } },
+        body,
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["adjustments"] });
+      queryClient.invalidateQueries({ queryKey: ["receipts-with-items"] });
+      queryClient.invalidateQueries({ queryKey: ["trips"] });
+      toast.success("Adjustment updated");
+    },
+    onError: () => {
+      toast.error("Failed to update adjustment");
+    },
+  });
+}
+
+export function useDeleteAdjustments() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (ids: string[]) => {
+      const { error } = await client.DELETE("/api/adjustments", {
+        body: ids,
+      });
+      if (error) throw error;
+    },
+    onMutate: async (ids) => {
+      await queryClient.cancelQueries({ queryKey: ["adjustments"] });
+      const previous = queryClient.getQueryData(["adjustments"]);
+      queryClient.setQueryData(
+        ["adjustments"],
+        (old: { id: string }[] | undefined) =>
+          old?.filter((item) => !ids.includes(item.id)),
+      );
+      return { previous };
+    },
+    onError: (_err, _ids, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["adjustments"], context.previous);
+      }
+      toast.error("Failed to delete adjustment(s)");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["adjustments"] });
+      queryClient.invalidateQueries({ queryKey: ["adjustments", "deleted"] });
+      queryClient.invalidateQueries({ queryKey: ["receipts-with-items"] });
+      queryClient.invalidateQueries({ queryKey: ["trips"] });
+    },
+    onSuccess: () => {
+      toast.success("Adjustment(s) deleted");
+    },
+  });
+}
+
+export function useDeletedAdjustments() {
+  return useQuery({
+    queryKey: ["adjustments", "deleted"],
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/adjustments/deleted");
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useRestoreAdjustment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await client.POST("/api/adjustments/{id}/restore", {
+        params: { path: { id } },
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["adjustments"] });
+      queryClient.invalidateQueries({ queryKey: ["adjustments", "deleted"] });
+      queryClient.invalidateQueries({ queryKey: ["receipts-with-items"] });
+      queryClient.invalidateQueries({ queryKey: ["trips"] });
+      toast.success("Adjustment restored");
+    },
+    onError: () => {
+      toast.error("Failed to restore adjustment");
+    },
+  });
+}

--- a/src/client/src/lib/problem-details.ts
+++ b/src/client/src/lib/problem-details.ts
@@ -1,0 +1,53 @@
+/**
+ * RFC 9457 Problem Details error parsing.
+ * Extracts field-level validation errors from a ProblemDetails response.
+ */
+
+export interface ProblemDetailsError {
+  type?: string | null;
+  title?: string | null;
+  status?: number | null;
+  detail?: string | null;
+  instance?: string | null;
+  errors?: Record<string, string[]>;
+}
+
+/**
+ * Attempts to parse an error thrown by openapi-fetch into ProblemDetails.
+ * Returns null if the error is not a ProblemDetails response.
+ */
+export function parseProblemDetails(
+  error: unknown,
+): ProblemDetailsError | null {
+  if (error == null || typeof error !== "object") return null;
+
+  const obj = error as Record<string, unknown>;
+
+  // openapi-fetch throws the response body directly as the error
+  if (typeof obj.status === "number" || typeof obj.title === "string") {
+    return obj as ProblemDetailsError;
+  }
+
+  return null;
+}
+
+/**
+ * Extracts a flat map of field name -> first error message from ProblemDetails.
+ * Field names are normalized to camelCase (e.g., "Amount" -> "amount").
+ */
+export function extractFieldErrors(
+  problem: ProblemDetailsError,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!problem.errors) return result;
+
+  for (const [field, messages] of Object.entries(problem.errors)) {
+    if (messages.length > 0) {
+      // Normalize: "Amount" -> "amount", "Type" -> "type"
+      const key = field.charAt(0).toLowerCase() + field.slice(1);
+      result[key] = messages[0];
+    }
+  }
+
+  return result;
+}

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { useReceiptWithItems } from "@/hooks/useAggregates";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
+import { ValidationWarnings } from "@/components/ValidationWarnings";
+import { BalanceSummaryCard } from "@/components/BalanceSummaryCard";
+import { ReceiptItemsCard } from "@/components/ReceiptItemsCard";
+import { AdjustmentsCard } from "@/components/AdjustmentsCard";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -14,15 +17,6 @@ import {
 } from "@/components/ui/card";
 import { ChangeHistory } from "@/components/ChangeHistory";
 import { CardSkeleton } from "@/components/ui/card-skeleton";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableFooter,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { formatCurrency } from "@/lib/format";
 
 function ReceiptDetail() {
@@ -35,19 +29,6 @@ function ReceiptDetail() {
     const trimmed = inputId.trim();
     if (trimmed) setReceiptId(trimmed);
   }
-
-  const grandTotal =
-    data?.items?.reduce(
-      (sum, item) => sum + item.quantity * item.unitPrice,
-      0,
-    ) ?? 0;
-
-  const itemsList = data?.items ?? [];
-  const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
-    items: itemsList,
-    getId: (item) => item.id,
-    enabled: itemsList.length > 0,
-  });
 
   return (
     <div className="space-y-6">
@@ -83,6 +64,10 @@ function ReceiptDetail() {
 
       {data && (
         <>
+          {data.warnings && data.warnings.length > 0 && (
+            <ValidationWarnings warnings={data.warnings} />
+          )}
+
           <Card>
             <CardHeader>
               <CardTitle>Receipt</CardTitle>
@@ -100,76 +85,23 @@ function ReceiptDetail() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Items ({data.items.length})</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {data.items.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  No items for this receipt.
-                </p>
-              ) : (
-                <div className="rounded-md border" ref={tableRef}>
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Code</TableHead>
-                        <TableHead>Description</TableHead>
-                        <TableHead className="text-right">Qty</TableHead>
-                        <TableHead className="text-right">Unit Price</TableHead>
-                        <TableHead className="text-right">Total</TableHead>
-                        <TableHead>Category</TableHead>
-                        <TableHead>Subcategory</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {data.items.map((item, index) => (
-                        <TableRow
-                          key={item.id}
-                          className={`cursor-pointer ${focusedId === item.id ? "bg-accent" : ""}`}
-                          onClick={(e) => {
-                            if ((e.target as HTMLElement).closest("button, input, a, [role='button']")) return;
-                            setFocusedIndex(index);
-                          }}
-                        >
-                          <TableCell className="font-mono">
-                            {item.receiptItemCode}
-                          </TableCell>
-                          <TableCell>{item.description}</TableCell>
-                          <TableCell className="text-right">
-                            {item.quantity}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            {formatCurrency(item.unitPrice)}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            {formatCurrency(item.quantity * item.unitPrice)}
-                          </TableCell>
-                          <TableCell>{item.category}</TableCell>
-                          <TableCell>{item.subcategory}</TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                    <TableFooter>
-                      <TableRow>
-                        <TableCell
-                          colSpan={4}
-                          className="text-right font-medium"
-                        >
-                          Grand Total
-                        </TableCell>
-                        <TableCell className="text-right font-bold">
-                          {formatCurrency(grandTotal)}
-                        </TableCell>
-                        <TableCell colSpan={2} />
-                      </TableRow>
-                    </TableFooter>
-                  </Table>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+          <BalanceSummaryCard
+            subtotal={data.subtotal}
+            taxAmount={data.receipt.taxAmount}
+            adjustmentTotal={data.adjustmentTotal}
+            expectedTotal={data.expectedTotal}
+          />
+
+          <ReceiptItemsCard
+            items={data.items}
+            subtotal={data.subtotal}
+          />
+
+          <AdjustmentsCard
+            receiptId={receiptId!}
+            adjustments={data.adjustments}
+            adjustmentTotal={data.adjustmentTotal}
+          />
 
           <Card>
             <CardHeader>

--- a/src/client/src/pages/Trips.tsx
+++ b/src/client/src/pages/Trips.tsx
@@ -3,7 +3,9 @@ import { useTripByReceiptId } from "@/hooks/useTrips";
 import { useReceipts } from "@/hooks/useReceipts";
 import { receiptToOption } from "@/lib/combobox-options";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
+import { ValidationWarnings } from "@/components/ValidationWarnings";
+import { BalanceSummaryCard } from "@/components/BalanceSummaryCard";
+import { ReceiptItemsCard } from "@/components/ReceiptItemsCard";
 import { Combobox } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
@@ -38,22 +40,21 @@ function Trips() {
     [receipts],
   );
 
-  const itemsTotal =
-    trip?.receipt?.items?.reduce(
-      (sum: number, item: { quantity: number; unitPrice: number }) => sum + item.quantity * item.unitPrice,
-      0,
-    ) ?? 0;
-
   const transactionsTotal =
     trip?.transactions?.reduce((sum: number, ta: { transaction: { amount: number } }) => sum + ta.transaction.amount, 0) ??
     0;
 
-  const tripItems = trip?.receipt?.items ?? [];
-  const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
-    items: tripItems as { id: string }[],
-    getId: (item: { id: string }) => item.id,
-    enabled: tripItems.length > 0,
-  });
+  // Balance equation values from the server-computed response
+  const subtotal = trip?.receipt?.subtotal ?? 0;
+  const adjustmentTotal = trip?.receipt?.adjustmentTotal ?? 0;
+  const expectedTotal = trip?.receipt?.expectedTotal ?? 0;
+  const taxAmount = trip?.receipt?.receipt?.taxAmount ?? 0;
+
+  // Combine warnings from both receipt and trip levels
+  const allWarnings = [
+    ...(trip?.receipt?.warnings ?? []),
+    ...(trip?.warnings ?? []),
+  ];
 
   return (
     <div className="space-y-6">
@@ -87,29 +88,18 @@ function Trips() {
 
       {trip && (
         <>
-          {/* Summary Cards */}
-          <div className="grid grid-cols-3 gap-4">
-            <Card>
-              <CardHeader className="pb-2">
-                <CardDescription>Items Total</CardDescription>
-                <CardTitle>{formatCurrency(itemsTotal)}</CardTitle>
-              </CardHeader>
-            </Card>
-            <Card>
-              <CardHeader className="pb-2">
-                <CardDescription>Transactions Total</CardDescription>
-                <CardTitle>{formatCurrency(transactionsTotal)}</CardTitle>
-              </CardHeader>
-            </Card>
-            <Card>
-              <CardHeader className="pb-2">
-                <CardDescription>Tax Amount</CardDescription>
-                <CardTitle>
-                  {formatCurrency(trip.receipt.receipt.taxAmount)}
-                </CardTitle>
-              </CardHeader>
-            </Card>
-          </div>
+          {allWarnings.length > 0 && (
+            <ValidationWarnings warnings={allWarnings} />
+          )}
+
+          <BalanceSummaryCard
+            subtotal={subtotal}
+            taxAmount={taxAmount}
+            adjustmentTotal={adjustmentTotal}
+            expectedTotal={expectedTotal}
+            transactionsTotal={transactionsTotal}
+            showBalance={trip.transactions.length > 0}
+          />
 
           {/* Receipt Info */}
           <Card>
@@ -129,71 +119,56 @@ function Trips() {
             </CardContent>
           </Card>
 
-          {/* Items Table */}
+          <ReceiptItemsCard
+            items={trip.receipt.items}
+            subtotal={subtotal}
+          />
+
+          {/* Adjustments Table (read-only in trip view) */}
           <Card>
             <CardHeader>
               <CardTitle>
-                Items ({trip.receipt.items.length})
+                Adjustments ({trip.receipt.adjustments.length})
               </CardTitle>
             </CardHeader>
             <CardContent>
-              {trip.receipt.items.length === 0 ? (
+              {trip.receipt.adjustments.length === 0 ? (
                 <p className="text-sm text-muted-foreground">
-                  No items for this receipt.
+                  No adjustments for this receipt.
                 </p>
               ) : (
-                <div className="rounded-md border" ref={tableRef}>
+                <div className="rounded-md border">
                   <Table>
                     <TableHeader>
                       <TableRow>
-                        <TableHead>Code</TableHead>
+                        <TableHead>Type</TableHead>
                         <TableHead>Description</TableHead>
-                        <TableHead className="text-right">Qty</TableHead>
-                        <TableHead className="text-right">
-                          Unit Price
-                        </TableHead>
-                        <TableHead className="text-right">Total</TableHead>
-                        <TableHead>Category</TableHead>
-                        <TableHead>Subcategory</TableHead>
+                        <TableHead className="text-right">Amount</TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {trip.receipt.items.map((item: { id: string; receiptItemCode: string; description: string; quantity: number; unitPrice: number; category: string; subcategory: string }, index: number) => (
-                        <TableRow
-                          key={item.id}
-                          className={`cursor-pointer ${focusedId === item.id ? "bg-accent" : ""}`}
-                          onClick={(e) => {
-                            if ((e.target as HTMLElement).closest("button, input, a, [role='button']")) return;
-                            setFocusedIndex(index);
-                          }}
-                        >
-                          <TableCell className="font-mono">
-                            {item.receiptItemCode}
+                      {trip.receipt.adjustments.map((adj: { id: string; type: string; description?: string | null; amount: number }) => (
+                        <TableRow key={adj.id}>
+                          <TableCell>
+                            <Badge variant="outline">{adj.type}</Badge>
                           </TableCell>
-                          <TableCell>{item.description}</TableCell>
-                          <TableCell className="text-right">
-                            {item.quantity}
+                          <TableCell className="text-muted-foreground">
+                            {adj.description ?? "\u2014"}
                           </TableCell>
                           <TableCell className="text-right">
-                            {formatCurrency(item.unitPrice)}
+                            {formatCurrency(adj.amount)}
                           </TableCell>
-                          <TableCell className="text-right">
-                            {formatCurrency(item.quantity * item.unitPrice)}
-                          </TableCell>
-                          <TableCell>{item.category}</TableCell>
-                          <TableCell>{item.subcategory}</TableCell>
                         </TableRow>
                       ))}
                     </TableBody>
                     <TableFooter>
                       <TableRow>
-                        <TableCell colSpan={4} className="text-right font-medium">
-                          Grand Total
+                        <TableCell colSpan={2} className="text-right font-medium">
+                          Adjustment Total
                         </TableCell>
                         <TableCell className="text-right font-bold">
-                          {formatCurrency(itemsTotal)}
+                          {formatCurrency(adjustmentTotal)}
                         </TableCell>
-                        <TableCell colSpan={2} />
                       </TableRow>
                     </TableFooter>
                   </Table>


### PR DESCRIPTION
## Summary
- Add adjustment CRUD UI within receipt detail views (create, edit, delete with type dropdown + amount)
- Display computed Subtotal, AdjustmentTotal, ExpectedTotal in both Trip and ReceiptDetail views with balance equation breakdown
- Handle 400 validation errors: parse ProblemDetails responses, display per-field server errors in forms
- Display soft validation warnings using shadcn Alert component in Trip and ReceiptDetail views
- Regenerate TypeScript types from updated OpenAPI spec (adjustments + warnings schemas)
- Extract reusable components: BalanceSummaryCard, ReceiptItemsCard, AdjustmentsCard, ValidationWarnings

## New Files
- `src/client/src/hooks/useAdjustments.ts` — Query/mutation hooks for adjustment CRUD
- `src/client/src/lib/problem-details.ts` — RFC 9457 ProblemDetails error parser
- `src/client/src/components/AdjustmentForm.tsx` — Zod-validated form with type dropdown
- `src/client/src/components/AdjustmentsCard.tsx` — Self-contained adjustment table with CRUD dialogs
- `src/client/src/components/BalanceSummaryCard.tsx` — Balance equation breakdown card
- `src/client/src/components/ReceiptItemsCard.tsx` — Extracted items table component
- `src/client/src/components/ValidationWarnings.tsx` — Warning display using shadcn Alert

## Test plan
- [ ] Verify TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Verify ESLint passes on all new/modified files
- [ ] Verify all 58 frontend tests pass
- [ ] Verify ReceiptDetail page displays adjustments, balance summary, and warnings
- [ ] Verify Trips page displays balance equation breakdown with Balanced/Unbalanced badge
- [ ] Verify adjustment create/edit/delete dialogs work in ReceiptDetail
- [ ] Verify ProblemDetails errors display per-field in adjustment form

🤖 Generated with [Claude Code](https://claude.com/claude-code)