### PR TITLE
style: reorder using statements to system-first standard (MGG-210)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,7 @@ insert_final_newline = true:warning
 
 # Organize usings
 dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = false
+dotnet_sort_system_directives_first = true
 file_header_template = unset
 
 # this. and Me. preferences

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Application.Interfaces.Services;
 using Common;
 using Infrastructure.Entities;
@@ -10,7 +11,6 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.DependencyInjection;
-using System.Text.Json;
 
 namespace Infrastructure;
 

--- a/src/Infrastructure/Migrations/20240829023650_Create.cs
+++ b/src/Infrastructure/Migrations/20240829023650_Create.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Infrastructure/Migrations/20240908181500_ForeignKeyUpdates.cs
+++ b/src/Infrastructure/Migrations/20240908181500_ForeignKeyUpdates.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Infrastructure/Migrations/20260219013729_AddIdentity.cs
+++ b/src/Infrastructure/Migrations/20260219013729_AddIdentity.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using System;
 
 #nullable disable
 

--- a/src/Infrastructure/Migrations/20260224104302_AddAuditTables.cs
+++ b/src/Infrastructure/Migrations/20260224104302_AddAuditTables.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Infrastructure/Migrations/20260226122654_AddUserTimestamps.cs
+++ b/src/Infrastructure/Migrations/20260226122654_AddUserTimestamps.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Infrastructure/Migrations/20260226122958_AddCategoryAndSubcategory.cs
+++ b/src/Infrastructure/Migrations/20260226122958_AddCategoryAndSubcategory.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Infrastructure/Migrations/20260226131700_AddItemTemplateEntity.cs
+++ b/src/Infrastructure/Migrations/20260226131700_AddItemTemplateEntity.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Infrastructure/Migrations/20260302005856_AddAdjustmentEntity.cs
+++ b/src/Infrastructure/Migrations/20260302005856_AddAdjustmentEntity.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Infrastructure/Services/ApiKeyService.cs
+++ b/src/Infrastructure/Services/ApiKeyService.cs
@@ -1,8 +1,8 @@
+using System.Security.Cryptography;
+using System.Text;
 using Application.Interfaces.Services;
 using Infrastructure.Entities;
 using Microsoft.EntityFrameworkCore;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace Infrastructure.Services;
 

--- a/src/Infrastructure/Services/TokenService.cs
+++ b/src/Infrastructure/Services/TokenService.cs
@@ -1,11 +1,11 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 using Application.Interfaces.Services;
 using Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
-using System.Security.Claims;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace Infrastructure.Services;
 

--- a/src/Presentation/API/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/src/Presentation/API/Authentication/ApiKeyAuthenticationHandler.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
 using Application.Interfaces.Services;
 using Common;
 using Infrastructure.Entities;
@@ -5,8 +7,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Security.Claims;
-using System.Text.Encodings.Web;
 
 namespace API.Authentication;
 

--- a/src/Presentation/API/Configuration/AuthConfiguration.cs
+++ b/src/Presentation/API/Configuration/AuthConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using API.Authentication;
 using API.Middleware;
 using Common;
@@ -5,7 +6,6 @@ using Infrastructure.Entities;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
-using System.Text;
 
 namespace API.Configuration;
 

--- a/src/Presentation/API/Controllers/ApiKeyController.cs
+++ b/src/Presentation/API/Controllers/ApiKeyController.cs
@@ -1,10 +1,10 @@
+using System.Security.Claims;
 using API.Generated.Dtos;
 using Application.Interfaces.Services;
 using Asp.Versioning;
 using Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
 
 namespace API.Controllers;
 

--- a/src/Presentation/API/Controllers/AuthAuditController.cs
+++ b/src/Presentation/API/Controllers/AuthAuditController.cs
@@ -1,9 +1,9 @@
+using System.Security.Claims;
 using API.Generated.Dtos;
 using Application.Interfaces.Services;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
 
 namespace API.Controllers;
 

--- a/src/Presentation/API/Controllers/AuthController.cs
+++ b/src/Presentation/API/Controllers/AuthController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using API.Generated.Dtos;
 using Application.Interfaces.Services;
 using Asp.Versioning;
@@ -6,7 +7,6 @@ using Infrastructure.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
 
 namespace API.Controllers;
 

--- a/src/Presentation/API/Controllers/UsersController.cs
+++ b/src/Presentation/API/Controllers/UsersController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using API.Generated.Dtos;
 using Application.Interfaces.Services;
 using Asp.Versioning;
@@ -6,7 +7,6 @@ using Infrastructure.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
 
 namespace API.Controllers;
 

--- a/src/Presentation/API/Middleware/OpenApiResponseValidationMiddleware.cs
+++ b/src/Presentation/API/Middleware/OpenApiResponseValidationMiddleware.cs
@@ -1,7 +1,7 @@
-using NJsonSchema;
 using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
+using NJsonSchema;
 
 namespace API.Middleware;
 

--- a/src/Presentation/API/Services/CurrentUserAccessor.cs
+++ b/src/Presentation/API/Services/CurrentUserAccessor.cs
@@ -1,5 +1,5 @@
-using Application.Interfaces.Services;
 using System.Security.Claims;
+using Application.Interfaces.Services;
 
 namespace API.Services;
 

--- a/tests/Presentation.API.Tests/Controllers/AuthAuditControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuthAuditControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using API.Controllers;
 using Application.Interfaces.Services;
 using FluentAssertions;
@@ -5,7 +6,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using System.Security.Claims;
 
 namespace Presentation.API.Tests.Controllers;
 

--- a/tests/Presentation.API.Tests/Middleware/ValidationExceptionMiddlewareTests.cs
+++ b/tests/Presentation.API.Tests/Middleware/ValidationExceptionMiddlewareTests.cs
@@ -1,10 +1,10 @@
+using System.Text.Json;
 using API.Middleware;
 using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using System.Text.Json;
 
 namespace Presentation.API.Tests.Middleware;
 

--- a/tests/Presentation.API.Tests/Services/CurrentUserAccessorTests.cs
+++ b/tests/Presentation.API.Tests/Services/CurrentUserAccessorTests.cs
@@ -1,7 +1,7 @@
+using System.Security.Claims;
 using API.Services;
 using Microsoft.AspNetCore.Http;
 using Moq;
-using System.Security.Claims;
 
 namespace Presentation.API.Tests.Services;
 


### PR DESCRIPTION
## Summary
- Changed `.editorconfig` `dotnet_sort_system_directives_first` from `false` to `true`
- Ran `dotnet format` across the entire solution to reorder all existing `using` statements
- Bulk formatting change only — **no behavioral changes**

The existing pre-commit hook (`dotnet format --verify-no-changes`) enforces this going forward automatically.

## Test plan
- [x] Solution builds with 0 warnings, 0 errors
- [x] All .NET tests pass (pre-commit hook ran full test suite)
- [x] Pre-commit hook passes (all 6 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)