### PR TITLE
Fix CSV export quoting in AuditLog exportToCsv (MGG-225)

### DIFF
--- a/src/client/src/pages/AuditLog.tsx
+++ b/src/client/src/pages/AuditLog.tsx
@@ -29,7 +29,7 @@ import { cn } from "@/lib/utils";
 const COUNT_OPTIONS = [50, 100, 200] as const;
 
 function csvField(value: string): string {
-  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+  if (value.includes(",") || value.includes('"') || value.includes("\n") || value.includes("\r")) {
     return `"${value.replace(/"/g, '""')}"`;
   }
   return value;

--- a/src/client/src/pages/AuditLog.tsx
+++ b/src/client/src/pages/AuditLog.tsx
@@ -28,6 +28,13 @@ import { cn } from "@/lib/utils";
 
 const COUNT_OPTIONS = [50, 100, 200] as const;
 
+function csvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
 function exportToCsv(logs: AuditLogEntry[]) {
   const headers = [
     "Timestamp",
@@ -48,8 +55,10 @@ function exportToCsv(logs: AuditLogEntry[]) {
       log.changedByUserId ?? "",
       log.changedByApiKeyId ?? "",
       log.ipAddress ?? "",
-      `"${log.changesJson.replace(/"/g, '""')}"`,
-    ].join(","),
+      log.changesJson,
+    ]
+      .map(csvField)
+      .join(","),
   );
   const csv = [headers.join(","), ...rows].join("\n");
   const blob = new Blob([csv], { type: "text/csv" });


### PR DESCRIPTION
## Summary
- Extract `csvField` helper that applies RFC-4180 quoting (wraps in double quotes and escapes internal quotes) when a field contains commas, double quotes, or newlines
- Apply `csvField` to all CSV fields instead of only `changesJson`, preventing malformed CSV output

## Test plan
- [x] Existing AuditLog tests pass (12/12)
- [ ] Manually export CSV with audit data containing commas/quotes in fields and verify well-formed output

🤖 Generated with [Claude Code](https://claude.com/claude-code)