### PR TITLE
feat(api): add correlation IDs, global exception handling, and security event logging (MGG-101)

### DIFF
--- a/src/Presentation/API/Configuration/ApplicationConfiguration.cs
+++ b/src/Presentation/API/Configuration/ApplicationConfiguration.cs
@@ -1,9 +1,11 @@
+using System.Security.Claims;
 using API.Filters;
 using API.Hubs;
 using API.Middleware;
 using API.Services;
 using API.Validators;
 using FluentValidation;
+using Serilog;
 
 namespace API.Configuration;
 
@@ -43,6 +45,19 @@ public static class ApplicationConfiguration
 
 	public static WebApplication UseApplicationServices(this WebApplication app)
 	{
+		app.UseSerilogRequestLogging(options =>
+		{
+			options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+			{
+				diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value);
+				diagnosticContext.Set("UserAgent", httpContext.Request.Headers.UserAgent.ToString());
+				string? userId = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+				if (userId is not null)
+				{
+					diagnosticContext.Set("UserId", userId);
+				}
+			};
+		});
 		app.UseMiddleware<ValidationExceptionMiddleware>();
 		app.UseHttpsRedirection();
 		app.UseRouting();

--- a/src/Presentation/API/Configuration/AuthConfiguration.cs
+++ b/src/Presentation/API/Configuration/AuthConfiguration.cs
@@ -50,6 +50,29 @@ public static class AuthConfiguration
 
 						return Task.CompletedTask;
 					},
+					OnAuthenticationFailed = context =>
+					{
+						ILoggerFactory loggerFactory = context.HttpContext.RequestServices
+							.GetRequiredService<ILoggerFactory>();
+						ILogger logger = loggerFactory.CreateLogger("API.Configuration.AuthConfiguration");
+						logger.LogWarning(
+							"Authentication failed. Path: {Path}, IP: {IP}, Error: {Error}",
+							context.Request.Path,
+							context.HttpContext.Connection.RemoteIpAddress,
+							context.Exception.Message);
+						return Task.CompletedTask;
+					},
+					OnChallenge = context =>
+					{
+						ILoggerFactory loggerFactory = context.HttpContext.RequestServices
+							.GetRequiredService<ILoggerFactory>();
+						ILogger logger = loggerFactory.CreateLogger("API.Configuration.AuthConfiguration");
+						logger.LogInformation(
+							"Authentication challenge issued. Path: {Path}, IP: {IP}",
+							context.Request.Path,
+							context.HttpContext.Connection.RemoteIpAddress);
+						return Task.CompletedTask;
+					},
 				};
 			})
 			.AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(

--- a/src/Presentation/API/Configuration/OpenApiConfiguration.cs
+++ b/src/Presentation/API/Configuration/OpenApiConfiguration.cs
@@ -19,6 +19,10 @@ public static class OpenApiConfiguration
 			app.MapScalarApiReference();
 			app.UseOpenApiResponseValidation();
 		}
+		else
+		{
+			app.UseHsts();
+		}
 
 		return app;
 	}

--- a/src/Presentation/API/Configuration/OpenApiConfiguration.cs
+++ b/src/Presentation/API/Configuration/OpenApiConfiguration.cs
@@ -19,11 +19,6 @@ public static class OpenApiConfiguration
 			app.MapScalarApiReference();
 			app.UseOpenApiResponseValidation();
 		}
-		else
-		{
-			app.UseExceptionHandler("/Error");
-			app.UseHsts();
-		}
 
 		return app;
 	}

--- a/src/Presentation/API/Controllers/Aggregates/ReceiptWithItemsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReceiptWithItemsController.cs
@@ -17,8 +17,6 @@ namespace API.Controllers.Aggregates;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class ReceiptWithItemsController(IMediator mediator, ReceiptWithItemsMapper mapper, ILogger<ReceiptWithItemsController> logger) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for receiptId: {receiptId}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
 	public const string RouteByReceiptId = "";
 
 	[HttpGet(RouteByReceiptId)]
@@ -26,29 +24,18 @@ public class ReceiptWithItemsController(IMediator mediator, ReceiptWithItemsMapp
 	[EndpointDescription("Returns a receipt and all its associated line items as a single aggregate, looked up by receipt ID.")]
 	[ProducesResponseType<ReceiptWithItemsResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<ReceiptWithItemsResponse>> GetReceiptWithItemsByReceiptId([FromQuery] Guid receiptId)
 	{
-		try
-		{
-			logger.LogDebug("GetReceiptWithItemsByReceiptId called with receiptId: {receiptId}", receiptId);
-			GetReceiptWithItemsByReceiptIdQuery query = new(receiptId);
-			ReceiptWithItems? result = await mediator.Send(query);
+		GetReceiptWithItemsByReceiptIdQuery query = new(receiptId);
+		ReceiptWithItems? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetReceiptWithItemsByReceiptId called with receiptId: {receiptId} not found", receiptId);
-				return NotFound();
-			}
-
-			ReceiptWithItemsResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetReceiptWithItemsByReceiptId called with receiptId: {receiptId} found", receiptId);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetReceiptWithItemsByReceiptId), receiptId);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("ReceiptWithItems for receipt {ReceiptId} not found", receiptId);
+			return NotFound();
 		}
+
+		ReceiptWithItemsResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 }

--- a/src/Presentation/API/Controllers/Aggregates/TransactionAccountController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/TransactionAccountController.cs
@@ -15,54 +15,40 @@ namespace API.Controllers.Aggregates;
 [Produces("application/json")]
 [Authorize]
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-public class TransactionAccountController(IMediator mediator, TransactionAccountMapper mapper, ILogger<TransactionAccountController> logger) : ControllerBase
+public class TransactionAccountController(IMediator mediator, TransactionAccountMapper mapper) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for id: {Id}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
-
 	[HttpGet("")]
 	[EndpointSummary("Get transaction accounts")]
 	[EndpointDescription("Returns transaction accounts filtered by transaction ID or receipt ID.")]
 	[ProducesResponseType<List<TransactionAccountResponse>>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> GetTransactionAccounts([FromQuery] Guid? transactionId = null, [FromQuery] Guid? receiptId = null)
 	{
-		try
+		if (transactionId.HasValue && receiptId.HasValue)
 		{
-			if (transactionId.HasValue && receiptId.HasValue)
-			{
-				return BadRequest("Provide either transactionId or receiptId, not both.");
-			}
-
-			if (transactionId.HasValue)
-			{
-				logger.LogDebug("GetTransactionAccounts called with transactionId: {transactionId}", transactionId.Value);
-				GetTransactionAccountByTransactionIdQuery query = new(transactionId.Value);
-				TransactionAccount? result = await mediator.Send(query);
-
-				List<TransactionAccountResponse> model = result != null
-					? [mapper.ToResponse(result)]
-					: [];
-				return Ok(model);
-			}
-
-			if (receiptId.HasValue)
-			{
-				logger.LogDebug("GetTransactionAccounts called with receiptId: {receiptId}", receiptId.Value);
-				GetTransactionAccountsByReceiptIdQuery query = new(receiptId.Value);
-				List<TransactionAccount>? result = await mediator.Send(query);
-
-				List<TransactionAccountResponse> model = [.. (result ?? []).Select(mapper.ToResponse)];
-				return Ok(model);
-			}
-
-			return BadRequest("Either transactionId or receiptId query parameter is required.");
+			return BadRequest("Provide either transactionId or receiptId, not both.");
 		}
-		catch (Exception ex)
+
+		if (transactionId.HasValue)
 		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetTransactionAccounts));
-			return StatusCode(500, "An error occurred while processing your request.");
+			GetTransactionAccountByTransactionIdQuery query = new(transactionId.Value);
+			TransactionAccount? result = await mediator.Send(query);
+
+			List<TransactionAccountResponse> model = result != null
+				? [mapper.ToResponse(result)]
+				: [];
+			return Ok(model);
 		}
+
+		if (receiptId.HasValue)
+		{
+			GetTransactionAccountsByReceiptIdQuery query = new(receiptId.Value);
+			List<TransactionAccount>? result = await mediator.Send(query);
+
+			List<TransactionAccountResponse> model = [.. (result ?? []).Select(mapper.ToResponse)];
+			return Ok(model);
+		}
+
+		return BadRequest("Either transactionId or receiptId query parameter is required.");
 	}
 }

--- a/src/Presentation/API/Controllers/Aggregates/TripController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/TripController.cs
@@ -17,8 +17,6 @@ namespace API.Controllers.Aggregates;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class TripController(IMediator mediator, TripMapper mapper, ILogger<TripController> logger) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for receiptId: {receiptId}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
 	public const string RouteByReceiptId = "";
 
 	[HttpGet(RouteByReceiptId)]
@@ -26,29 +24,18 @@ public class TripController(IMediator mediator, TripMapper mapper, ILogger<TripC
 	[EndpointDescription("Returns the full trip aggregate for a receipt, including the receipt, its items, transactions, and associated accounts.")]
 	[ProducesResponseType<TripResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<TripResponse>> GetTripByReceiptId([FromQuery] Guid receiptId)
 	{
-		try
-		{
-			logger.LogDebug("GetTripById called with receiptId: {receiptId}", receiptId);
-			GetTripByReceiptIdQuery query = new(receiptId);
-			Trip? result = await mediator.Send(query);
+		GetTripByReceiptIdQuery query = new(receiptId);
+		Trip? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetTripById called with receiptId: {receiptId} not found", receiptId);
-				return NotFound();
-			}
-
-			TripResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetTripById called with receiptId: {receiptId} found", receiptId);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetTripByReceiptId), receiptId);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Trip for receipt {ReceiptId} not found", receiptId);
+			return NotFound();
 		}
+
+		TripResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 }

--- a/src/Presentation/API/Controllers/ApiKeyController.cs
+++ b/src/Presentation/API/Controllers/ApiKeyController.cs
@@ -22,73 +22,55 @@ public class ApiKeyController(
 	[EndpointSummary("Get all API keys for the authenticated user")]
 	[ProducesResponseType<List<ApiKeyResponse>>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<ApiKeyResponse>>> GetApiKeys()
 	{
-		try
+		string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+		if (userId is null)
 		{
-			string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (userId is null)
-			{
-				return Unauthorized();
-			}
-
-			IReadOnlyList<ApiKeyInfo> keys = await apiKeyService.GetApiKeysForUserAsync(userId);
-			List<ApiKeyResponse> response = [.. keys.Select(k => new ApiKeyResponse
-			{
-				Id = k.Id,
-				Name = k.Name,
-				CreatedAt = k.CreatedAt,
-				LastUsedAt = k.LastUsedAt,
-				ExpiresAt = k.ExpiresAt,
-				IsRevoked = k.IsRevoked,
-			})];
-
-			return Ok(response);
+			return Unauthorized();
 		}
-		catch (Exception ex)
+
+		IReadOnlyList<ApiKeyInfo> keys = await apiKeyService.GetApiKeysForUserAsync(userId);
+		List<ApiKeyResponse> response = [.. keys.Select(k => new ApiKeyResponse
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(GetApiKeys));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+			Id = k.Id,
+			Name = k.Name,
+			CreatedAt = k.CreatedAt,
+			LastUsedAt = k.LastUsedAt,
+			ExpiresAt = k.ExpiresAt,
+			IsRevoked = k.IsRevoked,
+		})];
+
+		return Ok(response);
 	}
 
 	[HttpPost]
 	[EndpointSummary("Create a new API key")]
 	[ProducesResponseType<CreateApiKeyResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<CreateApiKeyResponse>> CreateApiKey([FromBody] CreateApiKeyRequest request)
 	{
-		try
+		string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+		if (userId is null)
 		{
-			string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (userId is null)
-			{
-				return Unauthorized();
-			}
-
-			string rawKey = await apiKeyService.CreateApiKeyAsync(userId, request.Name, request.ExpiresAt);
-
-			IReadOnlyList<ApiKeyInfo> keys = await apiKeyService.GetApiKeysForUserAsync(userId);
-			ApiKeyInfo? created = keys.OrderByDescending(k => k.CreatedAt).FirstOrDefault(k => k.Name == request.Name);
-
-			await LogAuthEventAsync(nameof(AuthEventType.ApiKeyCreated), userId, null, true, null, created?.Id);
-
-			return Ok(new CreateApiKeyResponse
-			{
-				Id = created?.Id ?? Guid.Empty,
-				Name = request.Name,
-				RawKey = rawKey,
-				CreatedAt = created?.CreatedAt ?? DateTimeOffset.UtcNow,
-				ExpiresAt = request.ExpiresAt,
-			});
+			return Unauthorized();
 		}
-		catch (Exception ex)
+
+		string rawKey = await apiKeyService.CreateApiKeyAsync(userId, request.Name, request.ExpiresAt);
+
+		IReadOnlyList<ApiKeyInfo> keys = await apiKeyService.GetApiKeysForUserAsync(userId);
+		ApiKeyInfo? created = keys.OrderByDescending(k => k.CreatedAt).FirstOrDefault(k => k.Name == request.Name);
+
+		await LogAuthEventAsync(nameof(AuthEventType.ApiKeyCreated), userId, null, true, null, created?.Id);
+
+		return Ok(new CreateApiKeyResponse
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(CreateApiKey));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+			Id = created?.Id ?? Guid.Empty,
+			Name = request.Name,
+			RawKey = rawKey,
+			CreatedAt = created?.CreatedAt ?? DateTimeOffset.UtcNow,
+			ExpiresAt = request.ExpiresAt,
+		});
 	}
 
 	[HttpDelete("{id}")]
@@ -96,30 +78,17 @@ public class ApiKeyController(
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RevokeApiKey([FromRoute] Guid id)
 	{
-		try
+		string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+		if (userId is null)
 		{
-			string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (userId is null)
-			{
-				return Unauthorized();
-			}
+			return Unauthorized();
+		}
 
-			await apiKeyService.RevokeApiKeyAsync(id, userId);
-			await LogAuthEventAsync(nameof(AuthEventType.ApiKeyRevoked), userId, null, true, null, id);
-			return NoContent();
-		}
-		catch (KeyNotFoundException)
-		{
-			return NotFound();
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, "Error occurred in {Method} for id: {Id}", nameof(RevokeApiKey), id);
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		await apiKeyService.RevokeApiKeyAsync(id, userId);
+		await LogAuthEventAsync(nameof(AuthEventType.ApiKeyRevoked), userId, null, true, null, id);
+		return NoContent();
 	}
 
 	private async Task LogAuthEventAsync(string eventType, string? userId, string? username, bool success, string? failureReason = null, Guid? apiKeyId = null)

--- a/src/Presentation/API/Controllers/AuditController.cs
+++ b/src/Presentation/API/Controllers/AuditController.cs
@@ -12,14 +12,11 @@ namespace API.Controllers;
 [Produces("application/json")]
 [Authorize]
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-public class AuditController(IAuditService auditService, ILogger<AuditController> logger) : ControllerBase
+public class AuditController(IAuditService auditService) : ControllerBase
 {
-	public const string MessageWithoutId = "Error occurred in {Method}";
-
 	[HttpGet("")]
 	[ProducesResponseType<List<AuditLogResponse>>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> GetAuditLogs(
 		[FromQuery] string? entityType = null,
 		[FromQuery] string? entityId = null,
@@ -27,49 +24,32 @@ public class AuditController(IAuditService auditService, ILogger<AuditController
 		[FromQuery] Guid? apiKeyId = null,
 		CancellationToken cancellationToken = default)
 	{
-		try
+		if (entityType != null && entityId != null)
 		{
-			if (entityType != null && entityId != null)
-			{
-				List<AuditLogDto> entityLogs = await auditService.GetByEntityAsync(entityType, entityId, cancellationToken);
-				return Ok(entityLogs);
-			}
-
-			if (userId != null)
-			{
-				List<AuditLogDto> userLogs = await auditService.GetByUserAsync(userId, cancellationToken);
-				return Ok(userLogs);
-			}
-
-			if (apiKeyId.HasValue)
-			{
-				List<AuditLogDto> apiKeyLogs = await auditService.GetByApiKeyAsync(apiKeyId.Value, cancellationToken);
-				return Ok(apiKeyLogs);
-			}
-
-			return BadRequest("At least one filter parameter (entityType+entityId, userId, or apiKeyId) is required.");
+			List<AuditLogDto> entityLogs = await auditService.GetByEntityAsync(entityType, entityId, cancellationToken);
+			return Ok(entityLogs);
 		}
-		catch (Exception ex)
+
+		if (userId != null)
 		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetAuditLogs));
-			return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+			List<AuditLogDto> userLogs = await auditService.GetByUserAsync(userId, cancellationToken);
+			return Ok(userLogs);
 		}
+
+		if (apiKeyId.HasValue)
+		{
+			List<AuditLogDto> apiKeyLogs = await auditService.GetByApiKeyAsync(apiKeyId.Value, cancellationToken);
+			return Ok(apiKeyLogs);
+		}
+
+		return BadRequest("At least one filter parameter (entityType+entityId, userId, or apiKeyId) is required.");
 	}
 
 	[HttpGet("recent")]
 	[ProducesResponseType<List<AuditLogResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> GetRecent([FromQuery] int count = 50, CancellationToken cancellationToken = default)
 	{
-		try
-		{
-			List<AuditLogDto> logs = await auditService.GetRecentAsync(count, cancellationToken);
-			return Ok(logs);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetRecent));
-			return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
-		}
+		List<AuditLogDto> logs = await auditService.GetRecentAsync(count, cancellationToken);
+		return Ok(logs);
 	}
 }

