### PR TITLE
test(client): improve unit test coverage for src and src/pages packages (MGG-224)

### DIFF
--- a/src/client/src/App.test.tsx
+++ b/src/client/src/App.test.tsx
@@ -101,97 +101,11 @@ vi.mock("@/components/ui/sonner", () => ({
   Toaster: () => null,
 }));
 
-// Import mocked components (vi.mock is hoisted, so these get the mocked versions)
-import { RootLayout } from "@/components/RootLayout";
-import { PublicLayout } from "@/components/PublicLayout";
-import { Layout } from "@/components/Layout";
-import { ProtectedRoute } from "@/components/ProtectedRoute";
-import { AdminRoute } from "@/components/AdminRoute";
-import Home from "@/pages/Home";
-import Login from "@/pages/Login";
-import ChangePassword from "@/pages/ChangePassword";
-import Accounts from "@/pages/Accounts";
-import Categories from "@/pages/Categories";
-import Subcategories from "@/pages/Subcategories";
-import Receipts from "@/pages/Receipts";
-import ReceiptItems from "@/pages/ReceiptItems";
-import Transactions from "@/pages/Transactions";
-import Trips from "@/pages/Trips";
-import ItemTemplates from "@/pages/ItemTemplates";
-import ReceiptDetail from "@/pages/ReceiptDetail";
-import TransactionDetail from "@/pages/TransactionDetail";
-import ApiKeys from "@/pages/ApiKeys";
-import AdminUsers from "@/pages/AdminUsers";
-import AuditLog from "@/pages/AuditLog";
-import SecurityLog from "@/pages/SecurityLog";
-import RecycleBin from "@/pages/RecycleBin";
-import NotFound from "@/pages/NotFound";
-
-// Build the route config matching App.tsx structure
-const routes = [
-  {
-    element: <RootLayout />,
-    children: [
-      {
-        element: <PublicLayout />,
-        children: [
-          { path: "/login", element: <Login /> },
-          { path: "/change-password", element: <ChangePassword /> },
-        ],
-      },
-      {
-        element: (
-          <ProtectedRoute>
-            <Layout />
-          </ProtectedRoute>
-        ),
-        children: [
-          { path: "/", element: <Home /> },
-          { path: "/accounts", element: <Accounts /> },
-          { path: "/categories", element: <Categories /> },
-          { path: "/subcategories", element: <Subcategories /> },
-          { path: "/receipts", element: <Receipts /> },
-          { path: "/receipt-items", element: <ReceiptItems /> },
-          { path: "/transactions", element: <Transactions /> },
-          { path: "/trips", element: <Trips /> },
-          { path: "/item-templates", element: <ItemTemplates /> },
-          { path: "/receipt-detail", element: <ReceiptDetail /> },
-          { path: "/transaction-detail", element: <TransactionDetail /> },
-          { path: "/api-keys", element: <ApiKeys /> },
-          { path: "/security", element: <SecurityLog /> },
-          {
-            path: "/audit",
-            element: (
-              <AdminRoute>
-                <AuditLog />
-              </AdminRoute>
-            ),
-          },
-          {
-            path: "/trash",
-            element: (
-              <AdminRoute>
-                <RecycleBin />
-              </AdminRoute>
-            ),
-          },
-          {
-            path: "/admin/users",
-            element: (
-              <AdminRoute>
-                <AdminUsers />
-              </AdminRoute>
-            ),
-          },
-        ],
-      },
-      { path: "*", element: <NotFound /> },
-    ],
-  },
-];
+// Import routeConfig from App.tsx (vi.mock is hoisted, so mocks are applied)
+import { routeConfig } from "./App";
 
 function renderRoute(path: string) {
-  const router = createMemoryRouter(routes, { initialEntries: [path] });
+  const router = createMemoryRouter(routeConfig, { initialEntries: [path] });
   return render(<RouterProvider router={router} />);
 }
 

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -24,7 +24,7 @@ import SecurityLog from "@/pages/SecurityLog";
 import RecycleBin from "@/pages/RecycleBin";
 import NotFound from "@/pages/NotFound";
 
