### PR TITLE
fix(frontend): resolve all TypeScript errors and test failures (MGG-220)

### DIFF
--- a/src/client/src/components/AdjustmentsCard.test.tsx
+++ b/src/client/src/components/AdjustmentsCard.test.tsx
@@ -3,6 +3,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AdjustmentsCard } from "./AdjustmentsCard";
 import { renderWithQueryClient } from "@/test/test-utils";
+import { mockMutationResult } from "@/test/mock-hooks";
 
 vi.mock("@/hooks/useAdjustments", () => ({
   useCreateAdjustment: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -166,10 +167,10 @@ describe("AdjustmentsCard", () => {
   it("opens delete confirmation dialog and calls deleteAdjustments.mutate on confirm", async () => {
     const { useDeleteAdjustments } = await import("@/hooks/useAdjustments");
     const mockDeleteMutate = vi.fn();
-    vi.mocked(useDeleteAdjustments).mockReturnValue({
+    vi.mocked(useDeleteAdjustments).mockReturnValue(mockMutationResult({
       mutate: mockDeleteMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useDeleteAdjustments>);
+    }));
 
     const user = userEvent.setup();
     renderWithQueryClient(
@@ -222,10 +223,10 @@ describe("AdjustmentsCard", () => {
   it("calls createAdjustment.mutate when create form is submitted", async () => {
     const { useCreateAdjustment } = await import("@/hooks/useAdjustments");
     const mockCreateMutate = vi.fn();
-    vi.mocked(useCreateAdjustment).mockReturnValue({
+    vi.mocked(useCreateAdjustment).mockReturnValue(mockMutationResult({
       mutate: mockCreateMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useCreateAdjustment>);
+    }));
 
     const user = userEvent.setup();
     renderWithQueryClient(
@@ -245,10 +246,10 @@ describe("AdjustmentsCard", () => {
   it("calls updateAdjustment.mutate when edit form is submitted", async () => {
     const { useUpdateAdjustment } = await import("@/hooks/useAdjustments");
     const mockUpdateMutate = vi.fn();
-    vi.mocked(useUpdateAdjustment).mockReturnValue({
+    vi.mocked(useUpdateAdjustment).mockReturnValue(mockMutationResult({
       mutate: mockUpdateMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useUpdateAdjustment>);
+    }));
 
     const user = userEvent.setup();
     renderWithQueryClient(
@@ -269,10 +270,10 @@ describe("AdjustmentsCard", () => {
   it("cancels delete dialog without deleting", async () => {
     const { useDeleteAdjustments } = await import("@/hooks/useAdjustments");
     const mockDeleteMutate = vi.fn();
-    vi.mocked(useDeleteAdjustments).mockReturnValue({
+    vi.mocked(useDeleteAdjustments).mockReturnValue(mockMutationResult({
       mutate: mockDeleteMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useDeleteAdjustments>);
+    }));
 
     const user = userEvent.setup();
     renderWithQueryClient(

--- a/src/client/src/components/ChangeHistory.test.tsx
+++ b/src/client/src/components/ChangeHistory.test.tsx
@@ -28,7 +28,7 @@ describe("ChangeHistory", () => {
     mockUseEntityAuditHistory.mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useEntityAuditHistory>);
+    } as unknown as ReturnType<typeof useEntityAuditHistory>);
 
     const { container } = renderWithProviders(
       <ChangeHistory entityType="Receipt" entityId="abc-123" />,
@@ -55,7 +55,7 @@ describe("ChangeHistory", () => {
     mockUseEntityAuditHistory.mockReturnValue({
       data: undefined,
       isLoading: false,
-    } as ReturnType<typeof useEntityAuditHistory>);
+    } as unknown as ReturnType<typeof useEntityAuditHistory>);
 
     renderWithProviders(
       <ChangeHistory entityType="Receipt" entityId="abc-123" />,

--- a/src/client/src/components/ChangeHistory.test.tsx
+++ b/src/client/src/components/ChangeHistory.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { ChangeHistory } from "./ChangeHistory";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { mockQueryResult } from "@/test/mock-hooks";
 
 vi.mock("@/hooks/useAudit", () => ({
   useEntityAuditHistory: vi.fn(),
@@ -25,10 +26,10 @@ function renderWithProviders(ui: React.ReactElement) {
 
 describe("ChangeHistory", () => {
   it("renders loading skeletons when data is loading", () => {
-    mockUseEntityAuditHistory.mockReturnValue({
+    mockUseEntityAuditHistory.mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useEntityAuditHistory>);
+    }));
 
     const { container } = renderWithProviders(
       <ChangeHistory entityType="Receipt" entityId="abc-123" />,
@@ -38,10 +39,10 @@ describe("ChangeHistory", () => {
   });
 
   it("renders empty state when no history is available", () => {
-    mockUseEntityAuditHistory.mockReturnValue({
+    mockUseEntityAuditHistory.mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useEntityAuditHistory>);
+    }));
 
     renderWithProviders(
       <ChangeHistory entityType="Receipt" entityId="abc-123" />,
@@ -52,10 +53,10 @@ describe("ChangeHistory", () => {
   });
 
   it("renders empty state when data is undefined (null-ish)", () => {
-    mockUseEntityAuditHistory.mockReturnValue({
+    mockUseEntityAuditHistory.mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: false,
-    } as unknown as ReturnType<typeof useEntityAuditHistory>);
+    }));
 
     renderWithProviders(
       <ChangeHistory entityType="Receipt" entityId="abc-123" />,
@@ -66,7 +67,7 @@ describe("ChangeHistory", () => {
   });
 
   it("renders timeline entries when data is available", () => {
-    mockUseEntityAuditHistory.mockReturnValue({
+    mockUseEntityAuditHistory.mockReturnValue(mockQueryResult({
       data: [
         {
           id: "log-1",
@@ -94,7 +95,7 @@ describe("ChangeHistory", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useEntityAuditHistory>);
+    }));
 
     renderWithProviders(
       <ChangeHistory entityType="Receipt" entityId="abc-123" />,
@@ -104,10 +105,10 @@ describe("ChangeHistory", () => {
   });
 
   it("passes correct entityType and entityId to the hook", () => {
-    mockUseEntityAuditHistory.mockReturnValue({
+    mockUseEntityAuditHistory.mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useEntityAuditHistory>);
+    }));
 
     renderWithProviders(
       <ChangeHistory entityType="Account" entityId="xyz-789" />,

--- a/src/client/src/components/GlobalSearchDialog.test.tsx
+++ b/src/client/src/components/GlobalSearchDialog.test.tsx
@@ -3,6 +3,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GlobalSearchDialog } from "./GlobalSearchDialog";
 import { renderWithQueryClient } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
 
 // cmdk uses ResizeObserver and scrollIntoView which are not available in jsdom
 beforeAll(() => {
@@ -67,12 +68,12 @@ describe("GlobalSearchDialog", () => {
 
   it("renders account items when accounts data is available", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
-    vi.mocked(useAccounts).mockReturnValue({
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
       data: [
         { id: "acc-1", accountCode: "ACC001", name: "Checking" },
         { id: "acc-2", accountCode: "ACC002", name: "Savings" },
       ],
-    } as unknown as ReturnType<typeof useAccounts>);
+    }));
 
     renderWithQueryClient(
       <GlobalSearchDialog open={true} onOpenChange={vi.fn()} />,
@@ -142,7 +143,7 @@ describe("GlobalSearchDialog", () => {
 
   it("renders receipt items when receiptItems data is available", async () => {
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
-    vi.mocked(useReceiptItems).mockReturnValue({
+    vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "ri-1",
@@ -151,7 +152,7 @@ describe("GlobalSearchDialog", () => {
           category: "Food",
         },
       ],
-    } as unknown as ReturnType<typeof useReceiptItems>);
+    }));
 
     renderWithQueryClient(
       <GlobalSearchDialog open={true} onOpenChange={vi.fn()} />,
@@ -164,11 +165,11 @@ describe("GlobalSearchDialog", () => {
 
   it("renders transaction items when transactions data is available", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
-    vi.mocked(useTransactions).mockReturnValue({
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
       data: [
         { id: "txn-1", amount: 42.5, date: "2024-01-15" },
       ],
-    } as unknown as ReturnType<typeof useTransactions>);
+    }));
 
     renderWithQueryClient(
       <GlobalSearchDialog open={true} onOpenChange={vi.fn()} />,
@@ -181,12 +182,12 @@ describe("GlobalSearchDialog", () => {
 
   it("renders receipt items when receipts data is available", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
-    vi.mocked(useReceipts).mockReturnValue({
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
       data: [
         { id: "r-1", description: "Grocery receipt", location: "Store A" },
         { id: "r-2", description: null, location: "Store B" },
       ],
-    } as unknown as ReturnType<typeof useReceipts>);
+    }));
 
     renderWithQueryClient(
       <GlobalSearchDialog open={true} onOpenChange={vi.fn()} />,
@@ -197,11 +198,11 @@ describe("GlobalSearchDialog", () => {
 
   it("selecting an account item closes dialog", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
-    vi.mocked(useAccounts).mockReturnValue({
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
       data: [
         { id: "acc-1", accountCode: "ACC001", name: "Checking" },
       ],
-    } as unknown as ReturnType<typeof useAccounts>);
+    }));
 
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
@@ -214,11 +215,11 @@ describe("GlobalSearchDialog", () => {
 
   it("selecting a receipt item closes dialog", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
-    vi.mocked(useReceipts).mockReturnValue({
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
       data: [
         { id: "r-1", description: "Test Receipt", location: "Downtown" },
       ],
-    } as unknown as ReturnType<typeof useReceipts>);
+    }));
 
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
@@ -231,11 +232,11 @@ describe("GlobalSearchDialog", () => {
 
   it("selecting a transaction item closes dialog", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
-    vi.mocked(useTransactions).mockReturnValue({
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
       data: [
         { id: "txn-1", amount: 100, date: "2024-06-01" },
       ],
-    } as unknown as ReturnType<typeof useTransactions>);
+    }));
 
     const user = userEvent.setup();
     const onOpenChange = vi.fn();

--- a/src/client/src/components/GlobalSearchDialog.test.tsx
+++ b/src/client/src/components/GlobalSearchDialog.test.tsx
@@ -72,7 +72,7 @@ describe("GlobalSearchDialog", () => {
         { id: "acc-1", accountCode: "ACC001", name: "Checking" },
         { id: "acc-2", accountCode: "ACC002", name: "Savings" },
       ],
-    } as ReturnType<typeof useAccounts>);
+    } as unknown as ReturnType<typeof useAccounts>);
 
     renderWithQueryClient(
       <GlobalSearchDialog open={true} onOpenChange={vi.fn()} />,
@@ -151,7 +151,7 @@ describe("GlobalSearchDialog", () => {
           category: "Food",
         },
       ],
-    } as ReturnType<typeof useReceiptItems>);
+    } as unknown as ReturnType<typeof useReceiptItems>);
 
     renderWithQueryClient(
       <GlobalSearchDialog open={true} onOpenChange={vi.fn()} />,
@@ -168,7 +168,7 @@ describe("GlobalSearchDialog", () => {
       data: [
         { id: "txn-1", amount: 42.5, date: "2024-01-15" },
       ],
-    } as ReturnType<typeof useTransactions>);
+    } as unknown as ReturnType<typeof useTransactions>);
 
     renderWithQueryClient(
       <GlobalSearchDialog open={true} onOpenChange={vi.fn()} />,
@@ -186,7 +186,7 @@ describe("GlobalSearchDialog", () => {
         { id: "r-1", description: "Grocery receipt", location: "Store A" },
         { id: "r-2", description: null, location: "Store B" },
       ],
-    } as ReturnType<typeof useReceipts>);
+    } as unknown as ReturnType<typeof useReceipts>);
 
     renderWithQueryClient(
       <GlobalSearchDialog open={true} onOpenChange={vi.fn()} />,
@@ -201,7 +201,7 @@ describe("GlobalSearchDialog", () => {
       data: [
         { id: "acc-1", accountCode: "ACC001", name: "Checking" },
       ],
-    } as ReturnType<typeof useAccounts>);
+    } as unknown as ReturnType<typeof useAccounts>);
 
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
@@ -218,7 +218,7 @@ describe("GlobalSearchDialog", () => {
       data: [
         { id: "r-1", description: "Test Receipt", location: "Downtown" },
       ],
-    } as ReturnType<typeof useReceipts>);
+    } as unknown as ReturnType<typeof useReceipts>);
 
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
@@ -235,7 +235,7 @@ describe("GlobalSearchDialog", () => {
       data: [
         { id: "txn-1", amount: 100, date: "2024-06-01" },
       ],
-    } as ReturnType<typeof useTransactions>);
+    } as unknown as ReturnType<typeof useTransactions>);
 
     const user = userEvent.setup();
     const onOpenChange = vi.fn();

--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -143,7 +143,7 @@ export function ItemTemplateForm({
                   <Combobox
                     options={categoryOptions}
                     value={field.value ?? ""}
-                    onChange={field.onChange}
+                    onValueChange={field.onChange}
                     placeholder="Select category..."
                     searchPlaceholder="Search categories..."
                     allowCustom
@@ -164,7 +164,7 @@ export function ItemTemplateForm({
                   <Combobox
                     options={subcategoryOptions}
                     value={field.value ?? ""}
-                    onChange={field.onChange}
+                    onValueChange={field.onChange}
                     placeholder="Select subcategory..."
                     searchPlaceholder="Search subcategories..."
                     allowCustom

--- a/src/client/src/components/ui/currency-input.test.tsx
+++ b/src/client/src/components/ui/currency-input.test.tsx
@@ -90,7 +90,7 @@ describe("CurrencyInput", () => {
     await user.type(input, "25.99");
 
     // Find the call with the final value
-    const calls = onChange.mock.calls.map((c: [number]) => c[0]);
+    const calls = onChange.mock.calls.map((c) => c[0]);
     expect(calls).toContain(25.99);
   });
 

--- a/src/client/src/contexts/AuthContext.test.tsx
+++ b/src/client/src/contexts/AuthContext.test.tsx
@@ -26,8 +26,9 @@ vi.mock("@/lib/auth", () => ({
 
 import client from "@/lib/api-client";
 import * as auth from "@/lib/auth";
+import type { Mock } from "vitest";
 
-const mockedClient = vi.mocked(client);
+const mockedClient = client as unknown as { POST: Mock; GET: Mock };
 const mockedAuth = vi.mocked(auth);
 
 // Helper JWT: header.payload.signature with payload = { email, role }
@@ -102,7 +103,7 @@ describe("AuthProvider", () => {
         mustResetPassword: false,
       },
       error: undefined,
-    } as any);
+    });
     mockedAuth.parseJwtPayload.mockReturnValue({
       email: "a@b.com",
       roles: ["User"],
@@ -136,7 +137,7 @@ describe("AuthProvider", () => {
     mockedClient.POST.mockResolvedValueOnce({
       data: undefined,
       error: undefined,
-    } as any);
+    });
 
     render(
       <AuthProvider>
@@ -163,7 +164,7 @@ describe("AuthProvider", () => {
         mustResetPassword: false,
       },
       error: undefined,
-    } as any);
+    });
     mockedAuth.parseJwtPayload.mockReturnValue({
       email: "a@b.com",
       roles: ["User"],

--- a/src/client/src/contexts/AuthContext.test.tsx
+++ b/src/client/src/contexts/AuthContext.test.tsx
@@ -102,7 +102,7 @@ describe("AuthProvider", () => {
         mustResetPassword: false,
       },
       error: undefined,
-    });
+    } as any);
     mockedAuth.parseJwtPayload.mockReturnValue({
       email: "a@b.com",
       roles: ["User"],
@@ -136,7 +136,7 @@ describe("AuthProvider", () => {
     mockedClient.POST.mockResolvedValueOnce({
       data: undefined,
       error: undefined,
-    });
+    } as any);
 
     render(
       <AuthProvider>
@@ -163,7 +163,7 @@ describe("AuthProvider", () => {
         mustResetPassword: false,
       },
       error: undefined,
-    });
+    } as any);
     mockedAuth.parseJwtPayload.mockReturnValue({
       email: "a@b.com",
       roles: ["User"],

--- a/src/client/src/hooks/useFormShortcuts.test.ts
+++ b/src/client/src/hooks/useFormShortcuts.test.ts
@@ -3,7 +3,7 @@ import { useFormShortcuts } from "./useFormShortcuts";
 import type { RefObject } from "react";
 
 vi.mock("react-hotkeys-hook", () => ({
-  useHotkeys: vi.fn((key: string, callback: () => void) => {
+  useHotkeys: vi.fn((_key: string, callback: () => void) => {
     // Simulate the hotkey by storing callback for testing
     document.addEventListener("keydown", (e) => {
       if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {

--- a/src/client/src/hooks/useSignalR.test.ts
+++ b/src/client/src/hooks/useSignalR.test.ts
@@ -129,7 +129,7 @@ describe("useSignalR", () => {
 
   describe("hub event handlers", () => {
     it("ReceiptCreated invalidates queries and shows toast", async () => {
-      const mockQueryClient = (useQueryClient as ReturnType<typeof vi.fn>)();
+      const mockQueryClient = vi.mocked(useQueryClient)();
 
       await renderEnabled();
 
@@ -149,7 +149,7 @@ describe("useSignalR", () => {
     });
 
     it("ReceiptUpdated invalidates queries and shows toast", async () => {
-      const mockQueryClient = (useQueryClient as ReturnType<typeof vi.fn>)();
+      const mockQueryClient = vi.mocked(useQueryClient)();
 
       await renderEnabled();
 
@@ -169,7 +169,7 @@ describe("useSignalR", () => {
     });
 
     it("ReceiptDeleted invalidates queries and shows toast", async () => {
-      const mockQueryClient = (useQueryClient as ReturnType<typeof vi.fn>)();
+      const mockQueryClient = vi.mocked(useQueryClient)();
 
       await renderEnabled();
 

--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -65,7 +65,7 @@ describe("Accounts", () => {
     vi.mocked(useAccounts).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useAccounts>);
+    } as unknown as ReturnType<typeof useAccounts>);
 
     const { container } = renderWithProviders(<Accounts />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe("Accounts", () => {
     vi.mocked(useAccounts).mockReturnValue({
       data: [],
       isLoading: false,
-    } as ReturnType<typeof useAccounts>);
+    } as unknown as ReturnType<typeof useAccounts>);
 
     renderWithProviders(<Accounts />);
     expect(

--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import Accounts from "./Accounts";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -62,10 +63,10 @@ describe("Accounts", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
-    vi.mocked(useAccounts).mockReturnValue({
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useAccounts>);
+    }));
 
     const { container } = renderWithProviders(<Accounts />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -73,10 +74,10 @@ describe("Accounts", () => {
 
   it("renders empty state when no accounts exist", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
-    vi.mocked(useAccounts).mockReturnValue({
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useAccounts>);
+    }));
 
     renderWithProviders(<Accounts />);
     expect(
@@ -105,14 +106,14 @@ describe("Accounts", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -151,14 +152,14 @@ describe("Accounts", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -186,14 +187,14 @@ describe("Accounts", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -223,14 +224,14 @@ describe("Accounts", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -260,14 +261,14 @@ describe("Accounts", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -308,24 +309,24 @@ describe("Accounts", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();
     const { useDeleteAccounts } = await import("@/hooks/useAccounts");
-    vi.mocked(useDeleteAccounts).mockReturnValue({
+    vi.mocked(useDeleteAccounts).mockReturnValue(mockMutationResult({
       mutate: mockMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useDeleteAccounts>);
+    }));
 
     const items = [
       { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
 import AdminUsers from "./AdminUsers";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -51,10 +52,10 @@ describe("AdminUsers", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
-    vi.mocked(useUsers).mockReturnValue({
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: { items: [], totalCount: 0 },
       isLoading: true,
-    } as unknown as ReturnType<typeof useUsers>);
+    }));
 
     const { container } = renderWithProviders(<AdminUsers />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -62,10 +63,10 @@ describe("AdminUsers", () => {
 
   it("renders empty state when no users exist", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
-    vi.mocked(useUsers).mockReturnValue({
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: { items: [], totalCount: 0 },
       isLoading: false,
-    } as unknown as ReturnType<typeof useUsers>);
+    }));
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByText(/no users found/i)).toBeInTheDocument();
@@ -73,7 +74,7 @@ describe("AdminUsers", () => {
 
   it("renders user table when users exist", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
-    vi.mocked(useUsers).mockReturnValue({
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: {
         items: [
           {
@@ -90,7 +91,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as unknown as ReturnType<typeof useUsers>);
+    }));
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByText("test@example.com")).toBeInTheDocument();
@@ -110,7 +111,7 @@ describe("AdminUsers", () => {
   it("opens edit user dialog when Edit button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useUsers } = await import("@/hooks/useUsers");
-    vi.mocked(useUsers).mockReturnValue({
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: {
         items: [
           {
@@ -127,7 +128,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as unknown as ReturnType<typeof useUsers>);
+    }));
 
     renderWithProviders(<AdminUsers />);
     await user.click(screen.getByRole("button", { name: /edit/i }));
@@ -140,7 +141,7 @@ describe("AdminUsers", () => {
   it("opens reset password dialog when Reset PW button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useUsers } = await import("@/hooks/useUsers");
-    vi.mocked(useUsers).mockReturnValue({
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: {
         items: [
           {
@@ -157,7 +158,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as unknown as ReturnType<typeof useUsers>);
+    }));
 
     renderWithProviders(<AdminUsers />);
     await user.click(screen.getByRole("button", { name: /reset pw/i }));
@@ -172,7 +173,7 @@ describe("AdminUsers", () => {
 
   it("disables Disable button for the current user", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
-    vi.mocked(useUsers).mockReturnValue({
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: {
         items: [
           {
@@ -189,7 +190,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as unknown as ReturnType<typeof useUsers>);
+    }));
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByRole("button", { name: /disable/i })).toBeDisabled();
@@ -197,7 +198,7 @@ describe("AdminUsers", () => {
 
   it("disables Disable button for already disabled users", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
-    vi.mocked(useUsers).mockReturnValue({
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: {
         items: [
           {
@@ -214,7 +215,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as unknown as ReturnType<typeof useUsers>);
+    }));
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByRole("button", { name: /disable/i })).toBeDisabled();
@@ -223,7 +224,7 @@ describe("AdminUsers", () => {
 
   it("shows user name formatted from first and last name", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
-    vi.mocked(useUsers).mockReturnValue({
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: {
         items: [
           {
@@ -240,7 +241,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as unknown as ReturnType<typeof useUsers>);
+    }));
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByText("John Doe")).toBeInTheDocument();
@@ -248,7 +249,7 @@ describe("AdminUsers", () => {
 
   it("shows dash when user has no first or last name", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
-    vi.mocked(useUsers).mockReturnValue({
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: {
         items: [
           {
@@ -265,7 +266,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as unknown as ReturnType<typeof useUsers>);
+    }));
 
     renderWithProviders(<AdminUsers />);
     // The name column should show "-"

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -54,7 +54,7 @@ describe("AdminUsers", () => {
     vi.mocked(useUsers).mockReturnValue({
       data: { items: [], totalCount: 0 },
       isLoading: true,
-    } as ReturnType<typeof useUsers>);
+    } as unknown as ReturnType<typeof useUsers>);
 
     const { container } = renderWithProviders(<AdminUsers />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe("AdminUsers", () => {
     vi.mocked(useUsers).mockReturnValue({
       data: { items: [], totalCount: 0 },
       isLoading: false,
-    } as ReturnType<typeof useUsers>);
+    } as unknown as ReturnType<typeof useUsers>);
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByText(/no users found/i)).toBeInTheDocument();
@@ -90,7 +90,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as ReturnType<typeof useUsers>);
+    } as unknown as ReturnType<typeof useUsers>);
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByText("test@example.com")).toBeInTheDocument();
@@ -127,7 +127,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as ReturnType<typeof useUsers>);
+    } as unknown as ReturnType<typeof useUsers>);
 
     renderWithProviders(<AdminUsers />);
     await user.click(screen.getByRole("button", { name: /edit/i }));
@@ -157,7 +157,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as ReturnType<typeof useUsers>);
+    } as unknown as ReturnType<typeof useUsers>);
 
     renderWithProviders(<AdminUsers />);
     await user.click(screen.getByRole("button", { name: /reset pw/i }));
@@ -189,7 +189,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as ReturnType<typeof useUsers>);
+    } as unknown as ReturnType<typeof useUsers>);
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByRole("button", { name: /disable/i })).toBeDisabled();
@@ -214,7 +214,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as ReturnType<typeof useUsers>);
+    } as unknown as ReturnType<typeof useUsers>);
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByRole("button", { name: /disable/i })).toBeDisabled();
@@ -240,7 +240,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as ReturnType<typeof useUsers>);
+    } as unknown as ReturnType<typeof useUsers>);
 
     renderWithProviders(<AdminUsers />);
     expect(screen.getByText("John Doe")).toBeInTheDocument();
@@ -265,7 +265,7 @@ describe("AdminUsers", () => {
         totalCount: 1,
       },
       isLoading: false,
-    } as ReturnType<typeof useUsers>);
+    } as unknown as ReturnType<typeof useUsers>);
 
     renderWithProviders(<AdminUsers />);
     // The name column should show "-"

--- a/src/client/src/pages/ApiKeys.test.tsx
+++ b/src/client/src/pages/ApiKeys.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithQueryClient } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
 import ApiKeys from "./ApiKeys";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -82,7 +83,7 @@ describe("ApiKeys", () => {
 
   it("renders table with API keys when data exists", async () => {
     const { useQuery } = await import("@tanstack/react-query");
-    vi.mocked(useQuery).mockReturnValue({
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "key-1",
@@ -94,7 +95,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useQuery>);
+    }));
 
     renderWithQueryClient(<ApiKeys />);
     expect(screen.getByText("Test Key")).toBeInTheDocument();
@@ -122,7 +123,7 @@ describe("ApiKeys", () => {
 
   it("shows revoked badge for revoked keys", async () => {
     const { useQuery } = await import("@tanstack/react-query");
-    vi.mocked(useQuery).mockReturnValue({
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "key-2",
@@ -134,7 +135,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useQuery>);
+    }));
 
     renderWithQueryClient(<ApiKeys />);
     expect(screen.getByText("revoked")).toBeInTheDocument();
@@ -143,7 +144,7 @@ describe("ApiKeys", () => {
 
   it("shows expired badge for expired keys", async () => {
     const { useQuery } = await import("@tanstack/react-query");
-    vi.mocked(useQuery).mockReturnValue({
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "key-3",
@@ -155,7 +156,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useQuery>);
+    }));
 
     renderWithQueryClient(<ApiKeys />);
     expect(screen.getByText("expired")).toBeInTheDocument();
@@ -164,7 +165,7 @@ describe("ApiKeys", () => {
   it("opens revoke confirmation dialog when Revoke button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useQuery } = await import("@tanstack/react-query");
-    vi.mocked(useQuery).mockReturnValue({
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "key-1",
@@ -176,7 +177,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useQuery>);
+    }));
 
     renderWithQueryClient(<ApiKeys />);
     await user.click(screen.getByRole("button", { name: /revoke/i }));
@@ -193,7 +194,7 @@ describe("ApiKeys", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();
     const { useQuery, useMutation } = await import("@tanstack/react-query");
-    vi.mocked(useQuery).mockReturnValue({
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "key-1",
@@ -205,7 +206,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useQuery>);
+    }));
     vi.mocked(useMutation).mockImplementation((() => ({
       mutate: mockMutate,
       isPending: false,
@@ -241,10 +242,10 @@ describe("ApiKeys", () => {
 
   it("shows loading skeleton when data is loading", async () => {
     const { useQuery } = await import("@tanstack/react-query");
-    vi.mocked(useQuery).mockReturnValue({
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
       data: [],
       isLoading: true,
-    } as unknown as ReturnType<typeof useQuery>);
+    }));
 
     const { container } = renderWithQueryClient(<ApiKeys />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -252,7 +253,7 @@ describe("ApiKeys", () => {
 
   it("formats dates correctly in the table", async () => {
     const { useQuery } = await import("@tanstack/react-query");
-    vi.mocked(useQuery).mockReturnValue({
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "key-1",
@@ -264,7 +265,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useQuery>);
+    }));
 
     renderWithQueryClient(<ApiKeys />);
     // Dates should be formatted as locale date strings, not raw ISO

--- a/src/client/src/pages/ApiKeys.test.tsx
+++ b/src/client/src/pages/ApiKeys.test.tsx
@@ -94,7 +94,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as ReturnType<typeof useQuery>);
+    } as unknown as ReturnType<typeof useQuery>);
 
     renderWithQueryClient(<ApiKeys />);
     expect(screen.getByText("Test Key")).toBeInTheDocument();
@@ -134,7 +134,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as ReturnType<typeof useQuery>);
+    } as unknown as ReturnType<typeof useQuery>);
 
     renderWithQueryClient(<ApiKeys />);
     expect(screen.getByText("revoked")).toBeInTheDocument();
@@ -155,7 +155,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as ReturnType<typeof useQuery>);
+    } as unknown as ReturnType<typeof useQuery>);
 
     renderWithQueryClient(<ApiKeys />);
     expect(screen.getByText("expired")).toBeInTheDocument();
@@ -176,7 +176,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as ReturnType<typeof useQuery>);
+    } as unknown as ReturnType<typeof useQuery>);
 
     renderWithQueryClient(<ApiKeys />);
     await user.click(screen.getByRole("button", { name: /revoke/i }));
@@ -205,7 +205,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as ReturnType<typeof useQuery>);
+    } as unknown as ReturnType<typeof useQuery>);
     vi.mocked(useMutation).mockImplementation((() => ({
       mutate: mockMutate,
       isPending: false,
@@ -244,7 +244,7 @@ describe("ApiKeys", () => {
     vi.mocked(useQuery).mockReturnValue({
       data: [],
       isLoading: true,
-    } as ReturnType<typeof useQuery>);
+    } as unknown as ReturnType<typeof useQuery>);
 
     const { container } = renderWithQueryClient(<ApiKeys />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -264,7 +264,7 @@ describe("ApiKeys", () => {
         },
       ],
       isLoading: false,
-    } as ReturnType<typeof useQuery>);
+    } as unknown as ReturnType<typeof useQuery>);
 
     renderWithQueryClient(<ApiKeys />);
     // Dates should be formatted as locale date strings, not raw ISO

--- a/src/client/src/pages/AuditLog.test.tsx
+++ b/src/client/src/pages/AuditLog.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
 import AuditLog from "./AuditLog";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -52,10 +53,10 @@ describe("AuditLog", () => {
 
   it("shows loading state in AuditLogTable when data is loading", async () => {
     const { useRecentAuditLogs } = await import("@/hooks/useAudit");
-    vi.mocked(useRecentAuditLogs).mockReturnValue({
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useRecentAuditLogs>);
+    }));
 
     renderWithProviders(<AuditLog />);
     expect(screen.getByText("Loading...")).toBeInTheDocument();
@@ -63,7 +64,7 @@ describe("AuditLog", () => {
 
   it("passes filtered logs to AuditLogTable", async () => {
     const { useRecentAuditLogs } = await import("@/hooks/useAudit");
-    vi.mocked(useRecentAuditLogs).mockReturnValue({
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "1",
@@ -78,7 +79,7 @@ describe("AuditLog", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useRecentAuditLogs>);
+    }));
 
     renderWithProviders(<AuditLog />);
     // The AuditLogTable mock renders "AuditLogTable" when not loading
@@ -88,7 +89,7 @@ describe("AuditLog", () => {
   it("filters logs by entity ID search", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useRecentAuditLogs } = await import("@/hooks/useAudit");
-    vi.mocked(useRecentAuditLogs).mockReturnValue({
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "1",
@@ -103,7 +104,7 @@ describe("AuditLog", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useRecentAuditLogs>);
+    }));
 
     renderWithProviders(<AuditLog />);
     const searchInput = screen.getByLabelText(/search audit log by entity id/i);
@@ -115,7 +116,7 @@ describe("AuditLog", () => {
 
   it("enables Export CSV button when logs exist", async () => {
     const { useRecentAuditLogs } = await import("@/hooks/useAudit");
-    vi.mocked(useRecentAuditLogs).mockReturnValue({
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
       data: [
         {
           id: "1",
@@ -130,7 +131,7 @@ describe("AuditLog", () => {
         },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useRecentAuditLogs>);
+    }));
 
     renderWithProviders(<AuditLog />);
     expect(

--- a/src/client/src/pages/AuditLog.test.tsx
+++ b/src/client/src/pages/AuditLog.test.tsx
@@ -55,7 +55,7 @@ describe("AuditLog", () => {
     vi.mocked(useRecentAuditLogs).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useRecentAuditLogs>);
+    } as unknown as ReturnType<typeof useRecentAuditLogs>);
 
     renderWithProviders(<AuditLog />);
     expect(screen.getByText("Loading...")).toBeInTheDocument();
@@ -78,7 +78,7 @@ describe("AuditLog", () => {
         },
       ],
       isLoading: false,
-    } as ReturnType<typeof useRecentAuditLogs>);
+    } as unknown as ReturnType<typeof useRecentAuditLogs>);
 
     renderWithProviders(<AuditLog />);
     // The AuditLogTable mock renders "AuditLogTable" when not loading
@@ -103,7 +103,7 @@ describe("AuditLog", () => {
         },
       ],
       isLoading: false,
-    } as ReturnType<typeof useRecentAuditLogs>);
+    } as unknown as ReturnType<typeof useRecentAuditLogs>);
 
     renderWithProviders(<AuditLog />);
     const searchInput = screen.getByLabelText(/search audit log by entity id/i);
@@ -130,7 +130,7 @@ describe("AuditLog", () => {
         },
       ],
       isLoading: false,
-    } as ReturnType<typeof useRecentAuditLogs>);
+    } as unknown as ReturnType<typeof useRecentAuditLogs>);
 
     renderWithProviders(<AuditLog />);
     expect(

--- a/src/client/src/pages/Categories.test.tsx
+++ b/src/client/src/pages/Categories.test.tsx
@@ -65,7 +65,7 @@ describe("Categories", () => {
     vi.mocked(useCategories).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useCategories>);
+    } as unknown as ReturnType<typeof useCategories>);
 
     const { container } = renderWithProviders(<Categories />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe("Categories", () => {
     vi.mocked(useCategories).mockReturnValue({
       data: [],
       isLoading: false,
-    } as ReturnType<typeof useCategories>);
+    } as unknown as ReturnType<typeof useCategories>);
 
     renderWithProviders(<Categories />);
     expect(

--- a/src/client/src/pages/Categories.test.tsx
+++ b/src/client/src/pages/Categories.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import Categories from "./Categories";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -62,10 +63,10 @@ describe("Categories", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useCategories } = await import("@/hooks/useCategories");
-    vi.mocked(useCategories).mockReturnValue({
+    vi.mocked(useCategories).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useCategories>);
+    }));
 
     const { container } = renderWithProviders(<Categories />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -73,10 +74,10 @@ describe("Categories", () => {
 
   it("renders empty state when no categories exist", async () => {
     const { useCategories } = await import("@/hooks/useCategories");
-    vi.mocked(useCategories).mockReturnValue({
+    vi.mocked(useCategories).mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useCategories>);
+    }));
 
     renderWithProviders(<Categories />);
     expect(
@@ -105,14 +106,14 @@ describe("Categories", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -149,14 +150,14 @@ describe("Categories", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -184,14 +185,14 @@ describe("Categories", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -216,24 +217,24 @@ describe("Categories", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();
     const { useDeleteCategories } = await import("@/hooks/useCategories");
-    vi.mocked(useDeleteCategories).mockReturnValue({
+    vi.mocked(useDeleteCategories).mockReturnValue(mockMutationResult({
       mutate: mockMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useDeleteCategories>);
+    }));
 
     const items = [
       { id: "1", name: "Food", description: "Food expenses" },
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -271,14 +272,14 @@ describe("Categories", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({

--- a/src/client/src/pages/ItemTemplates.test.tsx
+++ b/src/client/src/pages/ItemTemplates.test.tsx
@@ -74,7 +74,7 @@ describe("ItemTemplates", () => {
     vi.mocked(useItemTemplates).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useItemTemplates>);
+    } as unknown as ReturnType<typeof useItemTemplates>);
 
     const { container } = renderWithProviders(<ItemTemplates />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -85,7 +85,7 @@ describe("ItemTemplates", () => {
     vi.mocked(useItemTemplates).mockReturnValue({
       data: [],
       isLoading: false,
-    } as ReturnType<typeof useItemTemplates>);
+    } as unknown as ReturnType<typeof useItemTemplates>);
 
     renderWithProviders(<ItemTemplates />);
     expect(

--- a/src/client/src/pages/ItemTemplates.test.tsx
+++ b/src/client/src/pages/ItemTemplates.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import ItemTemplates from "./ItemTemplates";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -71,10 +72,10 @@ describe("ItemTemplates", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useItemTemplates } = await import("@/hooks/useItemTemplates");
-    vi.mocked(useItemTemplates).mockReturnValue({
+    vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useItemTemplates>);
+    }));
 
     const { container } = renderWithProviders(<ItemTemplates />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -82,10 +83,10 @@ describe("ItemTemplates", () => {
 
   it("renders empty state when no templates exist", async () => {
     const { useItemTemplates } = await import("@/hooks/useItemTemplates");
-    vi.mocked(useItemTemplates).mockReturnValue({
+    vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useItemTemplates>);
+    }));
 
     renderWithProviders(<ItemTemplates />);
     expect(
@@ -113,14 +114,14 @@ describe("ItemTemplates", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -157,14 +158,14 @@ describe("ItemTemplates", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -192,14 +193,14 @@ describe("ItemTemplates", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -224,24 +225,24 @@ describe("ItemTemplates", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();
     const { useDeleteItemTemplates } = await import("@/hooks/useItemTemplates");
-    vi.mocked(useDeleteItemTemplates).mockReturnValue({
+    vi.mocked(useDeleteItemTemplates).mockReturnValue(mockMutationResult({
       mutate: mockMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useDeleteItemTemplates>);
+    }));
 
     const items = [
       { id: "1", name: "Coffee", description: "Morning coffee", defaultCategory: "Food", defaultSubcategory: "Drinks", defaultUnitPrice: 4.50, defaultUnitPriceCurrency: "USD", defaultPricingMode: "quantity", defaultItemCode: "COF-001" },
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({

--- a/src/client/src/pages/ReceiptDetail.test.tsx
+++ b/src/client/src/pages/ReceiptDetail.test.tsx
@@ -79,7 +79,7 @@ describe("ReceiptDetail", () => {
       data: undefined,
       isLoading: true,
       isError: false,
-    } as ReturnType<typeof useReceiptWithItems>);
+    } as unknown as ReturnType<typeof useReceiptWithItems>);
 
     const { container } = renderWithProviders(<ReceiptDetail />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -105,7 +105,7 @@ describe("ReceiptDetail", () => {
       data: undefined,
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useReceiptWithItems>);
+    } as unknown as ReturnType<typeof useReceiptWithItems>);
 
     renderWithProviders(<ReceiptDetail />);
 
@@ -125,7 +125,7 @@ describe("ReceiptDetail", () => {
       data: undefined,
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useReceiptWithItems>);
+    } as unknown as ReturnType<typeof useReceiptWithItems>);
 
     renderWithProviders(<ReceiptDetail />);
 
@@ -155,7 +155,7 @@ describe("ReceiptDetail", () => {
       },
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useReceiptWithItems>);
+    } as unknown as ReturnType<typeof useReceiptWithItems>);
 
     renderWithProviders(<ReceiptDetail />);
     expect(screen.getByText(/walmart/i)).toBeInTheDocument();
@@ -170,7 +170,7 @@ describe("ReceiptDetail", () => {
       data: undefined,
       isLoading: false,
       isError: true,
-    } as ReturnType<typeof useReceiptWithItems>);
+    } as unknown as ReturnType<typeof useReceiptWithItems>);
 
     renderWithProviders(<ReceiptDetail />);
 

--- a/src/client/src/pages/ReceiptDetail.test.tsx
+++ b/src/client/src/pages/ReceiptDetail.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
 import ReceiptDetail from "./ReceiptDetail";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -75,11 +76,11 @@ describe("ReceiptDetail", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useReceiptWithItems } = await import("@/hooks/useAggregates");
-    vi.mocked(useReceiptWithItems).mockReturnValue({
+    vi.mocked(useReceiptWithItems).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
       isError: false,
-    } as unknown as ReturnType<typeof useReceiptWithItems>);
+    }));
 
     const { container } = renderWithProviders(<ReceiptDetail />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -101,11 +102,11 @@ describe("ReceiptDetail", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useReceiptWithItems } = await import("@/hooks/useAggregates");
     const mockHook = vi.mocked(useReceiptWithItems);
-    mockHook.mockReturnValue({
+    mockHook.mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof useReceiptWithItems>);
+    }));
 
     renderWithProviders(<ReceiptDetail />);
 
@@ -121,11 +122,11 @@ describe("ReceiptDetail", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useReceiptWithItems } = await import("@/hooks/useAggregates");
     const mockHook = vi.mocked(useReceiptWithItems);
-    mockHook.mockReturnValue({
+    mockHook.mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof useReceiptWithItems>);
+    }));
 
     renderWithProviders(<ReceiptDetail />);
 
@@ -137,7 +138,7 @@ describe("ReceiptDetail", () => {
 
   it("renders receipt data when loaded", async () => {
     const { useReceiptWithItems } = await import("@/hooks/useAggregates");
-    vi.mocked(useReceiptWithItems).mockReturnValue({
+    vi.mocked(useReceiptWithItems).mockReturnValue(mockQueryResult({
       data: {
         receipt: {
           id: "r1",
@@ -155,7 +156,7 @@ describe("ReceiptDetail", () => {
       },
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof useReceiptWithItems>);
+    }));
 
     renderWithProviders(<ReceiptDetail />);
     expect(screen.getByText(/walmart/i)).toBeInTheDocument();
@@ -166,11 +167,11 @@ describe("ReceiptDetail", () => {
   it("renders error state when receipt is not found", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useReceiptWithItems } = await import("@/hooks/useAggregates");
-    vi.mocked(useReceiptWithItems).mockReturnValue({
+    vi.mocked(useReceiptWithItems).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: false,
       isError: true,
-    } as unknown as ReturnType<typeof useReceiptWithItems>);
+    }));
 
     renderWithProviders(<ReceiptDetail />);
 

--- a/src/client/src/pages/ReceiptItems.test.tsx
+++ b/src/client/src/pages/ReceiptItems.test.tsx
@@ -83,7 +83,7 @@ describe("ReceiptItems", () => {
     vi.mocked(useReceiptItems).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useReceiptItems>);
+    } as unknown as ReturnType<typeof useReceiptItems>);
 
     const { container } = renderWithProviders(<ReceiptItems />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -94,7 +94,7 @@ describe("ReceiptItems", () => {
     vi.mocked(useReceiptItems).mockReturnValue({
       data: [],
       isLoading: false,
-    } as ReturnType<typeof useReceiptItems>);
+    } as unknown as ReturnType<typeof useReceiptItems>);
 
     renderWithProviders(<ReceiptItems />);
     expect(

--- a/src/client/src/pages/ReceiptItems.test.tsx
+++ b/src/client/src/pages/ReceiptItems.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import ReceiptItems from "./ReceiptItems";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -80,10 +81,10 @@ describe("ReceiptItems", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
-    vi.mocked(useReceiptItems).mockReturnValue({
+    vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useReceiptItems>);
+    }));
 
     const { container } = renderWithProviders(<ReceiptItems />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -91,10 +92,10 @@ describe("ReceiptItems", () => {
 
   it("renders empty state when no receipt items exist", async () => {
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
-    vi.mocked(useReceiptItems).mockReturnValue({
+    vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useReceiptItems>);
+    }));
 
     renderWithProviders(<ReceiptItems />);
     expect(
@@ -122,14 +123,14 @@ describe("ReceiptItems", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -156,14 +157,14 @@ describe("ReceiptItems", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -188,24 +189,24 @@ describe("ReceiptItems", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();
     const { useDeleteReceiptItems } = await import("@/hooks/useReceiptItems");
-    vi.mocked(useDeleteReceiptItems).mockReturnValue({
+    vi.mocked(useDeleteReceiptItems).mockReturnValue(mockMutationResult({
       mutate: mockMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useDeleteReceiptItems>);
+    }));
 
     const items = [
       { id: "ri1", receiptId: "r1", receiptItemCode: "RI-001", description: "Milk", quantity: 2, unitPrice: 3.99, category: "Groceries", subcategory: "Dairy", pricingMode: "quantity" as const },
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -243,14 +244,14 @@ describe("ReceiptItems", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -65,7 +65,7 @@ describe("Receipts", () => {
     vi.mocked(useReceipts).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useReceipts>);
+    } as unknown as ReturnType<typeof useReceipts>);
 
     const { container } = renderWithProviders(<Receipts />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe("Receipts", () => {
     vi.mocked(useReceipts).mockReturnValue({
       data: [],
       isLoading: false,
-    } as ReturnType<typeof useReceipts>);
+    } as unknown as ReturnType<typeof useReceipts>);
 
     renderWithProviders(<Receipts />);
     expect(

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import Receipts from "./Receipts";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -62,10 +63,10 @@ describe("Receipts", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
-    vi.mocked(useReceipts).mockReturnValue({
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useReceipts>);
+    }));
 
     const { container } = renderWithProviders(<Receipts />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -73,10 +74,10 @@ describe("Receipts", () => {
 
   it("renders empty state when no receipts exist", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
-    vi.mocked(useReceipts).mockReturnValue({
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useReceipts>);
+    }));
 
     renderWithProviders(<Receipts />);
     expect(
@@ -105,14 +106,14 @@ describe("Receipts", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -150,14 +151,14 @@ describe("Receipts", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -185,14 +186,14 @@ describe("Receipts", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -217,24 +218,24 @@ describe("Receipts", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();
     const { useDeleteReceipts } = await import("@/hooks/useReceipts");
-    vi.mocked(useDeleteReceipts).mockReturnValue({
+    vi.mocked(useDeleteReceipts).mockReturnValue(mockMutationResult({
       mutate: mockMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useDeleteReceipts>);
+    }));
 
     const items = [
       { id: "1", description: "Grocery", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -272,14 +273,14 @@ describe("Receipts", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({

--- a/src/client/src/pages/RecycleBin.test.tsx
+++ b/src/client/src/pages/RecycleBin.test.tsx
@@ -66,7 +66,7 @@ describe("RecycleBin", () => {
     vi.mocked(useDeletedAccounts).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useDeletedAccounts>);
+    } as unknown as ReturnType<typeof useDeletedAccounts>);
 
     const { container } = renderWithProviders(<RecycleBin />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe("RecycleBin", () => {
     vi.mocked(useDeletedAccounts).mockReturnValue({
       data: [],
       isLoading: false,
-    } as ReturnType<typeof useDeletedAccounts>);
+    } as unknown as ReturnType<typeof useDeletedAccounts>);
 
     renderWithProviders(<RecycleBin />);
     expect(
@@ -106,7 +106,7 @@ describe("RecycleBin", () => {
         { id: "a1", name: "Old Account", accountCode: "ACC-OLD" },
       ],
       isLoading: false,
-    } as ReturnType<typeof useDeletedAccounts>);
+    } as unknown as ReturnType<typeof useDeletedAccounts>);
 
     const { useDeletedCategories } = await import("@/hooks/useCategories");
     vi.mocked(useDeletedCategories).mockReturnValue({
@@ -114,7 +114,7 @@ describe("RecycleBin", () => {
         { id: "c1", name: "Deleted Category" },
       ],
       isLoading: false,
-    } as ReturnType<typeof useDeletedCategories>);
+    } as unknown as ReturnType<typeof useDeletedCategories>);
 
     renderWithProviders(<RecycleBin />);
     expect(screen.getByText("Account")).toBeInTheDocument();
@@ -130,7 +130,7 @@ describe("RecycleBin", () => {
         { id: "a1", name: "Old Account", accountCode: "ACC-OLD" },
       ],
       isLoading: false,
-    } as ReturnType<typeof useDeletedAccounts>);
+    } as unknown as ReturnType<typeof useDeletedAccounts>);
 
     renderWithProviders(<RecycleBin />);
     // Should have an "All" tab and an "Account" tab

--- a/src/client/src/pages/RecycleBin.test.tsx
+++ b/src/client/src/pages/RecycleBin.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
 import RecycleBin from "./RecycleBin";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -63,10 +64,10 @@ describe("RecycleBin", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useDeletedAccounts } = await import("@/hooks/useAccounts");
-    vi.mocked(useDeletedAccounts).mockReturnValue({
+    vi.mocked(useDeletedAccounts).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useDeletedAccounts>);
+    }));
 
     const { container } = renderWithProviders(<RecycleBin />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -74,10 +75,10 @@ describe("RecycleBin", () => {
 
   it("renders the All tab", async () => {
     const { useDeletedAccounts } = await import("@/hooks/useAccounts");
-    vi.mocked(useDeletedAccounts).mockReturnValue({
+    vi.mocked(useDeletedAccounts).mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useDeletedAccounts>);
+    }));
 
     renderWithProviders(<RecycleBin />);
     expect(
@@ -101,20 +102,20 @@ describe("RecycleBin", () => {
 
   it("renders deleted items in the table when data exists", async () => {
     const { useDeletedAccounts } = await import("@/hooks/useAccounts");
-    vi.mocked(useDeletedAccounts).mockReturnValue({
+    vi.mocked(useDeletedAccounts).mockReturnValue(mockQueryResult({
       data: [
         { id: "a1", name: "Old Account", accountCode: "ACC-OLD" },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useDeletedAccounts>);
+    }));
 
     const { useDeletedCategories } = await import("@/hooks/useCategories");
-    vi.mocked(useDeletedCategories).mockReturnValue({
+    vi.mocked(useDeletedCategories).mockReturnValue(mockQueryResult({
       data: [
         { id: "c1", name: "Deleted Category" },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useDeletedCategories>);
+    }));
 
     renderWithProviders(<RecycleBin />);
     expect(screen.getByText("Account")).toBeInTheDocument();
@@ -125,12 +126,12 @@ describe("RecycleBin", () => {
 
   it("renders entity type tabs when deleted items exist", async () => {
     const { useDeletedAccounts } = await import("@/hooks/useAccounts");
-    vi.mocked(useDeletedAccounts).mockReturnValue({
+    vi.mocked(useDeletedAccounts).mockReturnValue(mockQueryResult({
       data: [
         { id: "a1", name: "Old Account", accountCode: "ACC-OLD" },
       ],
       isLoading: false,
-    } as unknown as ReturnType<typeof useDeletedAccounts>);
+    }));
 
     renderWithProviders(<RecycleBin />);
     // Should have an "All" tab and an "Account" tab

--- a/src/client/src/pages/SecurityLog.test.tsx
+++ b/src/client/src/pages/SecurityLog.test.tsx
@@ -57,7 +57,7 @@ describe("SecurityLog", () => {
     const { usePermission } = await import("@/hooks/usePermission");
     vi.mocked(usePermission).mockReturnValue({
       isAdmin: () => false,
-    } as ReturnType<typeof usePermission>);
+    } as unknown as ReturnType<typeof usePermission>);
 
     renderWithProviders(<SecurityLog />);
     expect(

--- a/src/client/src/pages/SecurityLog.test.tsx
+++ b/src/client/src/pages/SecurityLog.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
 import SecurityLog from "./SecurityLog";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -55,9 +56,9 @@ describe("SecurityLog", () => {
 
   it("hides admin tabs when user is not admin", async () => {
     const { usePermission } = await import("@/hooks/usePermission");
-    vi.mocked(usePermission).mockReturnValue({
+    vi.mocked(usePermission).mockReturnValue(mockQueryResult({
       isAdmin: () => false,
-    } as unknown as ReturnType<typeof usePermission>);
+    }));
 
     renderWithProviders(<SecurityLog />);
     expect(

--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -69,7 +69,7 @@ describe("Subcategories", () => {
     vi.mocked(useSubcategories).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useSubcategories>);
+    } as unknown as ReturnType<typeof useSubcategories>);
 
     const { container } = renderWithProviders(<Subcategories />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -80,7 +80,7 @@ describe("Subcategories", () => {
     vi.mocked(useSubcategories).mockReturnValue({
       data: [],
       isLoading: false,
-    } as ReturnType<typeof useSubcategories>);
+    } as unknown as ReturnType<typeof useSubcategories>);
 
     renderWithProviders(<Subcategories />);
     expect(

--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import Subcategories from "./Subcategories";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -66,10 +67,10 @@ describe("Subcategories", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useSubcategories).mockReturnValue({
+    vi.mocked(useSubcategories).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useSubcategories>);
+    }));
 
     const { container } = renderWithProviders(<Subcategories />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -77,10 +78,10 @@ describe("Subcategories", () => {
 
   it("renders empty state when no subcategories exist", async () => {
     const { useSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useSubcategories).mockReturnValue({
+    vi.mocked(useSubcategories).mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useSubcategories>);
+    }));
 
     renderWithProviders(<Subcategories />);
     expect(
@@ -109,14 +110,14 @@ describe("Subcategories", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -152,14 +153,14 @@ describe("Subcategories", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -184,24 +185,24 @@ describe("Subcategories", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();
     const { useDeleteSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useDeleteSubcategories).mockReturnValue({
+    vi.mocked(useDeleteSubcategories).mockReturnValue(mockMutationResult({
       mutate: mockMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useDeleteSubcategories>);
+    }));
 
     const items = [
       { id: "1", name: "Dairy", categoryId: "c1", categoryName: "Food", description: "Dairy products" },
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({

--- a/src/client/src/pages/TransactionDetail.test.tsx
+++ b/src/client/src/pages/TransactionDetail.test.tsx
@@ -151,7 +151,7 @@ describe("TransactionDetail", () => {
       ],
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useTransactionAccountsByReceiptId>);
+    } as unknown as ReturnType<typeof useTransactionAccountsByReceiptId>);
 
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithProviders(<TransactionDetail />);
@@ -172,7 +172,7 @@ describe("TransactionDetail", () => {
       data: undefined,
       isLoading: false,
       isError: true,
-    } as ReturnType<typeof useTransactionAccountsByReceiptId>);
+    } as unknown as ReturnType<typeof useTransactionAccountsByReceiptId>);
 
     renderWithProviders(<TransactionDetail />);
 

--- a/src/client/src/pages/TransactionDetail.test.tsx
+++ b/src/client/src/pages/TransactionDetail.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
 import TransactionDetail from "./TransactionDetail";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -142,7 +143,7 @@ describe("TransactionDetail", () => {
 
   it("renders transaction data when loaded via receipt lookup", async () => {
     const { useTransactionAccountsByReceiptId } = await import("@/hooks/useAggregates");
-    vi.mocked(useTransactionAccountsByReceiptId).mockReturnValue({
+    vi.mocked(useTransactionAccountsByReceiptId).mockReturnValue(mockQueryResult({
       data: [
         {
           transaction: { id: "t1", amount: 50.00, date: "2024-01-15" },
@@ -151,7 +152,7 @@ describe("TransactionDetail", () => {
       ],
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof useTransactionAccountsByReceiptId>);
+    }));
 
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithProviders(<TransactionDetail />);
@@ -168,11 +169,11 @@ describe("TransactionDetail", () => {
   it("renders error state when no data found", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useTransactionAccountsByReceiptId } = await import("@/hooks/useAggregates");
-    vi.mocked(useTransactionAccountsByReceiptId).mockReturnValue({
+    vi.mocked(useTransactionAccountsByReceiptId).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: false,
       isError: true,
-    } as unknown as ReturnType<typeof useTransactionAccountsByReceiptId>);
+    }));
 
     renderWithProviders(<TransactionDetail />);
 

--- a/src/client/src/pages/Transactions.test.tsx
+++ b/src/client/src/pages/Transactions.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import Transactions from "./Transactions";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -71,10 +72,10 @@ describe("Transactions", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
-    vi.mocked(useTransactions).mockReturnValue({
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
-    } as unknown as ReturnType<typeof useTransactions>);
+    }));
 
     const { container } = renderWithProviders(<Transactions />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -82,10 +83,10 @@ describe("Transactions", () => {
 
   it("renders empty state when no transactions exist", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
-    vi.mocked(useTransactions).mockReturnValue({
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
       data: [],
       isLoading: false,
-    } as unknown as ReturnType<typeof useTransactions>);
+    }));
 
     renderWithProviders(<Transactions />);
     expect(
@@ -114,14 +115,14 @@ describe("Transactions", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -157,14 +158,14 @@ describe("Transactions", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -189,24 +190,24 @@ describe("Transactions", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();
     const { useDeleteTransactions } = await import("@/hooks/useTransactions");
-    vi.mocked(useDeleteTransactions).mockReturnValue({
+    vi.mocked(useDeleteTransactions).mockReturnValue(mockMutationResult({
       mutate: mockMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof useDeleteTransactions>);
+    }));
 
     const items = [
       { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({
@@ -244,14 +245,14 @@ describe("Transactions", () => {
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue({
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
       results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
       totalCount: items.length,
       isSearching: false,
       clearSearch: vi.fn(),
-    } as unknown as ReturnType<typeof useFuzzySearch>);
+    }));
 
     const { usePagination } = await import("@/hooks/usePagination");
     vi.mocked(usePagination).mockReturnValue({

--- a/src/client/src/pages/Transactions.test.tsx
+++ b/src/client/src/pages/Transactions.test.tsx
@@ -74,7 +74,7 @@ describe("Transactions", () => {
     vi.mocked(useTransactions).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as ReturnType<typeof useTransactions>);
+    } as unknown as ReturnType<typeof useTransactions>);
 
     const { container } = renderWithProviders(<Transactions />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -85,7 +85,7 @@ describe("Transactions", () => {
     vi.mocked(useTransactions).mockReturnValue({
       data: [],
       isLoading: false,
-    } as ReturnType<typeof useTransactions>);
+    } as unknown as ReturnType<typeof useTransactions>);
 
     renderWithProviders(<Transactions />);
     expect(

--- a/src/client/src/pages/Trips.test.tsx
+++ b/src/client/src/pages/Trips.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
 import Trips from "./Trips";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -45,11 +46,11 @@ describe("Trips", () => {
 
   it("renders loading skeletons when trip is loading", async () => {
     const { useTripByReceiptId } = await import("@/hooks/useTrips");
-    vi.mocked(useTripByReceiptId).mockReturnValue({
+    vi.mocked(useTripByReceiptId).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: true,
       isError: false,
-    } as unknown as ReturnType<typeof useTripByReceiptId>);
+    }));
 
     const { container } = renderWithProviders(<Trips />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -57,11 +58,11 @@ describe("Trips", () => {
 
   it("renders error state when trip is not found", async () => {
     const { useTripByReceiptId } = await import("@/hooks/useTrips");
-    vi.mocked(useTripByReceiptId).mockReturnValue({
+    vi.mocked(useTripByReceiptId).mockReturnValue(mockQueryResult({
       data: undefined,
       isLoading: false,
       isError: true,
-    } as unknown as ReturnType<typeof useTripByReceiptId>);
+    }));
 
     renderWithProviders(<Trips />);
     // Error state shows when receiptId is set and isError is true
@@ -70,7 +71,7 @@ describe("Trips", () => {
 
   it("renders trip data when loaded", async () => {
     const { useTripByReceiptId } = await import("@/hooks/useTrips");
-    vi.mocked(useTripByReceiptId).mockReturnValue({
+    vi.mocked(useTripByReceiptId).mockReturnValue(mockQueryResult({
       data: {
         receipt: {
           receipt: {
@@ -92,7 +93,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof useTripByReceiptId>);
+    }));
 
     renderWithProviders(<Trips />);
     expect(screen.getByText(/walmart/i)).toBeInTheDocument();
@@ -101,7 +102,7 @@ describe("Trips", () => {
 
   it("renders transactions when trip has transactions", async () => {
     const { useTripByReceiptId } = await import("@/hooks/useTrips");
-    vi.mocked(useTripByReceiptId).mockReturnValue({
+    vi.mocked(useTripByReceiptId).mockReturnValue(mockQueryResult({
       data: {
         receipt: {
           receipt: {
@@ -128,7 +129,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof useTripByReceiptId>);
+    }));
 
     renderWithProviders(<Trips />);
     expect(screen.getByText("ACC-001")).toBeInTheDocument();
@@ -137,7 +138,7 @@ describe("Trips", () => {
 
   it("renders adjustments when trip has adjustments", async () => {
     const { useTripByReceiptId } = await import("@/hooks/useTrips");
-    vi.mocked(useTripByReceiptId).mockReturnValue({
+    vi.mocked(useTripByReceiptId).mockReturnValue(mockQueryResult({
       data: {
         receipt: {
           receipt: {
@@ -161,7 +162,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof useTripByReceiptId>);
+    }));
 
     renderWithProviders(<Trips />);
     expect(screen.getByText("Discount")).toBeInTheDocument();
@@ -170,7 +171,7 @@ describe("Trips", () => {
 
   it("shows no transactions message when trip has no transactions", async () => {
     const { useTripByReceiptId } = await import("@/hooks/useTrips");
-    vi.mocked(useTripByReceiptId).mockReturnValue({
+    vi.mocked(useTripByReceiptId).mockReturnValue(mockQueryResult({
       data: {
         receipt: {
           receipt: {
@@ -192,7 +193,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof useTripByReceiptId>);
+    }));
 
     renderWithProviders(<Trips />);
     expect(
@@ -202,7 +203,7 @@ describe("Trips", () => {
 
   it("shows no adjustments message when trip has no adjustments", async () => {
     const { useTripByReceiptId } = await import("@/hooks/useTrips");
-    vi.mocked(useTripByReceiptId).mockReturnValue({
+    vi.mocked(useTripByReceiptId).mockReturnValue(mockQueryResult({
       data: {
         receipt: {
           receipt: {
@@ -224,7 +225,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof useTripByReceiptId>);
+    }));
 
     renderWithProviders(<Trips />);
     expect(

--- a/src/client/src/pages/Trips.test.tsx
+++ b/src/client/src/pages/Trips.test.tsx
@@ -49,7 +49,7 @@ describe("Trips", () => {
       data: undefined,
       isLoading: true,
       isError: false,
-    } as ReturnType<typeof useTripByReceiptId>);
+    } as unknown as ReturnType<typeof useTripByReceiptId>);
 
     const { container } = renderWithProviders(<Trips />);
     expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
@@ -61,7 +61,7 @@ describe("Trips", () => {
       data: undefined,
       isLoading: false,
       isError: true,
-    } as ReturnType<typeof useTripByReceiptId>);
+    } as unknown as ReturnType<typeof useTripByReceiptId>);
 
     renderWithProviders(<Trips />);
     // Error state shows when receiptId is set and isError is true
@@ -92,7 +92,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useTripByReceiptId>);
+    } as unknown as ReturnType<typeof useTripByReceiptId>);
 
     renderWithProviders(<Trips />);
     expect(screen.getByText(/walmart/i)).toBeInTheDocument();
@@ -128,7 +128,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useTripByReceiptId>);
+    } as unknown as ReturnType<typeof useTripByReceiptId>);
 
     renderWithProviders(<Trips />);
     expect(screen.getByText("ACC-001")).toBeInTheDocument();
@@ -161,7 +161,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useTripByReceiptId>);
+    } as unknown as ReturnType<typeof useTripByReceiptId>);
 
     renderWithProviders(<Trips />);
     expect(screen.getByText("Discount")).toBeInTheDocument();
@@ -192,7 +192,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useTripByReceiptId>);
+    } as unknown as ReturnType<typeof useTripByReceiptId>);
 
     renderWithProviders(<Trips />);
     expect(
@@ -224,7 +224,7 @@ describe("Trips", () => {
       },
       isLoading: false,
       isError: false,
-    } as ReturnType<typeof useTripByReceiptId>);
+    } as unknown as ReturnType<typeof useTripByReceiptId>);
 
     renderWithProviders(<Trips />);
     expect(

--- a/src/client/src/test/mock-hooks.ts
+++ b/src/client/src/test/mock-hooks.ts
@@ -1,0 +1,66 @@
+import type { UseQueryResult, UseMutationResult } from "@tanstack/react-query";
+
+/**
+ * Creates a mock UseQueryResult with sensible defaults.
+ * Use this instead of `as unknown as ReturnType<typeof useXxx>` double-casts.
+ *
+ * The return is typed as `any` so it can be passed to `mockReturnValue`
+ * on any query hook without needing a cast at the call site.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function mockQueryResult(overrides: Record<string, any> = {}): any {
+  return {
+    data: undefined,
+    error: null,
+    isError: false,
+    isPending: true,
+    isLoading: true,
+    isLoadingError: false,
+    isRefetchError: false,
+    isSuccess: false,
+    isFetching: false,
+    isFetched: false,
+    isFetchedAfterMount: false,
+    isRefetching: false,
+    isStale: false,
+    isPlaceholderData: false,
+    status: "pending" as const,
+    fetchStatus: "idle" as const,
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    refetch: vi.fn(),
+    promise: Promise.resolve(undefined),
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a mock UseMutationResult with sensible defaults.
+ * Use this instead of `as unknown as ReturnType<typeof useXxx>` double-casts
+ * for mutation hooks.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function mockMutationResult(overrides: Record<string, any> = {}): any {
+  return {
+    data: undefined,
+    error: null,
+    isError: false,
+    isIdle: true,
+    isPending: false,
+    isSuccess: false,
+    status: "idle" as const,
+    failureCount: 0,
+    failureReason: null,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    context: undefined,
+    variables: undefined,
+    submittedAt: 0,
+    isPaused: false,
+    ...overrides,
+  };
+}

--- a/src/client/src/test/setup.ts
+++ b/src/client/src/test/setup.ts
@@ -1,2 +1,15 @@
 /// <reference types="vitest/globals" />
 import "@testing-library/jest-dom/vitest";
+
+// Polyfill localStorage for jsdom environments where it's not properly initialized
+if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.setItem !== 'function') {
+  const store: Record<string, string> = {};
+  globalThis.localStorage = {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() { return Object.keys(store).length; },
+  } as Storage;
+}

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -1,5 +1,4 @@
-/// <reference types="vitest" />
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";

--- a/tests/Infrastructure.Tests/Services/AuthAuditCleanupServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/AuthAuditCleanupServiceTests.cs
@@ -90,16 +90,21 @@ public class AuthAuditCleanupServiceTests
 	public async Task ExecuteAsync_ContinuesOnException()
 	{
 		// Arrange
+		TaskCompletionSource invoked = new();
 		_auditServiceMock
 			.Setup(s => s.CleanupOldEntriesAsync(180, It.IsAny<CancellationToken>()))
-			.ThrowsAsync(new InvalidOperationException("Database error"));
+			.Returns<int, CancellationToken>((_, _) =>
+			{
+				invoked.TrySetResult();
+				return Task.FromException<int>(new InvalidOperationException("Database error"));
+			});
 
 		AuthAuditCleanupService service = new(_scopeFactoryMock.Object, _loggerMock.Object);
 		using CancellationTokenSource cts = new();
 
 		// Act — should not throw
 		await service.StartAsync(cts.Token);
-		await Task.Delay(100);
+		await invoked.Task.WaitAsync(TimeSpan.FromSeconds(5));
 		cts.Cancel();
 		Func<Task> act = async () => await service.StopAsync(CancellationToken.None);
 


### PR DESCRIPTION
## Summary
- Fix `vite.config.ts` import to use `vitest/config` so the `test` property is recognized
- Add `localStorage` polyfill to test setup for jsdom 28.x compatibility (fixes 36 test failures)
- Fix `ItemTemplateForm.tsx` using wrong prop name (`onChange` → `onValueChange`) for `Combobox`
- Add `as unknown as` intermediate cast to partial `UseQueryResult` mocks across 15 test files
- Use `vi.mocked()` instead of manual cast in `useSignalR.test.ts`
- Add `as any` to incomplete `FetchResponse` type casts

## Linear Issue
https://linear.app/mggarofalo/issue/MGG-220/fix-frontend-typescript-errors-and-test-failures

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] All frontend tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)