--- a/src/Presentation/API/Controllers/AuthAuditController.cs
+++ b/src/Presentation/API/Controllers/AuthAuditController.cs
@@ -13,64 +13,35 @@ namespace API.Controllers;
 [Produces("application/json")]
 [Authorize]
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-public class AuthAuditController(IAuthAuditService authAuditService, ILogger<AuthAuditController> logger) : ControllerBase
+public class AuthAuditController(IAuthAuditService authAuditService) : ControllerBase
 {
-	public const string MessageWithoutId = "Error occurred in {Method}";
-
 	[HttpGet("me")]
 	[ProducesResponseType<List<AuthAuditLogResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> GetMyAuditLog([FromQuery] int count = 50, CancellationToken cancellationToken = default)
 	{
-		try
+		string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+		if (userId is null)
 		{
-			string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (userId is null)
-			{
-				return Unauthorized();
-			}
+			return Unauthorized();
+		}
 
-			List<AuthAuditEntryDto> logs = await authAuditService.GetMyAuditLogAsync(userId, count, cancellationToken);
-			return Ok(logs);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetMyAuditLog));
-			return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
-		}
+		List<AuthAuditEntryDto> logs = await authAuditService.GetMyAuditLogAsync(userId, count, cancellationToken);
+		return Ok(logs);
 	}
 
 	[HttpGet("recent")]
 	[ProducesResponseType<List<AuthAuditLogResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> GetRecent([FromQuery] int count = 50, CancellationToken cancellationToken = default)
 	{
-		try
-		{
-			List<AuthAuditEntryDto> logs = await authAuditService.GetRecentAsync(count, cancellationToken);
-			return Ok(logs);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetRecent));
-			return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
-		}
+		List<AuthAuditEntryDto> logs = await authAuditService.GetRecentAsync(count, cancellationToken);
+		return Ok(logs);
 	}
 
 	[HttpGet("failed")]
 	[ProducesResponseType<List<AuthAuditLogResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> GetFailed([FromQuery] int count = 50, CancellationToken cancellationToken = default)
 	{
-		try
-		{
-			List<AuthAuditEntryDto> logs = await authAuditService.GetFailedAttemptsAsync(count, cancellationToken);
-			return Ok(logs);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetFailed));
-			return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
-		}
+		List<AuthAuditEntryDto> logs = await authAuditService.GetFailedAttemptsAsync(count, cancellationToken);
+		return Ok(logs);
 	}
 }

--- a/src/Presentation/API/Controllers/AuthController.cs
+++ b/src/Presentation/API/Controllers/AuthController.cs
@@ -26,48 +26,39 @@ public class AuthController(
 	[EndpointSummary("Login with email and password")]
 	[ProducesResponseType<TokenResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<TokenResponse>> Login([FromBody] LoginRequest request)
 	{
-		try
+		ApplicationUser? user = await userManager.FindByEmailAsync(request.Email);
+		if (user is null || !await userManager.CheckPasswordAsync(user, request.Password))
 		{
-			ApplicationUser? user = await userManager.FindByEmailAsync(request.Email);
-			if (user is null || !await userManager.CheckPasswordAsync(user, request.Password))
-			{
-				await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user?.Id, request.Email, false, "Invalid credentials");
-				return Unauthorized();
-			}
-
-			if (await userManager.IsLockedOutAsync(user))
-			{
-				await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user.Id, request.Email, false, "Account disabled");
-				return Unauthorized();
-			}
-
-			IList<string> roles = await userManager.GetRolesAsync(user);
-			string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword);
-			string refreshToken = tokenService.GenerateRefreshToken();
-
-			user.RefreshToken = refreshToken;
-			user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
-			user.LastLoginAt = DateTimeOffset.UtcNow;
-			await userManager.UpdateAsync(user);
-
-			await LogAuthEventAsync(nameof(AuthEventType.Login), user.Id, user.Email, true);
-
-			return Ok(new TokenResponse
-			{
-				AccessToken = accessToken,
-				RefreshToken = refreshToken,
-				ExpiresIn = 3600,
-				MustResetPassword = user.MustResetPassword,
-			});
+			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user?.Id, request.Email, false, "Invalid credentials");
+			return Unauthorized();
 		}
-		catch (Exception ex)
+
+		if (await userManager.IsLockedOutAsync(user))
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(Login));
-			return StatusCode(500, "An error occurred while processing your request.");
+			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user.Id, request.Email, false, "Account disabled");
+			return Unauthorized();
 		}
+
+		IList<string> roles = await userManager.GetRolesAsync(user);
+		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword);
+		string refreshToken = tokenService.GenerateRefreshToken();
+
+		user.RefreshToken = refreshToken;
+		user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
+		user.LastLoginAt = DateTimeOffset.UtcNow;
+		await userManager.UpdateAsync(user);
+
+		await LogAuthEventAsync(nameof(AuthEventType.Login), user.Id, user.Email, true);
+
+		return Ok(new TokenResponse
+		{
+			AccessToken = accessToken,
+			RefreshToken = refreshToken,
+			ExpiresIn = 3600,
+			MustResetPassword = user.MustResetPassword,
+		});
 	}
 
 	[HttpPost("refresh")]
@@ -75,42 +66,33 @@ public class AuthController(
 	[EndpointSummary("Refresh access token")]
 	[ProducesResponseType<TokenResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<TokenResponse>> RefreshToken([FromBody] RefreshTokenRequest request, CancellationToken cancellationToken)
 	{
-		try
+		string? userId = await userService.FindUserIdByRefreshTokenAsync(request.RefreshToken, cancellationToken);
+		ApplicationUser? user = userId is not null ? await userManager.FindByIdAsync(userId) : null;
+
+		if (user is null
+			|| user.RefreshTokenExpiresAt is null
+			|| user.RefreshTokenExpiresAt < DateTimeOffset.UtcNow)
 		{
-			string? userId = await userService.FindUserIdByRefreshTokenAsync(request.RefreshToken, cancellationToken);
-			ApplicationUser? user = userId is not null ? await userManager.FindByIdAsync(userId) : null;
-
-			if (user is null
-				|| user.RefreshTokenExpiresAt is null
-				|| user.RefreshTokenExpiresAt < DateTimeOffset.UtcNow)
-			{
-				return Unauthorized();
-			}
-
-			IList<string> roles = await userManager.GetRolesAsync(user);
-			string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword);
-			string newRefreshToken = tokenService.GenerateRefreshToken();
-
-			user.RefreshToken = newRefreshToken;
-			user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
-			await userManager.UpdateAsync(user);
-
-			return Ok(new TokenResponse
-			{
-				AccessToken = accessToken,
-				RefreshToken = newRefreshToken,
-				ExpiresIn = 3600,
-				MustResetPassword = user.MustResetPassword,
-			});
+			return Unauthorized();
 		}
-		catch (Exception ex)
+
+		IList<string> roles = await userManager.GetRolesAsync(user);
+		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword);
+		string newRefreshToken = tokenService.GenerateRefreshToken();
+
+		user.RefreshToken = newRefreshToken;
+		user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
+		await userManager.UpdateAsync(user);
+
+		return Ok(new TokenResponse
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(RefreshToken));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+			AccessToken = accessToken,
+			RefreshToken = newRefreshToken,
+			ExpiresIn = 3600,
+			MustResetPassword = user.MustResetPassword,
+		});
 	}
 
 	[HttpPost("logout")]
@@ -118,34 +100,25 @@ public class AuthController(
 	[EndpointSummary("Logout and invalidate refresh token")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> Logout()
 	{
-		try
+		string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+		if (userId is null)
 		{
-			string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (userId is null)
-			{
-				return Unauthorized();
-			}
-
-			ApplicationUser? user = await userManager.FindByIdAsync(userId);
-			if (user is not null)
-			{
-				user.RefreshToken = null;
-				user.RefreshTokenExpiresAt = null;
-				await userManager.UpdateAsync(user);
-			}
-
-			await LogAuthEventAsync(nameof(AuthEventType.Logout), userId, user?.Email, true);
-
-			return NoContent();
+			return Unauthorized();
 		}
-		catch (Exception ex)
+
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is not null)
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(Logout));
-			return StatusCode(500, "An error occurred while processing your request.");
+			user.RefreshToken = null;
+			user.RefreshTokenExpiresAt = null;
+			await userManager.UpdateAsync(user);
 		}
+
+		await LogAuthEventAsync(nameof(AuthEventType.Logout), userId, user?.Email, true);
+
+		return NoContent();
 	}
 
 	[HttpPost("change-password")]
@@ -154,54 +127,45 @@ public class AuthController(
 	[ProducesResponseType<TokenResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<TokenResponse>> ChangePassword([FromBody] ChangePasswordRequest request)
 	{
-		try
+		string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+		if (userId is null)
 		{
-			string? userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (userId is null)
-			{
-				return Unauthorized();
-			}
-
-			ApplicationUser? user = await userManager.FindByIdAsync(userId);
-			if (user is null)
-			{
-				return Unauthorized();
-			}
-
-			IdentityResult result = await userManager.ChangePasswordAsync(user, request.CurrentPassword, request.NewPassword);
-			if (!result.Succeeded)
-			{
-				return BadRequest(result.Errors.Select(e => e.Description));
-			}
-
-			user.MustResetPassword = false;
-
-			IList<string> roles = await userManager.GetRolesAsync(user);
-			string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, false);
-			string refreshToken = tokenService.GenerateRefreshToken();
-
-			user.RefreshToken = refreshToken;
-			user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
-			await userManager.UpdateAsync(user);
-
-			await LogAuthEventAsync(nameof(AuthEventType.PasswordChanged), user.Id, user.Email, true);
-
-			return Ok(new TokenResponse
-			{
-				AccessToken = accessToken,
-				RefreshToken = refreshToken,
-				ExpiresIn = 3600,
-				MustResetPassword = false,
-			});
+			return Unauthorized();
 		}
-		catch (Exception ex)
+
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is null)
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(ChangePassword));
-			return StatusCode(500, "An error occurred while processing your request.");
+			return Unauthorized();
 		}
+
+		IdentityResult result = await userManager.ChangePasswordAsync(user, request.CurrentPassword, request.NewPassword);
+		if (!result.Succeeded)
+		{
+			return BadRequest(result.Errors.Select(e => e.Description));
+		}
+
+		user.MustResetPassword = false;
+
+		IList<string> roles = await userManager.GetRolesAsync(user);
+		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, false);
+		string refreshToken = tokenService.GenerateRefreshToken();
+
+		user.RefreshToken = refreshToken;
+		user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
+		await userManager.UpdateAsync(user);
+
+		await LogAuthEventAsync(nameof(AuthEventType.PasswordChanged), user.Id, user.Email, true);
+
+		return Ok(new TokenResponse
+		{
+			AccessToken = accessToken,
+			RefreshToken = refreshToken,
+			ExpiresIn = 3600,
+			MustResetPassword = false,
+		});
 	}
 
 	private async Task LogAuthEventAsync(string eventType, string? userId, string? username, bool success, string? failureReason = null)

--- a/src/Presentation/API/Controllers/Core/AccountsController.cs
+++ b/src/Presentation/API/Controllers/Core/AccountsController.cs
@@ -21,8 +21,6 @@ namespace API.Controllers.Core;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class AccountsController(IMediator mediator, AccountMapper mapper, ILogger<AccountsController> logger) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for id: {Id}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
 	public const string RouteCreate = "";
@@ -38,175 +36,100 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, ILogge
 	[EndpointDescription("Returns a single account matching the provided GUID.")]
 	[ProducesResponseType<AccountResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<AccountResponse>> GetAccountById([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("GetAccountById called with id: {Id}", id);
-			GetAccountByIdQuery query = new(id);
-			Account? result = await mediator.Send(query);
+		GetAccountByIdQuery query = new(id);
+		Account? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetAccountById called with id: {Id} not found", id);
-				return NotFound();
-			}
-
-			AccountResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetAccountById called with id: {Id} found", id);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetAccountById), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Account {Id} not found", id);
+			return NotFound();
 		}
