### PR TITLE
refactor(client): decompose large page components (MGG-211)

### DIFF
--- a/src/client/src/components/AccountDialogs.tsx
+++ b/src/client/src/components/AccountDialogs.tsx
@@ -1,0 +1,129 @@
+import {
+  useCreateAccount,
+  useUpdateAccount,
+  useDeleteAccounts,
+} from "@/hooks/useAccounts";
+import { AccountForm } from "@/components/AccountForm";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface AccountResponse {
+  id: string;
+  accountCode: string;
+  name: string;
+  isActive: boolean;
+}
+
+interface AccountDialogsProps {
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+  editAccount: AccountResponse | null;
+  onEditClose: () => void;
+  deleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+  selectedIds: string[];
+  onDeleteComplete: () => void;
+}
+
+export function AccountDialogs({
+  createOpen,
+  onCreateOpenChange,
+  editAccount,
+  onEditClose,
+  deleteOpen,
+  onDeleteOpenChange,
+  selectedIds,
+  onDeleteComplete,
+}: AccountDialogsProps) {
+  const createAccount = useCreateAccount();
+  const updateAccount = useUpdateAccount();
+  const deleteAccounts = useDeleteAccounts();
+
+  return (
+    <>
+      <Dialog open={createOpen} onOpenChange={onCreateOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Account</DialogTitle>
+          </DialogHeader>
+          <AccountForm
+            mode="create"
+            isSubmitting={createAccount.isPending}
+            onCancel={() => onCreateOpenChange(false)}
+            onSubmit={(values) => {
+              createAccount.mutate(values, {
+                onSuccess: () => onCreateOpenChange(false),
+              });
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editAccount !== null}
+        onOpenChange={(open) => !open && onEditClose()}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Account</DialogTitle>
+          </DialogHeader>
+          {editAccount && (
+            <AccountForm
+              mode="edit"
+              defaultValues={{
+                accountCode: editAccount.accountCode,
+                name: editAccount.name,
+                isActive: editAccount.isActive,
+              }}
+              isSubmitting={updateAccount.isPending}
+              onCancel={onEditClose}
+              onSubmit={(values) => {
+                updateAccount.mutate(
+                  { id: editAccount.id, ...values },
+                  { onSuccess: onEditClose },
+                );
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={onDeleteOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Accounts</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete {selectedIds.length} account(s)?
+            This action can be undone by restoring.
+          </p>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="outline"
+              onClick={() => onDeleteOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteAccounts.isPending}
+              onClick={() => {
+                onDeleteComplete();
+                deleteAccounts.mutate(selectedIds);
+              }}
+            >
+              {deleteAccounts.isPending && <Spinner size="sm" />}
+              {deleteAccounts.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/client/src/components/CategoryDialogs.tsx
+++ b/src/client/src/components/CategoryDialogs.tsx
@@ -1,0 +1,127 @@
+import {
+  useCreateCategory,
+  useUpdateCategory,
+  useDeleteCategories,
+} from "@/hooks/useCategories";
+import { CategoryForm } from "@/components/CategoryForm";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface CategoryResponse {
+  id: string;
+  name: string;
+  description?: string | null;
+}
+
+interface CategoryDialogsProps {
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+  editCategory: CategoryResponse | null;
+  onEditClose: () => void;
+  deleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+  selectedIds: string[];
+  onDeleteComplete: () => void;
+}
+
+export function CategoryDialogs({
+  createOpen,
+  onCreateOpenChange,
+  editCategory,
+  onEditClose,
+  deleteOpen,
+  onDeleteOpenChange,
+  selectedIds,
+  onDeleteComplete,
+}: CategoryDialogsProps) {
+  const createCategory = useCreateCategory();
+  const updateCategory = useUpdateCategory();
+  const deleteCategories = useDeleteCategories();
+
+  return (
+    <>
+      <Dialog open={createOpen} onOpenChange={onCreateOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Category</DialogTitle>
+          </DialogHeader>
+          <CategoryForm
+            mode="create"
+            isSubmitting={createCategory.isPending}
+            onCancel={() => onCreateOpenChange(false)}
+            onSubmit={(values) => {
+              createCategory.mutate(values, {
+                onSuccess: () => onCreateOpenChange(false),
+              });
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editCategory !== null}
+        onOpenChange={(open) => !open && onEditClose()}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Category</DialogTitle>
+          </DialogHeader>
+          {editCategory && (
+            <CategoryForm
+              mode="edit"
+              defaultValues={{
+                name: editCategory.name,
+                description: editCategory.description ?? "",
+              }}
+              isSubmitting={updateCategory.isPending}
+              onCancel={onEditClose}
+              onSubmit={(values) => {
+                updateCategory.mutate(
+                  { id: editCategory.id, ...values },
+                  { onSuccess: onEditClose },
+                );
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={onDeleteOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Categories</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete {selectedIds.length} category(ies)?
+            This action can be undone by restoring.
+          </p>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="outline"
+              onClick={() => onDeleteOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteCategories.isPending}
+              onClick={() => {
+                onDeleteComplete();
+                deleteCategories.mutate(selectedIds);
+              }}
+            >
+              {deleteCategories.isPending && <Spinner size="sm" />}
+              {deleteCategories.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/client/src/components/CreateApiKeyDialog.tsx
+++ b/src/client/src/components/CreateApiKeyDialog.tsx
@@ -1,0 +1,137 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+import { showError } from "@/lib/toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const createKeySchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  expiresAt: z.string().optional(),
+});
+
+type CreateKeyFormValues = z.infer<typeof createKeySchema>;
+
+interface CreateApiKeyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onKeyCreated: (rawKey: string) => void;
+}
+
+export function CreateApiKeyDialog({
+  open,
+  onOpenChange,
+  onKeyCreated,
+}: CreateApiKeyDialogProps) {
+  const queryClient = useQueryClient();
+
+  const createMutation = useMutation({
+    mutationFn: async (values: CreateKeyFormValues) => {
+      const { data, error } = await client.POST("/api/apikeys", {
+        body: {
+          name: values.name,
+          expiresAt: values.expiresAt || undefined,
+        },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["apiKeys"] });
+      if (data) {
+        onKeyCreated(data.rawKey);
+      }
+      onOpenChange(false);
+    },
+    onError: () => {
+      showError("Failed to create API key.");
+    },
+  });
+
+  const form = useForm<CreateKeyFormValues>({
+    resolver: zodResolver(createKeySchema),
+    defaultValues: { name: "", expiresAt: "" },
+  });
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (nextOpen) {
+      form.reset();
+    }
+    onOpenChange(nextOpen);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create API Key</DialogTitle>
+          <DialogDescription>
+            Generate a new API key for programmatic access.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit((v) => createMutation.mutate(v))}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="e.g. Paperless Integration"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="expiresAt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Expiration Date (optional)</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={createMutation.isPending}
+            >
+              {createMutation.isPending && <Spinner size="sm" />}
+              {createMutation.isPending ? "Creating..." : "Create Key"}
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/client/src/components/CreateUserDialog.tsx
+++ b/src/client/src/components/CreateUserDialog.tsx
@@ -1,0 +1,187 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useCreateUser } from "@/hooks/useUsers";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const AVAILABLE_ROLES = ["Admin", "User"];
+
+const createUserSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+  role: z.string().min(1, "Role is required"),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+});
+
+type CreateUserFormValues = z.infer<typeof createUserSchema>;
+
+interface CreateUserDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CreateUserDialog({ open, onOpenChange }: CreateUserDialogProps) {
+  const createUser = useCreateUser();
+
+  const form = useForm<CreateUserFormValues>({
+    resolver: zodResolver(createUserSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+      role: "User",
+      firstName: "",
+      lastName: "",
+    },
+  });
+
+  async function onSubmit(values: CreateUserFormValues) {
+    await createUser.mutateAsync({
+      email: values.email,
+      password: values.password,
+      role: values.role,
+      firstName: values.firstName || null,
+      lastName: values.lastName || null,
+    });
+    onOpenChange(false);
+    form.reset();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create User</DialogTitle>
+          <DialogDescription>
+            Create a new user account. They will be required to change their
+            password on first login.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="firstName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>First Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="John" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="lastName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Last Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Doe" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="name@example.com"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder="At least 8 characters"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select a role" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {AVAILABLE_ROLES.map((role) => (
+                        <SelectItem key={role} value={role}>
+                          {role}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting && <Spinner size="sm" />}
+                {form.formState.isSubmitting ? "Creating..." : "Create User"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/client/src/components/CreatedKeyDialog.tsx
+++ b/src/client/src/components/CreatedKeyDialog.tsx
@@ -1,0 +1,56 @@
+import { showSuccess, showError } from "@/lib/toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface CreatedKeyDialogProps {
+  rawKey: string | null;
+  onClose: () => void;
+}
+
+export function CreatedKeyDialog({ rawKey, onClose }: CreatedKeyDialogProps) {
+  async function handleCopyKey() {
+    if (!rawKey) return;
+    try {
+      await navigator.clipboard.writeText(rawKey);
+      showSuccess("API key copied to clipboard.");
+    } catch {
+      showError("Failed to copy to clipboard.");
+    }
+  }
+
+  return (
+    <Dialog
+      open={rawKey !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>API Key Created</DialogTitle>
+        </DialogHeader>
+        <Alert>
+          <AlertDescription>
+            Save this key now. You won&apos;t be able to see it again.
+          </AlertDescription>
+        </Alert>
+        <Input
+          readOnly
+          value={rawKey ?? ""}
+          onClick={(e) => (e.target as HTMLInputElement).select()}
+          className="font-mono text-sm"
+        />
+        <Button onClick={handleCopyKey} className="w-full">
+          Copy to Clipboard
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/client/src/components/DeactivateUserDialog.tsx
+++ b/src/client/src/components/DeactivateUserDialog.tsx
@@ -1,0 +1,54 @@
+import { useDeleteUser } from "@/hooks/useUsers";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface DeactivateUserDialogProps {
+  user: { id: string; email: string } | null;
+  onClose: () => void;
+}
+
+export function DeactivateUserDialog({
+  user,
+  onClose,
+}: DeactivateUserDialogProps) {
+  const deleteUser = useDeleteUser();
+
+  return (
+    <AlertDialog open={!!user} onOpenChange={() => onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Deactivate User</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to deactivate{" "}
+            <span className="font-semibold">{user?.email}</span>? They will no
+            longer be able to log in.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={async () => {
+              if (user) {
+                await deleteUser.mutateAsync(user.id);
+                onClose();
+              }
+            }}
+          >
+            {deleteUser.isPending && <Spinner size="sm" />}
+            Deactivate
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/client/src/components/EditUserDialog.tsx
+++ b/src/client/src/components/EditUserDialog.tsx
@@ -1,0 +1,202 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useUpdateUser } from "@/hooks/useUsers";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const AVAILABLE_ROLES = ["Admin", "User"];
+
+const editUserSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+  role: z.string().min(1, "Role is required"),
+  isDisabled: z.boolean(),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+});
+
+type EditUserFormValues = z.infer<typeof editUserSchema>;
+
+export interface EditableUser {
+  id: string;
+  email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  role: string;
+  isDisabled: boolean;
+}
+
+interface EditUserDialogProps {
+  user: EditableUser | null;
+  onClose: () => void;
+}
+
+export function EditUserDialog({ user, onClose }: EditUserDialogProps) {
+  const updateUser = useUpdateUser();
+
+  const form = useForm<EditUserFormValues>({
+    resolver: zodResolver(editUserSchema),
+  });
+
+  useEffect(() => {
+    if (user) {
+      form.reset({
+        email: user.email,
+        role: user.role,
+        isDisabled: user.isDisabled,
+        firstName: user.firstName ?? "",
+        lastName: user.lastName ?? "",
+      });
+    }
+  }, [user, form]);
+
+  async function onSubmit(values: EditUserFormValues) {
+    if (!user) return;
+    await updateUser.mutateAsync({
+      userId: user.id,
+      body: {
+        email: values.email,
+        role: values.role,
+        isDisabled: values.isDisabled,
+        firstName: values.firstName || null,
+        lastName: values.lastName || null,
+      },
+    });
+    onClose();
+  }
+
+  return (
+    <Dialog open={!!user} onOpenChange={() => onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit User</DialogTitle>
+          <DialogDescription>
+            Update user details, role, and account status.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="firstName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>First Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="John" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="lastName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Last Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Doe" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input type="email" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {AVAILABLE_ROLES.map((role) => (
+                        <SelectItem key={role} value={role}>
+                          {role}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="isDisabled"
+              render={({ field }) => (
+                <FormItem>
+                  <div className="flex items-center gap-3">
+                    <FormControl>
+                      <input
+                        type="checkbox"
+                        checked={field.value}
+                        onChange={field.onChange}
+                        className="h-4 w-4 rounded border-gray-300"
+                        aria-label="Disable account"
+                      />
+                    </FormControl>
+                    <Label>Account Disabled</Label>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting && <Spinner size="sm" />}
+                {form.formState.isSubmitting ? "Saving..." : "Save Changes"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/client/src/components/ItemTemplateDialogs.tsx
+++ b/src/client/src/components/ItemTemplateDialogs.tsx
@@ -1,0 +1,156 @@
+import {
+  useCreateItemTemplate,
+  useUpdateItemTemplate,
+  useDeleteItemTemplates,
+} from "@/hooks/useItemTemplates";
+import { ItemTemplateForm } from "@/components/ItemTemplateForm";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ItemTemplateResponse {
+  id: string;
+  name: string;
+  description?: string | null;
+  defaultCategory?: string | null;
+  defaultSubcategory?: string | null;
+  defaultUnitPrice?: number | null;
+  defaultUnitPriceCurrency?: string | null;
+  defaultPricingMode?: string | null;
+  defaultItemCode?: string | null;
+}
+
+interface ItemTemplateDialogsProps {
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+  editTemplate: ItemTemplateResponse | null;
+  onEditClose: () => void;
+  deleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+  selectedIds: string[];
+  onDeleteComplete: () => void;
+}
+
+export function ItemTemplateDialogs({
+  createOpen,
+  onCreateOpenChange,
+  editTemplate,
+  onEditClose,
+  deleteOpen,
+  onDeleteOpenChange,
+  selectedIds,
+  onDeleteComplete,
+}: ItemTemplateDialogsProps) {
+  const createItemTemplate = useCreateItemTemplate();
+  const updateItemTemplate = useUpdateItemTemplate();
+  const deleteItemTemplates = useDeleteItemTemplates();
+
+  return (
+    <>
+      <Dialog open={createOpen} onOpenChange={onCreateOpenChange}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Create Item Template</DialogTitle>
+          </DialogHeader>
+          <ItemTemplateForm
+            mode="create"
+            isSubmitting={createItemTemplate.isPending}
+            onCancel={() => onCreateOpenChange(false)}
+            onSubmit={(values) => {
+              createItemTemplate.mutate(
+                {
+                  name: values.name,
+                  description: values.description || null,
+                  defaultCategory: values.defaultCategory || null,
+                  defaultSubcategory: values.defaultSubcategory || null,
+                  defaultUnitPrice: values.defaultUnitPrice ?? null,
+                  defaultPricingMode: values.defaultPricingMode || null,
+                  defaultItemCode: values.defaultItemCode || null,
+                },
+                { onSuccess: () => onCreateOpenChange(false) },
+              );
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editTemplate !== null}
+        onOpenChange={(open) => !open && onEditClose()}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Edit Item Template</DialogTitle>
+          </DialogHeader>
+          {editTemplate && (
+            <ItemTemplateForm
+              mode="edit"
+              defaultValues={{
+                name: editTemplate.name,
+                description: editTemplate.description ?? "",
+                defaultCategory: editTemplate.defaultCategory ?? "",
+                defaultSubcategory: editTemplate.defaultSubcategory ?? "",
+                defaultUnitPrice: editTemplate.defaultUnitPrice ?? undefined,
+                defaultPricingMode: editTemplate.defaultPricingMode ?? "",
+                defaultItemCode: editTemplate.defaultItemCode ?? "",
+              }}
+              isSubmitting={updateItemTemplate.isPending}
+              onCancel={onEditClose}
+              onSubmit={(values) => {
+                updateItemTemplate.mutate(
+                  {
+                    id: editTemplate.id,
+                    name: values.name,
+                    description: values.description || null,
+                    defaultCategory: values.defaultCategory || null,
+                    defaultSubcategory: values.defaultSubcategory || null,
+                    defaultUnitPrice: values.defaultUnitPrice ?? null,
+                    defaultPricingMode: values.defaultPricingMode || null,
+                    defaultItemCode: values.defaultItemCode || null,
+                  },
+                  { onSuccess: onEditClose },
+                );
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={onDeleteOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Item Templates</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete {selectedIds.length} item
+            template(s)? This action can be undone by restoring.
+          </p>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="outline"
+              onClick={() => onDeleteOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteItemTemplates.isPending}
+              onClick={() => {
+                onDeleteComplete();
+                deleteItemTemplates.mutate(selectedIds);
+              }}
+            >
+              {deleteItemTemplates.isPending && <Spinner size="sm" />}
+              {deleteItemTemplates.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -38,8 +38,8 @@ import {
   NavigationMenuLink,
   NavigationMenuList,
   NavigationMenuTrigger,
-  navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
+import { navigationMenuTriggerStyle } from "@/components/ui/navigation-menu-trigger-style";
 import { cn } from "@/lib/utils";
 
 const connectionStateColors: Record<SignalRConnectionState, string> = {

--- a/src/client/src/components/ReceiptDialogs.tsx
+++ b/src/client/src/components/ReceiptDialogs.tsx
@@ -1,0 +1,139 @@
+import {
+  useCreateReceipt,
+  useUpdateReceipt,
+  useDeleteReceipts,
+} from "@/hooks/useReceipts";
+import { ReceiptForm } from "@/components/ReceiptForm";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ReceiptResponse {
+  id: string;
+  description?: string | null;
+  location: string;
+  date: string;
+  taxAmount: number;
+}
+
+interface ReceiptDialogsProps {
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+  editReceipt: ReceiptResponse | null;
+  onEditClose: () => void;
+  deleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+  selectedIds: string[];
+  onDeleteComplete: () => void;
+}
+
+export function ReceiptDialogs({
+  createOpen,
+  onCreateOpenChange,
+  editReceipt,
+  onEditClose,
+  deleteOpen,
+  onDeleteOpenChange,
+  selectedIds,
+  onDeleteComplete,
+}: ReceiptDialogsProps) {
+  const createReceipt = useCreateReceipt();
+  const updateReceipt = useUpdateReceipt();
+  const deleteReceipts = useDeleteReceipts();
+
+  return (
+    <>
+      <Dialog open={createOpen} onOpenChange={onCreateOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Receipt</DialogTitle>
+          </DialogHeader>
+          <ReceiptForm
+            mode="create"
+            isSubmitting={createReceipt.isPending}
+            onCancel={() => onCreateOpenChange(false)}
+            onSubmit={(values) => {
+              createReceipt.mutate(
+                {
+                  ...values,
+                  description: values.description || null,
+                },
+                { onSuccess: () => onCreateOpenChange(false) },
+              );
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editReceipt !== null}
+        onOpenChange={(open) => !open && onEditClose()}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Receipt</DialogTitle>
+          </DialogHeader>
+          {editReceipt && (
+            <ReceiptForm
+              mode="edit"
+              defaultValues={{
+                description: editReceipt.description ?? "",
+                location: editReceipt.location,
+                date: editReceipt.date,
+                taxAmount: editReceipt.taxAmount,
+              }}
+              isSubmitting={updateReceipt.isPending}
+              onCancel={onEditClose}
+              onSubmit={(values) => {
+                updateReceipt.mutate(
+                  {
+                    id: editReceipt.id,
+                    ...values,
+                    description: values.description || null,
+                  },
+                  { onSuccess: onEditClose },
+                );
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={onDeleteOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Receipts</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete {selectedIds.length} receipt(s)?
+            This action can be undone by restoring.
+          </p>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="outline"
+              onClick={() => onDeleteOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteReceipts.isPending}
+              onClick={() => {
+                onDeleteComplete();
+                deleteReceipts.mutate(selectedIds);
+              }}
+            >
+              {deleteReceipts.isPending && <Spinner size="sm" />}
+              {deleteReceipts.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/client/src/components/ReceiptItemDialogs.tsx
+++ b/src/client/src/components/ReceiptItemDialogs.tsx
@@ -1,0 +1,147 @@
+import {
+  useCreateReceiptItem,
+  useUpdateReceiptItem,
+  useDeleteReceiptItems,
+} from "@/hooks/useReceiptItems";
+import { ReceiptItemForm } from "@/components/ReceiptItemForm";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ReceiptItemResponse {
+  id: string;
+  receiptId: string;
+  receiptItemCode: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  category: string;
+  subcategory: string;
+  pricingMode: "quantity" | "flat";
+}
+
+interface ReceiptItemDialogsProps {
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+  editItem: ReceiptItemResponse | null;
+  onEditClose: () => void;
+  deleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+  selectedIds: string[];
+  onDeleteComplete: () => void;
+}
+
+export function ReceiptItemDialogs({
+  createOpen,
+  onCreateOpenChange,
+  editItem,
+  onEditClose,
+  deleteOpen,
+  onDeleteOpenChange,
+  selectedIds,
+  onDeleteComplete,
+}: ReceiptItemDialogsProps) {
+  const createItem = useCreateReceiptItem();
+  const updateItem = useUpdateReceiptItem();
+  const deleteItems = useDeleteReceiptItems();
+
+  return (
+    <>
+      <Dialog open={createOpen} onOpenChange={onCreateOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Receipt Item</DialogTitle>
+          </DialogHeader>
+          <ReceiptItemForm
+            mode="create"
+            isSubmitting={createItem.isPending}
+            onCancel={() => onCreateOpenChange(false)}
+            onSubmit={(values) => {
+              const { receiptId, ...body } = values;
+              createItem.mutate(
+                { receiptId, body },
+                { onSuccess: () => onCreateOpenChange(false) },
+              );
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editItem !== null}
+        onOpenChange={(open) => {
+          if (!open) onEditClose();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Receipt Item</DialogTitle>
+          </DialogHeader>
+          {editItem && (
+            <ReceiptItemForm
+              mode="edit"
+              defaultValues={{
+                receiptId: editItem.receiptId,
+                receiptItemCode: editItem.receiptItemCode,
+                description: editItem.description,
+                pricingMode: editItem.pricingMode ?? "quantity",
+                quantity: editItem.quantity,
+                unitPrice: editItem.unitPrice,
+                category: editItem.category,
+                subcategory: editItem.subcategory,
+              }}
+              isSubmitting={updateItem.isPending}
+              onCancel={onEditClose}
+              onSubmit={(values) => {
+                const { receiptId, ...rest } = values;
+                updateItem.mutate(
+                  {
+                    receiptId,
+                    body: { id: editItem.id, ...rest },
+                  },
+                  { onSuccess: onEditClose },
+                );
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={onDeleteOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Receipt Items</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete {selectedIds.length} item(s)? This
+            action can be undone by restoring.
+          </p>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="outline"
+              onClick={() => onDeleteOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteItems.isPending}
+              onClick={() => {
+                onDeleteComplete();
+                deleteItems.mutate(selectedIds);
+              }}
+            >
+              {deleteItems.isPending && <Spinner size="sm" />}
+              {deleteItems.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/client/src/components/ResetPasswordDialog.tsx
+++ b/src/client/src/components/ResetPasswordDialog.tsx
@@ -1,0 +1,106 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useResetUserPassword } from "@/hooks/useUsers";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const resetPasswordSchema = z.object({
+  newPassword: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;
+
+interface ResetPasswordDialogProps {
+  userId: string | null;
+  onClose: () => void;
+}
+
+export function ResetPasswordDialog({
+  userId,
+  onClose,
+}: ResetPasswordDialogProps) {
+  const resetPassword = useResetUserPassword();
+
+  const form = useForm<ResetPasswordFormValues>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { newPassword: "" },
+  });
+
+  async function onSubmit(values: ResetPasswordFormValues) {
+    if (!userId) return;
+    await resetPassword.mutateAsync({
+      userId,
+      newPassword: values.newPassword,
+    });
+    onClose();
+    form.reset();
+  }
+
+  function handleOpenChange(open: boolean) {
+    if (!open) {
+      onClose();
+      form.reset();
+    }
+  }
+
+  return (
+    <Dialog open={!!userId} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reset Password</DialogTitle>
+          <DialogDescription>
+            Set a new password for this user. They will be required to change it
+            on their next login.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="newPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>New Password</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder="At least 8 characters"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting && <Spinner size="sm" />}
+                {form.formState.isSubmitting
+                  ? "Resetting..."
+                  : "Reset Password"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/client/src/components/RevokeApiKeyDialog.tsx
+++ b/src/client/src/components/RevokeApiKeyDialog.tsx
@@ -1,0 +1,75 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+import { showSuccess, showError } from "@/lib/toast";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface RevokeApiKeyDialogProps {
+  keyId: string | null;
+  onClose: () => void;
+}
+
+export function RevokeApiKeyDialog({
+  keyId,
+  onClose,
+}: RevokeApiKeyDialogProps) {
+  const queryClient = useQueryClient();
+
+  const revokeMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await client.DELETE("/api/apikeys/{id}", {
+        params: { path: { id } },
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["apiKeys"] });
+      showSuccess("API key revoked.");
+      onClose();
+    },
+    onError: () => {
+      showError("Failed to revoke API key.");
+    },
+  });
+
+  return (
+    <Dialog
+      open={keyId !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Revoke API Key</DialogTitle>
+          <DialogDescription>
+            This action cannot be undone. The API key will be immediately
+            invalidated.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex gap-2 justify-end">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={revokeMutation.isPending}
+            onClick={() => {
+              if (keyId) revokeMutation.mutate(keyId);
+            }}
+          >
+            {revokeMutation.isPending && <Spinner size="sm" />}
+            {revokeMutation.isPending ? "Revoking..." : "Revoke"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/client/src/components/SubcategoryDialogs.tsx
+++ b/src/client/src/components/SubcategoryDialogs.tsx
@@ -1,0 +1,129 @@
+import {
+  useCreateSubcategory,
+  useUpdateSubcategory,
+  useDeleteSubcategories,
+} from "@/hooks/useSubcategories";
+import { SubcategoryForm } from "@/components/SubcategoryForm";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface SubcategoryResponse {
+  id: string;
+  name: string;
+  categoryId: string;
+  description?: string | null;
+}
+
+interface SubcategoryDialogsProps {
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+  editSubcategory: SubcategoryResponse | null;
+  onEditClose: () => void;
+  deleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+  selectedIds: string[];
+  onDeleteComplete: () => void;
+}
+
+export function SubcategoryDialogs({
+  createOpen,
+  onCreateOpenChange,
+  editSubcategory,
+  onEditClose,
+  deleteOpen,
+  onDeleteOpenChange,
+  selectedIds,
+  onDeleteComplete,
+}: SubcategoryDialogsProps) {
+  const createSubcategory = useCreateSubcategory();
+  const updateSubcategory = useUpdateSubcategory();
+  const deleteSubcategories = useDeleteSubcategories();
+
+  return (
+    <>
+      <Dialog open={createOpen} onOpenChange={onCreateOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Subcategory</DialogTitle>
+          </DialogHeader>
+          <SubcategoryForm
+            mode="create"
+            isSubmitting={createSubcategory.isPending}
+            onCancel={() => onCreateOpenChange(false)}
+            onSubmit={(values) => {
+              createSubcategory.mutate(values, {
+                onSuccess: () => onCreateOpenChange(false),
+              });
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editSubcategory !== null}
+        onOpenChange={(open) => !open && onEditClose()}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Subcategory</DialogTitle>
+          </DialogHeader>
+          {editSubcategory && (
+            <SubcategoryForm
+              mode="edit"
+              defaultValues={{
+                name: editSubcategory.name,
+                categoryId: editSubcategory.categoryId,
+                description: editSubcategory.description ?? "",
+              }}
+              isSubmitting={updateSubcategory.isPending}
+              onCancel={onEditClose}
+              onSubmit={(values) => {
+                updateSubcategory.mutate(
+                  { id: editSubcategory.id, ...values },
+                  { onSuccess: onEditClose },
+                );
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={onDeleteOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Subcategories</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete {selectedIds.length}{" "}
+            subcategory(ies)? This action can be undone by restoring.
+          </p>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="outline"
+              onClick={() => onDeleteOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteSubcategories.isPending}
+              onClick={() => {
+                onDeleteComplete();
+                deleteSubcategories.mutate(selectedIds);
+              }}
+            >
+              {deleteSubcategories.isPending && <Spinner size="sm" />}
+              {deleteSubcategories.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/client/src/components/TransactionDialogs.tsx
+++ b/src/client/src/components/TransactionDialogs.tsx
@@ -1,0 +1,146 @@
+import {
+  useCreateTransaction,
+  useUpdateTransaction,
+  useDeleteTransactions,
+} from "@/hooks/useTransactions";
+import { TransactionForm } from "@/components/TransactionForm";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface TransactionResponse {
+  id: string;
+  receiptId: string;
+  accountId: string;
+  amount: number;
+  date: string;
+}
+
+interface TransactionDialogsProps {
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+  editTransaction: TransactionResponse | null;
+  onEditClose: () => void;
+  deleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+  selectedIds: string[];
+  onDeleteComplete: () => void;
+}
+
+export function TransactionDialogs({
+  createOpen,
+  onCreateOpenChange,
+  editTransaction,
+  onEditClose,
+  deleteOpen,
+  onDeleteOpenChange,
+  selectedIds,
+  onDeleteComplete,
+}: TransactionDialogsProps) {
+  const createTransaction = useCreateTransaction();
+  const updateTransaction = useUpdateTransaction();
+  const deleteTransactions = useDeleteTransactions();
+
+  return (
+    <>
+      <Dialog open={createOpen} onOpenChange={onCreateOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Transaction</DialogTitle>
+          </DialogHeader>
+          <TransactionForm
+            mode="create"
+            isSubmitting={createTransaction.isPending}
+            onCancel={() => onCreateOpenChange(false)}
+            onSubmit={(values) => {
+              createTransaction.mutate(
+                {
+                  receiptId: values.receiptId,
+                  accountId: values.accountId,
+                  body: { amount: values.amount, date: values.date },
+                },
+                { onSuccess: () => onCreateOpenChange(false) },
+              );
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editTransaction !== null}
+        onOpenChange={(open) => {
+          if (!open) onEditClose();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Transaction</DialogTitle>
+          </DialogHeader>
+          {editTransaction && (
+            <TransactionForm
+              mode="edit"
+              defaultValues={{
+                receiptId: editTransaction.receiptId,
+                accountId: editTransaction.accountId,
+                amount: editTransaction.amount,
+                date: editTransaction.date,
+              }}
+              isSubmitting={updateTransaction.isPending}
+              onCancel={onEditClose}
+              onSubmit={(values) => {
+                updateTransaction.mutate(
+                  {
+                    receiptId: values.receiptId,
+                    accountId: values.accountId,
+                    body: {
+                      id: editTransaction.id,
+                      amount: values.amount,
+                      date: values.date,
+                    },
+                  },
+                  { onSuccess: onEditClose },
+                );
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={onDeleteOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Transactions</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete {selectedIds.length} transaction(s)?
+            This action can be undone by restoring.
+          </p>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="outline"
+              onClick={() => onDeleteOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteTransactions.isPending}
+              onClick={() => {
+                onDeleteComplete();
+                deleteTransactions.mutate(selectedIds);
+              }}
+            >
+              {deleteTransactions.isPending && <Spinner size="sm" />}
+              {deleteTransactions.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/client/src/components/ui/navigation-menu-trigger-style.ts
+++ b/src/client/src/components/ui/navigation-menu-trigger-style.ts
@@ -1,0 +1,5 @@
+import { cva } from "class-variance-authority"
+
+export const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1"
+)

--- a/src/client/src/components/ui/navigation-menu.tsx
+++ b/src/client/src/components/ui/navigation-menu.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
-import { cva } from "class-variance-authority"
 import { ChevronDownIcon } from "lucide-react"
 import { NavigationMenu as NavigationMenuPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
+import { navigationMenuTriggerStyle } from "./navigation-menu-trigger-style"
 
 function NavigationMenu({
   className,
@@ -57,10 +57,6 @@ function NavigationMenuItem({
     />
   )
 }
-
-const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1"
-)
 
 function NavigationMenuTrigger({
   className,
@@ -164,5 +160,4 @@ export {
   NavigationMenuLink,
   NavigationMenuIndicator,
   NavigationMenuViewport,
-  navigationMenuTriggerStyle,
 }

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -1,10 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
-import {
-  useAccounts,
-  useCreateAccount,
-  useUpdateAccount,
-  useDeleteAccounts,
-} from "@/hooks/useAccounts";
+import { useAccounts } from "@/hooks/useAccounts";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
@@ -13,7 +8,7 @@ import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import type { FuseSearchConfig, FilterDefinition } from "@/lib/search";
 import { applyFilters } from "@/lib/search";
 import type { FilterValues } from "@/components/FilterPanel";
-import { AccountForm } from "@/components/AccountForm";
+import { AccountDialogs } from "@/components/AccountDialogs";
 import { FuzzySearchInput } from "@/components/FuzzySearchInput";
 import { FilterPanel } from "@/components/FilterPanel";
 import type { FilterField } from "@/components/FilterPanel";
@@ -24,12 +19,6 @@ import { Pagination } from "@/components/Pagination";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Table,
   TableBody,
   TableCell,
@@ -38,7 +27,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { Spinner } from "@/components/ui/spinner";
 
 interface AccountResponse {
   id: string;
@@ -65,9 +53,6 @@ const FILTER_DEFS: FilterDefinition[] = [
 function Accounts() {
   usePageTitle("Accounts");
   const { data: accounts, isLoading } = useAccounts();
-  const createAccount = useCreateAccount();
-  const updateAccount = useUpdateAccount();
-  const deleteAccounts = useDeleteAccounts();
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [createOpen, setCreateOpen] = useState(false);
@@ -301,85 +286,19 @@ function Accounts() {
         </>
       )}
 
-      {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Account</DialogTitle>
-          </DialogHeader>
-          <AccountForm
-            mode="create"
-            isSubmitting={createAccount.isPending}
-            onCancel={() => setCreateOpen(false)}
-            onSubmit={(values) => {
-              createAccount.mutate(values, {
-                onSuccess: () => setCreateOpen(false),
-              });
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-
-      {/* Edit Dialog */}
-      <Dialog
-        open={editAccount !== null}
-        onOpenChange={(open) => !open && setEditAccount(null)}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Account</DialogTitle>
-          </DialogHeader>
-          {editAccount && (
-            <AccountForm
-              mode="edit"
-              defaultValues={{
-                accountCode: editAccount.accountCode,
-                name: editAccount.name,
-                isActive: editAccount.isActive,
-              }}
-              isSubmitting={updateAccount.isPending}
-              onCancel={() => setEditAccount(null)}
-              onSubmit={(values) => {
-                updateAccount.mutate(
-                  { id: editAccount.id, ...values },
-                  { onSuccess: () => setEditAccount(null) },
-                );
-              }}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Accounts</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Are you sure you want to delete {selected.size} account(s)? This
-            action can be undone by restoring.
-          </p>
-          <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={deleteAccounts.isPending}
-              onClick={() => {
-                const ids = [...selected];
-                setSelected(new Set());
-                setDeleteOpen(false);
-                deleteAccounts.mutate(ids);
-              }}
-            >
-              {deleteAccounts.isPending && <Spinner size="sm" />}
-              {deleteAccounts.isPending ? "Deleting..." : "Delete"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <AccountDialogs
+        createOpen={createOpen}
+        onCreateOpenChange={setCreateOpen}
+        editAccount={editAccount}
+        onEditClose={() => setEditAccount(null)}
+        deleteOpen={deleteOpen}
+        onDeleteOpenChange={setDeleteOpen}
+        selectedIds={[...selected]}
+        onDeleteComplete={() => {
+          setSelected(new Set());
+          setDeleteOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -1,21 +1,15 @@
 import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import {
-  useUsers,
-  useCreateUser,
-  useUpdateUser,
-  useDeleteUser,
-  useResetUserPassword,
-} from "@/hooks/useUsers";
+import { useUsers } from "@/hooks/useUsers";
 import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
+import { CreateUserDialog } from "@/components/CreateUserDialog";
+import { EditUserDialog } from "@/components/EditUserDialog";
+import type { EditableUser } from "@/components/EditUserDialog";
+import { ResetPasswordDialog } from "@/components/ResetPasswordDialog";
+import { DeactivateUserDialog } from "@/components/DeactivateUserDialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { Spinner } from "@/components/ui/spinner";
 import {
   Table,
   TableBody,
@@ -25,68 +19,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Label } from "@/components/ui/label";
 
-const AVAILABLE_ROLES = ["Admin", "User"];
-
-const createUserSchema = z.object({
-  email: z.string().email("Please enter a valid email address"),
-  password: z.string().min(8, "Password must be at least 8 characters"),
-  role: z.string().min(1, "Role is required"),
-  firstName: z.string().optional(),
-  lastName: z.string().optional(),
-});
-
-type CreateUserFormValues = z.infer<typeof createUserSchema>;
-
-const editUserSchema = z.object({
-  email: z.string().email("Please enter a valid email address"),
-  role: z.string().min(1, "Role is required"),
-  isDisabled: z.boolean(),
-  firstName: z.string().optional(),
-  lastName: z.string().optional(),
-});
-
-type EditUserFormValues = z.infer<typeof editUserSchema>;
-
-const resetPasswordSchema = z.object({
-  newPassword: z.string().min(8, "Password must be at least 8 characters"),
-});
-
-type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;
+function formatDate(dateStr: string | null | undefined) {
+  if (!dateStr) return "-";
+  return new Date(dateStr).toLocaleDateString();
+}
 
 function AdminUsers() {
   usePageTitle("User Management");
@@ -96,20 +33,8 @@ function AdminUsers() {
   const pageSize = 20;
   const { data, isLoading } = useUsers(page, pageSize);
 
-  const createUser = useCreateUser();
-  const updateUser = useUpdateUser();
-  const deleteUser = useDeleteUser();
-  const resetPassword = useResetUserPassword();
-
   const [createOpen, setCreateOpen] = useState(false);
-  const [editUser, setEditUser] = useState<{
-    id: string;
-    email: string;
-    firstName?: string | null;
-    lastName?: string | null;
-    role: string;
-    isDisabled: boolean;
-  } | null>(null);
+  const [editUser, setEditUser] = useState<EditableUser | null>(null);
   const [resetUserId, setResetUserId] = useState<string | null>(null);
   const [deactivateUser, setDeactivateUser] = useState<{
     id: string;
@@ -127,63 +52,6 @@ function AdminUsers() {
     enabled: listItems.length > 0,
   });
 
-  const createForm = useForm<CreateUserFormValues>({
-    resolver: zodResolver(createUserSchema),
-    defaultValues: {
-      email: "",
-      password: "",
-      role: "User",
-      firstName: "",
-      lastName: "",
-    },
-  });
-
-  const editForm = useForm<EditUserFormValues>({
-    resolver: zodResolver(editUserSchema),
-  });
-
-  const resetForm = useForm<ResetPasswordFormValues>({
-    resolver: zodResolver(resetPasswordSchema),
-    defaultValues: { newPassword: "" },
-  });
-
-  async function onCreateSubmit(values: CreateUserFormValues) {
-    await createUser.mutateAsync({
-      email: values.email,
-      password: values.password,
-      role: values.role,
-      firstName: values.firstName || null,
-      lastName: values.lastName || null,
-    });
-    setCreateOpen(false);
-    createForm.reset();
-  }
-
-  async function onEditSubmit(values: EditUserFormValues) {
-    if (!editUser) return;
-    await updateUser.mutateAsync({
-      userId: editUser.id,
-      body: {
-        email: values.email,
-        role: values.role,
-        isDisabled: values.isDisabled,
-        firstName: values.firstName || null,
-        lastName: values.lastName || null,
-      },
-    });
-    setEditUser(null);
-  }
-
-  async function onResetSubmit(values: ResetPasswordFormValues) {
-    if (!resetUserId) return;
-    await resetPassword.mutateAsync({
-      userId: resetUserId,
-      newPassword: values.newPassword,
-    });
-    setResetUserId(null);
-    resetForm.reset();
-  }
-
   function openEdit(user: (typeof items)[0]) {
     const primaryRole = user.roles[0] ?? "User";
     setEditUser({
@@ -194,18 +62,6 @@ function AdminUsers() {
       role: primaryRole,
       isDisabled: user.isDisabled,
     });
-    editForm.reset({
-      email: user.email,
-      role: primaryRole,
-      isDisabled: user.isDisabled,
-      firstName: user.firstName ?? "",
-      lastName: user.lastName ?? "",
-    });
-  }
-
-  function formatDate(dateStr: string | null | undefined) {
-    if (!dateStr) return "-";
-    return new Date(dateStr).toLocaleDateString();
   }
 
   return (
@@ -349,330 +205,16 @@ function AdminUsers() {
         </>
       )}
 
-      {/* Create User Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create User</DialogTitle>
-            <DialogDescription>
-              Create a new user account. They will be required to change their
-              password on first login.
-            </DialogDescription>
-          </DialogHeader>
-          <Form {...createForm}>
-            <form
-              onSubmit={createForm.handleSubmit(onCreateSubmit)}
-              className="space-y-4"
-            >
-              <div className="grid grid-cols-2 gap-4">
-                <FormField
-                  control={createForm.control}
-                  name="firstName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>First Name</FormLabel>
-                      <FormControl>
-                        <Input placeholder="John" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={createForm.control}
-                  name="lastName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Last Name</FormLabel>
-                      <FormControl>
-                        <Input placeholder="Doe" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <FormField
-                control={createForm.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="email"
-                        placeholder="name@example.com"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={createForm.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Password</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="password"
-                        placeholder="At least 8 characters"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={createForm.control}
-                name="role"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Role</FormLabel>
-                    <Select
-                      onValueChange={field.onChange}
-                      defaultValue={field.value}
-                    >
-                      <FormControl>
-                        <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Select a role" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {AVAILABLE_ROLES.map((role) => (
-                          <SelectItem key={role} value={role}>
-                            {role}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <DialogFooter>
-                <Button
-                  type="submit"
-                  disabled={createForm.formState.isSubmitting}
-                >
-                  {createForm.formState.isSubmitting && <Spinner size="sm" />}
-                  {createForm.formState.isSubmitting
-                    ? "Creating..."
-                    : "Create User"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-
-      {/* Edit User Dialog */}
-      <Dialog open={!!editUser} onOpenChange={() => setEditUser(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit User</DialogTitle>
-            <DialogDescription>
-              Update user details, role, and account status.
-            </DialogDescription>
-          </DialogHeader>
-          <Form {...editForm}>
-            <form
-              onSubmit={editForm.handleSubmit(onEditSubmit)}
-              className="space-y-4"
-            >
-              <div className="grid grid-cols-2 gap-4">
-                <FormField
-                  control={editForm.control}
-                  name="firstName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>First Name</FormLabel>
-                      <FormControl>
-                        <Input placeholder="John" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={editForm.control}
-                  name="lastName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Last Name</FormLabel>
-                      <FormControl>
-                        <Input placeholder="Doe" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <FormField
-                control={editForm.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input type="email" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={editForm.control}
-                name="role"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Role</FormLabel>
-                    <Select
-                      onValueChange={field.onChange}
-                      value={field.value}
-                    >
-                      <FormControl>
-                        <SelectTrigger className="w-full">
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {AVAILABLE_ROLES.map((role) => (
-                          <SelectItem key={role} value={role}>
-                            {role}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={editForm.control}
-                name="isDisabled"
-                render={({ field }) => (
-                  <FormItem>
-                    <div className="flex items-center gap-3">
-                      <FormControl>
-                        <input
-                          type="checkbox"
-                          checked={field.value}
-                          onChange={field.onChange}
-                          className="h-4 w-4 rounded border-gray-300"
-                          aria-label="Disable account"
-                        />
-                      </FormControl>
-                      <Label>Account Disabled</Label>
-                    </div>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <DialogFooter>
-                <Button
-                  type="submit"
-                  disabled={editForm.formState.isSubmitting}
-                >
-                  {editForm.formState.isSubmitting && <Spinner size="sm" />}
-                  {editForm.formState.isSubmitting
-                    ? "Saving..."
-                    : "Save Changes"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-
-      {/* Reset Password Dialog */}
-      <Dialog
-        open={!!resetUserId}
-        onOpenChange={() => {
-          setResetUserId(null);
-          resetForm.reset();
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Reset Password</DialogTitle>
-            <DialogDescription>
-              Set a new password for this user. They will be required to change
-              it on their next login.
-            </DialogDescription>
-          </DialogHeader>
-          <Form {...resetForm}>
-            <form
-              onSubmit={resetForm.handleSubmit(onResetSubmit)}
-              className="space-y-4"
-            >
-              <FormField
-                control={resetForm.control}
-                name="newPassword"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>New Password</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="password"
-                        placeholder="At least 8 characters"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <DialogFooter>
-                <Button
-                  type="submit"
-                  disabled={resetForm.formState.isSubmitting}
-                >
-                  {resetForm.formState.isSubmitting && <Spinner size="sm" />}
-                  {resetForm.formState.isSubmitting
-                    ? "Resetting..."
-                    : "Reset Password"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-
-      {/* Deactivate Confirmation */}
-      <AlertDialog
-        open={!!deactivateUser}
-        onOpenChange={() => setDeactivateUser(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Deactivate User</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to deactivate{" "}
-              <span className="font-semibold">{deactivateUser?.email}</span>?
-              They will no longer be able to log in.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={async () => {
-                if (deactivateUser) {
-                  await deleteUser.mutateAsync(deactivateUser.id);
-                  setDeactivateUser(null);
-                }
-              }}
-            >
-              {deleteUser.isPending && <Spinner size="sm" />}
-              Deactivate
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <CreateUserDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <EditUserDialog user={editUser} onClose={() => setEditUser(null)} />
+      <ResetPasswordDialog
+        userId={resetUserId}
+        onClose={() => setResetUserId(null)}
+      />
+      <DeactivateUserDialog
+        user={deactivateUser}
+        onClose={() => setDeactivateUser(null)}
+      />
     </div>
   );
 }

--- a/src/client/src/pages/ApiKeys.tsx
+++ b/src/client/src/pages/ApiKeys.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
+import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import client from "@/lib/api-client";
-import { showSuccess, showError } from "@/lib/toast";
+import { CreateApiKeyDialog } from "@/components/CreateApiKeyDialog";
+import { CreatedKeyDialog } from "@/components/CreatedKeyDialog";
+import { RevokeApiKeyDialog } from "@/components/RevokeApiKeyDialog";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -14,25 +15,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
-import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import {
   Table,
   TableBody,
@@ -42,14 +24,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { Spinner } from "@/components/ui/spinner";
-
-const createKeySchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  expiresAt: z.string().optional(),
-});
-
-type CreateKeyFormValues = z.infer<typeof createKeySchema>;
 
 function getKeyStatus(key: {
   isRevoked: boolean;
@@ -80,7 +54,6 @@ function formatDate(dateStr: string | null | undefined): string {
 
 function ApiKeys() {
   usePageTitle("API Keys");
-  const queryClient = useQueryClient();
   const [createOpen, setCreateOpen] = useState(false);
   const [createdKey, setCreatedKey] = useState<string | null>(null);
   const [revokeId, setRevokeId] = useState<string | null>(null);
@@ -96,77 +69,13 @@ function ApiKeys() {
     },
   });
 
-  const createMutation = useMutation({
-    mutationFn: async (values: CreateKeyFormValues) => {
-      const { data, error } = await client.POST("/api/apikeys", {
-        body: {
-          name: values.name,
-          expiresAt: values.expiresAt || undefined,
-        },
-      });
-      if (error) throw error;
-      return data;
-    },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ["apiKeys"] });
-      if (data) {
-        setCreatedKey(data.rawKey);
-      }
-      setCreateOpen(false);
-    },
-    onError: () => {
-      showError("Failed to create API key.");
-    },
-  });
-
-  const revokeMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const { error } = await client.DELETE("/api/apikeys/{id}", {
-        params: { path: { id } },
-      });
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["apiKeys"] });
-      showSuccess("API key revoked.");
-      setRevokeId(null);
-    },
-    onError: () => {
-      showError("Failed to revoke API key.");
-    },
-  });
-
-  const createForm = useForm<CreateKeyFormValues>({
-    resolver: zodResolver(createKeySchema),
-    defaultValues: { name: "", expiresAt: "" },
-  });
-
-  function handleCreateOpen() {
-    createForm.reset();
-    setCreateOpen(true);
-  }
-
   useEffect(() => {
     function onNewItem() {
-      handleCreateOpen();
+      setCreateOpen(true);
     }
     window.addEventListener("shortcut:new-item", onNewItem);
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   });
-
-  function handleCreateSubmit(values: CreateKeyFormValues) {
-    createMutation.mutate(values);
-  }
-
-  async function handleCopyKey() {
-    if (!createdKey) return;
-    try {
-      await navigator.clipboard.writeText(createdKey);
-      showSuccess("API key copied to clipboard.");
-    } catch {
-      showError("Failed to copy to clipboard.");
-    }
-  }
 
   const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
     items: apiKeys as { id: string }[],
@@ -183,7 +92,7 @@ function ApiKeys() {
             Manage API keys for programmatic access
           </p>
         </div>
-        <Button onClick={handleCreateOpen}>Create API Key</Button>
+        <Button onClick={() => setCreateOpen(true)}>Create API Key</Button>
       </div>
 
       <Card>
@@ -203,175 +112,79 @@ function ApiKeys() {
             </p>
           ) : (
             <div ref={tableRef}>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead>Last Used</TableHead>
-                  <TableHead>Expires</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {apiKeys.map((key, index) => {
-                  const status = getKeyStatus(key);
-                  return (
-                    <TableRow
-                      key={key.id}
-                      className={`cursor-pointer ${focusedId === key.id ? "bg-accent" : ""}`}
-                      onClick={(e) => {
-                        if ((e.target as HTMLElement).closest("button, input, a, [role='button']")) return;
-                        setFocusedIndex(index);
-                      }}
-                    >
-                      <TableCell className="font-medium">{key.name}</TableCell>
-                      <TableCell>{formatDate(key.createdAt)}</TableCell>
-                      <TableCell>{formatDate(key.lastUsedAt)}</TableCell>
-                      <TableCell>{formatDate(key.expiresAt)}</TableCell>
-                      <TableCell>
-                        <Badge variant={statusBadgeVariant(status)}>
-                          {status}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {status === "active" && (
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => setRevokeId(key.id)}
-                          >
-                            Revoke
-                          </Button>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Created</TableHead>
+                    <TableHead>Last Used</TableHead>
+                    <TableHead>Expires</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {apiKeys.map((key, index) => {
+                    const status = getKeyStatus(key);
+                    return (
+                      <TableRow
+                        key={key.id}
+                        className={`cursor-pointer ${focusedId === key.id ? "bg-accent" : ""}`}
+                        onClick={(e) => {
+                          if (
+                            (e.target as HTMLElement).closest(
+                              "button, input, a, [role='button']",
+                            )
+                          )
+                            return;
+                          setFocusedIndex(index);
+                        }}
+                      >
+                        <TableCell className="font-medium">
+                          {key.name}
+                        </TableCell>
+                        <TableCell>{formatDate(key.createdAt)}</TableCell>
+                        <TableCell>{formatDate(key.lastUsedAt)}</TableCell>
+                        <TableCell>{formatDate(key.expiresAt)}</TableCell>
+                        <TableCell>
+                          <Badge variant={statusBadgeVariant(status)}>
+                            {status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {status === "active" && (
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => setRevokeId(key.id)}
+                            >
+                              Revoke
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
             </div>
           )}
         </CardContent>
       </Card>
 
-      {/* Create API Key Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create API Key</DialogTitle>
-            <DialogDescription>
-              Generate a new API key for programmatic access.
-            </DialogDescription>
-          </DialogHeader>
-          <Form {...createForm}>
-            <form
-              onSubmit={createForm.handleSubmit(handleCreateSubmit)}
-              className="space-y-4"
-            >
-              <FormField
-                control={createForm.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Name</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder="e.g. Paperless Integration"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={createForm.control}
-                name="expiresAt"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Expiration Date (optional)</FormLabel>
-                    <FormControl>
-                      <Input type="date" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <Button
-                type="submit"
-                className="w-full"
-                disabled={createMutation.isPending}
-              >
-                {createMutation.isPending && <Spinner size="sm" />}
-                {createMutation.isPending ? "Creating..." : "Create Key"}
-              </Button>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-
-      {/* Created Key Display Dialog */}
-      <Dialog
-        open={createdKey !== null}
-        onOpenChange={(open) => {
-          if (!open) setCreatedKey(null);
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>API Key Created</DialogTitle>
-          </DialogHeader>
-          <Alert>
-            <AlertDescription>
-              Save this key now. You won&apos;t be able to see it again.
-            </AlertDescription>
-          </Alert>
-          <Input
-            readOnly
-            value={createdKey ?? ""}
-            onClick={(e) => (e.target as HTMLInputElement).select()}
-            className="font-mono text-sm"
-          />
-          <Button onClick={handleCopyKey} className="w-full">
-            Copy to Clipboard
-          </Button>
-        </DialogContent>
-      </Dialog>
-
-      {/* Revoke Confirmation Dialog */}
-      <Dialog
-        open={revokeId !== null}
-        onOpenChange={(open) => {
-          if (!open) setRevokeId(null);
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Revoke API Key</DialogTitle>
-            <DialogDescription>
-              This action cannot be undone. The API key will be immediately
-              invalidated.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex gap-2 justify-end">
-            <Button variant="outline" onClick={() => setRevokeId(null)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={revokeMutation.isPending}
-              onClick={() => {
-                if (revokeId) revokeMutation.mutate(revokeId);
-              }}
-            >
-              {revokeMutation.isPending && <Spinner size="sm" />}
-              {revokeMutation.isPending ? "Revoking..." : "Revoke"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <CreateApiKeyDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onKeyCreated={setCreatedKey}
+      />
+      <CreatedKeyDialog
+        rawKey={createdKey}
+        onClose={() => setCreatedKey(null)}
+      />
+      <RevokeApiKeyDialog
+        keyId={revokeId}
+        onClose={() => setRevokeId(null)}
+      />
     </div>
   );
 }

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -1,29 +1,18 @@
 import { useState, useMemo, useEffect } from "react";
-import {
-  useCategories,
-  useCreateCategory,
-  useUpdateCategory,
-  useDeleteCategories,
-} from "@/hooks/useCategories";
+import { useCategories } from "@/hooks/useCategories";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
 import { usePagination } from "@/hooks/usePagination";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import type { FuseSearchConfig } from "@/lib/search";
-import { CategoryForm } from "@/components/CategoryForm";
+import { CategoryDialogs } from "@/components/CategoryDialogs";
 import { FuzzySearchInput } from "@/components/FuzzySearchInput";
 import { SearchHighlight } from "@/components/SearchHighlight";
 import { getMatchIndices } from "@/lib/search-highlight";
 import { NoResults } from "@/components/NoResults";
 import { Pagination } from "@/components/Pagination";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import {
   Table,
   TableBody,
@@ -33,7 +22,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { Spinner } from "@/components/ui/spinner";
 
 interface CategoryResponse {
   id: string;
@@ -51,9 +39,6 @@ const SEARCH_CONFIG: FuseSearchConfig<CategoryResponse> = {
 function Categories() {
   usePageTitle("Categories");
   const { data: categories, isLoading } = useCategories();
-  const createCategory = useCreateCategory();
-  const updateCategory = useUpdateCategory();
-  const deleteCategories = useDeleteCategories();
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [createOpen, setCreateOpen] = useState(false);
@@ -262,84 +247,19 @@ function Categories() {
         </>
       )}
 
-      {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Category</DialogTitle>
-          </DialogHeader>
-          <CategoryForm
-            mode="create"
-            isSubmitting={createCategory.isPending}
-            onCancel={() => setCreateOpen(false)}
-            onSubmit={(values) => {
-              createCategory.mutate(values, {
-                onSuccess: () => setCreateOpen(false),
-              });
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-
-      {/* Edit Dialog */}
-      <Dialog
-        open={editCategory !== null}
-        onOpenChange={(open) => !open && setEditCategory(null)}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Category</DialogTitle>
-          </DialogHeader>
-          {editCategory && (
-            <CategoryForm
-              mode="edit"
-              defaultValues={{
-                name: editCategory.name,
-                description: editCategory.description ?? "",
-              }}
-              isSubmitting={updateCategory.isPending}
-              onCancel={() => setEditCategory(null)}
-              onSubmit={(values) => {
-                updateCategory.mutate(
-                  { id: editCategory.id, ...values },
-                  { onSuccess: () => setEditCategory(null) },
-                );
-              }}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Categories</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Are you sure you want to delete {selected.size} category(ies)? This
-            action can be undone by restoring.
-          </p>
-          <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={deleteCategories.isPending}
-              onClick={() => {
-                const ids = [...selected];
-                setSelected(new Set());
-                setDeleteOpen(false);
-                deleteCategories.mutate(ids);
-              }}
-            >
-              {deleteCategories.isPending && <Spinner size="sm" />}
-              {deleteCategories.isPending ? "Deleting..." : "Delete"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <CategoryDialogs
+        createOpen={createOpen}
+        onCreateOpenChange={setCreateOpen}
+        editCategory={editCategory}
+        onEditClose={() => setEditCategory(null)}
+        deleteOpen={deleteOpen}
+        onDeleteOpenChange={setDeleteOpen}
+        selectedIds={[...selected]}
+        onDeleteComplete={() => {
+          setSelected(new Set());
+          setDeleteOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -1,17 +1,12 @@
 import { useState, useMemo, useEffect } from "react";
-import {
-  useItemTemplates,
-  useCreateItemTemplate,
-  useUpdateItemTemplate,
-  useDeleteItemTemplates,
-} from "@/hooks/useItemTemplates";
+import { useItemTemplates } from "@/hooks/useItemTemplates";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
 import { usePagination } from "@/hooks/usePagination";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import type { FuseSearchConfig } from "@/lib/search";
-import { ItemTemplateForm } from "@/components/ItemTemplateForm";
+import { ItemTemplateDialogs } from "@/components/ItemTemplateDialogs";
 import { FuzzySearchInput } from "@/components/FuzzySearchInput";
 import { SearchHighlight } from "@/components/SearchHighlight";
 import { getMatchIndices } from "@/lib/search-highlight";
@@ -19,12 +14,6 @@ import { NoResults } from "@/components/NoResults";
 import { Pagination } from "@/components/Pagination";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import {
   Table,
   TableBody,
@@ -34,7 +23,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { Spinner } from "@/components/ui/spinner";
 
 interface ItemTemplateResponse {
   id: string;
@@ -60,9 +48,6 @@ const SEARCH_CONFIG: FuseSearchConfig<ItemTemplateResponse> = {
 function ItemTemplates() {
   usePageTitle("Item Templates");
   const { data: itemTemplates, isLoading } = useItemTemplates();
-  const createItemTemplate = useCreateItemTemplate();
-  const updateItemTemplate = useUpdateItemTemplate();
-  const deleteItemTemplates = useDeleteItemTemplates();
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [createOpen, setCreateOpen] = useState(false);
@@ -293,107 +278,19 @@ function ItemTemplates() {
         </>
       )}
 
-      {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>Create Item Template</DialogTitle>
-          </DialogHeader>
-          <ItemTemplateForm
-            mode="create"
-            isSubmitting={createItemTemplate.isPending}
-            onCancel={() => setCreateOpen(false)}
-            onSubmit={(values) => {
-              createItemTemplate.mutate(
-                {
-                  name: values.name,
-                  description: values.description || null,
-                  defaultCategory: values.defaultCategory || null,
-                  defaultSubcategory: values.defaultSubcategory || null,
-                  defaultUnitPrice: values.defaultUnitPrice ?? null,
-                  defaultPricingMode: values.defaultPricingMode || null,
-                  defaultItemCode: values.defaultItemCode || null,
-                },
-                { onSuccess: () => setCreateOpen(false) },
-              );
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-
-      {/* Edit Dialog */}
-      <Dialog
-        open={editTemplate !== null}
-        onOpenChange={(open) => !open && setEditTemplate(null)}
-      >
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>Edit Item Template</DialogTitle>
-          </DialogHeader>
-          {editTemplate && (
-            <ItemTemplateForm
-              mode="edit"
-              defaultValues={{
-                name: editTemplate.name,
-                description: editTemplate.description ?? "",
-                defaultCategory: editTemplate.defaultCategory ?? "",
-                defaultSubcategory: editTemplate.defaultSubcategory ?? "",
-                defaultUnitPrice: editTemplate.defaultUnitPrice ?? undefined,
-                defaultPricingMode: editTemplate.defaultPricingMode ?? "",
-                defaultItemCode: editTemplate.defaultItemCode ?? "",
-              }}
-              isSubmitting={updateItemTemplate.isPending}
-              onCancel={() => setEditTemplate(null)}
-              onSubmit={(values) => {
-                updateItemTemplate.mutate(
-                  {
-                    id: editTemplate.id,
-                    name: values.name,
-                    description: values.description || null,
-                    defaultCategory: values.defaultCategory || null,
-                    defaultSubcategory: values.defaultSubcategory || null,
-                    defaultUnitPrice: values.defaultUnitPrice ?? null,
-                    defaultPricingMode: values.defaultPricingMode || null,
-                    defaultItemCode: values.defaultItemCode || null,
-                  },
-                  { onSuccess: () => setEditTemplate(null) },
-                );
-              }}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Item Templates</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Are you sure you want to delete {selected.size} item template(s)?
-            This action can be undone by restoring.
-          </p>
-          <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={deleteItemTemplates.isPending}
-              onClick={() => {
-                const ids = [...selected];
-                setSelected(new Set());
-                setDeleteOpen(false);
-                deleteItemTemplates.mutate(ids);
-              }}
-            >
-              {deleteItemTemplates.isPending && <Spinner size="sm" />}
-              {deleteItemTemplates.isPending ? "Deleting..." : "Delete"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <ItemTemplateDialogs
+        createOpen={createOpen}
+        onCreateOpenChange={setCreateOpen}
+        editTemplate={editTemplate}
+        onEditClose={() => setEditTemplate(null)}
+        deleteOpen={deleteOpen}
+        onDeleteOpenChange={setDeleteOpen}
+        selectedIds={[...selected]}
+        onDeleteComplete={() => {
+          setSelected(new Set());
+          setDeleteOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/client/src/pages/ReceiptItems.tsx
+++ b/src/client/src/pages/ReceiptItems.tsx
@@ -1,10 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
-import {
-  useReceiptItems,
-  useCreateReceiptItem,
-  useUpdateReceiptItem,
-  useDeleteReceiptItems,
-} from "@/hooks/useReceiptItems";
+import { useReceiptItems } from "@/hooks/useReceiptItems";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
@@ -13,7 +8,7 @@ import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import type { FuseSearchConfig, FilterDefinition } from "@/lib/search";
 import { applyFilters } from "@/lib/search";
 import type { FilterValues } from "@/components/FilterPanel";
-import { ReceiptItemForm } from "@/components/ReceiptItemForm";
+import { ReceiptItemDialogs } from "@/components/ReceiptItemDialogs";
 import { FuzzySearchInput } from "@/components/FuzzySearchInput";
 import { FilterPanel } from "@/components/FilterPanel";
 import type { FilterField } from "@/components/FilterPanel";
@@ -22,12 +17,6 @@ import { getMatchIndices } from "@/lib/search-highlight";
 import { NoResults } from "@/components/NoResults";
 import { Pagination } from "@/components/Pagination";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import {
   Table,
   TableBody,
@@ -38,7 +27,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
 
 interface ReceiptItemResponse {
@@ -70,9 +58,6 @@ const FILTER_DEFS: FilterDefinition[] = [
 function ReceiptItems() {
   usePageTitle("Receipt Items");
   const { data: items, isLoading } = useReceiptItems();
-  const createItem = useCreateReceiptItem();
-  const updateItem = useUpdateReceiptItem();
-  const deleteItems = useDeleteReceiptItems();
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [createOpen, setCreateOpen] = useState(false);
@@ -177,10 +162,7 @@ function ReceiptItems() {
     items: paginatedItems,
     getId: (item) => item.id,
     enabled: !anyDialogOpen,
-    onOpen: (item) => {
-      setEditItem(item);
-      setEditReceiptId(item.receiptId);
-    },
+    onOpen: (item) => setEditItem(item),
     onDelete: () => setDeleteOpen(true),
     onSelectAll: () =>
       setSelected(new Set(paginatedItems.map((item) => item.id))),
@@ -337,10 +319,7 @@ function ReceiptItems() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => {
-                            setEditItem(item);
-                            setEditReceiptId(item.receiptId);
-                          }}
+                          onClick={() => setEditItem(item)}
                         >
                           Edit
                         </Button>
@@ -373,95 +352,19 @@ function ReceiptItems() {
         </>
       )}
 
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Receipt Item</DialogTitle>
-          </DialogHeader>
-          <ReceiptItemForm
-            mode="create"
-            isSubmitting={createItem.isPending}
-            onCancel={() => setCreateOpen(false)}
-            onSubmit={(values) => {
-              const { receiptId, ...body } = values;
-              createItem.mutate(
-                { receiptId, body },
-                { onSuccess: () => setCreateOpen(false) },
-              );
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
-        open={editItem !== null}
-        onOpenChange={(open) => {
-          if (!open) setEditItem(null);
+      <ReceiptItemDialogs
+        createOpen={createOpen}
+        onCreateOpenChange={setCreateOpen}
+        editItem={editItem}
+        onEditClose={() => setEditItem(null)}
+        deleteOpen={deleteOpen}
+        onDeleteOpenChange={setDeleteOpen}
+        selectedIds={[...selected]}
+        onDeleteComplete={() => {
+          setSelected(new Set());
+          setDeleteOpen(false);
         }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Receipt Item</DialogTitle>
-          </DialogHeader>
-          {editItem && (
-            <ReceiptItemForm
-              mode="edit"
-              defaultValues={{
-                receiptId: editItem.receiptId,
-                receiptItemCode: editItem.receiptItemCode,
-                description: editItem.description,
-                pricingMode: editItem.pricingMode ?? "quantity",
-                quantity: editItem.quantity,
-                unitPrice: editItem.unitPrice,
-                category: editItem.category,
-                subcategory: editItem.subcategory,
-              }}
-              isSubmitting={updateItem.isPending}
-              onCancel={() => setEditItem(null)}
-              onSubmit={(values) => {
-                const { receiptId, ...rest } = values;
-                updateItem.mutate(
-                  {
-                    receiptId,
-                    body: { id: editItem.id, ...rest },
-                  },
-                  { onSuccess: () => setEditItem(null) },
-                );
-              }}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Receipt Items</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Are you sure you want to delete {selected.size} item(s)? This action
-            can be undone by restoring.
-          </p>
-          <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={deleteItems.isPending}
-              onClick={() => {
-                const ids = [...selected];
-                setSelected(new Set());
-                setDeleteOpen(false);
-                deleteItems.mutate(ids);
-              }}
-            >
-              {deleteItems.isPending && <Spinner size="sm" />}
-              {deleteItems.isPending ? "Deleting..." : "Delete"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      />
     </div>
   );
 }

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -1,10 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
-import {
-  useReceipts,
-  useCreateReceipt,
-  useUpdateReceipt,
-  useDeleteReceipts,
-} from "@/hooks/useReceipts";
+import { useReceipts } from "@/hooks/useReceipts";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
@@ -13,7 +8,7 @@ import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import type { FuseSearchConfig, FilterDefinition } from "@/lib/search";
 import { applyFilters } from "@/lib/search";
 import type { FilterValues } from "@/components/FilterPanel";
-import { ReceiptForm } from "@/components/ReceiptForm";
+import { ReceiptDialogs } from "@/components/ReceiptDialogs";
 import { FuzzySearchInput } from "@/components/FuzzySearchInput";
 import { FilterPanel } from "@/components/FilterPanel";
 import type { FilterField } from "@/components/FilterPanel";
@@ -23,12 +18,6 @@ import { NoResults } from "@/components/NoResults";
 import { Pagination } from "@/components/Pagination";
 import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Table,
   TableBody,
   TableCell,
@@ -37,7 +26,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
 
 interface ReceiptResponse {
@@ -68,9 +56,6 @@ const FILTER_DEFS: FilterDefinition[] = [
 function Receipts() {
   usePageTitle("Receipts");
   const { data: receipts, isLoading } = useReceipts();
-  const createReceipt = useCreateReceipt();
-  const updateReceipt = useUpdateReceipt();
-  const deleteReceipts = useDeleteReceipts();
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [createOpen, setCreateOpen] = useState(false);
@@ -314,91 +299,19 @@ function Receipts() {
         </>
       )}
 
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Receipt</DialogTitle>
-          </DialogHeader>
-          <ReceiptForm
-            mode="create"
-            isSubmitting={createReceipt.isPending}
-            onCancel={() => setCreateOpen(false)}
-            onSubmit={(values) => {
-              createReceipt.mutate(
-                {
-                  ...values,
-                  description: values.description || null,
-                },
-                { onSuccess: () => setCreateOpen(false) },
-              );
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
-        open={editReceipt !== null}
-        onOpenChange={(open) => !open && setEditReceipt(null)}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Receipt</DialogTitle>
-          </DialogHeader>
-          {editReceipt && (
-            <ReceiptForm
-              mode="edit"
-              defaultValues={{
-                description: editReceipt.description ?? "",
-                location: editReceipt.location,
-                date: editReceipt.date,
-                taxAmount: editReceipt.taxAmount,
-              }}
-              isSubmitting={updateReceipt.isPending}
-              onCancel={() => setEditReceipt(null)}
-              onSubmit={(values) => {
-                updateReceipt.mutate(
-                  {
-                    id: editReceipt.id,
-                    ...values,
-                    description: values.description || null,
-                  },
-                  { onSuccess: () => setEditReceipt(null) },
-                );
-              }}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Receipts</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Are you sure you want to delete {selected.size} receipt(s)? This
-            action can be undone by restoring.
-          </p>
-          <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={deleteReceipts.isPending}
-              onClick={() => {
-                const ids = [...selected];
-                setSelected(new Set());
-                setDeleteOpen(false);
-                deleteReceipts.mutate(ids);
-              }}
-            >
-              {deleteReceipts.isPending && <Spinner size="sm" />}
-              {deleteReceipts.isPending ? "Deleting..." : "Delete"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <ReceiptDialogs
+        createOpen={createOpen}
+        onCreateOpenChange={setCreateOpen}
+        editReceipt={editReceipt}
+        onEditClose={() => setEditReceipt(null)}
+        deleteOpen={deleteOpen}
+        onDeleteOpenChange={setDeleteOpen}
+        selectedIds={[...selected]}
+        onDeleteComplete={() => {
+          setSelected(new Set());
+          setDeleteOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -1,10 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
-import {
-  useSubcategories,
-  useCreateSubcategory,
-  useUpdateSubcategory,
-  useDeleteSubcategories,
-} from "@/hooks/useSubcategories";
+import { useSubcategories } from "@/hooks/useSubcategories";
 import { useCategories } from "@/hooks/useCategories";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
@@ -14,7 +9,7 @@ import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import type { FuseSearchConfig, FilterDefinition } from "@/lib/search";
 import { applyFilters } from "@/lib/search";
 import type { FilterValues } from "@/components/FilterPanel";
-import { SubcategoryForm } from "@/components/SubcategoryForm";
+import { SubcategoryDialogs } from "@/components/SubcategoryDialogs";
 import { FuzzySearchInput } from "@/components/FuzzySearchInput";
 import { FilterPanel } from "@/components/FilterPanel";
 import type { FilterField } from "@/components/FilterPanel";
@@ -24,12 +19,6 @@ import { NoResults } from "@/components/NoResults";
 import { Pagination } from "@/components/Pagination";
 import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Table,
   TableBody,
   TableCell,
@@ -38,7 +27,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { Spinner } from "@/components/ui/spinner";
 
 interface SubcategoryResponse {
   id: string;
@@ -64,9 +52,6 @@ function Subcategories() {
   const { data: subcategories, isLoading: subcategoriesLoading } =
     useSubcategories();
   const { data: categories, isLoading: categoriesLoading } = useCategories();
-  const createSubcategory = useCreateSubcategory();
-  const updateSubcategory = useUpdateSubcategory();
-  const deleteSubcategories = useDeleteSubcategories();
 
   const isLoading = subcategoriesLoading || categoriesLoading;
 
@@ -351,85 +336,19 @@ function Subcategories() {
         </>
       )}
 
-      {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Subcategory</DialogTitle>
-          </DialogHeader>
-          <SubcategoryForm
-            mode="create"
-            isSubmitting={createSubcategory.isPending}
-            onCancel={() => setCreateOpen(false)}
-            onSubmit={(values) => {
-              createSubcategory.mutate(values, {
-                onSuccess: () => setCreateOpen(false),
-              });
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-
-      {/* Edit Dialog */}
-      <Dialog
-        open={editSubcategory !== null}
-        onOpenChange={(open) => !open && setEditSubcategory(null)}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Subcategory</DialogTitle>
-          </DialogHeader>
-          {editSubcategory && (
-            <SubcategoryForm
-              mode="edit"
-              defaultValues={{
-                name: editSubcategory.name,
-                categoryId: editSubcategory.categoryId,
-                description: editSubcategory.description ?? "",
-              }}
-              isSubmitting={updateSubcategory.isPending}
-              onCancel={() => setEditSubcategory(null)}
-              onSubmit={(values) => {
-                updateSubcategory.mutate(
-                  { id: editSubcategory.id, ...values },
-                  { onSuccess: () => setEditSubcategory(null) },
-                );
-              }}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Subcategories</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Are you sure you want to delete {selected.size} subcategory(ies)?
-            This action can be undone by restoring.
-          </p>
-          <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={deleteSubcategories.isPending}
-              onClick={() => {
-                const ids = [...selected];
-                setSelected(new Set());
-                setDeleteOpen(false);
-                deleteSubcategories.mutate(ids);
-              }}
-            >
-              {deleteSubcategories.isPending && <Spinner size="sm" />}
-              {deleteSubcategories.isPending ? "Deleting..." : "Delete"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <SubcategoryDialogs
+        createOpen={createOpen}
+        onCreateOpenChange={setCreateOpen}
+        editSubcategory={editSubcategory}
+        onEditClose={() => setEditSubcategory(null)}
+        deleteOpen={deleteOpen}
+        onDeleteOpenChange={setDeleteOpen}
+        selectedIds={[...selected]}
+        onDeleteComplete={() => {
+          setSelected(new Set());
+          setDeleteOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -1,10 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
-import {
-  useTransactions,
-  useCreateTransaction,
-  useUpdateTransaction,
-  useDeleteTransactions,
-} from "@/hooks/useTransactions";
+import { useTransactions } from "@/hooks/useTransactions";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
@@ -13,7 +8,7 @@ import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import type { FuseSearchConfig, FilterDefinition } from "@/lib/search";
 import { applyFilters } from "@/lib/search";
 import type { FilterValues } from "@/components/FilterPanel";
-import { TransactionForm } from "@/components/TransactionForm";
+import { TransactionDialogs } from "@/components/TransactionDialogs";
 import { FuzzySearchInput } from "@/components/FuzzySearchInput";
 import { FilterPanel } from "@/components/FilterPanel";
 import type { FilterField } from "@/components/FilterPanel";
@@ -23,12 +18,6 @@ import { NoResults } from "@/components/NoResults";
 import { Pagination } from "@/components/Pagination";
 import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Table,
   TableBody,
   TableCell,
@@ -37,7 +26,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
 
 interface TransactionResponse {
@@ -65,9 +53,6 @@ const FILTER_DEFS: FilterDefinition[] = [
 function Transactions() {
   usePageTitle("Transactions");
   const { data: transactions, isLoading } = useTransactions();
-  const createTransaction = useCreateTransaction();
-  const updateTransaction = useUpdateTransaction();
-  const deleteTransactions = useDeleteTransactions();
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [createOpen, setCreateOpen] = useState(false);
@@ -146,11 +131,7 @@ function Transactions() {
     items: paginatedItems,
     getId: (t) => t.id,
     enabled: !anyDialogOpen,
-    onOpen: (t) => {
-      setEditTransaction(t);
-      setEditReceiptId(t.receiptId);
-      setEditAccountId(t.accountId);
-    },
+    onOpen: (t) => setEditTransaction(t),
     onDelete: () => setDeleteOpen(true),
     onSelectAll: () =>
       setSelected(new Set(paginatedItems.map((t) => t.id))),
@@ -277,11 +258,7 @@ function Transactions() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => {
-                            setEditTransaction(txn);
-                            setEditReceiptId(txn.receiptId);
-                            setEditAccountId(txn.accountId);
-                          }}
+                          onClick={() => setEditTransaction(txn)}
                         >
                           Edit
                         </Button>
@@ -303,98 +280,19 @@ function Transactions() {
         </>
       )}
 
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Transaction</DialogTitle>
-          </DialogHeader>
-          <TransactionForm
-            mode="create"
-            isSubmitting={createTransaction.isPending}
-            onCancel={() => setCreateOpen(false)}
-            onSubmit={(values) => {
-              createTransaction.mutate(
-                {
-                  receiptId: values.receiptId,
-                  accountId: values.accountId,
-                  body: { amount: values.amount, date: values.date },
-                },
-                { onSuccess: () => setCreateOpen(false) },
-              );
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
-        open={editTransaction !== null}
-        onOpenChange={(open) => {
-          if (!open) setEditTransaction(null);
+      <TransactionDialogs
+        createOpen={createOpen}
+        onCreateOpenChange={setCreateOpen}
+        editTransaction={editTransaction}
+        onEditClose={() => setEditTransaction(null)}
+        deleteOpen={deleteOpen}
+        onDeleteOpenChange={setDeleteOpen}
+        selectedIds={[...selected]}
+        onDeleteComplete={() => {
+          setSelected(new Set());
+          setDeleteOpen(false);
         }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Transaction</DialogTitle>
-          </DialogHeader>
-          {editTransaction && (
-            <TransactionForm
-              mode="edit"
-              defaultValues={{
-                receiptId: editTransaction.receiptId,
-                accountId: editTransaction.accountId,
-                amount: editTransaction.amount,
-                date: editTransaction.date,
-              }}
-              isSubmitting={updateTransaction.isPending}
-              onCancel={() => setEditTransaction(null)}
-              onSubmit={(values) => {
-                updateTransaction.mutate(
-                  {
-                    receiptId: values.receiptId,
-                    accountId: values.accountId,
-                    body: {
-                      id: editTransaction.id,
-                      amount: values.amount,
-                      date: values.date,
-                    },
-                  },
-                  { onSuccess: () => setEditTransaction(null) },
-                );
-              }}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Transactions</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Are you sure you want to delete {selected.size} transaction(s)? This
-            action can be undone by restoring.
-          </p>
-          <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={deleteTransactions.isPending}
-              onClick={() => {
-                const ids = [...selected];
-                setSelected(new Set());
-                setDeleteOpen(false);
-                deleteTransactions.mutate(ids);
-              }}
-            >
-              {deleteTransactions.isPending && <Spinner size="sm" />}
-              {deleteTransactions.isPending ? "Deleting..." : "Delete"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extract CRUD dialog logic from 9 page components into 14 dedicated dialog components, reducing page sizes by 23% overall (AdminUsers -67%, ApiKeys -49%)
- Fix undefined function references (`setEditReceiptId`, `setEditAccountId`) in ReceiptItems and Transactions pages
- Move `navigationMenuTriggerStyle` to separate module to resolve ESLint `react-refresh/only-export-components` violation

## Test plan
- [x] All 73 existing tests pass (10 test files)
- [x] TypeScript `tsc --noEmit` clean
- [x] ESLint clean (0 errors, 0 warnings)
- [x] Pre-commit hooks pass (lint, format, build, .NET tests)
- [x] Manual smoke test: verify CRUD dialogs open/close correctly on each page
- [x] Manual smoke test: verify keyboard navigation still works on table pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)