### PR TITLE
fix(tooling): resolve punycode deprecation warning in Spectral lint (MGG-209)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,7 +4,7 @@ set -e
 echo "=== Pre-commit hook ==="
 
 echo "[1/6] Linting OpenAPI spec..."
-NODE_OPTIONS="--no-deprecation" npx spectral lint openapi/spec.yaml --fail-severity warn
+NODE_OPTIONS="--disable-warning=DEP0040" npx spectral lint openapi/spec.yaml --fail-severity warn
 
 echo "[2/6] Checking code formatting..."
 dotnet format Receipts.slnx --verify-no-changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mggarofalo-mgg-106-rewrite-create-linear-issuesmjs-with-dedup-lifecycle",
+  "name": "Receipts",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@linear/sdk": "^75.0.0",
         "@stoplight/spectral-cli": "^6.15.0",
+        "cross-env": "^10.1.0",
         "js-yaml": "^4.1.0"
       }
     },
@@ -19,6 +20,13 @@
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
@@ -1040,6 +1048,39 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
@@ -2260,6 +2301,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2562,6 +2610,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-parse": {
@@ -2886,6 +2944,29 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/side-channel": {
@@ -3324,6 +3405,22 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which-boxed-primitive": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "private": true,
   "scripts": {
-    "lint:spec": "spectral lint openapi/spec.yaml --fail-severity warn",
+    "lint:spec": "cross-env NODE_OPTIONS=--disable-warning=DEP0040 spectral lint openapi/spec.yaml --fail-severity warn",
     "check:drift": "node scripts/check-drift.mjs",
     "check:breaking": "node scripts/check-breaking.mjs"
   },
   "devDependencies": {
     "@linear/sdk": "^75.0.0",
     "@stoplight/spectral-cli": "^6.15.0",
+    "cross-env": "^10.1.0",
     "js-yaml": "^4.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- Replaced blanket `--no-deprecation` with targeted `--disable-warning=DEP0040` in the pre-commit hook
- Added `cross-env` to the npm `lint:spec` script for cross-platform env var support
- Spectral 6.15.0 is the latest — no upstream fix exists for this transitive dependency issue

## Test plan
- [x] `npx spectral lint openapi/spec.yaml` with `NODE_OPTIONS=--disable-warning=DEP0040` produces no deprecation warnings
- [x] `npm run lint:spec` works on Windows (via cross-env)
- [x] Pre-commit hook passes all 6 checks
- [x] Spectral lint still functions correctly (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)