### PR TITLE
fix(client): fix hook bugs and reduce unnecessary re-renders (MGG-193)

### DIFF
--- a/src/client/src/hooks/useGlobalShortcuts.ts
+++ b/src/client/src/hooks/useGlobalShortcuts.ts
@@ -9,7 +9,7 @@ export function useGlobalShortcuts() {
   // ? — Toggle help modal (useKeyboardShortcut because react-hotkeys-hook
   // doesn't match the "?" key)
   const toggleHelp = useCallback(
-    () => ctx?.setHelpOpen(!ctx.helpOpen),
+    () => ctx?.setHelpOpen(!ctx?.helpOpen),
     [ctx],
   );
   useKeyboardShortcut({

--- a/src/client/src/hooks/useListKeyboardNav.ts
+++ b/src/client/src/hooks/useListKeyboardNav.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 export interface UseListKeyboardNavOptions<T> {
@@ -26,13 +26,15 @@ export function useListKeyboardNav<T>({
 }: UseListKeyboardNavOptions<T>) {
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const tableRef = useRef<HTMLDivElement>(null);
-  const [prevItemsLength, setPrevItemsLength] = useState(items.length);
+  const prevItemsLengthRef = useRef(items.length);
 
-  // Reset focus when items change (state adjustment during render)
-  if (prevItemsLength !== items.length) {
-    setPrevItemsLength(items.length);
-    setFocusedIndex(-1);
-  }
+  // Reset focus when items change
+  useEffect(() => {
+    if (prevItemsLengthRef.current !== items.length) {
+      prevItemsLengthRef.current = items.length;
+      setFocusedIndex(-1);
+    }
+  }, [items.length]);
 
   const scrollToRow = useCallback((index: number) => {
     const row = tableRef.current?.querySelectorAll("tbody tr")[index];

--- a/src/client/src/pages/ApiKeys.tsx
+++ b/src/client/src/pages/ApiKeys.tsx
@@ -152,7 +152,7 @@ function ApiKeys() {
     }
     window.addEventListener("shortcut:new-item", onNewItem);
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
-  });
+  }, []);
 
   function handleCreateSubmit(values: CreateKeyFormValues) {
     createMutation.mutate(values);


### PR DESCRIPTION
## Summary
- **Bug fix**: Added missing `[]` dependency array to `useEffect` in `ApiKeys.tsx` — listener was being added/removed on every render
- **Anti-pattern fix**: Converted state-during-render pattern in `useListKeyboardNav.ts` to `useEffect` + ref
- **Null guard**: Added `?.` guard on `ctx.helpOpen` in `useGlobalShortcuts.ts`

Skipped low-priority `onSaveFilter` `useCallback` wrapping since `FilterPanel` is not `React.memo`'d (no actual re-render prevention benefit).

## Test plan
- [x] All 73 frontend tests pass
- [x] Pre-commit hook passes all 6 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)