-export const router = createBrowserRouter([
+export const routeConfig = [
   {
     element: <RootLayout />,
     children: [
@@ -84,4 +84,6 @@ export const router = createBrowserRouter([
       { path: "*", element: <NotFound /> },
     ],
   },
-]);
+];
+
+export const router = createBrowserRouter(routeConfig);

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -1,4 +1,3 @@
-import { createBrowserRouter } from "react-router";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { AdminRoute } from "@/components/AdminRoute";
 import { Layout } from "@/components/Layout";
@@ -86,4 +85,3 @@ export const routeConfig = [
   },
 ];
 
-export const router = createBrowserRouter(routeConfig);

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { RouterProvider } from "react-router";
+import { createBrowserRouter, RouterProvider } from "react-router";
 import {
   MutationCache,
   QueryCache,
@@ -12,8 +12,10 @@ import { ThemeProvider } from "next-themes";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ShortcutsProvider } from "@/contexts/ShortcutsContext";
-import { router } from "./App.tsx";
+import { routeConfig } from "./App.tsx";
 import "./index.css";
+
+const router = createBrowserRouter(routeConfig);
 
 function handleGlobalError(error: unknown) {
   if (

--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -291,6 +291,55 @@ describe("Accounts", () => {
     ).toBeInTheDocument();
   });
 
+  it("closes create dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithProviders(<Accounts />);
+    await user.click(screen.getByRole("button", { name: /new account/i }));
+    expect(screen.getByRole("heading", { name: /create account/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /create account/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes edit dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Accounts />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByRole("heading", { name: /edit account/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /edit account/i })).not.toBeInTheDocument();
+    });
+  });
+
   it("opens create dialog on shortcut:new-item event", async () => {
     const { act } = await import("@testing-library/react");
     renderWithProviders(<Accounts />);
@@ -303,6 +352,95 @@ describe("Accounts", () => {
     expect(
       screen.getByRole("heading", { name: /create account/i }),
     ).toBeInTheDocument();
+  });
+
+  it("submits create form and calls createAccount.mutate", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useCreateAccount } = await import("@/hooks/useAccounts");
+    vi.mocked(useCreateAccount).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    renderWithProviders(<Accounts />);
+    await user.click(screen.getByRole("button", { name: /new account/i }));
+
+    await user.type(screen.getByLabelText(/account code/i), "ACC-NEW");
+    await user.type(screen.getByLabelText(/^name$/i), "New Account");
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+  });
+
+  it("submits edit form and calls updateAccount.mutate", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useUpdateAccount } = await import("@/hooks/useAccounts");
+    vi.mocked(useUpdateAccount).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    const items = [
+      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Accounts />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const nameInput = screen.getByLabelText(/^name$/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Updated Account");
+    await user.click(screen.getByRole("button", { name: /update account/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+  });
+
+  it("renders NoResults when search returns no matches", async () => {
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+      data: [{ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }],
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "xyz",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 0,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Accounts />);
+    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
   });
 
   it("calls deleteAccounts.mutate when delete is confirmed", async () => {

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -324,7 +324,7 @@ describe("AdminUsers", () => {
 
     // After clicking Next, useUsers will be called with page=2
     // We verify by checking the component re-renders (pagination state update)
-    expect(useUsers).toHaveBeenCalled();
+    expect(useUsers).toHaveBeenLastCalledWith(2, 20);
   });
 
   it("closes edit dialog when dialog is dismissed", async () => {

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -273,4 +273,160 @@ describe("AdminUsers", () => {
     const cells = screen.getAllByRole("cell");
     expect(cells[0].textContent).toBe("-");
   });
+
+  it("renders pagination when totalPages > 1", async () => {
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: {
+        items: Array.from({ length: 20 }, (_, i) => ({
+          id: String(i + 1),
+          email: `user${i + 1}@example.com`,
+          firstName: `User`,
+          lastName: `${i + 1}`,
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        })),
+        totalCount: 25,
+      },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    expect(screen.getByText(/page 1 of 2/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /next/i })).not.toBeDisabled();
+  });
+
+  it("advances page when Next button is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: {
+        items: Array.from({ length: 20 }, (_, i) => ({
+          id: String(i + 1),
+          email: `user${i + 1}@example.com`,
+          firstName: `User`,
+          lastName: `${i + 1}`,
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        })),
+        totalCount: 25,
+      },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    // After clicking Next, useUsers will be called with page=2
+    // We verify by checking the component re-renders (pagination state update)
+    expect(useUsers).toHaveBeenCalled();
+  });
+
+  it("closes edit dialog when dialog is dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: {
+        items: [
+          {
+            id: "1",
+            email: "test@example.com",
+            firstName: "John",
+            lastName: "Doe",
+            roles: ["Admin"],
+            isDisabled: false,
+            createdAt: "2024-01-01",
+            lastLoginAt: "2024-01-15",
+          },
+        ],
+        totalCount: 1,
+      },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByText(/update user details/i)).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByText(/update user details/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes reset password dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: {
+        items: [
+          {
+            id: "1",
+            email: "test@example.com",
+            firstName: "John",
+            lastName: "Doe",
+            roles: ["Admin"],
+            isDisabled: false,
+            createdAt: "2024-01-01",
+            lastLoginAt: "2024-01-15",
+          },
+        ],
+        totalCount: 1,
+      },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /reset pw/i }));
+    expect(screen.getByRole("heading", { name: /reset password/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /reset password/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("opens deactivate dialog and calls deleteUser on confirm", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutateAsync = vi.fn().mockResolvedValue(undefined);
+    const { useUsers, useDeleteUser } = await import("@/hooks/useUsers");
+    vi.mocked(useDeleteUser).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as ReturnType<typeof useDeleteUser>);
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: {
+        items: [
+          {
+            id: "2",
+            email: "other@example.com",
+            firstName: "Other",
+            lastName: "User",
+            roles: ["User"],
+            isDisabled: false,
+            createdAt: "2024-01-01",
+            lastLoginAt: "2024-01-15",
+          },
+        ],
+        totalCount: 1,
+      },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /disable/i }));
+
+    expect(screen.getByRole("heading", { name: /deactivate user/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /deactivate/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith("2");
+    });
+  });
 });

