### PR TITLE
Reject same password in change password flow (MGG-216)

### DIFF
--- a/src/Presentation/API/Validators/ChangePasswordRequestValidator.cs
+++ b/src/Presentation/API/Validators/ChangePasswordRequestValidator.cs
@@ -1,0 +1,19 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class ChangePasswordRequestValidator : AbstractValidator<ChangePasswordRequest>
+{
+	public ChangePasswordRequestValidator()
+	{
+		RuleFor(x => x.CurrentPassword)
+			.NotEmpty();
+
+		RuleFor(x => x.NewPassword)
+			.NotEmpty()
+			.MinimumLength(8)
+			.NotEqual(x => x.CurrentPassword)
+			.WithMessage("New password must be different from current password.");
+	}
+}

--- a/src/client/src/pages/ChangePassword.tsx
+++ b/src/client/src/pages/ChangePassword.tsx
@@ -30,6 +30,10 @@ const changePasswordSchema = z
     newPassword: z.string().min(8, "Password must be at least 8 characters"),
     confirmPassword: z.string().min(1, "Please confirm your new password"),
   })
+  .refine((data) => data.newPassword !== data.currentPassword, {
+    message: "New password must be different from current password",
+    path: ["newPassword"],
+  })
   .refine((data) => data.newPassword === data.confirmPassword, {
     message: "Passwords do not match",
     path: ["confirmPassword"],

--- a/tests/Presentation.API.Tests/Validators/ChangePasswordRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/ChangePasswordRequestValidatorTests.cs
@@ -1,0 +1,118 @@
+using API.Generated.Dtos;
+using API.Validators;
+using FluentValidation.Results;
+
+namespace Presentation.API.Tests.Validators;
+
+public class ChangePasswordRequestValidatorTests
+{
+	private readonly ChangePasswordRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_PasswordsAreDifferentAndValid()
+	{
+		// Arrange
+		ChangePasswordRequest request = new()
+		{
+			CurrentPassword = "OldPassword1",
+			NewPassword = "NewPassword1"
+		};
+
+		// Act
+		ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_NewPasswordMatchesCurrentPassword()
+	{
+		// Arrange
+		ChangePasswordRequest request = new()
+		{
+			CurrentPassword = "SamePassword1",
+			NewPassword = "SamePassword1"
+		};
+
+		// Act
+		ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e =>
+			e.PropertyName == "NewPassword" &&
+			e.ErrorMessage == "New password must be different from current password.");
+	}
+
+	[Fact]
+	public void Should_Fail_When_CurrentPasswordIsEmpty()
+	{
+		// Arrange
+		ChangePasswordRequest request = new()
+		{
+			CurrentPassword = "",
+			NewPassword = "ValidPass1"
+		};
+
+		// Act
+		ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.PropertyName == "CurrentPassword");
+	}
+
+	[Fact]
+	public void Should_Fail_When_NewPasswordIsEmpty()
+	{
+		// Arrange
+		ChangePasswordRequest request = new()
+		{
+			CurrentPassword = "OldPassword1",
+			NewPassword = ""
+		};
+
+		// Act
+		ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.PropertyName == "NewPassword");
+	}
+
+	[Fact]
+	public void Should_Fail_When_NewPasswordIsTooShort()
+	{
+		// Arrange
+		ChangePasswordRequest request = new()
+		{
+			CurrentPassword = "OldPassword1",
+			NewPassword = "short"
+		};
+
+		// Act
+		ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.PropertyName == "NewPassword");
+	}
+
+	[Fact]
+	public void Should_Pass_When_NewPasswordIsExactly8Characters()
+	{
+		// Arrange
+		ChangePasswordRequest request = new()
+		{
+			CurrentPassword = "OldPassword1",
+			NewPassword = "12345678"
+		};
+
+		// Act
+		ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+}


### PR DESCRIPTION
## Summary
- New `ChangePasswordRequestValidator` with FluentValidation `NotEqual` rule ensuring new password differs from current password
- Added matching client-side Zod `.refine()` validation on the ChangePassword page for immediate feedback
- 6 backend validator tests, 4 frontend page tests all pass

## Test plan
- [x] `ChangePasswordRequestValidator` tests pass (6/6)
- [x] ChangePassword page frontend tests pass (4/4)
- [x] Full solution build succeeds with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)