+
+		AccountResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all accounts")]
 	[ProducesResponseType<List<AccountResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<AccountResponse>>> GetAllAccounts()
 	{
-		try
-		{
-			logger.LogDebug("GetAllAccounts called");
-			GetAllAccountsQuery query = new();
-			List<Account> result = await mediator.Send(query);
-			logger.LogDebug("GetAllAccounts called with {Count} accounts", result.Count);
+		GetAllAccountsQuery query = new();
+		List<Account> result = await mediator.Send(query);
 
-			List<AccountResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetAllAccounts));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<AccountResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted accounts")]
 	[EndpointDescription("Returns all accounts that have been soft-deleted.")]
 	[ProducesResponseType<List<AccountResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<AccountResponse>>> GetDeletedAccounts()
 	{
-		try
-		{
-			logger.LogDebug("GetDeletedAccounts called");
-			GetDeletedAccountsQuery query = new();
-			List<Account> result = await mediator.Send(query);
-			logger.LogDebug("GetDeletedAccounts called with {Count} accounts", result.Count);
+		GetDeletedAccountsQuery query = new();
+		List<Account> result = await mediator.Send(query);
 
-			List<AccountResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetDeletedAccounts));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<AccountResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single account")]
 	[ProducesResponseType<AccountResponse>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<AccountResponse>> CreateAccount([FromBody] CreateAccountRequest model)
 	{
-		try
-		{
-			logger.LogDebug("CreateAccount called");
-			CreateAccountCommand command = new([mapper.ToDomain(model)]);
-			List<Account> accounts = await mediator.Send(command);
-			return Ok(mapper.ToResponse(accounts[0]));
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateAccount));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateAccountCommand command = new([mapper.ToDomain(model)]);
+		List<Account> accounts = await mediator.Send(command);
+		return Ok(mapper.ToResponse(accounts[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create accounts in batch")]
 	[ProducesResponseType<List<AccountResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<AccountResponse>>> CreateAccounts([FromBody] List<CreateAccountRequest> models)
 	{
-		try
-		{
-			logger.LogDebug("CreateAccounts called with {Count} accounts", models.Count);
-			CreateAccountCommand command = new([.. models.Select(mapper.ToDomain)]);
-			List<Account> accounts = await mediator.Send(command);
-			return Ok(accounts.Select(mapper.ToResponse).ToList());
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateAccounts));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateAccountCommand command = new([.. models.Select(mapper.ToDomain)]);
+		List<Account> accounts = await mediator.Send(command);
+		return Ok(accounts.Select(mapper.ToResponse).ToList());
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single account")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateAccount([FromRoute] Guid id, [FromBody] UpdateAccountRequest model)
 	{
-		try
-		{
-			logger.LogDebug("UpdateAccount called for id: {Id}", id);
-			UpdateAccountCommand command = new([mapper.ToDomain(model)]);
-			bool result = await mediator.Send(command);
+		UpdateAccountCommand command = new([mapper.ToDomain(model)]);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("UpdateAccount called for id: {Id}, but not found", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(UpdateAccount), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Account {Id} not found for update", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update accounts in batch")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateAccounts([FromBody] List<UpdateAccountRequest> models)
 	{
-		try
+		UpdateAccountCommand command = new([.. models.Select(mapper.ToDomain)]);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("UpdateAccounts called with {Count} accounts", models.Count);
-			UpdateAccountCommand command = new([.. models.Select(mapper.ToDomain)]);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("UpdateAccounts called with {Count} accounts, but not found", models.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("UpdateAccounts called with {Count} accounts, and found", models.Count);
-
-			return NoContent();
+			logger.LogWarning("Accounts batch update failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(UpdateAccounts));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpDelete(RouteDelete)]
@@ -214,30 +137,18 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, ILogge
 	[EndpointDescription("Deletes one or more accounts by their IDs. Returns 404 if any account is not found.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> DeleteAccounts([FromBody] List<Guid> ids)
 	{
-		try
+		DeleteAccountCommand command = new(ids);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("DeleteAccounts called with {Count} ids", ids.Count);
-			DeleteAccountCommand command = new(ids);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("DeleteAccounts called with {Count} ids, but not found", ids.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("DeleteAccounts called with {Count} ids, and found", ids.Count);
-
-			return NoContent();
+			logger.LogWarning("Accounts delete failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(DeleteAccounts));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpPost(RouteRestore)]
@@ -245,27 +156,17 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, ILogge
 	[EndpointDescription("Restores a previously soft-deleted account by clearing its DeletedAt timestamp.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RestoreAccount([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("RestoreAccount called with id: {Id}", id);
-			RestoreAccountCommand command = new(id);
-			bool result = await mediator.Send(command);
+		RestoreAccountCommand command = new(id);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("RestoreAccount called with id: {Id}, but not found or not deleted", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(RestoreAccount), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Account {Id} not found or not deleted for restore", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/Core/AdjustmentsController.cs
+++ b/src/Presentation/API/Controllers/Core/AdjustmentsController.cs
@@ -21,9 +21,6 @@ namespace API.Controllers.Core;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, ILogger<AdjustmentsController> logger) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for id: {Id}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
-
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
 	public const string RouteCreate = "~/api/receipts/{receiptId}/adjustments";
@@ -37,135 +34,81 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 	[EndpointDescription("Returns a single adjustment matching the provided GUID.")]
 	[ProducesResponseType<AdjustmentResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<AdjustmentResponse>> GetAdjustmentById([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("GetAdjustmentById called with id: {Id}", id);
-			GetAdjustmentByIdQuery query = new(id);
-			Adjustment? result = await mediator.Send(query);
+		GetAdjustmentByIdQuery query = new(id);
+		Adjustment? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetAdjustmentById called with id: {Id} not found", id);
-				return NotFound();
-			}
-
-			AdjustmentResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetAdjustmentById called with id: {Id} found", id);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetAdjustmentById), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Adjustment {Id} not found", id);
+			return NotFound();
 		}
+
+		AdjustmentResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all adjustments")]
 	[ProducesResponseType<List<AdjustmentResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<AdjustmentResponse>>> GetAllAdjustments([FromQuery] Guid? receiptId = null)
 	{
-		try
+		if (receiptId.HasValue)
 		{
-			if (receiptId.HasValue)
-			{
-				logger.LogDebug("GetAllAdjustments called with receiptId: {ReceiptId}", receiptId.Value);
-				GetAdjustmentsByReceiptIdQuery byReceiptQuery = new(receiptId.Value);
-				List<Adjustment>? byReceiptResult = await mediator.Send(byReceiptQuery);
+			GetAdjustmentsByReceiptIdQuery byReceiptQuery = new(receiptId.Value);
+			List<Adjustment>? byReceiptResult = await mediator.Send(byReceiptQuery);
 
-				List<AdjustmentResponse> byReceiptModel = [.. (byReceiptResult ?? []).Select(mapper.ToResponse)];
-				return Ok(byReceiptModel);
-			}
-
-			logger.LogDebug("GetAllAdjustments called");
-			GetAllAdjustmentsQuery query = new();
-			List<Adjustment> result = await mediator.Send(query);
-			logger.LogDebug("GetAllAdjustments called with {Count} adjustments", result.Count);
-
-			List<AdjustmentResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
+			List<AdjustmentResponse> byReceiptModel = [.. (byReceiptResult ?? []).Select(mapper.ToResponse)];
+			return Ok(byReceiptModel);
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetAllAdjustments));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		GetAllAdjustmentsQuery query = new();
+		List<Adjustment> result = await mediator.Send(query);
+
+		List<AdjustmentResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted adjustments")]
 	[EndpointDescription("Returns all adjustments that have been soft-deleted.")]
 	[ProducesResponseType<List<AdjustmentResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<AdjustmentResponse>>> GetDeletedAdjustments()
 	{
-		try
-		{
-			logger.LogDebug("GetDeletedAdjustments called");
-			GetDeletedAdjustmentsQuery query = new();
-			List<Adjustment> result = await mediator.Send(query);
-			logger.LogDebug("GetDeletedAdjustments called with {Count} adjustments", result.Count);
+		GetDeletedAdjustmentsQuery query = new();
+		List<Adjustment> result = await mediator.Send(query);
 
-			List<AdjustmentResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetDeletedAdjustments));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<AdjustmentResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single adjustment")]
 	[ProducesResponseType<AdjustmentResponse>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<AdjustmentResponse>> CreateAdjustment([FromBody] CreateAdjustmentRequest model, [FromRoute] Guid receiptId)
 	{
-		try
-		{
-			logger.LogDebug("CreateAdjustment called");
-			CreateAdjustmentCommand command = new([mapper.ToDomain(model)], receiptId);
-			List<Adjustment> adjustments = await mediator.Send(command);
-			return Ok(mapper.ToResponse(adjustments[0]));
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateAdjustment));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateAdjustmentCommand command = new([mapper.ToDomain(model)], receiptId);
+		List<Adjustment> adjustments = await mediator.Send(command);
+		return Ok(mapper.ToResponse(adjustments[0]));
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single adjustment")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateAdjustment([FromBody] UpdateAdjustmentRequest model, [FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("UpdateAdjustment called");
-			UpdateAdjustmentCommand command = new([mapper.ToDomain(model)]);
-			bool result = await mediator.Send(command);
+		UpdateAdjustmentCommand command = new([mapper.ToDomain(model)]);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("UpdateAdjustment called, but not found");
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithoutId, nameof(UpdateAdjustment));
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Adjustment {Id} not found for update", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 
 	[HttpDelete(RouteDelete)]
@@ -173,30 +116,18 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 	[EndpointDescription("Deletes one or more adjustments by their IDs. Returns 404 if any adjustment is not found.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> DeleteAdjustments([FromBody] List<Guid> ids)
 	{
-		try
+		DeleteAdjustmentCommand command = new(ids);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("DeleteAdjustments called with {Count} adjustment ids", ids.Count);
-			DeleteAdjustmentCommand command = new(ids);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("DeleteAdjustments called with {Count} adjustment ids, but not found", ids.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("DeleteAdjustments called with {Count} adjustment ids, and found", ids.Count);
-
-			return NoContent();
+			logger.LogWarning("Adjustments delete failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(DeleteAdjustments));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpPost(RouteRestore)]
@@ -204,27 +135,17 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 	[EndpointDescription("Restores a previously soft-deleted adjustment by clearing its DeletedAt timestamp.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RestoreAdjustment([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("RestoreAdjustment called with id: {Id}", id);
-			RestoreAdjustmentCommand command = new(id);
-			bool result = await mediator.Send(command);
+		RestoreAdjustmentCommand command = new(id);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("RestoreAdjustment called with id: {Id}, but not found or not deleted", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(RestoreAdjustment), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Adjustment {Id} not found or not deleted for restore", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/Core/CategoriesController.cs
+++ b/src/Presentation/API/Controllers/Core/CategoriesController.cs
@@ -4,7 +4,6 @@ using Application.Commands.Category.Create;
 using Application.Commands.Category.Delete;
 using Application.Commands.Category.Restore;
 using Application.Commands.Category.Update;
-using Application.Exceptions;
 using Application.Queries.Core.Category;
 using Asp.Versioning;
 using Domain.Core;
@@ -22,8 +21,6 @@ namespace API.Controllers.Core;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILogger<CategoriesController> logger) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for id: {Id}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
 	public const string RouteCreate = "";
@@ -39,187 +36,102 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	[EndpointDescription("Returns a single category matching the provided GUID.")]
 	[ProducesResponseType<CategoryResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<CategoryResponse>> GetCategoryById([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("GetCategoryById called with id: {Id}", id);
-			GetCategoryByIdQuery query = new(id);
-			Category? result = await mediator.Send(query);
+		GetCategoryByIdQuery query = new(id);
+		Category? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetCategoryById called with id: {Id} not found", id);
-				return NotFound();
-			}
-
-			CategoryResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetCategoryById called with id: {Id} found", id);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetCategoryById), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Category {Id} not found", id);
+			return NotFound();
 		}
+
+		CategoryResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all categories")]
 	[ProducesResponseType<List<CategoryResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<CategoryResponse>>> GetAllCategories()
 	{
-		try
-		{
-			logger.LogDebug("GetAllCategories called");
-			GetAllCategoriesQuery query = new();
-			List<Category> result = await mediator.Send(query);
-			logger.LogDebug("GetAllCategories called with {Count} categories", result.Count);
+		GetAllCategoriesQuery query = new();
+		List<Category> result = await mediator.Send(query);
 
-			List<CategoryResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetAllCategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<CategoryResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted categories")]
 	[EndpointDescription("Returns all categories that have been soft-deleted.")]
 	[ProducesResponseType<List<CategoryResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<CategoryResponse>>> GetDeletedCategories()
 	{
-		try
-		{
-			logger.LogDebug("GetDeletedCategories called");
-			GetDeletedCategoriesQuery query = new();
-			List<Category> result = await mediator.Send(query);
-			logger.LogDebug("GetDeletedCategories called with {Count} categories", result.Count);
+		GetDeletedCategoriesQuery query = new();
+		List<Category> result = await mediator.Send(query);
 
-			List<CategoryResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetDeletedCategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<CategoryResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single category")]
 	[ProducesResponseType<CategoryResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status409Conflict)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<CategoryResponse>> CreateCategory([FromBody] CreateCategoryRequest model)
 	{
-		try
-		{
-			logger.LogDebug("CreateCategory called");
-			CreateCategoryCommand command = new([mapper.ToDomain(model)]);
-			List<Category> categories = await mediator.Send(command);
-			return Ok(mapper.ToResponse(categories[0]));
-		}
-		catch (DuplicateEntityException ex)
-		{
-			logger.LogWarning(ex, "Duplicate category name in {Method}", nameof(CreateCategory));
-			return Conflict(ex.Message);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateCategory));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateCategoryCommand command = new([mapper.ToDomain(model)]);
+		List<Category> categories = await mediator.Send(command);
+		return Ok(mapper.ToResponse(categories[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create categories in batch")]
 	[ProducesResponseType<List<CategoryResponse>>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status409Conflict)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<CategoryResponse>>> CreateCategories([FromBody] List<CreateCategoryRequest> models)
 	{
-		try
-		{
-			logger.LogDebug("CreateCategories called with {Count} categories", models.Count);
-			CreateCategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
-			List<Category> categories = await mediator.Send(command);
-			return Ok(categories.Select(mapper.ToResponse).ToList());
-		}
-		catch (DuplicateEntityException ex)
-		{
-			logger.LogWarning(ex, "Duplicate category name in {Method}", nameof(CreateCategories));
-			return Conflict(ex.Message);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateCategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateCategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
+		List<Category> categories = await mediator.Send(command);
+		return Ok(categories.Select(mapper.ToResponse).ToList());
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single category")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateCategory([FromRoute] Guid id, [FromBody] UpdateCategoryRequest model)
 	{
-		try
-		{
-			logger.LogDebug("UpdateCategory called for id: {Id}", id);
-			UpdateCategoryCommand command = new([mapper.ToDomain(model)]);
-			bool result = await mediator.Send(command);
+		UpdateCategoryCommand command = new([mapper.ToDomain(model)]);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("UpdateCategory called for id: {Id}, but not found", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(UpdateCategory), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Category {Id} not found for update", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update categories in batch")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateCategories([FromBody] List<UpdateCategoryRequest> models)
 	{
-		try
+		UpdateCategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("UpdateCategories called with {Count} categories", models.Count);
-			UpdateCategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("UpdateCategories called with {Count} categories, but not found", models.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("UpdateCategories called with {Count} categories, and found", models.Count);
-
-			return NoContent();
+			logger.LogWarning("Categories batch update failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(UpdateCategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpDelete(RouteDelete)]
@@ -227,30 +139,18 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	[EndpointDescription("Deletes one or more categories by their IDs. Returns 404 if any category is not found.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> DeleteCategories([FromBody] List<Guid> ids)
 	{
-		try
+		DeleteCategoryCommand command = new(ids);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("DeleteCategories called with {Count} ids", ids.Count);
-			DeleteCategoryCommand command = new(ids);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("DeleteCategories called with {Count} ids, but not found", ids.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("DeleteCategories called with {Count} ids, and found", ids.Count);
-
-			return NoContent();
+			logger.LogWarning("Categories delete failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(DeleteCategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpPost(RouteRestore)]
@@ -258,27 +158,17 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	[EndpointDescription("Restores a previously soft-deleted category by clearing its DeletedAt timestamp.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RestoreCategory([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("RestoreCategory called with id: {Id}", id);
-			RestoreCategoryCommand command = new(id);
-			bool result = await mediator.Send(command);
+		RestoreCategoryCommand command = new(id);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("RestoreCategory called with id: {Id}, but not found or not deleted", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(RestoreCategory), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Category {Id} not found or not deleted for restore", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/Core/ItemTemplatesController.cs
+++ b/src/Presentation/API/Controllers/Core/ItemTemplatesController.cs
@@ -21,8 +21,6 @@ namespace API.Controllers.Core;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapper, ILogger<ItemTemplatesController> logger) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for id: {Id}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
 	public const string RouteCreate = "";
@@ -36,125 +34,72 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[EndpointDescription("Returns a single item template matching the provided GUID.")]
 	[ProducesResponseType<ItemTemplateResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<ItemTemplateResponse>> GetItemTemplateById([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("GetItemTemplateById called with id: {Id}", id);
-			GetItemTemplateByIdQuery query = new(id);
-			ItemTemplate? result = await mediator.Send(query);
+		GetItemTemplateByIdQuery query = new(id);
+		ItemTemplate? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetItemTemplateById called with id: {Id} not found", id);
-				return NotFound();
-			}
-
-			ItemTemplateResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetItemTemplateById called with id: {Id} found", id);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetItemTemplateById), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("ItemTemplate {Id} not found", id);
+			return NotFound();
 		}
+
+		ItemTemplateResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all item templates")]
 	[ProducesResponseType<List<ItemTemplateResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<ItemTemplateResponse>>> GetAllItemTemplates()
 	{
-		try
-		{
-			logger.LogDebug("GetAllItemTemplates called");
-			GetAllItemTemplatesQuery query = new();
-			List<ItemTemplate> result = await mediator.Send(query);
-			logger.LogDebug("GetAllItemTemplates called with {Count} item templates", result.Count);
+		GetAllItemTemplatesQuery query = new();
+		List<ItemTemplate> result = await mediator.Send(query);
 
-			List<ItemTemplateResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetAllItemTemplates));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<ItemTemplateResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted item templates")]
 	[EndpointDescription("Returns all item templates that have been soft-deleted.")]
 	[ProducesResponseType<List<ItemTemplateResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<ItemTemplateResponse>>> GetDeletedItemTemplates()
 	{
-		try
-		{
-			logger.LogDebug("GetDeletedItemTemplates called");
-			GetDeletedItemTemplatesQuery query = new();
-			List<ItemTemplate> result = await mediator.Send(query);
-			logger.LogDebug("GetDeletedItemTemplates called with {Count} item templates", result.Count);
+		GetDeletedItemTemplatesQuery query = new();
+		List<ItemTemplate> result = await mediator.Send(query);
 
-			List<ItemTemplateResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetDeletedItemTemplates));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<ItemTemplateResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single item template")]
 	[ProducesResponseType<ItemTemplateResponse>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<ItemTemplateResponse>> CreateItemTemplate([FromBody] CreateItemTemplateRequest model)
 	{
-		try
-		{
-			logger.LogDebug("CreateItemTemplate called");
-			CreateItemTemplateCommand command = new([mapper.ToDomain(model)]);
-			List<ItemTemplate> itemTemplates = await mediator.Send(command);
-			return Ok(mapper.ToResponse(itemTemplates[0]));
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateItemTemplate));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateItemTemplateCommand command = new([mapper.ToDomain(model)]);
+		List<ItemTemplate> itemTemplates = await mediator.Send(command);
+		return Ok(mapper.ToResponse(itemTemplates[0]));
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single item template")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateItemTemplate([FromRoute] Guid id, [FromBody] UpdateItemTemplateRequest model)
 	{
-		try
-		{
-			logger.LogDebug("UpdateItemTemplate called for id: {Id}", id);
-			UpdateItemTemplateCommand command = new([mapper.ToDomain(model)]);
-			bool result = await mediator.Send(command);
+		UpdateItemTemplateCommand command = new([mapper.ToDomain(model)]);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("UpdateItemTemplate called for id: {Id}, but not found", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(UpdateItemTemplate), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("ItemTemplate {Id} not found for update", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 
 	[HttpDelete(RouteDelete)]
@@ -162,30 +107,18 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[EndpointDescription("Deletes one or more item templates by their IDs. Returns 404 if any item template is not found.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> DeleteItemTemplates([FromBody] List<Guid> ids)
 	{
-		try
+		DeleteItemTemplateCommand command = new(ids);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("DeleteItemTemplates called with {Count} ids", ids.Count);
-			DeleteItemTemplateCommand command = new(ids);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("DeleteItemTemplates called with {Count} ids, but not found", ids.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("DeleteItemTemplates called with {Count} ids, and found", ids.Count);
-
-			return NoContent();
+			logger.LogWarning("ItemTemplates delete failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(DeleteItemTemplates));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpPost(RouteRestore)]
@@ -193,27 +126,17 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[EndpointDescription("Restores a previously soft-deleted item template by clearing its DeletedAt timestamp.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RestoreItemTemplate([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("RestoreItemTemplate called with id: {Id}", id);
-			RestoreItemTemplateCommand command = new(id);
-			bool result = await mediator.Send(command);
+		RestoreItemTemplateCommand command = new(id);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("RestoreItemTemplate called with id: {Id}, but not found or not deleted", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(RestoreItemTemplate), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("ItemTemplate {Id} not found or not deleted for restore", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/Core/ReceiptItemsController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptItemsController.cs
@@ -21,9 +21,6 @@ namespace API.Controllers.Core;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper, ILogger<ReceiptItemsController> logger) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for id: {Id}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
-
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
 	public const string RouteCreate = "~/api/receipts/{receiptId}/receipt-items";
@@ -39,185 +36,109 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	[EndpointDescription("Returns a single receipt item matching the provided GUID.")]
 	[ProducesResponseType<ReceiptItemResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<ReceiptItemResponse>> GetReceiptItemById([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("GetReceiptItemById called with id: {Id}", id);
-			GetReceiptItemByIdQuery query = new(id);
-			ReceiptItem? result = await mediator.Send(query);
+		GetReceiptItemByIdQuery query = new(id);
+		ReceiptItem? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetReceiptItemById called with id: {Id} not found", id);
-				return NotFound();
-			}
-
-			ReceiptItemResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetReceiptItemById called with id: {Id} found", id);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetReceiptItemById), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("ReceiptItem {Id} not found", id);
+			return NotFound();
 		}
+
+		ReceiptItemResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all receipt items")]
 	[ProducesResponseType<List<ReceiptItemResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<ReceiptItemResponse>>> GetAllReceiptItems([FromQuery] Guid? receiptId = null)
 	{
-		try
+		if (receiptId.HasValue)
 		{
-			if (receiptId.HasValue)
-			{
-				logger.LogDebug("GetAllReceiptItems called with receiptId: {ReceiptId}", receiptId.Value);
-				GetReceiptItemsByReceiptIdQuery byReceiptQuery = new(receiptId.Value);
-				List<ReceiptItem>? byReceiptResult = await mediator.Send(byReceiptQuery);
+			GetReceiptItemsByReceiptIdQuery byReceiptQuery = new(receiptId.Value);
+			List<ReceiptItem>? byReceiptResult = await mediator.Send(byReceiptQuery);
 
-				List<ReceiptItemResponse> byReceiptModel = [.. (byReceiptResult ?? []).Select(mapper.ToResponse)];
-				return Ok(byReceiptModel);
-			}
-
-			logger.LogDebug("GetAllReceiptItems called");
-			GetAllReceiptItemsQuery query = new();
-			List<ReceiptItem> result = await mediator.Send(query);
-			logger.LogDebug("GetAllReceiptItems called with {Count} receipt items", result.Count);
-
-			List<ReceiptItemResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
+			List<ReceiptItemResponse> byReceiptModel = [.. (byReceiptResult ?? []).Select(mapper.ToResponse)];
+			return Ok(byReceiptModel);
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetAllReceiptItems));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		GetAllReceiptItemsQuery query = new();
+		List<ReceiptItem> result = await mediator.Send(query);
+
+		List<ReceiptItemResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted receipt items")]
 	[EndpointDescription("Returns all receipt items that have been soft-deleted.")]
 	[ProducesResponseType<List<ReceiptItemResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<ReceiptItemResponse>>> GetDeletedReceiptItems()
 	{
-		try
-		{
-			logger.LogDebug("GetDeletedReceiptItems called");
-			GetDeletedReceiptItemsQuery query = new();
-			List<ReceiptItem> result = await mediator.Send(query);
-			logger.LogDebug("GetDeletedReceiptItems called with {Count} receipt items", result.Count);
+		GetDeletedReceiptItemsQuery query = new();
+		List<ReceiptItem> result = await mediator.Send(query);
 
-			List<ReceiptItemResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetDeletedReceiptItems));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<ReceiptItemResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single receipt item")]
 	[ProducesResponseType<ReceiptItemResponse>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<ReceiptItemResponse>> CreateReceiptItem([FromBody] CreateReceiptItemRequest model, [FromRoute] Guid receiptId)
 	{
-		try
-		{
-			logger.LogDebug("CreateReceiptItem called");
-			CreateReceiptItemCommand command = new([mapper.ToDomain(model)], receiptId);
-			List<ReceiptItem> receiptItems = await mediator.Send(command);
-			return Ok(mapper.ToResponse(receiptItems[0]));
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateReceiptItem));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateReceiptItemCommand command = new([mapper.ToDomain(model)], receiptId);
+		List<ReceiptItem> receiptItems = await mediator.Send(command);
+		return Ok(mapper.ToResponse(receiptItems[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create receipt items in batch")]
 	[ProducesResponseType<List<ReceiptItemResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<ReceiptItemResponse>>> CreateReceiptItems([FromBody] List<CreateReceiptItemRequest> models, [FromRoute] Guid receiptId)
 	{
-		try
-		{
-			logger.LogDebug("CreateReceiptItems called with {Count} receipt items", models.Count);
-			CreateReceiptItemCommand command = new([.. models.Select(mapper.ToDomain)], receiptId);
-			List<ReceiptItem> receiptItems = await mediator.Send(command);
-			return Ok(receiptItems.Select(mapper.ToResponse).ToList());
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateReceiptItems));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateReceiptItemCommand command = new([.. models.Select(mapper.ToDomain)], receiptId);
+		List<ReceiptItem> receiptItems = await mediator.Send(command);
+		return Ok(receiptItems.Select(mapper.ToResponse).ToList());
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single receipt item")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateReceiptItem([FromBody] UpdateReceiptItemRequest model, [FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("UpdateReceiptItem called");
-			UpdateReceiptItemCommand command = new([mapper.ToDomain(model)]);
-			bool result = await mediator.Send(command);
+		UpdateReceiptItemCommand command = new([mapper.ToDomain(model)]);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("UpdateReceiptItem called, but not found");
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithoutId, nameof(UpdateReceiptItem));
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("ReceiptItem {Id} not found for update", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update receipt items in batch")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateReceiptItems([FromBody] List<UpdateReceiptItemRequest> models)
 	{
-		try
+		UpdateReceiptItemCommand command = new([.. models.Select(mapper.ToDomain)]);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("UpdateReceiptItems called with {Count} receipt items", models.Count);
-			UpdateReceiptItemCommand command = new([.. models.Select(mapper.ToDomain)]);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("UpdateReceiptItems called with {Count} receipt items, but not found", models.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("UpdateReceiptItems called with {Count} receipt items, and updated", models.Count);
-
-			return NoContent();
+			logger.LogWarning("ReceiptItems batch update failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(UpdateReceiptItems));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpDelete(RouteDelete)]
@@ -225,30 +146,18 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	[EndpointDescription("Deletes one or more receipt items by their IDs. Returns 404 if any item is not found.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> DeleteReceiptItems([FromBody] List<Guid> ids)
 	{
-		try
+		DeleteReceiptItemCommand command = new(ids);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("DeleteReceiptItems called with {Count} receipt item ids", ids.Count);
-			DeleteReceiptItemCommand command = new(ids);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("DeleteReceiptItems called with {Count} receipt item ids, but not found", ids.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("DeleteReceiptItems called with {Count} receipt item ids, and deleted", ids.Count);
-
-			return NoContent();
+			logger.LogWarning("ReceiptItems delete failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(DeleteReceiptItems));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpPost(RouteRestore)]
@@ -256,27 +165,17 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	[EndpointDescription("Restores a previously soft-deleted receipt item by clearing its DeletedAt timestamp.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RestoreReceiptItem([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("RestoreReceiptItem called with id: {Id}", id);
-			RestoreReceiptItemCommand command = new(id);
-			bool result = await mediator.Send(command);
+		RestoreReceiptItemCommand command = new(id);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("RestoreReceiptItem called with id: {Id}, but not found or not deleted", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(RestoreReceiptItem), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("ReceiptItem {Id} not found or not deleted for restore", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/Core/ReceiptsController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptsController.cs
@@ -27,9 +27,6 @@ public class ReceiptsController(
 	ILogger<ReceiptsController> logger,
 	IHubContext<ReceiptsHub, IReceiptsHubClient> hubContext) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for id: {Id}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
-
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
 	public const string RouteCreate = "";
@@ -45,199 +42,124 @@ public class ReceiptsController(
 	[EndpointDescription("Returns a single receipt matching the provided GUID.")]
 	[ProducesResponseType<ReceiptResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<ReceiptResponse>> GetReceiptById([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("GetReceiptById called with id: {Id}", id);
-			GetReceiptByIdQuery query = new(id);
-			Receipt? result = await mediator.Send(query);
+		GetReceiptByIdQuery query = new(id);
+		Receipt? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetReceiptById called with id: {Id} not found", id);
-				return NotFound();
-			}
-
-			ReceiptResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetReceiptById called with id: {Id} found", id);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetReceiptById), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Receipt {Id} not found", id);
+			return NotFound();
 		}
+
+		ReceiptResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all receipts")]
 	[ProducesResponseType<List<ReceiptResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<ReceiptResponse>>> GetAllReceipts()
 	{
-		try
-		{
-			logger.LogDebug("GetAllReceipts called");
-			GetAllReceiptsQuery query = new();
-			List<Receipt> result = await mediator.Send(query);
-			logger.LogDebug("GetAllReceipts called with {Count} receipts", result.Count);
+		GetAllReceiptsQuery query = new();
+		List<Receipt> result = await mediator.Send(query);
 
-			List<ReceiptResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetAllReceipts));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<ReceiptResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted receipts")]
 	[EndpointDescription("Returns all receipts that have been soft-deleted.")]
 	[ProducesResponseType<List<ReceiptResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<ReceiptResponse>>> GetDeletedReceipts()
 	{
-		try
-		{
-			logger.LogDebug("GetDeletedReceipts called");
-			GetDeletedReceiptsQuery query = new();
-			List<Receipt> result = await mediator.Send(query);
-			logger.LogDebug("GetDeletedReceipts called with {Count} receipts", result.Count);
+		GetDeletedReceiptsQuery query = new();
+		List<Receipt> result = await mediator.Send(query);
 
-			List<ReceiptResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetDeletedReceipts));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<ReceiptResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single receipt")]
 	[ProducesResponseType<ReceiptResponse>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<ReceiptResponse>> CreateReceipt([FromBody] CreateReceiptRequest model)
 	{
-		try
-		{
-			logger.LogDebug("CreateReceipt called");
-			CreateReceiptCommand command = new([mapper.ToDomain(model)]);
-			List<Receipt> receipts = await mediator.Send(command);
-			ReceiptResponse response = mapper.ToResponse(receipts[0]);
-			await hubContext.Clients.All.ReceiptCreated(response);
-			return Ok(response);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateReceipt));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateReceiptCommand command = new([mapper.ToDomain(model)]);
+		List<Receipt> receipts = await mediator.Send(command);
+		ReceiptResponse response = mapper.ToResponse(receipts[0]);
+		await hubContext.Clients.All.ReceiptCreated(response);
+		return Ok(response);
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create receipts in batch")]
 	[ProducesResponseType<List<ReceiptResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<ReceiptResponse>>> CreateReceipts([FromBody] List<CreateReceiptRequest> models)
 	{
-		try
+		CreateReceiptCommand command = new([.. models.Select(mapper.ToDomain)]);
+		List<Receipt> receipts = await mediator.Send(command);
+		List<ReceiptResponse> responses = receipts.Select(mapper.ToResponse).ToList();
+		foreach (ReceiptResponse response in responses)
 		{
-			logger.LogDebug("CreateReceipts called with {Count} receipts", models.Count);
-			CreateReceiptCommand command = new([.. models.Select(mapper.ToDomain)]);
-			List<Receipt> receipts = await mediator.Send(command);
-			List<ReceiptResponse> responses = receipts.Select(mapper.ToResponse).ToList();
-			foreach (ReceiptResponse response in responses)
-			{
-				await hubContext.Clients.All.ReceiptCreated(response);
-			}
-			return Ok(responses);
+			await hubContext.Clients.All.ReceiptCreated(response);
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateReceipts));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		return Ok(responses);
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single receipt")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateReceipt([FromRoute] Guid id, [FromBody] UpdateReceiptRequest model)
 	{
-		try
+		UpdateReceiptCommand command = new([mapper.ToDomain(model)]);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("UpdateReceipt called for id: {Id}", id);
-			UpdateReceiptCommand command = new([mapper.ToDomain(model)]);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("UpdateReceipt called for id: {Id}, but not found", id);
-				return NotFound();
-			}
-
-			GetReceiptByIdQuery fetchQuery = new(id);
-			Receipt? updatedReceipt = await mediator.Send(fetchQuery);
-			if (updatedReceipt != null)
-			{
-				await hubContext.Clients.All.ReceiptUpdated(mapper.ToResponse(updatedReceipt));
-			}
-
-			return NoContent();
+			logger.LogWarning("Receipt {Id} not found for update", id);
+			return NotFound();
 		}
-		catch (Exception ex)
+
+		GetReceiptByIdQuery fetchQuery = new(id);
+		Receipt? updatedReceipt = await mediator.Send(fetchQuery);
+		if (updatedReceipt != null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(UpdateReceipt), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			await hubContext.Clients.All.ReceiptUpdated(mapper.ToResponse(updatedReceipt));
 		}
+
+		return NoContent();
 	}
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update receipts in batch")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateReceipts([FromBody] List<UpdateReceiptRequest> models)
 	{
-		try
+		UpdateReceiptCommand command = new([.. models.Select(mapper.ToDomain)]);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("UpdateReceipts called with {Count} receipts", models.Count);
-			UpdateReceiptCommand command = new([.. models.Select(mapper.ToDomain)]);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("UpdateReceipts called with {Count} receipts, but not found", models.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("UpdateReceipts called with {Count} receipts, and found", models.Count);
-
-			foreach (UpdateReceiptRequest model in models)
-			{
-				GetReceiptByIdQuery fetchQuery = new(model.Id);
-				Receipt? updatedReceipt = await mediator.Send(fetchQuery);
-				if (updatedReceipt != null)
-				{
-					await hubContext.Clients.All.ReceiptUpdated(mapper.ToResponse(updatedReceipt));
-				}
-			}
-
-			return NoContent();
+			logger.LogWarning("Receipts batch update failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
+
+		foreach (UpdateReceiptRequest model in models)
 		{
-			logger.LogError(ex, MessageWithoutId, nameof(UpdateReceipts));
-			return StatusCode(500, "An error occurred while processing your request.");
+			GetReceiptByIdQuery fetchQuery = new(model.Id);
+			Receipt? updatedReceipt = await mediator.Send(fetchQuery);
+			if (updatedReceipt != null)
+			{
+				await hubContext.Clients.All.ReceiptUpdated(mapper.ToResponse(updatedReceipt));
+			}
 		}
+
+		return NoContent();
 	}
 
 	[HttpDelete(RouteDelete)]
@@ -245,35 +167,23 @@ public class ReceiptsController(
 	[EndpointDescription("Deletes one or more receipts by their IDs. Returns 404 if any receipt is not found.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> DeleteReceipts([FromBody] List<Guid> ids)
 	{
-		try
+		DeleteReceiptCommand command = new(ids);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("DeleteReceipts called with {Count} receipt ids", ids.Count);
-			DeleteReceiptCommand command = new(ids);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("DeleteReceipts called with {Count} receipt ids, but not found", ids.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("DeleteReceipts called with {Count} receipt ids, and found", ids.Count);
-
-			foreach (Guid id in ids)
-			{
-				await hubContext.Clients.All.ReceiptDeleted(id);
-			}
-
-			return NoContent();
+			logger.LogWarning("Receipts delete failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
+
+		foreach (Guid id in ids)
 		{
-			logger.LogError(ex, MessageWithoutId, nameof(DeleteReceipts));
-			return StatusCode(500, "An error occurred while processing your request.");
+			await hubContext.Clients.All.ReceiptDeleted(id);
 		}
+
+		return NoContent();
 	}
 
 	[HttpPost(RouteRestore)]
@@ -281,27 +191,17 @@ public class ReceiptsController(
 	[EndpointDescription("Restores a previously soft-deleted receipt and its associated items and transactions.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RestoreReceipt([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("RestoreReceipt called with id: {Id}", id);
-			RestoreReceiptCommand command = new(id);
-			bool result = await mediator.Send(command);
+		RestoreReceiptCommand command = new(id);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("RestoreReceipt called with id: {Id}, but not found or not deleted", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(RestoreReceipt), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Receipt {Id} not found or not deleted for restore", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/Core/SubcategoriesController.cs
+++ b/src/Presentation/API/Controllers/Core/SubcategoriesController.cs
@@ -4,7 +4,6 @@ using Application.Commands.Subcategory.Create;
 using Application.Commands.Subcategory.Delete;
 using Application.Commands.Subcategory.Restore;
 using Application.Commands.Subcategory.Update;
-using Application.Exceptions;
 using Application.Queries.Core.Subcategory;
 using Asp.Versioning;
 using Domain.Core;
@@ -22,8 +21,6 @@ namespace API.Controllers.Core;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class SubcategoriesController(IMediator mediator, SubcategoryMapper mapper, ILogger<SubcategoriesController> logger) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for id: {Id}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
 	public const string RouteCreate = "";
@@ -39,197 +36,111 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 	[EndpointDescription("Returns a single subcategory matching the provided GUID.")]
 	[ProducesResponseType<SubcategoryResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<SubcategoryResponse>> GetSubcategoryById([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("GetSubcategoryById called with id: {Id}", id);
-			GetSubcategoryByIdQuery query = new(id);
-			Subcategory? result = await mediator.Send(query);
+		GetSubcategoryByIdQuery query = new(id);
+		Subcategory? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetSubcategoryById called with id: {Id} not found", id);
-				return NotFound();
-			}
-
-			SubcategoryResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetSubcategoryById called with id: {Id} found", id);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetSubcategoryById), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Subcategory {Id} not found", id);
+			return NotFound();
 		}
+
+		SubcategoryResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all subcategories")]
 	[ProducesResponseType<List<SubcategoryResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<SubcategoryResponse>>> GetAllSubcategories([FromQuery] Guid? categoryId = null)
 	{
-		try
+		if (categoryId.HasValue)
 		{
-			if (categoryId.HasValue)
-			{
-				logger.LogDebug("GetAllSubcategories called with categoryId: {CategoryId}", categoryId.Value);
-				GetSubcategoriesByCategoryIdQuery byCategoryQuery = new(categoryId.Value);
-				List<Subcategory> byCategoryResult = await mediator.Send(byCategoryQuery);
+			GetSubcategoriesByCategoryIdQuery byCategoryQuery = new(categoryId.Value);
+			List<Subcategory> byCategoryResult = await mediator.Send(byCategoryQuery);
 
-				List<SubcategoryResponse> byCategoryModel = [.. byCategoryResult.Select(mapper.ToResponse)];
-				return Ok(byCategoryModel);
-			}
-
-			logger.LogDebug("GetAllSubcategories called");
-			GetAllSubcategoriesQuery query = new();
-			List<Subcategory> result = await mediator.Send(query);
-			logger.LogDebug("GetAllSubcategories called with {Count} subcategories", result.Count);
-
-			List<SubcategoryResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
+			List<SubcategoryResponse> byCategoryModel = [.. byCategoryResult.Select(mapper.ToResponse)];
+			return Ok(byCategoryModel);
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetAllSubcategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		GetAllSubcategoriesQuery query = new();
+		List<Subcategory> result = await mediator.Send(query);
+
+		List<SubcategoryResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted subcategories")]
 	[EndpointDescription("Returns all subcategories that have been soft-deleted.")]
 	[ProducesResponseType<List<SubcategoryResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<SubcategoryResponse>>> GetDeletedSubcategories()
 	{
-		try
-		{
-			logger.LogDebug("GetDeletedSubcategories called");
-			GetDeletedSubcategoriesQuery query = new();
-			List<Subcategory> result = await mediator.Send(query);
-			logger.LogDebug("GetDeletedSubcategories called with {Count} subcategories", result.Count);
+		GetDeletedSubcategoriesQuery query = new();
+		List<Subcategory> result = await mediator.Send(query);
 
-			List<SubcategoryResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetDeletedSubcategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<SubcategoryResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single subcategory")]
 	[ProducesResponseType<SubcategoryResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status409Conflict)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<SubcategoryResponse>> CreateSubcategory([FromBody] CreateSubcategoryRequest model)
 	{
-		try
-		{
-			logger.LogDebug("CreateSubcategory called");
-			CreateSubcategoryCommand command = new([mapper.ToDomain(model)]);
-			List<Subcategory> subcategories = await mediator.Send(command);
-			return Ok(mapper.ToResponse(subcategories[0]));
-		}
-		catch (DuplicateEntityException ex)
-		{
-			logger.LogWarning(ex, "Duplicate subcategory name in {Method}", nameof(CreateSubcategory));
-			return Conflict(ex.Message);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateSubcategory));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateSubcategoryCommand command = new([mapper.ToDomain(model)]);
+		List<Subcategory> subcategories = await mediator.Send(command);
+		return Ok(mapper.ToResponse(subcategories[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create subcategories in batch")]
 	[ProducesResponseType<List<SubcategoryResponse>>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status409Conflict)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<SubcategoryResponse>>> CreateSubcategories([FromBody] List<CreateSubcategoryRequest> models)
 	{
-		try
-		{
-			logger.LogDebug("CreateSubcategories called with {Count} subcategories", models.Count);
-			CreateSubcategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
-			List<Subcategory> subcategories = await mediator.Send(command);
-			return Ok(subcategories.Select(mapper.ToResponse).ToList());
-		}
-		catch (DuplicateEntityException ex)
-		{
-			logger.LogWarning(ex, "Duplicate subcategory name in {Method}", nameof(CreateSubcategories));
-			return Conflict(ex.Message);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateSubcategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateSubcategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
+		List<Subcategory> subcategories = await mediator.Send(command);
+		return Ok(subcategories.Select(mapper.ToResponse).ToList());
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single subcategory")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateSubcategory([FromRoute] Guid id, [FromBody] UpdateSubcategoryRequest model)
 	{
-		try
-		{
-			logger.LogDebug("UpdateSubcategory called for id: {Id}", id);
-			UpdateSubcategoryCommand command = new([mapper.ToDomain(model)]);
-			bool result = await mediator.Send(command);
+		UpdateSubcategoryCommand command = new([mapper.ToDomain(model)]);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("UpdateSubcategory called for id: {Id}, but not found", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(UpdateSubcategory), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Subcategory {Id} not found for update", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update subcategories in batch")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateSubcategories([FromBody] List<UpdateSubcategoryRequest> models)
 	{
-		try
+		UpdateSubcategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("UpdateSubcategories called with {Count} subcategories", models.Count);
-			UpdateSubcategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("UpdateSubcategories called with {Count} subcategories, but not found", models.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("UpdateSubcategories called with {Count} subcategories, and found", models.Count);
-
-			return NoContent();
+			logger.LogWarning("Subcategories batch update failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(UpdateSubcategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpDelete(RouteDelete)]
@@ -237,30 +148,18 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 	[EndpointDescription("Deletes one or more subcategories by their IDs. Returns 404 if any subcategory is not found.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> DeleteSubcategories([FromBody] List<Guid> ids)
 	{
-		try
+		DeleteSubcategoryCommand command = new(ids);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("DeleteSubcategories called with {Count} ids", ids.Count);
-			DeleteSubcategoryCommand command = new(ids);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("DeleteSubcategories called with {Count} ids, but not found", ids.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("DeleteSubcategories called with {Count} ids, and found", ids.Count);
-
-			return NoContent();
+			logger.LogWarning("Subcategories delete failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(DeleteSubcategories));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpPost(RouteRestore)]
@@ -268,27 +167,17 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 	[EndpointDescription("Restores a previously soft-deleted subcategory by clearing its DeletedAt timestamp.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RestoreSubcategory([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("RestoreSubcategory called with id: {Id}", id);
-			RestoreSubcategoryCommand command = new(id);
-			bool result = await mediator.Send(command);
+		RestoreSubcategoryCommand command = new(id);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("RestoreSubcategory called with id: {Id}, but not found or not deleted", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(RestoreSubcategory), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Subcategory {Id} not found or not deleted for restore", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/Core/TransactionsController.cs
+++ b/src/Presentation/API/Controllers/Core/TransactionsController.cs
@@ -21,9 +21,6 @@ namespace API.Controllers.Core;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class TransactionsController(IMediator mediator, TransactionMapper mapper, ILogger<TransactionsController> logger) : ControllerBase
 {
-	public const string MessageWithId = "Error occurred in {Method} for id: {Id}";
-	public const string MessageWithoutId = "Error occurred in {Method}";
-
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
 	public const string RouteCreate = "~/api/receipts/{receiptId}/transactions";
@@ -39,206 +36,130 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 	[EndpointDescription("Returns a single transaction matching the provided GUID.")]
 	[ProducesResponseType<TransactionResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<TransactionResponse>> GetTransactionById([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("GetTransactionById called with id: {Id}", id);
-			GetTransactionByIdQuery query = new(id);
-			Transaction? result = await mediator.Send(query);
+		GetTransactionByIdQuery query = new(id);
+		Transaction? result = await mediator.Send(query);
 
-			if (result == null)
-			{
-				logger.LogWarning("GetTransactionById called with id: {Id} not found", id);
-				return NotFound();
-			}
-
-			TransactionResponse model = mapper.ToResponse(result);
-			logger.LogDebug("GetTransactionById called with id: {Id} found", id);
-			return Ok(model);
-		}
-		catch (Exception ex)
+		if (result == null)
 		{
-			logger.LogError(ex, MessageWithId, nameof(GetTransactionById), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Transaction {Id} not found", id);
+			return NotFound();
 		}
+
+		TransactionResponse model = mapper.ToResponse(result);
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all transactions")]
 	[ProducesResponseType<List<TransactionResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<TransactionResponse>>> GetAllTransactions([FromQuery] Guid? receiptId = null)
 	{
-		try
+		if (receiptId.HasValue)
 		{
-			if (receiptId.HasValue)
-			{
-				logger.LogDebug("GetAllTransactions called with receiptId: {ReceiptId}", receiptId.Value);
-				GetTransactionsByReceiptIdQuery byReceiptQuery = new(receiptId.Value);
-				List<Transaction>? byReceiptResult = await mediator.Send(byReceiptQuery);
+			GetTransactionsByReceiptIdQuery byReceiptQuery = new(receiptId.Value);
+			List<Transaction>? byReceiptResult = await mediator.Send(byReceiptQuery);
 
-				List<TransactionResponse> byReceiptModel = [.. (byReceiptResult ?? []).Select(mapper.ToResponse)];
-				return Ok(byReceiptModel);
-			}
-
-			logger.LogDebug("GetAllTransactions called");
-			GetAllTransactionsQuery query = new();
-			List<Transaction> result = await mediator.Send(query);
-			logger.LogDebug("GetAllTransactions called with {Count} transactions", result.Count);
-
-			List<TransactionResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
+			List<TransactionResponse> byReceiptModel = [.. (byReceiptResult ?? []).Select(mapper.ToResponse)];
+			return Ok(byReceiptModel);
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetAllTransactions));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		GetAllTransactionsQuery query = new();
+		List<Transaction> result = await mediator.Send(query);
+
+		List<TransactionResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted transactions")]
 	[EndpointDescription("Returns all transactions that have been soft-deleted.")]
 	[ProducesResponseType<List<TransactionResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<TransactionResponse>>> GetDeletedTransactions()
 	{
-		try
-		{
-			logger.LogDebug("GetDeletedTransactions called");
-			GetDeletedTransactionsQuery query = new();
-			List<Transaction> result = await mediator.Send(query);
-			logger.LogDebug("GetDeletedTransactions called with {Count} transactions", result.Count);
+		GetDeletedTransactionsQuery query = new();
+		List<Transaction> result = await mediator.Send(query);
 
-			List<TransactionResponse> model = [.. result.Select(mapper.ToResponse)];
-			return Ok(model);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(GetDeletedTransactions));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<TransactionResponse> model = [.. result.Select(mapper.ToResponse)];
+		return Ok(model);
 	}
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single transaction")]
 	[ProducesResponseType<TransactionResponse>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<TransactionResponse>> CreateTransaction([FromBody] CreateTransactionRequest model, [FromRoute] Guid receiptId)
 	{
-		try
-		{
-			logger.LogDebug("CreateTransaction called");
-			CreateTransactionCommand command = new([mapper.ToDomain(model)], receiptId, model.AccountId);
-			List<Transaction> transactions = await mediator.Send(command);
-			return Ok(mapper.ToResponse(transactions[0]));
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateTransaction));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		CreateTransactionCommand command = new([mapper.ToDomain(model)], receiptId, model.AccountId);
+		List<Transaction> transactions = await mediator.Send(command);
+		return Ok(mapper.ToResponse(transactions[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create transactions in batch")]
 	[ProducesResponseType<List<TransactionResponse>>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<List<TransactionResponse>>> CreateTransactions([FromBody] List<CreateTransactionRequest> models, [FromRoute] Guid receiptId)
 	{
-		try
+		IEnumerable<IGrouping<Guid, CreateTransactionRequest>> groups = models.GroupBy(m => m.AccountId);
+
+		List<Task<List<Transaction>>> tasks = [.. groups.Select(group =>
 		{
-			logger.LogDebug("CreateTransactions called with {Count} transactions", models.Count);
+			CreateTransactionCommand command = new(
+				[.. group.Select(mapper.ToDomain)],
+				receiptId,
+				group.Key);
+			return mediator.Send(command);
+		})];
 
-			IEnumerable<IGrouping<Guid, CreateTransactionRequest>> groups = models.GroupBy(m => m.AccountId);
+		await Task.WhenAll(tasks);
 
-			List<Task<List<Transaction>>> tasks = [.. groups.Select(group =>
-			{
-				CreateTransactionCommand command = new(
-					[.. group.Select(mapper.ToDomain)],
-					receiptId,
-					group.Key);
-				return mediator.Send(command);
-			})];
-
-			await Task.WhenAll(tasks);
-
-			List<TransactionResponse> results = [.. tasks.SelectMany(t => t.Result.Select(mapper.ToResponse))];
-			return Ok(results);
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(CreateTransactions));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		List<TransactionResponse> results = [.. tasks.SelectMany(t => t.Result.Select(mapper.ToResponse))];
+		return Ok(results);
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single transaction")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateTransaction([FromBody] UpdateTransactionRequest model, [FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("UpdateTransaction called");
-			UpdateTransactionCommand command = new([mapper.ToDomain(model)], model.AccountId);
-			bool result = await mediator.Send(command);
+		UpdateTransactionCommand command = new([mapper.ToDomain(model)], model.AccountId);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("UpdateTransaction called, but not found");
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithoutId, nameof(UpdateTransaction));
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Transaction {Id} not found for update", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update transactions in batch")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> UpdateTransactions([FromBody] List<UpdateTransactionRequest> models)
 	{
-		try
+		IEnumerable<IGrouping<Guid, UpdateTransactionRequest>> groups = models.GroupBy(m => m.AccountId);
+
+		List<Task<bool>> tasks = [.. groups.Select(group =>
 		{
-			logger.LogDebug("UpdateTransactions called with {Count} transactions", models.Count);
+			UpdateTransactionCommand command = new(
+				[.. group.Select(mapper.ToDomain)],
+				group.Key);
+			return mediator.Send(command);
+		})];
 
-			IEnumerable<IGrouping<Guid, UpdateTransactionRequest>> groups = models.GroupBy(m => m.AccountId);
+		await Task.WhenAll(tasks);
 
-			List<Task<bool>> tasks = [.. groups.Select(group =>
-			{
-				UpdateTransactionCommand command = new(
-					[.. group.Select(mapper.ToDomain)],
-					group.Key);
-				return mediator.Send(command);
-			})];
-
-			await Task.WhenAll(tasks);
-
-			if (tasks.Any(t => !t.Result))
-			{
-				logger.LogWarning("UpdateTransactions called with {Count} transactions, but some not found", models.Count);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (tasks.Any(t => !t.Result))
 		{
-			logger.LogError(ex, MessageWithoutId, nameof(UpdateTransactions));
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Transactions batch update failed — some not found");
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 
 	[HttpDelete(RouteDelete)]
@@ -246,30 +167,18 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 	[EndpointDescription("Deletes one or more transactions by their IDs. Returns 404 if any transaction is not found.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<bool>> DeleteTransactions([FromBody] List<Guid> ids)
 	{
-		try
+		DeleteTransactionCommand command = new(ids);
+		bool result = await mediator.Send(command);
+
+		if (!result)
 		{
-			logger.LogDebug("DeleteTransactions called with {Count} transaction ids", ids.Count);
-			DeleteTransactionCommand command = new(ids);
-			bool result = await mediator.Send(command);
-
-			if (!result)
-			{
-				logger.LogWarning("DeleteTransactions called with {Count} transaction ids, but not found", ids.Count);
-				return NotFound();
-			}
-
-			logger.LogDebug("DeleteTransactions called with {Count} transaction ids, and found", ids.Count);
-
-			return NoContent();
+			logger.LogWarning("Transactions delete failed — not found");
+			return NotFound();
 		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, MessageWithoutId, nameof(DeleteTransactions));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+
+		return NoContent();
 	}
 
 	[HttpPost(RouteRestore)]
@@ -277,27 +186,17 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 	[EndpointDescription("Restores a previously soft-deleted transaction by clearing its DeletedAt timestamp.")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RestoreTransaction([FromRoute] Guid id)
 	{
-		try
-		{
-			logger.LogDebug("RestoreTransaction called with id: {Id}", id);
-			RestoreTransactionCommand command = new(id);
-			bool result = await mediator.Send(command);
+		RestoreTransactionCommand command = new(id);
+		bool result = await mediator.Send(command);
 
-			if (!result)
-			{
-				logger.LogWarning("RestoreTransaction called with id: {Id}, but not found or not deleted", id);
-				return NotFound();
-			}
-
-			return NoContent();
-		}
-		catch (Exception ex)
+		if (!result)
 		{
-			logger.LogError(ex, MessageWithId, nameof(RestoreTransaction), id);
-			return StatusCode(500, "An error occurred while processing your request.");
+			logger.LogWarning("Transaction {Id} not found or not deleted for restore", id);
+			return NotFound();
 		}
+
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/Core/TrashController.cs
+++ b/src/Presentation/API/Controllers/Core/TrashController.cs
@@ -17,20 +17,11 @@ public class TrashController(IMediator mediator, ILogger<TrashController> logger
 	[HttpPost("purge")]
 	[EndpointSummary("Permanently delete all soft-deleted items")]
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult> PurgeTrash()
 	{
-		try
-		{
-			logger.LogWarning("PurgeTrash called — permanently deleting all soft-deleted items");
-			PurgeTrashCommand command = new();
-			await mediator.Send(command);
-			return NoContent();
-		}
-		catch (Exception ex)
-		{
-			logger.LogError(ex, "Error in {Method}", nameof(PurgeTrash));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+		logger.LogWarning("PurgeTrash called — permanently deleting all soft-deleted items");
+		PurgeTrashCommand command = new();
+		await mediator.Send(command);
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/UserRolesController.cs
+++ b/src/Presentation/API/Controllers/UserRolesController.cs
@@ -16,35 +16,25 @@ namespace API.Controllers;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 [ProducesResponseType(StatusCodes.Status403Forbidden)]
 public class UserRolesController(
-	UserManager<ApplicationUser> userManager,
-	ILogger<UserRolesController> logger) : ControllerBase
+	UserManager<ApplicationUser> userManager) : ControllerBase
 {
 	[HttpGet]
 	[EndpointSummary("List roles for a user")]
 	[ProducesResponseType<UserRolesResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<UserRolesResponse>> GetUserRoles([FromRoute] string userId)
 	{
-		try
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is null)
 		{
-			ApplicationUser? user = await userManager.FindByIdAsync(userId);
-			if (user is null)
-			{
-				return NotFound();
-			}
+			return NotFound();
+		}
 
-			IList<string> roles = await userManager.GetRolesAsync(user);
-			return Ok(new UserRolesResponse
-			{
-				Roles = [.. roles],
-			});
-		}
-		catch (Exception ex)
+		IList<string> roles = await userManager.GetRolesAsync(user);
+		return Ok(new UserRolesResponse
 		{
-			logger.LogError(ex, "Error occurred in {Method} for userId: {UserId}", nameof(GetUserRoles), userId);
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+			Roles = [.. roles],
+		});
 	}
 
 	[HttpPost("{role}")]
@@ -52,30 +42,21 @@ public class UserRolesController(
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> AssignUserRole([FromRoute] string userId, [FromRoute] string role)
 	{
-		try
+		if (!AppRoles.All.Contains(role))
 		{
-			if (!AppRoles.All.Contains(role))
-			{
-				return BadRequest($"Invalid role '{role}'. Valid roles: {string.Join(", ", AppRoles.All)}");
-			}
-
-			ApplicationUser? user = await userManager.FindByIdAsync(userId);
-			if (user is null)
-			{
-				return NotFound();
-			}
-
-			await userManager.AddToRoleAsync(user, role);
-			return NoContent();
+			return BadRequest($"Invalid role '{role}'. Valid roles: {string.Join(", ", AppRoles.All)}");
 		}
-		catch (Exception ex)
+
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is null)
 		{
-			logger.LogError(ex, "Error occurred in {Method} for userId: {UserId}, role: {Role}", nameof(AssignUserRole), userId, role);
-			return StatusCode(500, "An error occurred while processing your request.");
+			return NotFound();
 		}
+
+		await userManager.AddToRoleAsync(user, role);
+		return NoContent();
 	}
 
 	[HttpDelete("{role}")]
@@ -83,29 +64,20 @@ public class UserRolesController(
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> RemoveUserRole([FromRoute] string userId, [FromRoute] string role)
 	{
-		try
+		if (!AppRoles.All.Contains(role))
 		{
-			if (!AppRoles.All.Contains(role))
-			{
-				return BadRequest($"Invalid role '{role}'. Valid roles: {string.Join(", ", AppRoles.All)}");
-			}
-
-			ApplicationUser? user = await userManager.FindByIdAsync(userId);
-			if (user is null)
-			{
-				return NotFound();
-			}
-
-			await userManager.RemoveFromRoleAsync(user, role);
-			return NoContent();
+			return BadRequest($"Invalid role '{role}'. Valid roles: {string.Join(", ", AppRoles.All)}");
 		}
-		catch (Exception ex)
+
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is null)
 		{
-			logger.LogError(ex, "Error occurred in {Method} for userId: {UserId}, role: {Role}", nameof(RemoveUserRole), userId, role);
-			return StatusCode(500, "An error occurred while processing your request.");
+			return NotFound();
 		}
+
+		await userManager.RemoveFromRoleAsync(user, role);
+		return NoContent();
 	}
 }

--- a/src/Presentation/API/Controllers/UsersController.cs
+++ b/src/Presentation/API/Controllers/UsersController.cs
@@ -26,118 +26,91 @@ public class UsersController(
 	[HttpGet]
 	[EndpointSummary("List all users with their roles")]
 	[ProducesResponseType<UserListResponse>(StatusCodes.Status200OK)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<UserListResponse>> ListUsers(
 		[FromQuery] int page = 1,
 		[FromQuery] int pageSize = 20)
 	{
-		try
-		{
-			PagedUserList result = await userService.ListUsersAsync(page, pageSize);
+		PagedUserList result = await userService.ListUsersAsync(page, pageSize);
 
-			List<UserSummaryResponse> items = result.Items.Select(MapToResponse).ToList();
+		List<UserSummaryResponse> items = result.Items.Select(MapToResponse).ToList();
 
-			return Ok(new UserListResponse
-			{
-				Items = items,
-				Page = result.Page,
-				PageSize = result.PageSize,
-				TotalCount = result.TotalCount,
-			});
-		}
-		catch (Exception ex)
+		return Ok(new UserListResponse
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(ListUsers));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+			Items = items,
+			Page = result.Page,
+			PageSize = result.PageSize,
+			TotalCount = result.TotalCount,
+		});
 	}
 
 	[HttpGet("{userId}")]
 	[EndpointSummary("Get a user by ID")]
 	[ProducesResponseType<UserSummaryResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<UserSummaryResponse>> GetUser(string userId)
 	{
-		try
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is null)
 		{
-			ApplicationUser? user = await userManager.FindByIdAsync(userId);
-			if (user is null)
-			{
-				return NotFound();
-			}
-
-			IList<string> roles = await userManager.GetRolesAsync(user);
-
-			return Ok(new UserSummaryResponse
-			{
-				Id = user.Id,
-				Email = user.Email ?? "",
-				FirstName = user.FirstName,
-				LastName = user.LastName,
-				Roles = [.. roles],
-				IsDisabled = user.LockoutEnabled && user.LockoutEnd > DateTimeOffset.UtcNow,
-				CreatedAt = user.CreatedAt,
-				LastLoginAt = user.LastLoginAt,
-			});
+			return NotFound();
 		}
-		catch (Exception ex)
+
+		IList<string> roles = await userManager.GetRolesAsync(user);
+
+		return Ok(new UserSummaryResponse
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(GetUser));
-			return StatusCode(500, "An error occurred while processing your request.");
-		}
+			Id = user.Id,
+			Email = user.Email ?? "",
+			FirstName = user.FirstName,
+			LastName = user.LastName,
+			Roles = [.. roles],
+			IsDisabled = user.LockoutEnabled && user.LockoutEnd > DateTimeOffset.UtcNow,
+			CreatedAt = user.CreatedAt,
+			LastLoginAt = user.LastLoginAt,
+		});
 	}
 
 	[HttpPost]
 	[EndpointSummary("Create a new user (admin only)")]
 	[ProducesResponseType<UserSummaryResponse>(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<ActionResult<UserSummaryResponse>> CreateUser([FromBody] CreateUserRequest request)
 	{
-		try
+		ApplicationUser user = new()
 		{
-			ApplicationUser user = new()
-			{
-				UserName = request.Email,
-				Email = request.Email,
-				FirstName = request.FirstName,
-				LastName = request.LastName,
-				MustResetPassword = true,
-				CreatedAt = DateTimeOffset.UtcNow,
-			};
+			UserName = request.Email,
+			Email = request.Email,
+			FirstName = request.FirstName,
+			LastName = request.LastName,
+			MustResetPassword = true,
+			CreatedAt = DateTimeOffset.UtcNow,
+		};
 
-			IdentityResult result = await userManager.CreateAsync(user, request.Password);
-			if (!result.Succeeded)
-			{
-				return BadRequest(result.Errors.Select(e => e.Description));
-			}
-
-			IdentityResult roleResult = await userManager.AddToRoleAsync(user, request.Role);
-			if (!roleResult.Succeeded)
-			{
-				return BadRequest(roleResult.Errors.Select(e => e.Description));
-			}
-
-			await LogAuthEventAsync(nameof(AuthEventType.UserRegistered), user.Id, user.Email);
-
-			return Ok(new UserSummaryResponse
-			{
-				Id = user.Id,
-				Email = user.Email!,
-				FirstName = user.FirstName,
-				LastName = user.LastName,
-				Roles = [request.Role],
-				IsDisabled = false,
-				CreatedAt = user.CreatedAt,
-				LastLoginAt = null,
-			});
-		}
-		catch (Exception ex)
+		IdentityResult result = await userManager.CreateAsync(user, request.Password);
+		if (!result.Succeeded)
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(CreateUser));
-			return StatusCode(500, "An error occurred while processing your request.");
+			return BadRequest(result.Errors.Select(e => e.Description));
 		}
+
+		IdentityResult roleResult = await userManager.AddToRoleAsync(user, request.Role);
+		if (!roleResult.Succeeded)
+		{
+			return BadRequest(roleResult.Errors.Select(e => e.Description));
+		}
+
+		await LogAuthEventAsync(nameof(AuthEventType.UserRegistered), user.Id, user.Email);
+
+		return Ok(new UserSummaryResponse
+		{
+			Id = user.Id,
+			Email = user.Email!,
+			FirstName = user.FirstName,
+			LastName = user.LastName,
+			Roles = [request.Role],
+			IsDisabled = false,
+			CreatedAt = user.CreatedAt,
+			LastLoginAt = null,
+		});
 	}
 
 	[HttpPut("{userId}")]
@@ -145,74 +118,65 @@ public class UsersController(
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> UpdateUser(string userId, [FromBody] UpdateUserRequest request)
 	{
-		try
+		string? currentUserId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is null)
 		{
-			string? currentUserId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+			return NotFound();
+		}
 
-			ApplicationUser? user = await userManager.FindByIdAsync(userId);
-			if (user is null)
-			{
-				return NotFound();
-			}
-
-			if (userId == currentUserId)
-			{
-				if (request.IsDisabled)
-				{
-					return BadRequest("Cannot disable your own account.");
-				}
-
-				IList<string> currentRoles = await userManager.GetRolesAsync(user);
-				if (currentRoles.Contains("Admin") && request.Role != "Admin")
-				{
-					return BadRequest("Cannot remove your own Admin role.");
-				}
-			}
-
-			user.Email = request.Email;
-			user.UserName = request.Email;
-			user.FirstName = request.FirstName;
-			user.LastName = request.LastName;
-
+		if (userId == currentUserId)
+		{
 			if (request.IsDisabled)
 			{
-				user.LockoutEnabled = true;
-				user.LockoutEnd = DateTimeOffset.MaxValue;
-			}
-			else
-			{
-				user.LockoutEnabled = false;
-				user.LockoutEnd = null;
+				return BadRequest("Cannot disable your own account.");
 			}
 
-			IdentityResult updateResult = await userManager.UpdateAsync(user);
-			if (!updateResult.Succeeded)
+			IList<string> currentRoles = await userManager.GetRolesAsync(user);
+			if (currentRoles.Contains("Admin") && request.Role != "Admin")
 			{
-				return BadRequest(updateResult.Errors.Select(e => e.Description));
+				return BadRequest("Cannot remove your own Admin role.");
 			}
-
-			IList<string> roles = await userManager.GetRolesAsync(user);
-			if (roles.Count > 0)
-			{
-				await userManager.RemoveFromRolesAsync(user, roles);
-			}
-
-			IdentityResult roleResult = await userManager.AddToRoleAsync(user, request.Role);
-			if (!roleResult.Succeeded)
-			{
-				return BadRequest(roleResult.Errors.Select(e => e.Description));
-			}
-
-			return NoContent();
 		}
-		catch (Exception ex)
+
+		user.Email = request.Email;
+		user.UserName = request.Email;
+		user.FirstName = request.FirstName;
+		user.LastName = request.LastName;
+
+		if (request.IsDisabled)
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(UpdateUser));
-			return StatusCode(500, "An error occurred while processing your request.");
+			user.LockoutEnabled = true;
+			user.LockoutEnd = DateTimeOffset.MaxValue;
 		}
+		else
+		{
+			user.LockoutEnabled = false;
+			user.LockoutEnd = null;
+		}
+
+		IdentityResult updateResult = await userManager.UpdateAsync(user);
+		if (!updateResult.Succeeded)
+		{
+			return BadRequest(updateResult.Errors.Select(e => e.Description));
+		}
+
+		IList<string> roles = await userManager.GetRolesAsync(user);
+		if (roles.Count > 0)
+		{
+			await userManager.RemoveFromRolesAsync(user, roles);
+		}
+
+		IdentityResult roleResult = await userManager.AddToRoleAsync(user, request.Role);
+		if (!roleResult.Succeeded)
+		{
+			return BadRequest(roleResult.Errors.Select(e => e.Description));
+		}
+
+		return NoContent();
 	}
 
 	[HttpDelete("{userId}")]
@@ -220,38 +184,29 @@ public class UsersController(
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> DeactivateUser(string userId)
 	{
-		try
+		string? currentUserId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+		if (userId == currentUserId)
 		{
-			string? currentUserId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (userId == currentUserId)
-			{
-				return BadRequest("Cannot deactivate your own account.");
-			}
-
-			ApplicationUser? user = await userManager.FindByIdAsync(userId);
-			if (user is null)
-			{
-				return NotFound();
-			}
-
-			user.LockoutEnabled = true;
-			user.LockoutEnd = DateTimeOffset.MaxValue;
-			user.RefreshToken = null;
-			user.RefreshTokenExpiresAt = null;
-			await userManager.UpdateAsync(user);
-
-			await LogAuthEventAsync(nameof(AuthEventType.AccountDisabled), user.Id, user.Email);
-
-			return NoContent();
+			return BadRequest("Cannot deactivate your own account.");
 		}
-		catch (Exception ex)
+
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is null)
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(DeactivateUser));
-			return StatusCode(500, "An error occurred while processing your request.");
+			return NotFound();
 		}
+
+		user.LockoutEnabled = true;
+		user.LockoutEnd = DateTimeOffset.MaxValue;
+		user.RefreshToken = null;
+		user.RefreshTokenExpiresAt = null;
+		await userManager.UpdateAsync(user);
+
+		await LogAuthEventAsync(nameof(AuthEventType.AccountDisabled), user.Id, user.Email);
+
+		return NoContent();
 	}
 
 	[HttpPost("{userId}/reset-password")]
@@ -259,38 +214,29 @@ public class UsersController(
 	[ProducesResponseType(StatusCodes.Status204NoContent)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
-	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
 	public async Task<IActionResult> AdminResetPassword(string userId, [FromBody] AdminResetPasswordRequest request)
 	{
-		try
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is null)
 		{
-			ApplicationUser? user = await userManager.FindByIdAsync(userId);
-			if (user is null)
-			{
-				return NotFound();
-			}
-
-			await userManager.RemovePasswordAsync(user);
-			IdentityResult result = await userManager.AddPasswordAsync(user, request.NewPassword);
-			if (!result.Succeeded)
-			{
-				return BadRequest(result.Errors.Select(e => e.Description));
-			}
-
-			user.MustResetPassword = true;
-			user.RefreshToken = null;
-			user.RefreshTokenExpiresAt = null;
-			await userManager.UpdateAsync(user);
-
-			await LogAuthEventAsync(nameof(AuthEventType.PasswordChanged), user.Id, user.Email);
-
-			return NoContent();
+			return NotFound();
 		}
-		catch (Exception ex)
+
+		await userManager.RemovePasswordAsync(user);
+		IdentityResult result = await userManager.AddPasswordAsync(user, request.NewPassword);
+		if (!result.Succeeded)
 		{
-			logger.LogError(ex, "Error occurred in {Method}", nameof(AdminResetPassword));
-			return StatusCode(500, "An error occurred while processing your request.");
+			return BadRequest(result.Errors.Select(e => e.Description));
 		}
+
+		user.MustResetPassword = true;
+		user.RefreshToken = null;
+		user.RefreshTokenExpiresAt = null;
+		await userManager.UpdateAsync(user);
+
+		await LogAuthEventAsync(nameof(AuthEventType.PasswordChanged), user.Id, user.Email);
+
+		return NoContent();
 	}
 
 	private static UserSummaryResponse MapToResponse(UserSummary user) => new()

--- a/src/Presentation/API/Middleware/AuthorizationLoggingHandler.cs
+++ b/src/Presentation/API/Middleware/AuthorizationLoggingHandler.cs
@@ -1,0 +1,27 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+
+namespace API.Middleware;
+
+public class AuthorizationLoggingHandler(ILogger<AuthorizationLoggingHandler> logger) : IAuthorizationMiddlewareResultHandler
+{
+	private readonly AuthorizationMiddlewareResultHandler _defaultHandler = new();
+
+	public async Task HandleAsync(
+		RequestDelegate next,
+		HttpContext context,
+		AuthorizationPolicy policy,
+		PolicyAuthorizationResult authorizeResult)
+	{
+		if (authorizeResult.Forbidden)
+		{
+			string? userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+			logger.LogWarning(
+				"Authorization denied for user {UserId}. Method: {Method}, Path: {Path}, IP: {IP}",
+				userId, context.Request.Method, context.Request.Path, context.Connection.RemoteIpAddress);
+		}
+
+		await _defaultHandler.HandleAsync(next, context, policy, authorizeResult);
+	}
+}

--- a/src/Presentation/API/Middleware/CorrelationIdMiddleware.cs
+++ b/src/Presentation/API/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+using Serilog.Context;
+
+namespace API.Middleware;
+
+public class CorrelationIdMiddleware(RequestDelegate next)
+{
+	public const string HeaderName = "X-Correlation-ID";
+	public const string ItemKey = "CorrelationId";
+
+	public async Task InvokeAsync(HttpContext context)
+	{
+		string correlationId = context.Request.Headers[HeaderName].FirstOrDefault()
+			?? Activity.Current?.TraceId.ToString()
+			?? Guid.NewGuid().ToString();
+
+		context.Items[ItemKey] = correlationId;
+
+		context.Response.OnStarting(() =>
+		{
+			context.Response.Headers[HeaderName] = correlationId;
+			return Task.CompletedTask;
+		});
+
+		using (LogContext.PushProperty(ItemKey, correlationId))
+		{
+			await next(context);
+		}
+	}
+}

--- a/src/Presentation/API/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/src/Presentation/API/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -1,0 +1,69 @@
+using Application.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Middleware;
+
+public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<GlobalExceptionHandlerMiddleware> logger)
+{
+	public async Task InvokeAsync(HttpContext context)
+	{
+		try
+		{
+			await next(context);
+		}
+		catch (DuplicateEntityException ex)
+		{
+			logger.LogWarning(ex, "Duplicate entity: {Message}", ex.Message);
+
+			ProblemDetails problemDetails = new()
+			{
+				Status = StatusCodes.Status409Conflict,
+				Title = "Conflict",
+				Detail = ex.Message,
+				Type = "https://tools.ietf.org/html/rfc9110#section-15.5.10",
+			};
+
+			context.Response.StatusCode = StatusCodes.Status409Conflict;
+			await context.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: "application/problem+json");
+		}
+		catch (KeyNotFoundException ex)
+		{
+			logger.LogWarning(ex, "Resource not found: {Message}", ex.Message);
+
+			ProblemDetails problemDetails = new()
+			{
+				Status = StatusCodes.Status404NotFound,
+				Title = "Not Found",
+				Detail = ex.Message,
+				Type = "https://tools.ietf.org/html/rfc9110#section-15.5.5",
+			};
+
+			context.Response.StatusCode = StatusCodes.Status404NotFound;
+			await context.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: "application/problem+json");
+		}
+		catch (Exception ex)
+		{
+			string errorId = Guid.NewGuid().ToString();
+			string correlationId = context.Items[CorrelationIdMiddleware.ItemKey]?.ToString() ?? "";
+
+			logger.LogError(ex,
+				"Unhandled exception. ErrorId: {ErrorId}, CorrelationId: {CorrelationId}, Method: {Method}, Path: {Path}",
+				errorId, correlationId, context.Request.Method, context.Request.Path);
+
+			ProblemDetails problemDetails = new()
+			{
+				Status = StatusCodes.Status500InternalServerError,
+				Title = "An error occurred while processing your request.",
+				Type = "https://tools.ietf.org/html/rfc9110#section-15.6.1",
+				Extensions =
+				{
+					["errorId"] = errorId,
+					["correlationId"] = correlationId,
+				},
+			};
+
+			context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+			await context.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: "application/problem+json");
+		}
+	}
+}

--- a/src/Presentation/API/Middleware/MustResetPasswordMiddleware.cs
+++ b/src/Presentation/API/Middleware/MustResetPasswordMiddleware.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Mvc;
+
 namespace API.Middleware;
 
 public class MustResetPasswordMiddleware(RequestDelegate next)
@@ -11,9 +13,16 @@ public class MustResetPasswordMiddleware(RequestDelegate next)
 			if (!path.Equals("/api/auth/change-password", StringComparison.OrdinalIgnoreCase)
 				&& !path.Equals("/api/auth/logout", StringComparison.OrdinalIgnoreCase))
 			{
+				ProblemDetails problemDetails = new()
+				{
+					Status = StatusCodes.Status403Forbidden,
+					Title = "Forbidden",
+					Detail = "Password change required",
+					Type = "https://tools.ietf.org/html/rfc9110#section-15.5.4",
+				};
+
 				context.Response.StatusCode = StatusCodes.Status403Forbidden;
-				context.Response.ContentType = "application/json";
-				await context.Response.WriteAsJsonAsync(new { error = "Password change required" });
+				await context.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: "application/problem+json");
 				return;
 			}
 		}

--- a/src/Presentation/API/Program.cs
+++ b/src/Presentation/API/Program.cs
@@ -1,5 +1,6 @@
 using API.Configuration;
 using API.Hubs;
+using API.Middleware;
 using API.Services;
 using Application.Interfaces;
 using Application.Services;
@@ -25,6 +26,8 @@ builder.Services
 WebApplication app = builder.Build();
 
 // Configure middleware
+app.UseMiddleware<CorrelationIdMiddleware>();
+app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
 app.UseOpenApiServices()
    .UseApplicationServices()
    .UseCorsServices()

--- a/src/Presentation/API/Services/LoggingService.cs
+++ b/src/Presentation/API/Services/LoggingService.cs
@@ -10,16 +10,22 @@ public static class LoggingService
 		LoggerConfiguration loggerConfiguration = new LoggerConfiguration()
 			.Enrich.FromLogContext();
 
+		loggerConfiguration
+			.MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Warning)
+			.MinimumLevel.Override("Microsoft.Hosting.Lifetime", Serilog.Events.LogEventLevel.Information);
+
+		string outputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] [{CorrelationId}] {Message:lj}{NewLine}{Exception}";
+
 		if (builder.Environment.IsDevelopment())
 		{
 			loggerConfiguration
-				.WriteTo.Console()
+				.WriteTo.Console(outputTemplate: outputTemplate)
 				.MinimumLevel.Debug();
 		}
 		else
 		{
 			loggerConfiguration
-				.WriteTo.Console()
+				.WriteTo.Console(outputTemplate: outputTemplate)
 				.MinimumLevel.Information();
 		}
 

--- a/src/Presentation/API/Services/ProgramService.cs
+++ b/src/Presentation/API/Services/ProgramService.cs
@@ -1,5 +1,8 @@
 using API.Mapping.Aggregates;
+using API.Middleware;
 using Application.Interfaces.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
 
 namespace API.Services;
 
@@ -23,6 +26,8 @@ public static class ProgramService
 			.AddSingleton<ReceiptWithItemsMapper>()
 			.AddSingleton<TransactionAccountMapper>()
 			.AddSingleton<TripMapper>();
+
+		services.AddSingleton<IAuthorizationMiddlewareResultHandler, AuthorizationLoggingHandler>();
 
 		services.AddSignalR();
 

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/ReceiptWithItemsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/ReceiptWithItemsControllerTests.cs
@@ -69,7 +69,7 @@ public class ReceiptWithItemsControllerTests
 	}
 
 	[Fact]
-	public async Task GetReceiptWithItemsByReceiptId_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetReceiptWithItemsByReceiptId_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = ReceiptWithItemsGenerator.Generate().Receipt.Id;
@@ -80,11 +80,9 @@ public class ReceiptWithItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<ReceiptWithItemsResponse> result = await _controller.GetReceiptWithItemsByReceiptId(receiptId);
+		Func<Task> act = () => _controller.GetReceiptWithItemsByReceiptId(receiptId);
 
 		// Assert
-		Assert.IsType<ObjectResult>(result.Result);
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/TransactionAccountControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/TransactionAccountControllerTests.cs
@@ -7,7 +7,6 @@ using Domain.Aggregates;
 using FluentAssertions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Moq;
 using SampleData.Domain.Aggregates;
 using SampleData.Domain.Core;
@@ -18,15 +17,13 @@ public class TransactionAccountControllerTests
 {
 	private readonly TransactionAccountMapper _mapper;
 	private readonly Mock<IMediator> _mediatorMock;
-	private readonly Mock<ILogger<TransactionAccountController>> _loggerMock;
 	private readonly TransactionAccountController _controller;
 
 	public TransactionAccountControllerTests()
 	{
 		_mediatorMock = new Mock<IMediator>();
 		_mapper = new TransactionAccountMapper();
-		_loggerMock = ControllerTestHelpers.GetLoggerMock<TransactionAccountController>();
-		_controller = new TransactionAccountController(_mediatorMock.Object, _mapper, _loggerMock.Object);
+		_controller = new TransactionAccountController(_mediatorMock.Object, _mapper);
 	}
 
 	[Fact]
@@ -72,7 +69,7 @@ public class TransactionAccountControllerTests
 	}
 
 	[Fact]
-	public async Task GetTransactionAccounts_ByTransactionId_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetTransactionAccounts_ByTransactionId_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid transactionId = TransactionAccountGenerator.Generate().Transaction.Id;
@@ -83,11 +80,10 @@ public class TransactionAccountControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		IActionResult result = await _controller.GetTransactionAccounts(transactionId: transactionId, receiptId: null);
+		Func<Task> act = () => _controller.GetTransactionAccounts(transactionId: transactionId, receiptId: null);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -134,7 +130,7 @@ public class TransactionAccountControllerTests
 	}
 
 	[Fact]
-	public async Task GetTransactionAccounts_ByReceiptId_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetTransactionAccounts_ByReceiptId_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = ReceiptGenerator.Generate().Id;
@@ -145,10 +141,9 @@ public class TransactionAccountControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		IActionResult result = await _controller.GetTransactionAccounts(transactionId: null, receiptId: receiptId);
+		Func<Task> act = () => _controller.GetTransactionAccounts(transactionId: null, receiptId: receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/TripControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/TripControllerTests.cs
@@ -69,7 +69,7 @@ public class TripControllerTests
 	}
 
 	[Fact]
-	public async Task GetTripByReceiptId_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetTripByReceiptId_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = TripGenerator.Generate().Receipt.Receipt.Id;
@@ -80,11 +80,9 @@ public class TripControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<TripResponse> result = await _controller.GetTripByReceiptId(receiptId);
+		Func<Task> act = () => _controller.GetTripByReceiptId(receiptId);
 
 		// Assert
-		Assert.IsType<ObjectResult>(result.Result);
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/AuditControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuditControllerTests.cs
@@ -2,7 +2,6 @@ using API.Controllers;
 using Application.Interfaces.Services;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Presentation.API.Tests.Controllers;
@@ -10,14 +9,12 @@ namespace Presentation.API.Tests.Controllers;
 public class AuditControllerTests
 {
 	private readonly Mock<IAuditService> _auditServiceMock;
-	private readonly Mock<ILogger<AuditController>> _loggerMock;
 	private readonly AuditController _controller;
 
 	public AuditControllerTests()
 	{
 		_auditServiceMock = new Mock<IAuditService>();
-		_loggerMock = ControllerTestHelpers.GetLoggerMock<AuditController>();
-		_controller = new AuditController(_auditServiceMock.Object, _loggerMock.Object);
+		_controller = new AuditController(_auditServiceMock.Object);
 	}
 
 	[Fact]
@@ -131,7 +128,7 @@ public class AuditControllerTests
 	}
 
 	[Fact]
-	public async Task GetAuditLogs_WithEntityParams_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task GetAuditLogs_WithEntityParams_ThrowsException_WhenServiceFails()
 	{
 		// Arrange
 		string entityType = "Account";
@@ -141,30 +138,28 @@ public class AuditControllerTests
 			.ThrowsAsync(new Exception("Test error"));
 
 		// Act
-		IActionResult result = await _controller.GetAuditLogs(entityType, entityId, null, null, CancellationToken.None);
+		Func<Task> act = () => _controller.GetAuditLogs(entityType, entityId, null, null, CancellationToken.None);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
-	public async Task GetRecent_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task GetRecent_ThrowsException_WhenServiceFails()
 	{
 		// Arrange
 		_auditServiceMock.Setup(s => s.GetRecentAsync(50, It.IsAny<CancellationToken>()))
 			.ThrowsAsync(new Exception("Test error"));
 
 		// Act
-		IActionResult result = await _controller.GetRecent(50, CancellationToken.None);
+		Func<Task> act = () => _controller.GetRecent(50, CancellationToken.None);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
-	public async Task GetAuditLogs_WithUserId_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task GetAuditLogs_WithUserId_ThrowsException_WhenServiceFails()
 	{
 		// Arrange
 		string userId = "test-user";
@@ -172,15 +167,14 @@ public class AuditControllerTests
 			.ThrowsAsync(new Exception("Test error"));
 
 		// Act
-		IActionResult result = await _controller.GetAuditLogs(null, null, userId, null, CancellationToken.None);
+		Func<Task> act = () => _controller.GetAuditLogs(null, null, userId, null, CancellationToken.None);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
-	public async Task GetAuditLogs_WithApiKeyId_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task GetAuditLogs_WithApiKeyId_ThrowsException_WhenServiceFails()
 	{
 		// Arrange
 		Guid apiKeyId = Guid.NewGuid();
@@ -188,10 +182,9 @@ public class AuditControllerTests
 			.ThrowsAsync(new Exception("Test error"));
 
 		// Act
-		IActionResult result = await _controller.GetAuditLogs(null, null, null, apiKeyId, CancellationToken.None);
+		Func<Task> act = () => _controller.GetAuditLogs(null, null, null, apiKeyId, CancellationToken.None);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/AuthAuditControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuthAuditControllerTests.cs
@@ -4,7 +4,6 @@ using Application.Interfaces.Services;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Presentation.API.Tests.Controllers;
@@ -12,14 +11,12 @@ namespace Presentation.API.Tests.Controllers;
 public class AuthAuditControllerTests
 {
 	private readonly Mock<IAuthAuditService> _authAuditServiceMock;
-	private readonly Mock<ILogger<AuthAuditController>> _loggerMock;
 	private readonly AuthAuditController _controller;
 
 	public AuthAuditControllerTests()
 	{
 		_authAuditServiceMock = new Mock<IAuthAuditService>();
-		_loggerMock = ControllerTestHelpers.GetLoggerMock<AuthAuditController>();
-		_controller = new AuthAuditController(_authAuditServiceMock.Object, _loggerMock.Object);
+		_controller = new AuthAuditController(_authAuditServiceMock.Object);
 	}
 
 	private void SetupUserClaims(string userId)
@@ -105,7 +102,7 @@ public class AuthAuditControllerTests
 	}
 
 	[Fact]
-	public async Task GetMyAuditLog_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task GetMyAuditLog_ThrowsException_WhenServiceFails()
 	{
 		// Arrange
 		string userId = "user-123";
@@ -115,15 +112,14 @@ public class AuthAuditControllerTests
 			.ThrowsAsync(new Exception("Test error"));
 
 		// Act
-		IActionResult result = await _controller.GetMyAuditLog(50, CancellationToken.None);
+		Func<Task> act = () => _controller.GetMyAuditLog(50, CancellationToken.None);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
-	public async Task GetRecent_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task GetRecent_ThrowsException_WhenServiceFails()
 	{
 		// Arrange
 		_authAuditServiceMock
@@ -131,15 +127,14 @@ public class AuthAuditControllerTests
 			.ThrowsAsync(new Exception("Test error"));
 
 		// Act
-		IActionResult result = await _controller.GetRecent(50, CancellationToken.None);
+		Func<Task> act = () => _controller.GetRecent(50, CancellationToken.None);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
-	public async Task GetFailed_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task GetFailed_ThrowsException_WhenServiceFails()
 	{
 		// Arrange
 		_authAuditServiceMock
@@ -147,10 +142,9 @@ public class AuthAuditControllerTests
 			.ThrowsAsync(new Exception("Test error"));
 
 		// Act
-		IActionResult result = await _controller.GetFailed(50, CancellationToken.None);
+		Func<Task> act = () => _controller.GetFailed(50, CancellationToken.None);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Core/AccountsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/AccountsControllerTests.cs
@@ -72,7 +72,7 @@ public class AccountsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAccountById_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAccountById_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = AccountGenerator.Generate().Id;
@@ -83,12 +83,10 @@ public class AccountsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<AccountResponse> result = await _controller.GetAccountById(id);
+		Func<Task> act = () => _controller.GetAccountById(id);
 
 		// Assert
-		Assert.IsType<ObjectResult>(result.Result);
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -114,7 +112,7 @@ public class AccountsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAllAccounts_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAllAccounts_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		_mediatorMock.Setup(m => m.Send(
@@ -123,12 +121,10 @@ public class AccountsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<AccountResponse>> result = await _controller.GetAllAccounts();
+		Func<Task> act = () => _controller.GetAllAccounts();
 
 		// Assert
-		Assert.IsType<ObjectResult>(result.Result);
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -156,7 +152,7 @@ public class AccountsControllerTests
 	}
 
 	[Fact]
-	public async Task CreateAccount_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task CreateAccount_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		CreateAccountRequest controllerInput = AccountDtoGenerator.GenerateCreateRequest();
@@ -167,12 +163,10 @@ public class AccountsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<AccountResponse> result = await _controller.CreateAccount(controllerInput);
+		Func<Task> act = () => _controller.CreateAccount(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -200,7 +194,7 @@ public class AccountsControllerTests
 	}
 
 	[Fact]
-	public async Task CreateAccounts_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task CreateAccounts_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<CreateAccountRequest> controllerInput = AccountDtoGenerator.GenerateCreateRequestList(2);
@@ -210,12 +204,10 @@ public class AccountsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<AccountResponse>> result = await _controller.CreateAccounts(controllerInput);
+		Func<Task> act = () => _controller.CreateAccounts(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -257,7 +249,7 @@ public class AccountsControllerTests
 	}
 
 	[Fact]
-	public async Task UpdateAccount_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task UpdateAccount_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		UpdateAccountRequest controllerInput = AccountDtoGenerator.GenerateUpdateRequest();
@@ -268,12 +260,10 @@ public class AccountsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.UpdateAccount(controllerInput.Id, controllerInput);
+		Func<Task> act = () => _controller.UpdateAccount(controllerInput.Id, controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -315,7 +305,7 @@ public class AccountsControllerTests
 	}
 
 	[Fact]
-	public async Task UpdateAccounts_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task UpdateAccounts_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<UpdateAccountRequest> controllerInput = AccountDtoGenerator.GenerateUpdateRequestList(2);
@@ -325,12 +315,10 @@ public class AccountsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.UpdateAccounts(controllerInput);
+		Func<Task> act = () => _controller.UpdateAccounts(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -391,7 +379,7 @@ public class AccountsControllerTests
 	}
 
 	[Fact]
-	public async Task DeleteAccounts_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task DeleteAccounts_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<Guid> ids = [.. AccountGenerator.GenerateList(2).Select(a => a.Id)];
@@ -402,12 +390,10 @@ public class AccountsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.DeleteAccounts(ids);
+		Func<Task> act = () => _controller.DeleteAccounts(ids);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -445,7 +431,7 @@ public class AccountsControllerTests
 	}
 
 	[Fact]
-	public async Task RestoreAccount_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task RestoreAccount_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
@@ -455,10 +441,9 @@ public class AccountsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		IActionResult result = await _controller.RestoreAccount(id);
+		Func<Task> act = () => _controller.RestoreAccount(id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Core/AdjustmentsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/AdjustmentsControllerTests.cs
@@ -72,7 +72,7 @@ public class AdjustmentsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAdjustmentById_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAdjustmentById_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = AdjustmentGenerator.Generate().Id;
@@ -83,11 +83,10 @@ public class AdjustmentsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<AdjustmentResponse> result = await _controller.GetAdjustmentById(id);
+		Func<Task> act = () => _controller.GetAdjustmentById(id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -112,7 +111,7 @@ public class AdjustmentsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAllAdjustments_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAllAdjustments_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		_mediatorMock.Setup(m => m.Send(
@@ -121,11 +120,10 @@ public class AdjustmentsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<AdjustmentResponse>> result = await _controller.GetAllAdjustments();
+		Func<Task> act = () => _controller.GetAllAdjustments();
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -150,7 +148,7 @@ public class AdjustmentsControllerTests
 	}
 
 	[Fact]
-	public async Task GetDeletedAdjustments_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetDeletedAdjustments_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		_mediatorMock.Setup(m => m.Send(
@@ -159,11 +157,10 @@ public class AdjustmentsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<AdjustmentResponse>> result = await _controller.GetDeletedAdjustments();
+		Func<Task> act = () => _controller.GetDeletedAdjustments();
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -209,7 +206,7 @@ public class AdjustmentsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAllAdjustments_WithReceiptId_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAllAdjustments_WithReceiptId_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -220,11 +217,10 @@ public class AdjustmentsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<AdjustmentResponse>> result = await _controller.GetAllAdjustments(receiptId);
+		Func<Task> act = () => _controller.GetAllAdjustments(receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -252,7 +248,7 @@ public class AdjustmentsControllerTests
 	}
 
 	[Fact]
-	public async Task CreateAdjustment_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task CreateAdjustment_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -264,12 +260,10 @@ public class AdjustmentsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<AdjustmentResponse> result = await _controller.CreateAdjustment(controllerInput, receiptId);
+		Func<Task> act = () => _controller.CreateAdjustment(controllerInput, receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -313,7 +307,7 @@ public class AdjustmentsControllerTests
 	}
 
 	[Fact]
-	public async Task UpdateAdjustment_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task UpdateAdjustment_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
@@ -325,12 +319,10 @@ public class AdjustmentsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.UpdateAdjustment(controllerInput, id);
+		Func<Task> act = () => _controller.UpdateAdjustment(controllerInput, id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -372,7 +364,7 @@ public class AdjustmentsControllerTests
 	}
 
 	[Fact]
-	public async Task DeleteAdjustments_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task DeleteAdjustments_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<Guid> ids = [.. AdjustmentGenerator.GenerateList(2).Select(a => a.Id)];
@@ -383,12 +375,10 @@ public class AdjustmentsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.DeleteAdjustments(ids);
+		Func<Task> act = () => _controller.DeleteAdjustments(ids);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -426,7 +416,7 @@ public class AdjustmentsControllerTests
 	}
 
 	[Fact]
-	public async Task RestoreAdjustment_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task RestoreAdjustment_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
@@ -436,10 +426,9 @@ public class AdjustmentsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		IActionResult result = await _controller.RestoreAdjustment(id);
+		Func<Task> act = () => _controller.RestoreAdjustment(id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptItemsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptItemsControllerTests.cs
@@ -72,7 +72,7 @@ public class ReceiptItemsControllerTests
 	}
 
 	[Fact]
-	public async Task GetReceiptItemById_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetReceiptItemById_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = ReceiptItemGenerator.Generate().Id;
@@ -83,11 +83,10 @@ public class ReceiptItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<ReceiptItemResponse> result = await _controller.GetReceiptItemById(id);
+		Func<Task> act = () => _controller.GetReceiptItemById(id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -113,7 +112,7 @@ public class ReceiptItemsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAllReceiptItems_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAllReceiptItems_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		_mediatorMock.Setup(m => m.Send(
@@ -122,11 +121,10 @@ public class ReceiptItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<ReceiptItemResponse>> result = await _controller.GetAllReceiptItems();
+		Func<Task> act = () => _controller.GetAllReceiptItems();
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -196,7 +194,7 @@ public class ReceiptItemsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAllReceiptItems_WithReceiptId_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAllReceiptItems_WithReceiptId_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -207,11 +205,10 @@ public class ReceiptItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<ReceiptItemResponse>> result = await _controller.GetAllReceiptItems(receiptId);
+		Func<Task> act = () => _controller.GetAllReceiptItems(receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -240,7 +237,7 @@ public class ReceiptItemsControllerTests
 	}
 
 	[Fact]
-	public async Task CreateReceiptItem_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task CreateReceiptItem_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -252,12 +249,10 @@ public class ReceiptItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<ReceiptItemResponse> result = await _controller.CreateReceiptItem(controllerInput, receiptId);
+		Func<Task> act = () => _controller.CreateReceiptItem(controllerInput, receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -286,7 +281,7 @@ public class ReceiptItemsControllerTests
 	}
 
 	[Fact]
-	public async Task CreateReceiptItems_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task CreateReceiptItems_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -298,12 +293,10 @@ public class ReceiptItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<ReceiptItemResponse>> result = await _controller.CreateReceiptItems(controllerInput, receiptId);
+		Func<Task> act = () => _controller.CreateReceiptItems(controllerInput, receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -345,7 +338,7 @@ public class ReceiptItemsControllerTests
 	}
 
 	[Fact]
-	public async Task UpdateReceiptItem_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task UpdateReceiptItem_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
@@ -357,12 +350,10 @@ public class ReceiptItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.UpdateReceiptItem(controllerInput, id);
+		Func<Task> act = () => _controller.UpdateReceiptItem(controllerInput, id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -402,7 +393,7 @@ public class ReceiptItemsControllerTests
 	}
 
 	[Fact]
-	public async Task UpdateReceiptItems_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task UpdateReceiptItems_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<UpdateReceiptItemRequest> controllerInput = ReceiptItemDtoGenerator.GenerateUpdateRequestList(2);
@@ -413,12 +404,10 @@ public class ReceiptItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.UpdateReceiptItems(controllerInput);
+		Func<Task> act = () => _controller.UpdateReceiptItems(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -476,7 +465,7 @@ public class ReceiptItemsControllerTests
 	}
 
 	[Fact]
-	public async Task DeleteReceiptItems_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task DeleteReceiptItems_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<Guid> controllerInput = [.. ReceiptItemGenerator.GenerateList(2).Select(ri => ri.Id)];
@@ -487,12 +476,10 @@ public class ReceiptItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.DeleteReceiptItems(controllerInput);
+		Func<Task> act = () => _controller.DeleteReceiptItems(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -530,7 +517,7 @@ public class ReceiptItemsControllerTests
 	}
 
 	[Fact]
-	public async Task RestoreReceiptItem_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task RestoreReceiptItem_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
@@ -540,10 +527,9 @@ public class ReceiptItemsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		IActionResult result = await _controller.RestoreReceiptItem(id);
+		Func<Task> act = () => _controller.RestoreReceiptItem(id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptsControllerTests.cs
@@ -87,7 +87,7 @@ public class ReceiptsControllerTests
 	}
 
 	[Fact]
-	public async Task GetReceiptById_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetReceiptById_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = ReceiptGenerator.Generate().Id;
@@ -98,12 +98,10 @@ public class ReceiptsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<ReceiptResponse> result = await _controller.GetReceiptById(id);
+		Func<Task> act = () => _controller.GetReceiptById(id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -129,7 +127,7 @@ public class ReceiptsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAllReceipts_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAllReceipts_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		_mediatorMock.Setup(m => m.Send(
@@ -138,12 +136,10 @@ public class ReceiptsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<ReceiptResponse>> result = await _controller.GetAllReceipts();
+		Func<Task> act = () => _controller.GetAllReceipts();
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -171,7 +167,7 @@ public class ReceiptsControllerTests
 	}
 
 	[Fact]
-	public async Task CreateReceipt_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task CreateReceipt_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		CreateReceiptRequest controllerInput = ReceiptDtoGenerator.GenerateCreateRequest();
@@ -182,12 +178,10 @@ public class ReceiptsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<ReceiptResponse> result = await _controller.CreateReceipt(controllerInput);
+		Func<Task> act = () => _controller.CreateReceipt(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -215,7 +209,7 @@ public class ReceiptsControllerTests
 	}
 
 	[Fact]
-	public async Task CreateReceipts_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task CreateReceipts_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<CreateReceiptRequest> controllerInput = ReceiptDtoGenerator.GenerateCreateRequestList(2);
@@ -226,12 +220,10 @@ public class ReceiptsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<ReceiptResponse>> result = await _controller.CreateReceipts(controllerInput);
+		Func<Task> act = () => _controller.CreateReceipts(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -271,7 +263,7 @@ public class ReceiptsControllerTests
 	}
 
 	[Fact]
-	public async Task UpdateReceipt_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task UpdateReceipt_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		UpdateReceiptRequest controllerInput = ReceiptDtoGenerator.GenerateUpdateRequest();
@@ -282,12 +274,10 @@ public class ReceiptsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.UpdateReceipt(controllerInput.Id, controllerInput);
+		Func<Task> act = () => _controller.UpdateReceipt(controllerInput.Id, controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -327,7 +317,7 @@ public class ReceiptsControllerTests
 	}
 
 	[Fact]
-	public async Task UpdateReceipts_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task UpdateReceipts_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<UpdateReceiptRequest> controllerInput = ReceiptDtoGenerator.GenerateUpdateRequestList(2);
@@ -338,12 +328,10 @@ public class ReceiptsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.UpdateReceipts(controllerInput);
+		Func<Task> act = () => _controller.UpdateReceipts(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -383,7 +371,7 @@ public class ReceiptsControllerTests
 	}
 
 	[Fact]
-	public async Task DeleteReceipts_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task DeleteReceipts_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<Guid> controllerInput = [.. ReceiptGenerator.GenerateList(2).Select(a => a.Id)];
@@ -394,12 +382,10 @@ public class ReceiptsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.DeleteReceipts(controllerInput);
+		Func<Task> act = () => _controller.DeleteReceipts(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -437,7 +423,7 @@ public class ReceiptsControllerTests
 	}
 
 	[Fact]
-	public async Task RestoreReceipt_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task RestoreReceipt_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
@@ -447,10 +433,9 @@ public class ReceiptsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		IActionResult result = await _controller.RestoreReceipt(id);
+		Func<Task> act = () => _controller.RestoreReceipt(id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Core/TransactionsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/TransactionsControllerTests.cs
@@ -72,7 +72,7 @@ public class TransactionsControllerTests
 	}
 
 	[Fact]
-	public async Task GetTransactionById_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetTransactionById_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = TransactionGenerator.Generate().Id;
@@ -83,11 +83,10 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<TransactionResponse> result = await _controller.GetTransactionById(id);
+		Func<Task> act = () => _controller.GetTransactionById(id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -113,7 +112,7 @@ public class TransactionsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAllTransactions_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAllTransactions_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		_mediatorMock.Setup(m => m.Send(
@@ -122,11 +121,10 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<TransactionResponse>> result = await _controller.GetAllTransactions();
+		Func<Task> act = () => _controller.GetAllTransactions();
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -196,7 +194,7 @@ public class TransactionsControllerTests
 	}
 
 	[Fact]
-	public async Task GetAllTransactions_WithReceiptId_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task GetAllTransactions_WithReceiptId_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -206,11 +204,10 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<TransactionResponse>> result = await _controller.GetAllTransactions(receiptId);
+		Func<Task> act = () => _controller.GetAllTransactions(receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -238,7 +235,7 @@ public class TransactionsControllerTests
 	}
 
 	[Fact]
-	public async Task CreateTransaction_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task CreateTransaction_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -250,12 +247,10 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<TransactionResponse> result = await _controller.CreateTransaction(controllerInput, receiptId);
+		Func<Task> act = () => _controller.CreateTransaction(controllerInput, receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -327,7 +322,7 @@ public class TransactionsControllerTests
 	}
 
 	[Fact]
-	public async Task CreateTransactions_WithMultipleAccountIds_ReturnsInternalServerError_WhenOneGroupThrows()
+	public async Task CreateTransactions_WithMultipleAccountIds_ThrowsException_WhenOneGroupFails()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -353,16 +348,14 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception("Group 2 failed"));
 
 		// Act
-		ActionResult<List<TransactionResponse>> result = await _controller.CreateTransactions(controllerInput, receiptId);
+		Func<Task> act = () => _controller.CreateTransactions(controllerInput, receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
-	public async Task CreateTransactions_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task CreateTransactions_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -375,12 +368,10 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<List<TransactionResponse>> result = await _controller.CreateTransactions(controllerInput, receiptId);
+		Func<Task> act = () => _controller.CreateTransactions(controllerInput, receiptId);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -422,7 +413,7 @@ public class TransactionsControllerTests
 	}
 
 	[Fact]
-	public async Task UpdateTransaction_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task UpdateTransaction_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
@@ -434,12 +425,10 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.UpdateTransaction(controllerInput, id);
+		Func<Task> act = () => _controller.UpdateTransaction(controllerInput, id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -542,7 +531,7 @@ public class TransactionsControllerTests
 	}
 
 	[Fact]
-	public async Task UpdateTransactions_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task UpdateTransactions_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<UpdateTransactionRequest> controllerInput = TransactionDtoGenerator.GenerateUpdateRequestList(2);
@@ -554,12 +543,10 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.UpdateTransactions(controllerInput);
+		Func<Task> act = () => _controller.UpdateTransactions(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -617,7 +604,7 @@ public class TransactionsControllerTests
 	}
 
 	[Fact]
-	public async Task DeleteTransactions_ReturnsInternalServerError_WhenExceptionIsThrown()
+	public async Task DeleteTransactions_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		List<Guid> controllerInput = [.. TransactionGenerator.GenerateList(2).Select(t => t.Id)];
@@ -628,12 +615,10 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		ActionResult<bool> result = await _controller.DeleteTransactions(controllerInput);
+		Func<Task> act = () => _controller.DeleteTransactions(controllerInput);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result.Result);
-		Assert.Equal(500, objectResult.StatusCode);
-		Assert.Equal("An error occurred while processing your request.", objectResult.Value);
+		await act.Should().ThrowAsync<Exception>();
 	}
 
 	[Fact]
@@ -671,7 +656,7 @@ public class TransactionsControllerTests
 	}
 
 	[Fact]
-	public async Task RestoreTransaction_ReturnsInternalServerError_WhenExceptionThrown()
+	public async Task RestoreTransaction_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
@@ -681,10 +666,9 @@ public class TransactionsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		IActionResult result = await _controller.RestoreTransaction(id);
+		Func<Task> act = () => _controller.RestoreTransaction(id);
 
 		// Assert
-		ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
-		Assert.Equal(500, objectResult.StatusCode);
+		await act.Should().ThrowAsync<Exception>();
 	}
 }

--- a/tests/Presentation.API.Tests/Middleware/AuthorizationLoggingHandlerTests.cs
+++ b/tests/Presentation.API.Tests/Middleware/AuthorizationLoggingHandlerTests.cs
@@ -1,0 +1,101 @@
+using System.Security.Claims;
+using API.Middleware;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Presentation.API.Tests.Middleware;
+
+public class AuthorizationLoggingHandlerTests
+{
+	private readonly Mock<ILogger<AuthorizationLoggingHandler>> _loggerMock = new();
+
+	[Fact]
+	public async Task HandleAsync_Forbidden_LogsWarning()
+	{
+		// Arrange
+		AuthorizationLoggingHandler handler = new(_loggerMock.Object);
+
+		Mock<IAuthenticationService> authServiceMock = new();
+		authServiceMock
+			.Setup(a => a.ForbidAsync(It.IsAny<HttpContext>(), It.IsAny<string?>(), It.IsAny<AuthenticationProperties?>()))
+			.Returns(Task.CompletedTask);
+
+		ServiceCollection services = new();
+		services.AddSingleton(authServiceMock.Object);
+		ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+		DefaultHttpContext context = new()
+		{
+			RequestServices = serviceProvider,
+			User = new ClaimsPrincipal(new ClaimsIdentity(
+			[
+				new Claim(ClaimTypes.NameIdentifier, "user-123")
+			]))
+		};
+		context.Request.Method = "GET";
+		context.Request.Path = "/api/admin";
+
+		AuthorizationPolicy policy = new AuthorizationPolicyBuilder()
+			.RequireAuthenticatedUser()
+			.Build();
+
+		AuthorizationFailure failure = AuthorizationFailure.ExplicitFail();
+		PolicyAuthorizationResult authorizeResult = PolicyAuthorizationResult.Forbid(failure);
+
+		RequestDelegate next = _ => Task.CompletedTask;
+
+		// Act
+		await handler.HandleAsync(next, context, policy, authorizeResult);
+
+		// Assert
+		_loggerMock.Verify(
+			x => x.Log(
+				LogLevel.Warning,
+				It.IsAny<EventId>(),
+				It.IsAny<It.IsAnyType>(),
+				It.IsAny<Exception>(),
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task HandleAsync_Success_DoesNotLogWarning()
+	{
+		// Arrange
+		AuthorizationLoggingHandler handler = new(_loggerMock.Object);
+		DefaultHttpContext context = new();
+
+		AuthorizationPolicy policy = new AuthorizationPolicyBuilder()
+			.RequireAuthenticatedUser()
+			.Build();
+
+		PolicyAuthorizationResult authorizeResult = PolicyAuthorizationResult.Success();
+
+		bool nextCalled = false;
+		RequestDelegate next = _ =>
+		{
+			nextCalled = true;
+			return Task.CompletedTask;
+		};
+
+		// Act
+		await handler.HandleAsync(next, context, policy, authorizeResult);
+
+		// Assert
+		_loggerMock.Verify(
+			x => x.Log(
+				LogLevel.Warning,
+				It.IsAny<EventId>(),
+				It.IsAny<It.IsAnyType>(),
+				It.IsAny<Exception>(),
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			Times.Never);
+		nextCalled.Should().BeTrue();
+	}
+}

--- a/tests/Presentation.API.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Presentation.API.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics;
+using API.Middleware;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+
+namespace Presentation.API.Tests.Middleware;
+
+public class CorrelationIdMiddlewareTests
+{
+	[Fact]
+	public async Task InvokeAsync_GeneratesCorrelationId_WhenNoHeaderProvided()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+		string? capturedCorrelationId = null;
+
+		CorrelationIdMiddleware middleware = new(ctx =>
+		{
+			capturedCorrelationId = ctx.Items[CorrelationIdMiddleware.ItemKey]?.ToString();
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		capturedCorrelationId.Should().NotBeNullOrEmpty();
+		Guid.TryParse(capturedCorrelationId, out _).Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task InvokeAsync_UsesExistingHeader_WhenProvided()
+	{
+		// Arrange
+		string expectedCorrelationId = "my-custom-correlation-id";
+		DefaultHttpContext context = new();
+		context.Request.Headers[CorrelationIdMiddleware.HeaderName] = expectedCorrelationId;
+		context.Response.Body = new MemoryStream();
+		string? capturedCorrelationId = null;
+
+		CorrelationIdMiddleware middleware = new(ctx =>
+		{
+			capturedCorrelationId = ctx.Items[CorrelationIdMiddleware.ItemKey]?.ToString();
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		capturedCorrelationId.Should().Be(expectedCorrelationId);
+	}
+
+	[Fact]
+	public async Task InvokeAsync_StoresCorrelationId_InHttpContextItems()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+		CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Items[CorrelationIdMiddleware.ItemKey].Should().NotBeNull();
+		context.Items[CorrelationIdMiddleware.ItemKey].Should().BeOfType<string>();
+	}
+
+	[Fact]
+	public async Task InvokeAsync_SetsResponseHeader_ViaOnStartingCallback()
+	{
+		// Arrange
+		string expectedCorrelationId = "test-correlation-id";
+		DefaultHttpContext context = new();
+		context.Request.Headers[CorrelationIdMiddleware.HeaderName] = expectedCorrelationId;
+
+		// Use a custom response feature that captures OnStarting callbacks
+		string? capturedHeaderValue = null;
+		CorrelationIdMiddleware middleware = new(ctx =>
+		{
+			// Verify OnStarting was registered by checking that the correlation ID
+			// is stored in HttpContext.Items (the header is set via OnStarting which
+			// fires when the actual response starts, not testable with DefaultHttpContext)
+			capturedHeaderValue = ctx.Items[CorrelationIdMiddleware.ItemKey]?.ToString();
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert — verify the correlation ID that would be written as a header
+		capturedHeaderValue.Should().Be(expectedCorrelationId);
+	}
+
+	[Fact]
+	public async Task InvokeAsync_UsesActivityTraceId_WhenNoHeaderAndActivityExists()
+	{
+		// Arrange
+		using Activity activity = new("test-activity");
+		activity.Start();
+		string expectedTraceId = activity.TraceId.ToString();
+
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+		string? capturedCorrelationId = null;
+
+		CorrelationIdMiddleware middleware = new(ctx =>
+		{
+			capturedCorrelationId = ctx.Items[CorrelationIdMiddleware.ItemKey]?.ToString();
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		capturedCorrelationId.Should().Be(expectedTraceId);
+	}
+
+	[Fact]
+	public async Task InvokeAsync_CallsNextMiddleware()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+		bool nextCalled = false;
+
+		CorrelationIdMiddleware middleware = new(_ =>
+		{
+			nextCalled = true;
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		nextCalled.Should().BeTrue();
+	}
+}

--- a/tests/Presentation.API.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
+++ b/tests/Presentation.API.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using API.Middleware;
+using Application.Exceptions;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Presentation.API.Tests.Middleware;
+
+public class GlobalExceptionHandlerMiddlewareTests
+{
+	private readonly Mock<ILogger<GlobalExceptionHandlerMiddleware>> _loggerMock = new();
+
+	[Fact]
+	public async Task InvokeAsync_NoException_PassesThrough()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+		GlobalExceptionHandlerMiddleware middleware = new(_ => Task.CompletedTask, _loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(200);
+	}
+
+	[Fact]
+	public async Task InvokeAsync_UnhandledException_Returns500ProblemDetails()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+		context.Items[CorrelationIdMiddleware.ItemKey] = "test-correlation-id";
+
+		GlobalExceptionHandlerMiddleware middleware = new(
+			_ => throw new InvalidOperationException("Something broke"),
+			_loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(500);
+		context.Response.ContentType.Should().Be("application/problem+json");
+
+		ProblemDetails? problemDetails = await DeserializeProblemDetails(context.Response);
+		problemDetails.Should().NotBeNull();
+		problemDetails!.Status.Should().Be(500);
+		problemDetails.Title.Should().Be("An error occurred while processing your request.");
+		problemDetails.Extensions.Should().ContainKey("errorId");
+		problemDetails.Extensions.Should().ContainKey("correlationId");
+		problemDetails.Extensions["correlationId"]!.ToString().Should().Be("test-correlation-id");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_UnhandledException_DoesNotLeakExceptionMessage()
+	{
+		// Arrange
+		string sensitiveMessage = "Connection string: Server=prod;Password=secret";
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+
+		GlobalExceptionHandlerMiddleware middleware = new(
+			_ => throw new Exception(sensitiveMessage),
+			_loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.Body.Position = 0;
+		using StreamReader reader = new(context.Response.Body);
+		string body = await reader.ReadToEndAsync();
+		body.Should().NotContain(sensitiveMessage);
+	}
+
+	[Fact]
+	public async Task InvokeAsync_DuplicateEntityException_Returns409ProblemDetails()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+
+		GlobalExceptionHandlerMiddleware middleware = new(
+			_ => throw new DuplicateEntityException("Category 'Food' already exists"),
+			_loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(409);
+		context.Response.ContentType.Should().Be("application/problem+json");
+
+		ProblemDetails? problemDetails = await DeserializeProblemDetails(context.Response);
+		problemDetails.Should().NotBeNull();
+		problemDetails!.Status.Should().Be(409);
+		problemDetails.Title.Should().Be("Conflict");
+		problemDetails.Detail.Should().Be("Category 'Food' already exists");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_KeyNotFoundException_Returns404ProblemDetails()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+
+		GlobalExceptionHandlerMiddleware middleware = new(
+			_ => throw new KeyNotFoundException("API key not found"),
+			_loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(404);
+		context.Response.ContentType.Should().Be("application/problem+json");
+
+		ProblemDetails? problemDetails = await DeserializeProblemDetails(context.Response);
+		problemDetails.Should().NotBeNull();
+		problemDetails!.Status.Should().Be(404);
+		problemDetails.Title.Should().Be("Not Found");
+		problemDetails.Detail.Should().Be("API key not found");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_UnhandledException_LogsError()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+
+		GlobalExceptionHandlerMiddleware middleware = new(
+			_ => throw new InvalidOperationException("test error"),
+			_loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		_loggerMock.Verify(
+			x => x.Log(
+				LogLevel.Error,
+				It.IsAny<EventId>(),
+				It.IsAny<It.IsAnyType>(),
+				It.IsAny<Exception>(),
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			Times.Once);
+	}
+
+	private static async Task<ProblemDetails?> DeserializeProblemDetails(HttpResponse response)
+	{
+		response.Body.Position = 0;
+		return await JsonSerializer.DeserializeAsync<ProblemDetails>(
+			response.Body,
+			new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+	}
+}


### PR DESCRIPTION
## Summary

- Add `CorrelationIdMiddleware` that propagates `X-Correlation-ID` through requests, responses, and Serilog log context
- Add `GlobalExceptionHandlerMiddleware` returning RFC 9110 ProblemDetails for all unhandled exceptions (409 for `DuplicateEntityException`, 404 for `KeyNotFoundException`, 500 with `errorId`/`correlationId` for all others)
- Add security event logging: JWT `OnAuthenticationFailed`/`OnChallenge` handlers and `AuthorizationLoggingHandler` for denied authorization
- Enable `UseSerilogRequestLogging()` with request host, user agent, and user ID enrichment
- Clean up 18 controllers: remove 96 catch blocks, 115 per-action `LogDebug` statements, and dead code — net reduction of ~530 lines
- Update `MustResetPasswordMiddleware` to return ProblemDetails instead of plain JSON
- Remove dead `UseExceptionHandler("/Error")` and `UseHsts()` from non-dev pipeline

## Test plan

- [x] `dotnet build` passes with 0 warnings (`TreatWarningsAsErrors=true`)
- [x] All 816 tests pass (0 failures)
- [x] `dotnet format --verify-no-changes` passes
- [ ] Manual: verify `X-Correlation-ID` response header on requests
- [ ] Manual: trigger 500 and verify ProblemDetails response with `errorId` and `correlationId`
- [ ] Manual: verify console logs include `CorrelationId` and request duration
- [ ] Manual: attempt request with expired JWT and verify security event logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)