--- a/src/client/src/pages/ApiKeys.test.tsx
+++ b/src/client/src/pages/ApiKeys.test.tsx
@@ -271,4 +271,133 @@ describe("ApiKeys", () => {
     // Dates should be formatted as locale date strings, not raw ISO
     expect(screen.queryByText("2024-06-15T00:00:00Z")).not.toBeInTheDocument();
   });
+
+  it("shows created key dialog when create mutation succeeds", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess({ rawKey: "test-secret-key-123" }, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "My Key");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    // The created key dialog should appear with the key
+    expect(await screen.findByRole("heading", { name: /api key created/i })).toBeInTheDocument();
+    expect(screen.getByText(/save this key now/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue("test-secret-key-123")).toBeInTheDocument();
+  });
+
+  it("copies key to clipboard when Copy to Clipboard button is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const mockWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: mockWriteText },
+      writable: true,
+      configurable: true,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess({ rawKey: "copy-me-key" }, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "Copy Test");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await screen.findByRole("heading", { name: /api key created/i });
+    await user.click(screen.getByRole("button", { name: /copy to clipboard/i }));
+
+    expect(mockWriteText).toHaveBeenCalledWith("copy-me-key");
+  });
+
+  it("cancels revoke dialog when Cancel button is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useQuery } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "key-1",
+          name: "Test Key",
+          createdAt: "2024-01-01T00:00:00Z",
+          lastUsedAt: null,
+          expiresAt: null,
+          isRevoked: false,
+        },
+      ],
+      isLoading: false,
+    }));
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    // Dialog should be open
+    expect(screen.getByRole("heading", { name: /revoke api key/i })).toBeInTheDocument();
+
+    // Click Cancel
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    // Dialog should close
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /revoke api key/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows create form submission with mutation", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useMutation } = await import("@tanstack/react-query");
+    vi.mocked(useMutation).mockImplementation((() => ({
+      mutate: mockMutate,
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "New API Key");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledWith(expect.objectContaining({ name: "New API Key" }));
+    });
+  });
+
+  it("formats date with null value as dash", async () => {
+    const { useQuery } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "key-1",
+          name: "Test Key",
+          createdAt: "2024-01-01T00:00:00Z",
+          lastUsedAt: null,
+          expiresAt: null,
+          isRevoked: false,
+        },
+      ],
+      isLoading: false,
+    }));
+
+    renderWithQueryClient(<ApiKeys />);
+    // lastUsedAt and expiresAt are null — should show "-"
+    const cells = screen.getAllByRole("cell");
+    const dashCells = cells.filter((c) => c.textContent === "-");
+    expect(dashCells.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/src/client/src/pages/AuditLog.test.tsx
+++ b/src/client/src/pages/AuditLog.test.tsx
@@ -17,10 +17,13 @@ vi.mock("@/hooks/useAudit", () => ({
 vi.mock("@/components/AuditLogTable", () => ({
   AuditLogTable: function MockAuditLogTable({
     isLoading,
+    logs,
   }: {
     isLoading: boolean;
+    logs: unknown[];
   }) {
-    return isLoading ? "Loading..." : "AuditLogTable";
+    if (isLoading) return "Loading...";
+    return <div data-testid="audit-table">AuditLogTable ({logs?.length ?? 0} rows)</div>;
   },
 }));
 
@@ -48,7 +51,7 @@ describe("AuditLog", () => {
 
   it("renders the AuditLogTable component", () => {
     renderWithProviders(<AuditLog />);
-    expect(screen.getByText("AuditLogTable")).toBeInTheDocument();
+    expect(screen.getByTestId("audit-table")).toBeInTheDocument();
   });
 
   it("shows loading state in AuditLogTable when data is loading", async () => {
@@ -83,7 +86,7 @@ describe("AuditLog", () => {
 
     renderWithProviders(<AuditLog />);
     // The AuditLogTable mock renders "AuditLogTable" when not loading
-    expect(screen.getByText("AuditLogTable")).toBeInTheDocument();
+    expect(screen.getByTestId("audit-table")).toBeInTheDocument();
   });
 
   it("filters logs by entity ID search", async () => {
@@ -111,7 +114,7 @@ describe("AuditLog", () => {
     await user.type(searchInput, "abc");
 
     // The mock AuditLogTable still renders, just with filtered data
-    expect(screen.getByText("AuditLogTable")).toBeInTheDocument();
+    expect(screen.getByTestId("audit-table")).toBeInTheDocument();
   });
 
   it("enables Export CSV button when logs exist", async () => {
@@ -137,6 +140,98 @@ describe("AuditLog", () => {
     expect(
       screen.getByRole("button", { name: /export csv/i }),
     ).not.toBeDisabled();
+  });
+
+  it("triggers CSV export when Export CSV button is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useRecentAuditLogs } = await import("@/hooks/useAudit");
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "abc-123",
+          action: "Created",
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: "user-1",
+          changedByApiKeyId: null,
+          ipAddress: "127.0.0.1",
+          changesJson: "{}",
+        },
+      ],
+      isLoading: false,
+    }));
+
+    const mockCreateObjectURL = vi.fn(() => "blob:mock-url");
+    const mockRevokeObjectURL = vi.fn();
+    const mockClick = vi.fn();
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = mockRevokeObjectURL;
+
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string, options?: ElementCreationOptions) => {
+      if (tag === "a") {
+        return { href: "", download: "", click: mockClick } as unknown as HTMLAnchorElement;
+      }
+      return originalCreateElement(tag, options);
+    });
+
+    renderWithProviders(<AuditLog />);
+    await user.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+    expect(mockClick).toHaveBeenCalled();
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    vi.restoreAllMocks();
+  });
+
+  it("renders entity type filter trigger", () => {
+    renderWithProviders(<AuditLog />);
+    // Radix Select renders trigger buttons; count the combobox elements
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("renders DateRangePicker From and To buttons", () => {
+    renderWithProviders(<AuditLog />);
+    const buttons = screen.getAllByRole("button");
+    const fromButton = buttons.find((b) => b.textContent === "From");
+    const toButton = buttons.find((b) => b.textContent === "To");
+    expect(fromButton).toBeDefined();
+    expect(toButton).toBeDefined();
+  });
+
+  it("filters logs by search term that excludes entries", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useRecentAuditLogs } = await import("@/hooks/useAudit");
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "abc-123",
+          action: "Created",
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: "user-1",
+          changedByApiKeyId: null,
+          ipAddress: "127.0.0.1",
+          changesJson: "{}",
+        },
+      ],
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AuditLog />);
+    expect(screen.getByTestId("audit-table")).toHaveTextContent("1 rows");
+
+    // Search for something that doesn't match
+    await user.type(screen.getByLabelText(/search audit log by entity id/i), "zzz");
+    expect(screen.getByTestId("audit-table")).toHaveTextContent("0 rows");
   });
 
 });

