### PR TITLE
chore(dx): add TypeScript and ESLint pre-commit checks for React client (MGG-213)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,25 +3,31 @@ set -e
 
 echo "=== Pre-commit hook ==="
 
-echo "[1/6] Linting OpenAPI spec..."
+echo "[1/8] Linting OpenAPI spec..."
 NODE_OPTIONS="--disable-warning=DEP0040" npx spectral lint openapi/spec.yaml --fail-severity warn
 
-echo "[2/6] Checking code formatting..."
+echo "[2/8] Checking code formatting..."
 dotnet format Receipts.slnx --verify-no-changes
 
-echo "[3/6] Building with warnings-as-errors..."
+echo "[3/8] Building with warnings-as-errors..."
 # Provide a build-time JWT key so GenerateOpenApiDocuments can start the host.
 # At runtime the real key is required via appsettings/Aspire configuration.
 Jwt__Key=build-time-spec-extraction-only-not-for-runtime \
 dotnet build Receipts.slnx -p:TreatWarningsAsErrors=true --no-restore
 
-echo "[4/6] Checking DTO staleness..."
+echo "[4/8] Checking DTO staleness..."
 git diff --exit-code -- src/Presentation/API/Generated/
 
-echo "[5/6] Checking spec drift..."
+echo "[5/8] Checking spec drift..."
 node scripts/check-drift.mjs
 
-echo "[6/6] Running tests..."
+echo "[6/8] Running .NET tests..."
 dotnet test Receipts.slnx --no-build --verbosity normal
+
+echo "[7/8] Checking TypeScript types..."
+npx tsc --noEmit --project src/client/tsconfig.json
+
+echo "[8/8] Linting React client..."
+npx eslint src/client/src
 
 echo "=== All checks passed ==="


### PR DESCRIPTION
## Summary
- Added `npx tsc --noEmit` (step 7/8) to catch TypeScript type errors before commit
- Added `npx eslint src/client/src` (step 8/8) to catch lint violations before commit
- Updated step numbering from [x/6] to [x/8]

This prevents issues like undefined function references from being silently committed (discovered during MGG-211).

## Test plan
- [x] Both new checks pass on the current codebase
- [x] Full pre-commit hook runs successfully (all 8 steps)
- [x] Commit succeeded with new hooks exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)