### PR TITLE
Add visibility toggle icon to password fields (MGG-217)

### DIFF
--- a/src/client/src/components/ui/password-input.test.tsx
+++ b/src/client/src/components/ui/password-input.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PasswordInput } from "./password-input";
+
+describe("PasswordInput", () => {
+  it("renders as a password input by default", () => {
+    render(<PasswordInput placeholder="Enter password" />);
+    const input = screen.getByPlaceholderText("Enter password");
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("shows 'Show password' toggle button", () => {
+    render(<PasswordInput />);
+    expect(screen.getByLabelText("Show password")).toBeInTheDocument();
+  });
+
+  it("toggles to text input when visibility button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput placeholder="Enter password" />);
+
+    const input = screen.getByPlaceholderText("Enter password");
+    const toggleButton = screen.getByLabelText("Show password");
+
+    await user.click(toggleButton);
+
+    expect(input).toHaveAttribute("type", "text");
+    expect(screen.getByLabelText("Hide password")).toBeInTheDocument();
+  });
+
+  it("toggles back to password input on second click", async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput placeholder="Enter password" />);
+
+    const input = screen.getByPlaceholderText("Enter password");
+    const toggleButton = screen.getByLabelText("Show password");
+
+    await user.click(toggleButton);
+    expect(input).toHaveAttribute("type", "text");
+
+    await user.click(screen.getByLabelText("Hide password"));
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("forwards props to the input element", () => {
+    render(
+      <PasswordInput
+        placeholder="test placeholder"
+        disabled
+        aria-invalid="true"
+      />,
+    );
+    const input = screen.getByPlaceholderText("test placeholder");
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("applies custom className", () => {
+    render(<PasswordInput className="custom-class" placeholder="test" />);
+    const input = screen.getByPlaceholderText("test");
+    expect(input.className).toContain("custom-class");
+  });
+
+  it("toggle button has tabIndex -1 to keep focus on input", () => {
+    render(<PasswordInput />);
+    const toggleButton = screen.getByLabelText("Show password");
+    expect(toggleButton).toHaveAttribute("tabindex", "-1");
+  });
+});

--- a/src/client/src/components/ui/password-input.tsx
+++ b/src/client/src/components/ui/password-input.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+const PasswordInput = React.forwardRef<
+  HTMLInputElement,
+  Omit<React.ComponentProps<"input">, "type">
+>(({ className, ...props }, ref) => {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div className="relative">
+      <input
+        type={visible ? "text" : "password"}
+        data-slot="input"
+        className={cn(
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 pr-10 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="absolute right-0 top-0 h-9 w-9 px-2 hover:bg-transparent"
+        tabIndex={-1}
+        aria-label={visible ? "Hide password" : "Show password"}
+        onClick={() => setVisible((v) => !v)}
+      >
+        {visible ? (
+          <EyeOff className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <Eye className="h-4 w-4 text-muted-foreground" />
+        )}
+      </Button>
+    </div>
+  );
+});
+
+PasswordInput.displayName = "PasswordInput";
+
+export { PasswordInput };

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -14,6 +14,7 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { Badge } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -416,8 +417,7 @@ function AdminUsers() {
                   <FormItem>
                     <FormLabel>Password</FormLabel>
                     <FormControl>
-                      <Input
-                        type="password"
+                      <PasswordInput
                         placeholder="At least 8 characters"
                         {...field}
                       />
@@ -616,8 +616,7 @@ function AdminUsers() {
                   <FormItem>
                     <FormLabel>New Password</FormLabel>
                     <FormControl>
-                      <Input
-                        type="password"
+                      <PasswordInput
                         placeholder="At least 8 characters"
                         {...field}
                       />

--- a/src/client/src/pages/ChangePassword.tsx
+++ b/src/client/src/pages/ChangePassword.tsx
@@ -21,7 +21,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
 const changePasswordSchema = z
@@ -91,8 +91,7 @@ function ChangePassword() {
                 <FormItem>
                   <FormLabel>Current Password</FormLabel>
                   <FormControl>
-                    <Input
-                      type="password"
+                    <PasswordInput
                       placeholder="Enter your current password"
                       autoComplete="current-password"
                       {...field}
@@ -109,8 +108,7 @@ function ChangePassword() {
                 <FormItem>
                   <FormLabel>New Password</FormLabel>
                   <FormControl>
-                    <Input
-                      type="password"
+                    <PasswordInput
                       placeholder="At least 8 characters"
                       autoComplete="new-password"
                       {...field}
@@ -127,8 +125,7 @@ function ChangePassword() {
                 <FormItem>
                   <FormLabel>Confirm New Password</FormLabel>
                   <FormControl>
-                    <Input
-                      type="password"
+                    <PasswordInput
                       placeholder="Re-enter your new password"
                       autoComplete="new-password"
                       {...field}

--- a/src/client/src/pages/Login.test.tsx
+++ b/src/client/src/pages/Login.test.tsx
@@ -25,7 +25,7 @@ describe("Login", () => {
   it("renders email and password fields", () => {
     renderWithProviders(<Login />);
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
   });
 
   it("renders the sign in button", () => {

--- a/src/client/src/pages/Login.tsx
+++ b/src/client/src/pages/Login.tsx
@@ -22,6 +22,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
 const loginSchema = z.object({
@@ -99,8 +100,7 @@ function Login() {
                   <FormItem>
                     <FormLabel>Password</FormLabel>
                     <FormControl>
-                      <Input
-                        type="password"
+                      <PasswordInput
                         placeholder="Enter your password"
                         autoComplete="current-password"
                         {...field}


### PR DESCRIPTION
## Summary
- New reusable `PasswordInput` component (`src/client/src/components/ui/password-input.tsx`) with eye/eye-off toggle using lucide-react icons
- Replaced all 6 `<Input type="password">` instances across Login, ChangePassword, and AdminUsers pages
- 7 unit tests for the new component, updated existing Login test for compatibility

## Test plan
- [x] `PasswordInput` component tests pass (7/7)
- [x] Login page tests pass (4/4)
- [x] ChangePassword page tests pass (4/4)
- [x] AdminUsers page tests pass (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)