### PR TITLE
test(api): add comprehensive controller test coverage (MGG-231)

### DIFF
--- a/tests/Presentation.API.Tests/Controllers/ApiKeyControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/ApiKeyControllerTests.cs
@@ -1,0 +1,125 @@
+using System.Security.Claims;
+using API.Controllers;
+using API.Generated.Dtos;
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Presentation.API.Tests.Controllers;
+
+public class ApiKeyControllerTests
+{
+	private readonly Mock<IApiKeyService> _apiKeyServiceMock;
+	private readonly Mock<IAuthAuditService> _authAuditServiceMock;
+	private readonly Mock<ILogger<ApiKeyController>> _loggerMock;
+	private readonly ApiKeyController _controller;
+
+	public ApiKeyControllerTests()
+	{
+		_apiKeyServiceMock = new Mock<IApiKeyService>();
+		_authAuditServiceMock = new Mock<IAuthAuditService>();
+		_loggerMock = ControllerTestHelpers.GetLoggerMock<ApiKeyController>();
+
+		_controller = new ApiKeyController(
+			_apiKeyServiceMock.Object,
+			_authAuditServiceMock.Object,
+			_loggerMock.Object);
+
+		_controller.ControllerContext = new ControllerContext
+		{
+			HttpContext = new DefaultHttpContext()
+		};
+	}
+
+	private void SetupUserClaims(string userId)
+	{
+		List<Claim> claims = [new Claim(ClaimTypes.NameIdentifier, userId)];
+		ClaimsIdentity identity = new(claims, "TestAuth");
+		ClaimsPrincipal principal = new(identity);
+		_controller.ControllerContext.HttpContext.User = principal;
+	}
+
+	// ── GetApiKeys ──────────────────────────────────────────
+
+	[Fact]
+	public async Task GetApiKeys_ReturnsOk_WhenAuthenticated()
+	{
+		SetupUserClaims("user-123");
+		List<ApiKeyInfo> keys =
+		[
+			new(Guid.NewGuid(), "key-1", DateTimeOffset.UtcNow, null, null, false),
+			new(Guid.NewGuid(), "key-2", DateTimeOffset.UtcNow, null, DateTimeOffset.UtcNow.AddDays(30), false),
+		];
+		_apiKeyServiceMock.Setup(s => s.GetApiKeysForUserAsync("user-123", It.IsAny<CancellationToken>())).ReturnsAsync(keys);
+
+		Results<Ok<List<ApiKeyResponse>>, UnauthorizedHttpResult> result = await _controller.GetApiKeys();
+
+		Ok<List<ApiKeyResponse>> okResult = Assert.IsType<Ok<List<ApiKeyResponse>>>(result.Result);
+		okResult.Value.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public async Task GetApiKeys_ReturnsUnauthorized_WhenNoClaims()
+	{
+		Results<Ok<List<ApiKeyResponse>>, UnauthorizedHttpResult> result = await _controller.GetApiKeys();
+
+		Assert.IsType<UnauthorizedHttpResult>(result.Result);
+	}
+
+	// ── CreateApiKey ────────────────────────────────────────
+
+	[Fact]
+	public async Task CreateApiKey_ReturnsOk_WhenAuthenticated()
+	{
+		SetupUserClaims("user-123");
+		Guid keyId = Guid.NewGuid();
+		DateTimeOffset createdAt = DateTimeOffset.UtcNow;
+
+		_apiKeyServiceMock.Setup(s => s.CreateApiKeyAsync("user-123", "my-key", null, It.IsAny<CancellationToken>()))
+			.ReturnsAsync("raw-key-value");
+		_apiKeyServiceMock.Setup(s => s.GetApiKeysForUserAsync("user-123", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new List<ApiKeyInfo> { new(keyId, "my-key", createdAt, null, null, false) });
+
+		Results<Ok<CreateApiKeyResponse>, UnauthorizedHttpResult> result = await _controller.CreateApiKey(
+			new CreateApiKeyRequest { Name = "my-key" });
+
+		Ok<CreateApiKeyResponse> okResult = Assert.IsType<Ok<CreateApiKeyResponse>>(result.Result);
+		okResult.Value!.RawKey.Should().Be("raw-key-value");
+		okResult.Value!.Name.Should().Be("my-key");
+	}
+
+	[Fact]
+	public async Task CreateApiKey_ReturnsUnauthorized_WhenNoClaims()
+	{
+		Results<Ok<CreateApiKeyResponse>, UnauthorizedHttpResult> result = await _controller.CreateApiKey(
+			new CreateApiKeyRequest { Name = "my-key" });
+
+		Assert.IsType<UnauthorizedHttpResult>(result.Result);
+	}
+
+	// ── RevokeApiKey ────────────────────────────────────────
+
+	[Fact]
+	public async Task RevokeApiKey_ReturnsNoContent_WhenAuthenticated()
+	{
+		SetupUserClaims("user-123");
+		Guid keyId = Guid.NewGuid();
+
+		Results<NoContent, UnauthorizedHttpResult> result = await _controller.RevokeApiKey(keyId);
+
+		Assert.IsType<NoContent>(result.Result);
+		_apiKeyServiceMock.Verify(s => s.RevokeApiKeyAsync(keyId, "user-123", It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task RevokeApiKey_ReturnsUnauthorized_WhenNoClaims()
+	{
+		Results<NoContent, UnauthorizedHttpResult> result = await _controller.RevokeApiKey(Guid.NewGuid());
+
+		Assert.IsType<UnauthorizedHttpResult>(result.Result);
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
@@ -361,4 +361,33 @@ public class AuthControllerTests
 		// Assert
 		Assert.IsType<Ok>(result);
 	}
+
+	// ── Logout ──────────────────────────────────────────────
+
+	[Fact]
+	public async Task Logout_ReturnsNoContent_AndClearsRefreshToken()
+	{
+		// Arrange
+		ApplicationUser user = CreateTestUser();
+		SetupUserClaims(user.Id);
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+
+		// Act
+		Results<NoContent, UnauthorizedHttpResult> result = await _controller.Logout();
+
+		// Assert
+		Assert.IsType<NoContent>(result.Result);
+		user.RefreshToken.Should().BeNull();
+		user.RefreshTokenExpiresAt.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Logout_ReturnsUnauthorized_WhenNoClaims()
+	{
+		// Act
+		Results<NoContent, UnauthorizedHttpResult> result = await _controller.Logout();
+
+		// Assert
+		Assert.IsType<UnauthorizedHttpResult>(result.Result);
+	}
 }

--- a/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
@@ -371,6 +371,7 @@ public class AuthControllerTests
 		ApplicationUser user = CreateTestUser();
 		SetupUserClaims(user.Id);
 		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
 
 		// Act
 		Results<NoContent, UnauthorizedHttpResult> result = await _controller.Logout();
@@ -379,6 +380,7 @@ public class AuthControllerTests
 		Assert.IsType<NoContent>(result.Result);
 		user.RefreshToken.Should().BeNull();
 		user.RefreshTokenExpiresAt.Should().BeNull();
+		_userManagerMock.Verify(m => m.UpdateAsync(user), Times.Once);
 	}
 
 	[Fact]

--- a/tests/Presentation.API.Tests/Controllers/Core/CategoriesControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/CategoriesControllerTests.cs
@@ -1,0 +1,416 @@
+using API.Controllers.Core;
+using API.Generated.Dtos;
+using API.Mapping.Core;
+using API.Services;
+using Application.Commands.Category.Create;
+using Application.Commands.Category.Delete;
+using Application.Commands.Category.Restore;
+using Application.Commands.Category.Update;
+using Application.Models;
+using Application.Queries.Core.Category;
+using Domain.Core;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SampleData.Domain.Core;
+using SampleData.Dtos.Core;
+
+namespace Presentation.API.Tests.Controllers.Core;
+
+public class CategoriesControllerTests
+{
+	private readonly CategoryMapper _mapper;
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly Mock<ILogger<CategoriesController>> _loggerMock;
+	private readonly Mock<IEntityChangeNotifier> _notifierMock;
+	private readonly CategoriesController _controller;
+
+	public CategoriesControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_mapper = new CategoryMapper();
+		_loggerMock = ControllerTestHelpers.GetLoggerMock<CategoriesController>();
+		_notifierMock = new Mock<IEntityChangeNotifier>();
+		_controller = new CategoriesController(_mediatorMock.Object, _mapper, _loggerMock.Object, _notifierMock.Object);
+	}
+
+	// ── GetCategoryById ─────────────────────────────────────
+
+	[Fact]
+	public async Task GetCategoryById_ReturnsOkResult_WhenCategoryExists()
+	{
+		Category category = CategoryGenerator.Generate();
+		CategoryResponse expectedReturn = _mapper.ToResponse(category);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryByIdQuery>(q => q.Id == category.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(category);
+
+		Results<Ok<CategoryResponse>, NotFound> result = await _controller.GetCategoryById(category.Id);
+
+		Ok<CategoryResponse> okResult = Assert.IsType<Ok<CategoryResponse>>(result.Result);
+		CategoryResponse actualReturn = Assert.IsType<CategoryResponse>(okResult.Value);
+		actualReturn.Should().BeEquivalentTo(expectedReturn);
+	}
+
+	[Fact]
+	public async Task GetCategoryById_ReturnsNotFound_WhenCategoryDoesNotExist()
+	{
+		Guid missingId = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryByIdQuery>(q => q.Id == missingId),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Category?)null);
+
+		Results<Ok<CategoryResponse>, NotFound> result = await _controller.GetCategoryById(missingId);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetCategoryById_ThrowsException_WhenMediatorFails()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryByIdQuery>(q => q.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.GetCategoryById(id);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── GetAllCategories ────────────────────────────────────
+
+	[Fact]
+	public async Task GetAllCategories_ReturnsOkResult_WithListOfCategories()
+	{
+		List<Category> categories = CategoryGenerator.GenerateList(2);
+		List<CategoryResponse> expectedReturn = [.. categories.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetAllCategoriesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Category>(categories, categories.Count, 0, 50));
+
+		Ok<CategoryListResponse> result = await _controller.GetAllCategories(0, 50);
+
+		CategoryListResponse actualReturn = result.Value!;
+		actualReturn.Data.Should().BeEquivalentTo(expectedReturn);
+		actualReturn.Total.Should().Be(categories.Count);
+		actualReturn.Offset.Should().Be(0);
+		actualReturn.Limit.Should().Be(50);
+	}
+
+	[Fact]
+	public async Task GetAllCategories_ThrowsException_WhenMediatorFails()
+	{
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetAllCategoriesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.GetAllCategories(0, 50);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── GetDeletedCategories ────────────────────────────────
+
+	[Fact]
+	public async Task GetDeletedCategories_ReturnsOkResult_WithListOfCategories()
+	{
+		List<Category> categories = CategoryGenerator.GenerateList(2);
+		List<CategoryResponse> expectedReturn = [.. categories.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDeletedCategoriesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Category>(categories, categories.Count, 0, 50));
+
+		Ok<CategoryListResponse> result = await _controller.GetDeletedCategories(0, 50);
+
+		CategoryListResponse actualReturn = result.Value!;
+		actualReturn.Data.Should().BeEquivalentTo(expectedReturn);
+		actualReturn.Total.Should().Be(categories.Count);
+	}
+
+	[Fact]
+	public async Task GetDeletedCategories_ThrowsException_WhenMediatorFails()
+	{
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDeletedCategoriesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.GetDeletedCategories(0, 50);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── CreateCategory ──────────────────────────────────────
+
+	[Fact]
+	public async Task CreateCategory_ReturnsOkResult_WithCreatedCategory()
+	{
+		Category category = CategoryGenerator.Generate();
+		CategoryResponse expectedReturn = _mapper.ToResponse(category);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateCategoryCommand>(c => c.Categories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync([category]);
+
+		CreateCategoryRequest controllerInput = CategoryDtoGenerator.GenerateCreateRequest();
+
+		Ok<CategoryResponse> result = await _controller.CreateCategory(controllerInput);
+
+		CategoryResponse actualReturn = result.Value!;
+		actualReturn.Should().BeEquivalentTo(expectedReturn);
+	}
+
+	[Fact]
+	public async Task CreateCategory_ThrowsException_WhenMediatorFails()
+	{
+		CreateCategoryRequest controllerInput = CategoryDtoGenerator.GenerateCreateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateCategoryCommand>(c => c.Categories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.CreateCategory(controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── CreateCategories (batch) ────────────────────────────
+
+	[Fact]
+	public async Task CreateCategories_ReturnsOkResult_WithCreatedCategories()
+	{
+		List<Category> categories = CategoryGenerator.GenerateList(2);
+		List<CategoryResponse> expectedReturn = [.. categories.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateCategoryCommand>(c => c.Categories.Count == categories.Count),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(categories);
+
+		List<CreateCategoryRequest> controllerInput = CategoryDtoGenerator.GenerateCreateRequestList(2);
+
+		Ok<List<CategoryResponse>> result = await _controller.CreateCategories(controllerInput);
+
+		List<CategoryResponse> actualReturn = result.Value!;
+		actualReturn.Should().BeEquivalentTo(expectedReturn);
+	}
+
+	[Fact]
+	public async Task CreateCategories_ThrowsException_WhenMediatorFails()
+	{
+		List<CreateCategoryRequest> controllerInput = CategoryDtoGenerator.GenerateCreateRequestList(2);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateCategoryCommand>(c => c.Categories.Count == controllerInput.Count),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.CreateCategories(controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── UpdateCategory ──────────────────────────────────────
+
+	[Fact]
+	public async Task UpdateCategory_ReturnsNoContent_WhenUpdateSucceeds()
+	{
+		UpdateCategoryRequest controllerInput = CategoryDtoGenerator.GenerateUpdateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateCategoryCommand>(c => c.Categories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateCategory(controllerInput.Id, controllerInput);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateCategory_ReturnsNotFound_WhenUpdateFails()
+	{
+		UpdateCategoryRequest controllerInput = CategoryDtoGenerator.GenerateUpdateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateCategoryCommand>(c => c.Categories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateCategory(controllerInput.Id, controllerInput);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateCategory_ThrowsException_WhenMediatorFails()
+	{
+		UpdateCategoryRequest controllerInput = CategoryDtoGenerator.GenerateUpdateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateCategoryCommand>(c => c.Categories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.UpdateCategory(controllerInput.Id, controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── UpdateCategories (batch) ────────────────────────────
+
+	[Fact]
+	public async Task UpdateCategories_ReturnsNoContent_WhenUpdateSucceeds()
+	{
+		List<UpdateCategoryRequest> controllerInput = CategoryDtoGenerator.GenerateUpdateRequestList(2);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateCategoryCommand>(c => c.Categories.Count == controllerInput.Count),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateCategories(controllerInput);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateCategories_ReturnsNotFound_WhenUpdateFails()
+	{
+		List<UpdateCategoryRequest> controllerInput = CategoryDtoGenerator.GenerateUpdateRequestList(2);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateCategoryCommand>(c => c.Categories.Count == controllerInput.Count),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateCategories(controllerInput);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateCategories_ThrowsException_WhenMediatorFails()
+	{
+		List<UpdateCategoryRequest> controllerInput = CategoryDtoGenerator.GenerateUpdateRequestList(2);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateCategoryCommand>(c => c.Categories.Count == controllerInput.Count),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.UpdateCategories(controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── DeleteCategories ────────────────────────────────────
+
+	[Fact]
+	public async Task DeleteCategories_ReturnsNoContent_WhenDeleteSucceeds()
+	{
+		List<Guid> ids = [.. CategoryGenerator.GenerateList(2).Select(c => c.Id)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteCategoryCommand>(c => c.Ids.SequenceEqual(ids)),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.DeleteCategories(ids);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteCategories_ReturnsNotFound_WhenDeleteFails()
+	{
+		List<Guid> ids = [CategoryGenerator.Generate().Id];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteCategoryCommand>(c => c.Ids.SequenceEqual(ids)),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.DeleteCategories(ids);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteCategories_ThrowsException_WhenMediatorFails()
+	{
+		List<Guid> ids = [.. CategoryGenerator.GenerateList(2).Select(c => c.Id)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteCategoryCommand>(c => c.Ids.SequenceEqual(ids)),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.DeleteCategories(ids);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── RestoreCategory ─────────────────────────────────────
+
+	[Fact]
+	public async Task RestoreCategory_ReturnsNoContent_WhenSuccessful()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RestoreCategoryCommand>(c => c.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.RestoreCategory(id);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task RestoreCategory_ReturnsNotFound_WhenEntityDoesNotExist()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RestoreCategoryCommand>(c => c.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.RestoreCategory(id);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task RestoreCategory_ThrowsException_WhenMediatorFails()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RestoreCategoryCommand>(c => c.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.RestoreCategory(id);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Core/ItemTemplatesControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ItemTemplatesControllerTests.cs
@@ -1,0 +1,333 @@
+using API.Controllers.Core;
+using API.Generated.Dtos;
+using API.Mapping.Core;
+using API.Services;
+using Application.Commands.ItemTemplate.Create;
+using Application.Commands.ItemTemplate.Delete;
+using Application.Commands.ItemTemplate.Restore;
+using Application.Commands.ItemTemplate.Update;
+using Application.Models;
+using Application.Queries.Core.ItemTemplate;
+using Domain.Core;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SampleData.Domain.Core;
+using SampleData.Dtos.Core;
+
+namespace Presentation.API.Tests.Controllers.Core;
+
+public class ItemTemplatesControllerTests
+{
+	private readonly ItemTemplateMapper _mapper;
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly Mock<ILogger<ItemTemplatesController>> _loggerMock;
+	private readonly Mock<IEntityChangeNotifier> _notifierMock;
+	private readonly ItemTemplatesController _controller;
+
+	public ItemTemplatesControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_mapper = new ItemTemplateMapper();
+		_loggerMock = ControllerTestHelpers.GetLoggerMock<ItemTemplatesController>();
+		_notifierMock = new Mock<IEntityChangeNotifier>();
+		_controller = new ItemTemplatesController(_mediatorMock.Object, _mapper, _loggerMock.Object, _notifierMock.Object);
+	}
+
+	// ── GetItemTemplateById ─────────────────────────────────
+
+	[Fact]
+	public async Task GetItemTemplateById_ReturnsOkResult_WhenItemTemplateExists()
+	{
+		ItemTemplate itemTemplate = ItemTemplateGenerator.Generate();
+		ItemTemplateResponse expectedReturn = _mapper.ToResponse(itemTemplate);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemTemplateByIdQuery>(q => q.Id == itemTemplate.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(itemTemplate);
+
+		Results<Ok<ItemTemplateResponse>, NotFound> result = await _controller.GetItemTemplateById(itemTemplate.Id);
+
+		Ok<ItemTemplateResponse> okResult = Assert.IsType<Ok<ItemTemplateResponse>>(result.Result);
+		ItemTemplateResponse actualReturn = Assert.IsType<ItemTemplateResponse>(okResult.Value);
+		actualReturn.Should().BeEquivalentTo(expectedReturn);
+	}
+
+	[Fact]
+	public async Task GetItemTemplateById_ReturnsNotFound_WhenItemTemplateDoesNotExist()
+	{
+		Guid missingId = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemTemplateByIdQuery>(q => q.Id == missingId),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync((ItemTemplate?)null);
+
+		Results<Ok<ItemTemplateResponse>, NotFound> result = await _controller.GetItemTemplateById(missingId);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetItemTemplateById_ThrowsException_WhenMediatorFails()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemTemplateByIdQuery>(q => q.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.GetItemTemplateById(id);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── GetAllItemTemplates ─────────────────────────────────
+
+	[Fact]
+	public async Task GetAllItemTemplates_ReturnsOkResult_WithListOfItemTemplates()
+	{
+		List<ItemTemplate> itemTemplates = ItemTemplateGenerator.GenerateList(2);
+		List<ItemTemplateResponse> expectedReturn = [.. itemTemplates.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetAllItemTemplatesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<ItemTemplate>(itemTemplates, itemTemplates.Count, 0, 50));
+
+		Ok<ItemTemplateListResponse> result = await _controller.GetAllItemTemplates(0, 50);
+
+		ItemTemplateListResponse actualReturn = result.Value!;
+		actualReturn.Data.Should().BeEquivalentTo(expectedReturn);
+		actualReturn.Total.Should().Be(itemTemplates.Count);
+		actualReturn.Offset.Should().Be(0);
+		actualReturn.Limit.Should().Be(50);
+	}
+
+	[Fact]
+	public async Task GetAllItemTemplates_ThrowsException_WhenMediatorFails()
+	{
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetAllItemTemplatesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.GetAllItemTemplates(0, 50);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── GetDeletedItemTemplates ─────────────────────────────
+
+	[Fact]
+	public async Task GetDeletedItemTemplates_ReturnsOkResult_WithListOfItemTemplates()
+	{
+		List<ItemTemplate> itemTemplates = ItemTemplateGenerator.GenerateList(2);
+		List<ItemTemplateResponse> expectedReturn = [.. itemTemplates.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDeletedItemTemplatesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<ItemTemplate>(itemTemplates, itemTemplates.Count, 0, 50));
+
+		Ok<ItemTemplateListResponse> result = await _controller.GetDeletedItemTemplates(0, 50);
+
+		ItemTemplateListResponse actualReturn = result.Value!;
+		actualReturn.Data.Should().BeEquivalentTo(expectedReturn);
+		actualReturn.Total.Should().Be(itemTemplates.Count);
+	}
+
+	[Fact]
+	public async Task GetDeletedItemTemplates_ThrowsException_WhenMediatorFails()
+	{
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDeletedItemTemplatesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.GetDeletedItemTemplates(0, 50);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── CreateItemTemplate ──────────────────────────────────
+
+	[Fact]
+	public async Task CreateItemTemplate_ReturnsOkResult_WithCreatedItemTemplate()
+	{
+		ItemTemplate itemTemplate = ItemTemplateGenerator.Generate();
+		ItemTemplateResponse expectedReturn = _mapper.ToResponse(itemTemplate);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateItemTemplateCommand>(c => c.ItemTemplates.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync([itemTemplate]);
+
+		CreateItemTemplateRequest controllerInput = ItemTemplateDtoGenerator.GenerateCreateRequest();
+
+		Ok<ItemTemplateResponse> result = await _controller.CreateItemTemplate(controllerInput);
+
+		ItemTemplateResponse actualReturn = result.Value!;
+		actualReturn.Should().BeEquivalentTo(expectedReturn);
+	}
+
+	[Fact]
+	public async Task CreateItemTemplate_ThrowsException_WhenMediatorFails()
+	{
+		CreateItemTemplateRequest controllerInput = ItemTemplateDtoGenerator.GenerateCreateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateItemTemplateCommand>(c => c.ItemTemplates.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.CreateItemTemplate(controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── UpdateItemTemplate ──────────────────────────────────
+
+	[Fact]
+	public async Task UpdateItemTemplate_ReturnsNoContent_WhenUpdateSucceeds()
+	{
+		UpdateItemTemplateRequest controllerInput = ItemTemplateDtoGenerator.GenerateUpdateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateItemTemplateCommand>(c => c.ItemTemplates.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateItemTemplate(controllerInput.Id, controllerInput);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateItemTemplate_ReturnsNotFound_WhenUpdateFails()
+	{
+		UpdateItemTemplateRequest controllerInput = ItemTemplateDtoGenerator.GenerateUpdateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateItemTemplateCommand>(c => c.ItemTemplates.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateItemTemplate(controllerInput.Id, controllerInput);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateItemTemplate_ThrowsException_WhenMediatorFails()
+	{
+		UpdateItemTemplateRequest controllerInput = ItemTemplateDtoGenerator.GenerateUpdateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateItemTemplateCommand>(c => c.ItemTemplates.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.UpdateItemTemplate(controllerInput.Id, controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── DeleteItemTemplates ─────────────────────────────────
+
+	[Fact]
+	public async Task DeleteItemTemplates_ReturnsNoContent_WhenDeleteSucceeds()
+	{
+		List<Guid> ids = [.. ItemTemplateGenerator.GenerateList(2).Select(t => t.Id)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteItemTemplateCommand>(c => c.Ids.SequenceEqual(ids)),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.DeleteItemTemplates(ids);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteItemTemplates_ReturnsNotFound_WhenDeleteFails()
+	{
+		List<Guid> ids = [ItemTemplateGenerator.Generate().Id];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteItemTemplateCommand>(c => c.Ids.SequenceEqual(ids)),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.DeleteItemTemplates(ids);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteItemTemplates_ThrowsException_WhenMediatorFails()
+	{
+		List<Guid> ids = [.. ItemTemplateGenerator.GenerateList(2).Select(t => t.Id)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteItemTemplateCommand>(c => c.Ids.SequenceEqual(ids)),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.DeleteItemTemplates(ids);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── RestoreItemTemplate ─────────────────────────────────
+
+	[Fact]
+	public async Task RestoreItemTemplate_ReturnsNoContent_WhenSuccessful()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RestoreItemTemplateCommand>(c => c.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.RestoreItemTemplate(id);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task RestoreItemTemplate_ReturnsNotFound_WhenEntityDoesNotExist()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RestoreItemTemplateCommand>(c => c.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.RestoreItemTemplate(id);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task RestoreItemTemplate_ThrowsException_WhenMediatorFails()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RestoreItemTemplateCommand>(c => c.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.RestoreItemTemplate(id);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Core/SubcategoriesControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/SubcategoriesControllerTests.cs
@@ -1,0 +1,435 @@
+using API.Controllers.Core;
+using API.Generated.Dtos;
+using API.Mapping.Core;
+using API.Services;
+using Application.Commands.Subcategory.Create;
+using Application.Commands.Subcategory.Delete;
+using Application.Commands.Subcategory.Restore;
+using Application.Commands.Subcategory.Update;
+using Application.Models;
+using Application.Queries.Core.Subcategory;
+using Domain.Core;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SampleData.Domain.Core;
+using SampleData.Dtos.Core;
+
+namespace Presentation.API.Tests.Controllers.Core;
+
+public class SubcategoriesControllerTests
+{
+	private readonly SubcategoryMapper _mapper;
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly Mock<ILogger<SubcategoriesController>> _loggerMock;
+	private readonly Mock<IEntityChangeNotifier> _notifierMock;
+	private readonly SubcategoriesController _controller;
+
+	public SubcategoriesControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_mapper = new SubcategoryMapper();
+		_loggerMock = ControllerTestHelpers.GetLoggerMock<SubcategoriesController>();
+		_notifierMock = new Mock<IEntityChangeNotifier>();
+		_controller = new SubcategoriesController(_mediatorMock.Object, _mapper, _loggerMock.Object, _notifierMock.Object);
+	}
+
+	// ── GetSubcategoryById ──────────────────────────────────
+
+	[Fact]
+	public async Task GetSubcategoryById_ReturnsOkResult_WhenSubcategoryExists()
+	{
+		Subcategory subcategory = SubcategoryGenerator.Generate();
+		SubcategoryResponse expectedReturn = _mapper.ToResponse(subcategory);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSubcategoryByIdQuery>(q => q.Id == subcategory.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(subcategory);
+
+		Results<Ok<SubcategoryResponse>, NotFound> result = await _controller.GetSubcategoryById(subcategory.Id);
+
+		Ok<SubcategoryResponse> okResult = Assert.IsType<Ok<SubcategoryResponse>>(result.Result);
+		SubcategoryResponse actualReturn = Assert.IsType<SubcategoryResponse>(okResult.Value);
+		actualReturn.Should().BeEquivalentTo(expectedReturn);
+	}
+
+	[Fact]
+	public async Task GetSubcategoryById_ReturnsNotFound_WhenSubcategoryDoesNotExist()
+	{
+		Guid missingId = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSubcategoryByIdQuery>(q => q.Id == missingId),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Subcategory?)null);
+
+		Results<Ok<SubcategoryResponse>, NotFound> result = await _controller.GetSubcategoryById(missingId);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetSubcategoryById_ThrowsException_WhenMediatorFails()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSubcategoryByIdQuery>(q => q.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.GetSubcategoryById(id);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── GetAllSubcategories ─────────────────────────────────
+
+	[Fact]
+	public async Task GetAllSubcategories_ReturnsOkResult_WithListOfSubcategories()
+	{
+		List<Subcategory> subcategories = SubcategoryGenerator.GenerateList(2);
+		List<SubcategoryResponse> expectedReturn = [.. subcategories.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetAllSubcategoriesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Subcategory>(subcategories, subcategories.Count, 0, 50));
+
+		Ok<SubcategoryListResponse> result = await _controller.GetAllSubcategories(null, 0, 50);
+
+		SubcategoryListResponse actualReturn = result.Value!;
+		actualReturn.Data.Should().BeEquivalentTo(expectedReturn);
+		actualReturn.Total.Should().Be(subcategories.Count);
+		actualReturn.Offset.Should().Be(0);
+		actualReturn.Limit.Should().Be(50);
+	}
+
+	[Fact]
+	public async Task GetAllSubcategories_WithCategoryId_ReturnsFilteredSubcategories()
+	{
+		Guid categoryId = Guid.NewGuid();
+		List<Subcategory> subcategories = SubcategoryGenerator.GenerateList(2);
+		List<SubcategoryResponse> expectedReturn = [.. subcategories.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSubcategoriesByCategoryIdQuery>(q => q.CategoryId == categoryId && q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Subcategory>(subcategories, subcategories.Count, 0, 50));
+
+		Ok<SubcategoryListResponse> result = await _controller.GetAllSubcategories(categoryId, 0, 50);
+
+		SubcategoryListResponse actualReturn = result.Value!;
+		actualReturn.Data.Should().BeEquivalentTo(expectedReturn);
+		actualReturn.Total.Should().Be(subcategories.Count);
+	}
+
+	[Fact]
+	public async Task GetAllSubcategories_ThrowsException_WhenMediatorFails()
+	{
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetAllSubcategoriesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.GetAllSubcategories(null, 0, 50);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── GetDeletedSubcategories ─────────────────────────────
+
+	[Fact]
+	public async Task GetDeletedSubcategories_ReturnsOkResult_WithListOfSubcategories()
+	{
+		List<Subcategory> subcategories = SubcategoryGenerator.GenerateList(2);
+		List<SubcategoryResponse> expectedReturn = [.. subcategories.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDeletedSubcategoriesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Subcategory>(subcategories, subcategories.Count, 0, 50));
+
+		Ok<SubcategoryListResponse> result = await _controller.GetDeletedSubcategories(0, 50);
+
+		SubcategoryListResponse actualReturn = result.Value!;
+		actualReturn.Data.Should().BeEquivalentTo(expectedReturn);
+		actualReturn.Total.Should().Be(subcategories.Count);
+	}
+
+	[Fact]
+	public async Task GetDeletedSubcategories_ThrowsException_WhenMediatorFails()
+	{
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDeletedSubcategoriesQuery>(q => q.Offset == 0 && q.Limit == 50),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.GetDeletedSubcategories(0, 50);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── CreateSubcategory ───────────────────────────────────
+
+	[Fact]
+	public async Task CreateSubcategory_ReturnsOkResult_WithCreatedSubcategory()
+	{
+		Subcategory subcategory = SubcategoryGenerator.Generate();
+		SubcategoryResponse expectedReturn = _mapper.ToResponse(subcategory);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateSubcategoryCommand>(c => c.Subcategories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync([subcategory]);
+
+		CreateSubcategoryRequest controllerInput = SubcategoryDtoGenerator.GenerateCreateRequest();
+
+		Ok<SubcategoryResponse> result = await _controller.CreateSubcategory(controllerInput);
+
+		SubcategoryResponse actualReturn = result.Value!;
+		actualReturn.Should().BeEquivalentTo(expectedReturn);
+	}
+
+	[Fact]
+	public async Task CreateSubcategory_ThrowsException_WhenMediatorFails()
+	{
+		CreateSubcategoryRequest controllerInput = SubcategoryDtoGenerator.GenerateCreateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateSubcategoryCommand>(c => c.Subcategories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.CreateSubcategory(controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── CreateSubcategories (batch) ─────────────────────────
+
+	[Fact]
+	public async Task CreateSubcategories_ReturnsOkResult_WithCreatedSubcategories()
+	{
+		List<Subcategory> subcategories = SubcategoryGenerator.GenerateList(2);
+		List<SubcategoryResponse> expectedReturn = [.. subcategories.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateSubcategoryCommand>(c => c.Subcategories.Count == subcategories.Count),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(subcategories);
+
+		List<CreateSubcategoryRequest> controllerInput = SubcategoryDtoGenerator.GenerateCreateRequestList(2);
+
+		Ok<List<SubcategoryResponse>> result = await _controller.CreateSubcategories(controllerInput);
+
+		List<SubcategoryResponse> actualReturn = result.Value!;
+		actualReturn.Should().BeEquivalentTo(expectedReturn);
+	}
+
+	[Fact]
+	public async Task CreateSubcategories_ThrowsException_WhenMediatorFails()
+	{
+		List<CreateSubcategoryRequest> controllerInput = SubcategoryDtoGenerator.GenerateCreateRequestList(2);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<CreateSubcategoryCommand>(c => c.Subcategories.Count == controllerInput.Count),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.CreateSubcategories(controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── UpdateSubcategory ───────────────────────────────────
+
+	[Fact]
+	public async Task UpdateSubcategory_ReturnsNoContent_WhenUpdateSucceeds()
+	{
+		UpdateSubcategoryRequest controllerInput = SubcategoryDtoGenerator.GenerateUpdateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateSubcategoryCommand>(c => c.Subcategories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateSubcategory(controllerInput.Id, controllerInput);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateSubcategory_ReturnsNotFound_WhenUpdateFails()
+	{
+		UpdateSubcategoryRequest controllerInput = SubcategoryDtoGenerator.GenerateUpdateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateSubcategoryCommand>(c => c.Subcategories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateSubcategory(controllerInput.Id, controllerInput);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateSubcategory_ThrowsException_WhenMediatorFails()
+	{
+		UpdateSubcategoryRequest controllerInput = SubcategoryDtoGenerator.GenerateUpdateRequest();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateSubcategoryCommand>(c => c.Subcategories.Count == 1),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.UpdateSubcategory(controllerInput.Id, controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── UpdateSubcategories (batch) ─────────────────────────
+
+	[Fact]
+	public async Task UpdateSubcategories_ReturnsNoContent_WhenUpdateSucceeds()
+	{
+		List<UpdateSubcategoryRequest> controllerInput = SubcategoryDtoGenerator.GenerateUpdateRequestList(2);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateSubcategoryCommand>(c => c.Subcategories.Count == controllerInput.Count),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateSubcategories(controllerInput);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateSubcategories_ReturnsNotFound_WhenUpdateFails()
+	{
+		List<UpdateSubcategoryRequest> controllerInput = SubcategoryDtoGenerator.GenerateUpdateRequestList(2);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateSubcategoryCommand>(c => c.Subcategories.Count == controllerInput.Count),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.UpdateSubcategories(controllerInput);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateSubcategories_ThrowsException_WhenMediatorFails()
+	{
+		List<UpdateSubcategoryRequest> controllerInput = SubcategoryDtoGenerator.GenerateUpdateRequestList(2);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<UpdateSubcategoryCommand>(c => c.Subcategories.Count == controllerInput.Count),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.UpdateSubcategories(controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── DeleteSubcategories ─────────────────────────────────
+
+	[Fact]
+	public async Task DeleteSubcategories_ReturnsNoContent_WhenDeleteSucceeds()
+	{
+		List<Guid> ids = [.. SubcategoryGenerator.GenerateList(2).Select(s => s.Id)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteSubcategoryCommand>(c => c.Ids.SequenceEqual(ids)),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.DeleteSubcategories(ids);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteSubcategories_ReturnsNotFound_WhenDeleteFails()
+	{
+		List<Guid> ids = [SubcategoryGenerator.Generate().Id];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteSubcategoryCommand>(c => c.Ids.SequenceEqual(ids)),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.DeleteSubcategories(ids);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteSubcategories_ThrowsException_WhenMediatorFails()
+	{
+		List<Guid> ids = [.. SubcategoryGenerator.GenerateList(2).Select(s => s.Id)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteSubcategoryCommand>(c => c.Ids.SequenceEqual(ids)),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.DeleteSubcategories(ids);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── RestoreSubcategory ──────────────────────────────────
+
+	[Fact]
+	public async Task RestoreSubcategory_ReturnsNoContent_WhenSuccessful()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RestoreSubcategoryCommand>(c => c.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound> result = await _controller.RestoreSubcategory(id);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task RestoreSubcategory_ReturnsNotFound_WhenEntityDoesNotExist()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RestoreSubcategoryCommand>(c => c.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		Results<NoContent, NotFound> result = await _controller.RestoreSubcategory(id);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task RestoreSubcategory_ThrowsException_WhenMediatorFails()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RestoreSubcategoryCommand>(c => c.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.RestoreSubcategory(id);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Core/TrashControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/TrashControllerTests.cs
@@ -1,0 +1,58 @@
+using API.Controllers.Core;
+using API.Services;
+using Application.Commands.Trash.Purge;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Presentation.API.Tests.Controllers.Core;
+
+public class TrashControllerTests
+{
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly Mock<ILogger<TrashController>> _loggerMock;
+	private readonly Mock<IEntityChangeNotifier> _notifierMock;
+	private readonly TrashController _controller;
+
+	public TrashControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_loggerMock = ControllerTestHelpers.GetLoggerMock<TrashController>();
+		_notifierMock = new Mock<IEntityChangeNotifier>();
+		_controller = new TrashController(_mediatorMock.Object, _loggerMock.Object, _notifierMock.Object);
+	}
+
+	[Fact]
+	public async Task PurgeTrash_ReturnsNoContent_AndNotifiesAllEntityTypes()
+	{
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<PurgeTrashCommand>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		NoContent result = await _controller.PurgeTrash();
+
+		Assert.IsType<NoContent>(result);
+
+		string[] expectedEntityTypes = ["receipt", "receipt-item", "transaction", "adjustment", "account", "category", "subcategory", "item-template"];
+		foreach (string entityType in expectedEntityTypes)
+		{
+			_notifierMock.Verify(n => n.NotifyAllChanged(entityType, "deleted"), Times.Once);
+		}
+	}
+
+	[Fact]
+	public async Task PurgeTrash_ThrowsException_WhenMediatorFails()
+	{
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<PurgeTrashCommand>(),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.PurgeTrash();
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/HealthControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/HealthControllerTests.cs
@@ -1,0 +1,17 @@
+using API.Controllers;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Presentation.API.Tests.Controllers;
+
+public class HealthControllerTests
+{
+	[Fact]
+	public void Get_ReturnsHealthy()
+	{
+		HealthController controller = new();
+
+		Ok<object> result = controller.Get();
+
+		Assert.NotNull(result.Value);
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/UserRolesControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/UserRolesControllerTests.cs
@@ -1,0 +1,131 @@
+using API.Controllers;
+using API.Generated.Dtos;
+using Common;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Presentation.API.Tests.Controllers;
+
+public class UserRolesControllerTests
+{
+	private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+	private readonly UserRolesController _controller;
+
+	public UserRolesControllerTests()
+	{
+		Mock<IUserStore<ApplicationUser>> userStoreMock = new();
+		_userManagerMock = new Mock<UserManager<ApplicationUser>>(
+			userStoreMock.Object,
+			new Mock<IOptions<IdentityOptions>>().Object,
+			new Mock<IPasswordHasher<ApplicationUser>>().Object,
+			Array.Empty<IUserValidator<ApplicationUser>>(),
+			Array.Empty<IPasswordValidator<ApplicationUser>>(),
+			new Mock<ILookupNormalizer>().Object,
+			new Mock<IdentityErrorDescriber>().Object,
+			new Mock<IServiceProvider>().Object,
+			new Mock<ILogger<UserManager<ApplicationUser>>>().Object);
+
+		_controller = new UserRolesController(_userManagerMock.Object);
+	}
+
+	private static ApplicationUser CreateTestUser(string id = "user-123")
+	{
+		return new ApplicationUser { Id = id, Email = "test@example.com", UserName = "test@example.com" };
+	}
+
+	// ── GetUserRoles ────────────────────────────────────────
+
+	[Fact]
+	public async Task GetUserRoles_ReturnsOk_WhenUserExists()
+	{
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin", "User" });
+
+		Results<Ok<UserRolesResponse>, NotFound> result = await _controller.GetUserRoles(user.Id);
+
+		Ok<UserRolesResponse> okResult = Assert.IsType<Ok<UserRolesResponse>>(result.Result);
+		okResult.Value!.Roles.Should().BeEquivalentTo(["Admin", "User"]);
+	}
+
+	[Fact]
+	public async Task GetUserRoles_ReturnsNotFound_WhenUserDoesNotExist()
+	{
+		_userManagerMock.Setup(m => m.FindByIdAsync("missing")).ReturnsAsync((ApplicationUser?)null);
+
+		Results<Ok<UserRolesResponse>, NotFound> result = await _controller.GetUserRoles("missing");
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	// ── AssignUserRole ──────────────────────────────────────
+
+	[Fact]
+	public async Task AssignUserRole_ReturnsNoContent_WhenSuccessful()
+	{
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(user, "Admin")).ReturnsAsync(IdentityResult.Success);
+
+		Results<NoContent, BadRequest<string>, NotFound> result = await _controller.AssignUserRole(user.Id, "Admin");
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task AssignUserRole_ReturnsBadRequest_WhenRoleIsInvalid()
+	{
+		Results<NoContent, BadRequest<string>, NotFound> result = await _controller.AssignUserRole("user-123", "InvalidRole");
+
+		BadRequest<string> badRequest = Assert.IsType<BadRequest<string>>(result.Result);
+		badRequest.Value.Should().Contain("Invalid role");
+	}
+
+	[Fact]
+	public async Task AssignUserRole_ReturnsNotFound_WhenUserDoesNotExist()
+	{
+		_userManagerMock.Setup(m => m.FindByIdAsync("missing")).ReturnsAsync((ApplicationUser?)null);
+
+		Results<NoContent, BadRequest<string>, NotFound> result = await _controller.AssignUserRole("missing", "Admin");
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	// ── RemoveUserRole ──────────────────────────────────────
+
+	[Fact]
+	public async Task RemoveUserRole_ReturnsNoContent_WhenSuccessful()
+	{
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.RemoveFromRoleAsync(user, "Admin")).ReturnsAsync(IdentityResult.Success);
+
+		Results<NoContent, BadRequest<string>, NotFound> result = await _controller.RemoveUserRole(user.Id, "Admin");
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task RemoveUserRole_ReturnsBadRequest_WhenRoleIsInvalid()
+	{
+		Results<NoContent, BadRequest<string>, NotFound> result = await _controller.RemoveUserRole("user-123", "InvalidRole");
+
+		BadRequest<string> badRequest = Assert.IsType<BadRequest<string>>(result.Result);
+		badRequest.Value.Should().Contain("Invalid role");
+	}
+
+	[Fact]
+	public async Task RemoveUserRole_ReturnsNotFound_WhenUserDoesNotExist()
+	{
+		_userManagerMock.Setup(m => m.FindByIdAsync("missing")).ReturnsAsync((ApplicationUser?)null);
+
+		Results<NoContent, BadRequest<string>, NotFound> result = await _controller.RemoveUserRole("missing", "Admin");
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/UsersControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/UsersControllerTests.cs
@@ -1,0 +1,351 @@
+using System.Security.Claims;
+using API.Controllers;
+using API.Generated.Dtos;
+using Application.Interfaces.Services;
+using Application.Models;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Presentation.API.Tests.Controllers;
+
+public class UsersControllerTests
+{
+	private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+	private readonly Mock<IUserService> _userServiceMock;
+	private readonly Mock<IAuthAuditService> _authAuditServiceMock;
+	private readonly Mock<ILogger<UsersController>> _loggerMock;
+	private readonly UsersController _controller;
+
+	public UsersControllerTests()
+	{
+		Mock<IUserStore<ApplicationUser>> userStoreMock = new();
+		_userManagerMock = new Mock<UserManager<ApplicationUser>>(
+			userStoreMock.Object,
+			new Mock<IOptions<IdentityOptions>>().Object,
+			new Mock<IPasswordHasher<ApplicationUser>>().Object,
+			Array.Empty<IUserValidator<ApplicationUser>>(),
+			Array.Empty<IPasswordValidator<ApplicationUser>>(),
+			new Mock<ILookupNormalizer>().Object,
+			new Mock<IdentityErrorDescriber>().Object,
+			new Mock<IServiceProvider>().Object,
+			new Mock<ILogger<UserManager<ApplicationUser>>>().Object);
+
+		_userServiceMock = new Mock<IUserService>();
+		_authAuditServiceMock = new Mock<IAuthAuditService>();
+		_loggerMock = ControllerTestHelpers.GetLoggerMock<UsersController>();
+
+		_controller = new UsersController(
+			_userServiceMock.Object,
+			_userManagerMock.Object,
+			_authAuditServiceMock.Object,
+			_loggerMock.Object);
+
+		_controller.ControllerContext = new ControllerContext
+		{
+			HttpContext = new DefaultHttpContext()
+		};
+	}
+
+	private void SetupUserClaims(string userId)
+	{
+		List<Claim> claims = [new Claim(ClaimTypes.NameIdentifier, userId)];
+		ClaimsIdentity identity = new(claims, "TestAuth");
+		ClaimsPrincipal principal = new(identity);
+		_controller.ControllerContext.HttpContext.User = principal;
+	}
+
+	private static ApplicationUser CreateTestUser(string id = "user-123", string email = "test@example.com")
+	{
+		return new ApplicationUser
+		{
+			Id = id,
+			Email = email,
+			UserName = email,
+			FirstName = "Test",
+			LastName = "User",
+			CreatedAt = DateTimeOffset.UtcNow,
+		};
+	}
+
+	// ── ListUsers ───────────────────────────────────────────
+
+	[Fact]
+	public async Task ListUsers_ReturnsOk_WithUserList()
+	{
+		List<UserSummary> users =
+		[
+			new("u1", "a@b.com", "A", "B", ["Admin"], false, DateTimeOffset.UtcNow, null),
+			new("u2", "c@d.com", "C", "D", ["User"], false, DateTimeOffset.UtcNow, null),
+		];
+		_userServiceMock.Setup(s => s.ListUsersAsync(0, 50, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<UserSummary>(users, 2, 0, 50));
+
+		Ok<UserListResponse> result = await _controller.ListUsers(0, 50);
+
+		UserListResponse response = result.Value!;
+		response.Data.Should().HaveCount(2);
+		response.Total.Should().Be(2);
+	}
+
+	// ── GetUser ─────────────────────────────────────────────
+
+	[Fact]
+	public async Task GetUser_ReturnsOk_WhenUserExists()
+	{
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin" });
+
+		Results<Ok<UserSummaryResponse>, NotFound> result = await _controller.GetUser(user.Id);
+
+		Ok<UserSummaryResponse> okResult = Assert.IsType<Ok<UserSummaryResponse>>(result.Result);
+		okResult.Value!.Email.Should().Be(user.Email);
+	}
+
+	[Fact]
+	public async Task GetUser_ReturnsNotFound_WhenUserDoesNotExist()
+	{
+		_userManagerMock.Setup(m => m.FindByIdAsync("missing")).ReturnsAsync((ApplicationUser?)null);
+
+		Results<Ok<UserSummaryResponse>, NotFound> result = await _controller.GetUser("missing");
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	// ── CreateUser ──────────────────────────────────────────
+
+	[Fact]
+	public async Task CreateUser_ReturnsOk_WhenSuccessful()
+	{
+		_userManagerMock.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), "Password1!"))
+			.ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(It.IsAny<ApplicationUser>(), "User"))
+			.ReturnsAsync(IdentityResult.Success);
+
+		Results<Ok<UserSummaryResponse>, BadRequest<IEnumerable<string>>> result = await _controller.CreateUser(
+			new CreateUserRequest { Email = "new@example.com", Password = "Password1!", FirstName = "New", LastName = "User", Role = "User" });
+
+		Ok<UserSummaryResponse> okResult = Assert.IsType<Ok<UserSummaryResponse>>(result.Result);
+		okResult.Value!.Email.Should().Be("new@example.com");
+	}
+
+	[Fact]
+	public async Task CreateUser_ReturnsBadRequest_WhenCreateFails()
+	{
+		_userManagerMock.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Password too weak" }));
+
+		Results<Ok<UserSummaryResponse>, BadRequest<IEnumerable<string>>> result = await _controller.CreateUser(
+			new CreateUserRequest { Email = "new@example.com", Password = "weak", FirstName = "New", LastName = "User", Role = "User" });
+
+		BadRequest<IEnumerable<string>> badRequest = Assert.IsType<BadRequest<IEnumerable<string>>>(result.Result);
+		badRequest.Value.Should().Contain("Password too weak");
+	}
+
+	[Fact]
+	public async Task CreateUser_ReturnsBadRequest_WhenRoleAssignmentFails()
+	{
+		_userManagerMock.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Role not found" }));
+
+		Results<Ok<UserSummaryResponse>, BadRequest<IEnumerable<string>>> result = await _controller.CreateUser(
+			new CreateUserRequest { Email = "new@example.com", Password = "Password1!", FirstName = "New", LastName = "User", Role = "BadRole" });
+
+		BadRequest<IEnumerable<string>> badRequest = Assert.IsType<BadRequest<IEnumerable<string>>>(result.Result);
+		badRequest.Value.Should().Contain("Role not found");
+	}
+
+	// ── UpdateUser ──────────────────────────────────────────
+
+	[Fact]
+	public async Task UpdateUser_ReturnsNoContent_WhenSuccessful()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.RemoveFromRolesAsync(user, It.IsAny<IEnumerable<string>>())).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(user, "Admin")).ReturnsAsync(IdentityResult.Success);
+
+		Results<NoContent, NotFound, BadRequest<string>, BadRequest<IEnumerable<string>>> result = await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "updated@example.com", FirstName = "Up", LastName = "Dated", Role = "Admin", IsDisabled = false });
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateUser_ReturnsNotFound_WhenUserDoesNotExist()
+	{
+		SetupUserClaims("admin-1");
+		_userManagerMock.Setup(m => m.FindByIdAsync("missing")).ReturnsAsync((ApplicationUser?)null);
+
+		Results<NoContent, NotFound, BadRequest<string>, BadRequest<IEnumerable<string>>> result = await _controller.UpdateUser(
+			"missing",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "User", IsDisabled = false });
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateUser_ReturnsBadRequest_WhenSelfDisable()
+	{
+		SetupUserClaims("user-123");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+
+		Results<NoContent, NotFound, BadRequest<string>, BadRequest<IEnumerable<string>>> result = await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "Admin", IsDisabled = true });
+
+		BadRequest<string> badRequest = Assert.IsType<BadRequest<string>>(result.Result);
+		badRequest.Value.Should().Contain("Cannot disable your own account");
+	}
+
+	[Fact]
+	public async Task UpdateUser_ReturnsBadRequest_WhenSelfRemoveAdmin()
+	{
+		SetupUserClaims("user-123");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin" });
+
+		Results<NoContent, NotFound, BadRequest<string>, BadRequest<IEnumerable<string>>> result = await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "User", IsDisabled = false });
+
+		BadRequest<string> badRequest = Assert.IsType<BadRequest<string>>(result.Result);
+		badRequest.Value.Should().Contain("Cannot remove your own Admin role");
+	}
+
+	[Fact]
+	public async Task UpdateUser_ReturnsBadRequest_WhenUpdateFails()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Update failed" }));
+
+		Results<NoContent, NotFound, BadRequest<string>, BadRequest<IEnumerable<string>>> result = await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "User", IsDisabled = false });
+
+		BadRequest<IEnumerable<string>> badRequest = Assert.IsType<BadRequest<IEnumerable<string>>>(result.Result);
+		badRequest.Value.Should().Contain("Update failed");
+	}
+
+	[Fact]
+	public async Task UpdateUser_ReturnsBadRequest_WhenRoleAssignmentFails()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.RemoveFromRolesAsync(user, It.IsAny<IEnumerable<string>>())).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(user, "Admin"))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Role failed" }));
+
+		Results<NoContent, NotFound, BadRequest<string>, BadRequest<IEnumerable<string>>> result = await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "Admin", IsDisabled = false });
+
+		BadRequest<IEnumerable<string>> badRequest = Assert.IsType<BadRequest<IEnumerable<string>>>(result.Result);
+		badRequest.Value.Should().Contain("Role failed");
+	}
+
+	// ── DeactivateUser ──────────────────────────────────────
+
+	[Fact]
+	public async Task DeactivateUser_ReturnsNoContent_WhenSuccessful()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+		Results<NoContent, BadRequest<string>, NotFound> result = await _controller.DeactivateUser("user-123");
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeactivateUser_ReturnsBadRequest_WhenSelfDeactivate()
+	{
+		SetupUserClaims("user-123");
+
+		Results<NoContent, BadRequest<string>, NotFound> result = await _controller.DeactivateUser("user-123");
+
+		BadRequest<string> badRequest = Assert.IsType<BadRequest<string>>(result.Result);
+		badRequest.Value.Should().Contain("Cannot deactivate your own account");
+	}
+
+	[Fact]
+	public async Task DeactivateUser_ReturnsNotFound_WhenUserDoesNotExist()
+	{
+		SetupUserClaims("admin-1");
+		_userManagerMock.Setup(m => m.FindByIdAsync("missing")).ReturnsAsync((ApplicationUser?)null);
+
+		Results<NoContent, BadRequest<string>, NotFound> result = await _controller.DeactivateUser("missing");
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	// ── AdminResetPassword ──────────────────────────────────
+
+	[Fact]
+	public async Task AdminResetPassword_ReturnsNoContent_WhenSuccessful()
+	{
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.RemovePasswordAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddPasswordAsync(user, "NewPassword1!")).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+		Results<NoContent, NotFound, BadRequest<IEnumerable<string>>> result = await _controller.AdminResetPassword(
+			user.Id,
+			new AdminResetPasswordRequest { NewPassword = "NewPassword1!" });
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task AdminResetPassword_ReturnsNotFound_WhenUserDoesNotExist()
+	{
+		_userManagerMock.Setup(m => m.FindByIdAsync("missing")).ReturnsAsync((ApplicationUser?)null);
+
+		Results<NoContent, NotFound, BadRequest<IEnumerable<string>>> result = await _controller.AdminResetPassword(
+			"missing",
+			new AdminResetPasswordRequest { NewPassword = "NewPassword1!" });
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task AdminResetPassword_ReturnsBadRequest_WhenPasswordFails()
+	{
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.RemovePasswordAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddPasswordAsync(user, "weak"))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Password too weak" }));
+
+		Results<NoContent, NotFound, BadRequest<IEnumerable<string>>> result = await _controller.AdminResetPassword(
+			user.Id,
+			new AdminResetPasswordRequest { NewPassword = "weak" });
+
+		BadRequest<IEnumerable<string>> badRequest = Assert.IsType<BadRequest<IEnumerable<string>>>(result.Result);
+		badRequest.Value.Should().Contain("Password too weak");
+	}
+}

--- a/tests/SampleData/Dtos/Core/CategoryDtoGenerator.cs
+++ b/tests/SampleData/Dtos/Core/CategoryDtoGenerator.cs
@@ -1,0 +1,35 @@
+using API.Generated.Dtos;
+
+namespace SampleData.Dtos.Core;
+
+public static class CategoryDtoGenerator
+{
+	public static CreateCategoryRequest GenerateCreateRequest()
+	{
+		return new CreateCategoryRequest
+		{
+			Name = "Test Category",
+			Description = "Test Description"
+		};
+	}
+
+	public static List<CreateCategoryRequest> GenerateCreateRequestList(int count)
+	{
+		return [.. Enumerable.Range(0, count).Select(_ => GenerateCreateRequest())];
+	}
+
+	public static UpdateCategoryRequest GenerateUpdateRequest()
+	{
+		return new UpdateCategoryRequest
+		{
+			Id = Guid.NewGuid(),
+			Name = "Test Category",
+			Description = "Test Description"
+		};
+	}
+
+	public static List<UpdateCategoryRequest> GenerateUpdateRequestList(int count)
+	{
+		return [.. Enumerable.Range(0, count).Select(_ => GenerateUpdateRequest())];
+	}
+}

--- a/tests/SampleData/Dtos/Core/ItemTemplateDtoGenerator.cs
+++ b/tests/SampleData/Dtos/Core/ItemTemplateDtoGenerator.cs
@@ -1,0 +1,45 @@
+using API.Generated.Dtos;
+
+namespace SampleData.Dtos.Core;
+
+public static class ItemTemplateDtoGenerator
+{
+	public static CreateItemTemplateRequest GenerateCreateRequest()
+	{
+		return new CreateItemTemplateRequest
+		{
+			Name = "Test Item Template",
+			DefaultCategory = "Test Category",
+			DefaultSubcategory = "Test Subcategory",
+			DefaultUnitPrice = 9.99,
+			DefaultPricingMode = "quantity",
+			DefaultItemCode = "ITEM-001",
+			Description = "Test Description"
+		};
+	}
+
+	public static List<CreateItemTemplateRequest> GenerateCreateRequestList(int count)
+	{
+		return [.. Enumerable.Range(0, count).Select(_ => GenerateCreateRequest())];
+	}
+
+	public static UpdateItemTemplateRequest GenerateUpdateRequest()
+	{
+		return new UpdateItemTemplateRequest
+		{
+			Id = Guid.NewGuid(),
+			Name = "Test Item Template",
+			DefaultCategory = "Test Category",
+			DefaultSubcategory = "Test Subcategory",
+			DefaultUnitPrice = 9.99,
+			DefaultPricingMode = "quantity",
+			DefaultItemCode = "ITEM-001",
+			Description = "Test Description"
+		};
+	}
+
+	public static List<UpdateItemTemplateRequest> GenerateUpdateRequestList(int count)
+	{
+		return [.. Enumerable.Range(0, count).Select(_ => GenerateUpdateRequest())];
+	}
+}

--- a/tests/SampleData/Dtos/Core/SubcategoryDtoGenerator.cs
+++ b/tests/SampleData/Dtos/Core/SubcategoryDtoGenerator.cs
@@ -1,0 +1,37 @@
+using API.Generated.Dtos;
+
+namespace SampleData.Dtos.Core;
+
+public static class SubcategoryDtoGenerator
+{
+	public static CreateSubcategoryRequest GenerateCreateRequest()
+	{
+		return new CreateSubcategoryRequest
+		{
+			Name = "Test Subcategory",
+			CategoryId = Guid.NewGuid(),
+			Description = "Test Description"
+		};
+	}
+
+	public static List<CreateSubcategoryRequest> GenerateCreateRequestList(int count)
+	{
+		return [.. Enumerable.Range(0, count).Select(_ => GenerateCreateRequest())];
+	}
+
+	public static UpdateSubcategoryRequest GenerateUpdateRequest()
+	{
+		return new UpdateSubcategoryRequest
+		{
+			Id = Guid.NewGuid(),
+			Name = "Test Subcategory",
+			CategoryId = Guid.NewGuid(),
+			Description = "Test Description"
+		};
+	}
+
+	public static List<UpdateSubcategoryRequest> GenerateUpdateRequestList(int count)
+	{
+		return [.. Enumerable.Range(0, count).Select(_ => GenerateUpdateRequest())];
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit tests for 8 previously untested controllers: CategoriesController, SubcategoriesController, ItemTemplatesController, TrashController, UserRolesController, UsersController, ApiKeyController, and HealthController
- Add Logout endpoint tests to existing AuthControllerTests
- Add DTO generators for Category, Subcategory, and ItemTemplate to support new tests

Resolves MGG-231

## Test plan
- All 932 tests pass (410 in Presentation.API.Tests, up from ~330)
- Pre-commit hooks pass cleanly
- `dotnet build Receipts.slnx` compiles with zero warnings