### PR TITLE
fix(client): persist subcategories created during item edit (MGG-214)

### DIFF
--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -6,7 +6,10 @@ import Fuse from "fuse.js";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useReceipts } from "@/hooks/useReceipts";
 import { useCategories } from "@/hooks/useCategories";
-import { useSubcategoriesByCategoryId } from "@/hooks/useSubcategories";
+import {
+  useSubcategoriesByCategoryId,
+  useCreateSubcategory,
+} from "@/hooks/useSubcategories";
 import { useItemTemplates } from "@/hooks/useItemTemplates";
 import { receiptToOption } from "@/lib/combobox-options";
 import { Button } from "@/components/ui/button";
@@ -150,6 +153,7 @@ export function ReceiptItemForm({
 
   const { data: subcategoriesData } =
     useSubcategoriesByCategoryId(selectedCategoryId);
+  const createSubcategory = useCreateSubcategory();
 
   const subcategoryOptions = useMemo(
     () =>
@@ -190,6 +194,21 @@ export function ReceiptItemForm({
       }
     }
   }, [watchedPricingMode, form]);
+
+  async function handleFormSubmit(values: ReceiptItemFormValues) {
+    const isCustomSubcategory =
+      values.subcategory &&
+      !subcategoryOptions.some((opt) => opt.value === values.subcategory);
+
+    if (isCustomSubcategory && selectedCategoryId) {
+      await createSubcategory.mutateAsync({
+        name: values.subcategory,
+        categoryId: selectedCategoryId,
+      });
+    }
+
+    onSubmit(values);
+  }
 
   const computedTotal = (watchedQuantity ?? 0) * (watchedUnitPrice ?? 0);
 
@@ -237,7 +256,7 @@ export function ReceiptItemForm({
     <Form {...form}>
       <form
         ref={formRef}
-        onSubmit={form.handleSubmit(onSubmit)}
+        onSubmit={form.handleSubmit(handleFormSubmit)}
         className="space-y-4"
       >
         <FormField


### PR DESCRIPTION
## Summary
- When a user types a custom subcategory name in the ReceiptItemForm Combobox, the subcategory entity is now created via the API before the receipt item is saved
- Previously, only the name string was stored on the receipt item — no subcategory entity was created, so the name would not appear in the dropdown for subsequent edits
- Uses `useCreateSubcategory` mutation with `mutateAsync` to ensure the subcategory exists before the item is saved
- The `useCreateSubcategory` hook already invalidates the subcategories query cache on success, so the dropdown updates automatically

## Test plan
- [x] All 73 frontend tests pass
- [x] TypeScript compiles clean
- [x] Pre-commit hook passes all checks
- [ ] Manual: Edit a receipt item, type a new subcategory name, save, edit another item — new subcategory should appear in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)