--- a/src/client/src/pages/Categories.test.tsx
+++ b/src/client/src/pages/Categories.test.tsx
@@ -213,6 +213,143 @@ describe("Categories", () => {
     ).toBeInTheDocument();
   });
 
+  it("submits create form and calls createCategory.mutate", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useCreateCategory } = await import("@/hooks/useCategories");
+    vi.mocked(useCreateCategory).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    renderWithProviders(<Categories />);
+    await user.click(screen.getByRole("button", { name: /new category/i }));
+
+    await user.type(screen.getByLabelText(/^name$/i), "New Category");
+    await user.click(screen.getByRole("button", { name: /create category/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+  });
+
+  it("submits edit form and calls updateCategory.mutate", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useUpdateCategory } = await import("@/hooks/useCategories");
+    vi.mocked(useUpdateCategory).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    const items = [
+      { id: "1", name: "Food", description: "Food expenses" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Categories />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const nameInput = screen.getByLabelText(/^name$/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Updated Category");
+    await user.click(screen.getByRole("button", { name: /update category/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+  });
+
+  it("renders NoResults when search returns no matches", async () => {
+    const { useCategories } = await import("@/hooks/useCategories");
+    vi.mocked(useCategories).mockReturnValue(mockQueryResult({
+      data: [{ id: "1", name: "Food", description: "Food expenses" }],
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "xyz",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 0,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Categories />);
+    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
+  });
+
+  it("closes create dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithProviders(<Categories />);
+    await user.click(screen.getByRole("button", { name: /new category/i }));
+    expect(screen.getByRole("heading", { name: /create category/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /create category/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes edit dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "1", name: "Food", description: "Food expenses" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Categories />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByRole("heading", { name: /edit category/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /edit category/i })).not.toBeInTheDocument();
+    });
+  });
+
   it("opens delete dialog and confirms deletion", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();

--- a/src/client/src/pages/ChangePassword.test.tsx
+++ b/src/client/src/pages/ChangePassword.test.tsx
@@ -44,4 +44,81 @@ describe("ChangePassword", () => {
       screen.getByText(/you must change your password before continuing/i),
     ).toBeInTheDocument();
   });
+
+  it("redirects to /login when user is null", async () => {
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      mustResetPassword: false,
+      changePassword: vi.fn(),
+      login: vi.fn(),
+      logout: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<ChangePassword />, { route: "/change-password" });
+    // Navigate replaces with /login — the component renders nothing visible
+    expect(screen.queryByRole("heading", { name: /change password/i })).not.toBeInTheDocument();
+  });
+
+  it("redirects to / when mustResetPassword is false", async () => {
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: { email: "test@example.com" } as ReturnType<typeof useAuth>["user"],
+      mustResetPassword: false,
+      changePassword: vi.fn(),
+      login: vi.fn(),
+      logout: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<ChangePassword />);
+    expect(screen.queryByRole("heading", { name: /change password/i })).not.toBeInTheDocument();
+  });
+
+  it("calls changePassword on successful form submission", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockChangePassword = vi.fn().mockResolvedValue(undefined);
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: { email: "test@example.com" } as ReturnType<typeof useAuth>["user"],
+      mustResetPassword: true,
+      changePassword: mockChangePassword,
+      login: vi.fn(),
+      logout: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<ChangePassword />);
+    await user.type(screen.getByLabelText(/^current password$/i), "OldPass123");
+    await user.type(screen.getByLabelText(/^new password$/i), "NewPass456");
+    await user.type(screen.getByLabelText(/^confirm new password$/i), "NewPass456");
+    await user.click(screen.getByRole("button", { name: /change password/i }));
+
+    await vi.waitFor(() => {
+      expect(mockChangePassword).toHaveBeenCalledWith("OldPass123", "NewPass456");
+    });
+  });
+
+  it("shows error alert on failed form submission", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockChangePassword = vi.fn().mockRejectedValue(new Error("fail"));
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: { email: "test@example.com" } as ReturnType<typeof useAuth>["user"],
+      mustResetPassword: true,
+      changePassword: mockChangePassword,
+      login: vi.fn(),
+      logout: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<ChangePassword />);
+    await user.type(screen.getByLabelText(/^current password$/i), "OldPass123");
+    await user.type(screen.getByLabelText(/^new password$/i), "NewPass456");
+    await user.type(screen.getByLabelText(/^confirm new password$/i), "NewPass456");
+    await user.click(screen.getByRole("button", { name: /change password/i }));
+
+    expect(await screen.findByText(/failed to change password/i)).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/ItemTemplates.test.tsx
+++ b/src/client/src/pages/ItemTemplates.test.tsx
@@ -140,6 +140,55 @@ describe("ItemTemplates", () => {
     expect(screen.getByText("Drinks")).toBeInTheDocument();
   });
 
+  it("closes edit dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "1", name: "Coffee", description: "Morning coffee", defaultCategory: "Food", defaultSubcategory: "Drinks", defaultUnitPrice: 4.50, defaultUnitPriceCurrency: "USD", defaultPricingMode: "quantity", defaultItemCode: "COF-001" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<ItemTemplates />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByRole("heading", { name: /edit item template/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /edit item template/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes create dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithProviders(<ItemTemplates />);
+    await user.click(screen.getByRole("button", { name: /new template/i }));
+    expect(screen.getByRole("heading", { name: /create item template/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /create item template/i })).not.toBeInTheDocument();
+    });
+  });
+
   it("opens create dialog when New Template button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithProviders(<ItemTemplates />);
@@ -219,6 +268,94 @@ describe("ItemTemplates", () => {
     expect(
       screen.getByRole("button", { name: /delete/i }),
     ).toBeInTheDocument();
+  });
+
+  it("submits edit form and calls updateItemTemplate.mutate", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useUpdateItemTemplate } = await import("@/hooks/useItemTemplates");
+    vi.mocked(useUpdateItemTemplate).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    const items = [
+      { id: "1", name: "Coffee", description: "Morning coffee", defaultCategory: "Food", defaultSubcategory: "Drinks", defaultUnitPrice: 4.50, defaultUnitPriceCurrency: "USD", defaultPricingMode: "quantity", defaultItemCode: "COF-001" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<ItemTemplates />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const nameInput = screen.getByLabelText(/^name$/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Updated Template");
+    await user.click(screen.getByRole("button", { name: /update template/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+  });
+
+  it("submits create form and calls createItemTemplate.mutate", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useCreateItemTemplate } = await import("@/hooks/useItemTemplates");
+    vi.mocked(useCreateItemTemplate).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    renderWithProviders(<ItemTemplates />);
+    await user.click(screen.getByRole("button", { name: /new template/i }));
+
+    await user.type(screen.getByLabelText(/^name$/i), "Coffee Template");
+    await user.click(screen.getByRole("button", { name: /create template/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+  });
+
+  it("renders NoResults when search returns no matches", async () => {
+    const { useItemTemplates } = await import("@/hooks/useItemTemplates");
+    vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
+      data: [{ id: "1", name: "Coffee", description: "Morning coffee", defaultCategory: "Food", defaultSubcategory: "Drinks", defaultUnitPrice: 4.50, defaultUnitPriceCurrency: "USD", defaultPricingMode: "quantity", defaultItemCode: "COF-001" }],
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "xyz",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 0,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<ItemTemplates />);
+    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
   });
 
   it("opens delete dialog and confirms deletion", async () => {

--- a/src/client/src/pages/Login.test.tsx
+++ b/src/client/src/pages/Login.test.tsx
@@ -41,4 +41,78 @@ describe("Login", () => {
       screen.getByText(/enter your credentials/i),
     ).toBeInTheDocument();
   });
+
+  it("redirects to / when user is already authenticated", async () => {
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: { email: "test@example.com" } as ReturnType<typeof useAuth>["user"],
+      mustResetPassword: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      changePassword: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<Login />);
+    expect(screen.queryByRole("heading", { name: /sign in/i })).not.toBeInTheDocument();
+  });
+
+  it("redirects to /change-password when mustResetPassword is true", async () => {
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: { email: "test@example.com" } as ReturnType<typeof useAuth>["user"],
+      mustResetPassword: true,
+      login: vi.fn(),
+      logout: vi.fn(),
+      changePassword: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<Login />);
+    expect(screen.queryByRole("heading", { name: /sign in/i })).not.toBeInTheDocument();
+  });
+
+  it("calls login on successful form submission", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockLogin = vi.fn().mockResolvedValue(undefined);
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      mustResetPassword: false,
+      login: mockLogin,
+      logout: vi.fn(),
+      changePassword: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<Login />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await vi.waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith("test@example.com", "Password123");
+    });
+  });
+
+  it("shows error alert on failed form submission", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockLogin = vi.fn().mockRejectedValue(new Error("fail"));
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      mustResetPassword: false,
+      login: mockLogin,
+      logout: vi.fn(),
+      changePassword: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<Login />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(await screen.findByText(/invalid email or password/i)).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/NotFound.test.tsx
+++ b/src/client/src/pages/NotFound.test.tsx
@@ -6,6 +6,14 @@ vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
 }));
 
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useNavigate: vi.fn(() => vi.fn()),
+  };
+});
+
 describe("NotFound", () => {
   it("renders the 404 text", () => {
     renderWithProviders(<NotFound />);
@@ -31,5 +39,17 @@ describe("NotFound", () => {
     expect(
       screen.getByRole("button", { name: /go home/i }),
     ).toBeInTheDocument();
+  });
+
+  it("calls navigate when Go Home button is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockNavigate = vi.fn();
+    const { useNavigate } = await import("react-router");
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate);
+
+    renderWithProviders(<NotFound />);
+    await user.click(screen.getByRole("button", { name: /go home/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/");
   });
 });

--- a/src/client/src/pages/ReceiptItems.test.tsx
+++ b/src/client/src/pages/ReceiptItems.test.tsx
@@ -65,6 +65,7 @@ vi.mock("@/hooks/useCategories", () => ({
 vi.mock("@/hooks/useSubcategories", () => ({
   useSubcategories: vi.fn(() => ({ data: [], isLoading: false })),
   useSubcategoriesByCategoryId: vi.fn(() => ({ data: [], isLoading: false })),
+  useCreateSubcategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/hooks/useItemTemplates", () => ({
@@ -148,6 +149,125 @@ describe("ReceiptItems", () => {
     expect(screen.getByText("RI-001")).toBeInTheDocument();
     expect(screen.getByText("Groceries")).toBeInTheDocument();
     expect(screen.getByText("Dairy")).toBeInTheDocument();
+  });
+
+  it("renders NoResults when search returns no matches", async () => {
+    const { useReceiptItems } = await import("@/hooks/useReceiptItems");
+    vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
+      data: [{ id: "ri1", receiptId: "r1", receiptItemCode: "RI-001", description: "Milk", quantity: 2, unitPrice: 3.99, category: "Groceries", subcategory: "Dairy", pricingMode: "quantity" }],
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "xyz",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 0,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<ReceiptItems />);
+    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
+  });
+
+  it("opens edit dialog when Edit button is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "ri1", receiptId: "r1", receiptItemCode: "RI-001", description: "Milk", quantity: 2, unitPrice: 3.99, category: "Groceries", subcategory: "Dairy", pricingMode: "quantity" as const },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<ReceiptItems />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(
+      screen.getByRole("heading", { name: /edit receipt item/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes edit dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "ri1", receiptId: "r1", receiptItemCode: "RI-001", description: "Milk", quantity: 2, unitPrice: 3.99, category: "Groceries", subcategory: "Dairy", pricingMode: "quantity" as const },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<ReceiptItems />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByRole("heading", { name: /edit receipt item/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /edit receipt item/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes create dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithProviders(<ReceiptItems />);
+    await user.click(screen.getByRole("button", { name: /new item/i }));
+    expect(screen.getByRole("heading", { name: /create receipt item/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /create receipt item/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("opens create dialog on shortcut:new-item event", async () => {
+    const { act } = await import("@testing-library/react");
+    renderWithProviders(<ReceiptItems />);
+
+    act(() => {
+      window.dispatchEvent(new Event("shortcut:new-item"));
+    });
+
+    await screen.findByRole("heading", { name: /create receipt item/i });
+    expect(
+      screen.getByRole("heading", { name: /create receipt item/i }),
+    ).toBeInTheDocument();
   });
 
   it("toggles checkbox selection and shows delete button", async () => {

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -144,6 +144,55 @@ describe("Receipts", () => {
     ).toBeInTheDocument();
   });
 
+  it("closes edit dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "1", description: "Grocery", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Receipts />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByRole("heading", { name: /edit receipt/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /edit receipt/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes create dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithProviders(<Receipts />);
+    await user.click(screen.getByRole("button", { name: /new receipt/i }));
+    expect(screen.getByRole("heading", { name: /create receipt/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /create receipt/i })).not.toBeInTheDocument();
+    });
+  });
+
   it("opens edit dialog when Edit button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
@@ -212,6 +261,96 @@ describe("Receipts", () => {
     expect(
       screen.getByRole("button", { name: /delete/i }),
     ).toBeInTheDocument();
+  });
+
+  it("submits edit form and calls updateReceipt.mutate", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useUpdateReceipt } = await import("@/hooks/useReceipts");
+    vi.mocked(useUpdateReceipt).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    const items = [
+      { id: "1", description: "Grocery", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Receipts />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const locationInput = screen.getByLabelText(/location/i);
+    await user.clear(locationInput);
+    await user.type(locationInput, "Target");
+    await user.click(screen.getByRole("button", { name: /update receipt/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+  });
+
+  it("submits create form and calls createReceipt.mutate", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useCreateReceipt } = await import("@/hooks/useReceipts");
+    vi.mocked(useCreateReceipt).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    renderWithProviders(<Receipts />);
+    await user.click(screen.getByRole("button", { name: /new receipt/i }));
+
+    await user.type(screen.getByLabelText(/location/i), "Walmart");
+    await user.type(screen.getByLabelText(/date/i), "2024-01-15");
+    await user.type(screen.getByLabelText(/tax amount/i), "5.25");
+    await user.click(screen.getByRole("button", { name: /create receipt/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+  });
+
+  it("renders NoResults when search returns no matches", async () => {
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "1", description: "Grocery", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }],
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "xyz",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 0,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Receipts />);
+    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
   });
 
   it("opens delete dialog and confirms deletion", async () => {

--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -232,6 +232,111 @@ describe("Subcategories", () => {
     }
   });
 
+  it("closes edit dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "1", name: "Dairy", categoryId: "c1", categoryName: "Food", description: "Dairy products" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Subcategories />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByRole("heading", { name: /edit subcategory/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /edit subcategory/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes create dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithProviders(<Subcategories />);
+    await user.click(screen.getByRole("button", { name: /new subcategory/i }));
+    expect(screen.getByRole("heading", { name: /create subcategory/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /create subcategory/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders NoResults when search returns no matches", async () => {
+    const { useSubcategories } = await import("@/hooks/useSubcategories");
+    vi.mocked(useSubcategories).mockReturnValue(mockQueryResult({
+      data: [{ id: "1", name: "Dairy", categoryId: "c1", description: "Dairy products" }],
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "xyz",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 0,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Subcategories />);
+    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
+  });
+
+  it("opens edit dialog when Edit button is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "1", name: "Dairy", categoryId: "c1", categoryName: "Food", description: "Dairy products" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Subcategories />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(
+      screen.getByRole("heading", { name: /edit subcategory/i }),
+    ).toBeInTheDocument();
+  });
+
   it("opens create dialog on shortcut:new-item event", async () => {
     const { act } = await import("@testing-library/react");
     renderWithProviders(<Subcategories />);

--- a/src/client/src/pages/Transactions.test.tsx
+++ b/src/client/src/pages/Transactions.test.tsx
@@ -151,6 +151,111 @@ describe("Transactions", () => {
     ).toBeInTheDocument();
   });
 
+  it("closes edit dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Transactions />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByRole("heading", { name: /edit transaction/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /edit transaction/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes create dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithProviders(<Transactions />);
+    await user.click(screen.getByRole("button", { name: /new transaction/i }));
+    expect(screen.getByRole("heading", { name: /create transaction/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /create transaction/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders NoResults when search returns no matches", async () => {
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: [{ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }],
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "xyz",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 0,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Transactions />);
+    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
+  });
+
+  it("opens edit dialog when Edit button is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 10,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
+    renderWithProviders(<Transactions />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(
+      screen.getByRole("heading", { name: /edit transaction/i }),
+    ).toBeInTheDocument();
+  });
+
   it("toggles checkbox selection and shows delete button", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [


### PR DESCRIPTION
## Summary
- Fix two CI-flagged unhealthy packages (below 80% minimum line rate)
- **src package**: 0% → 100% lines by extracting `routeConfig` from `App.tsx` so `App.test.tsx` imports it instead of duplicating routes
- **src/pages package**: 71.74% → 80.16% lines with 29 new tests across 15 files covering form submissions, dialog open/close/cancel, redirects, filters, error states, and keyboard shortcuts

## Test plan
- [x] All 804 tests pass (`npx vitest run`)
- [x] `src` package at 100% line coverage
- [x] `src/pages` package at 80.16% line coverage (above 80% threshold)
- [x] No changes to backend code — `dotnet test` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)