### PR TITLE
fix(client): add API request timeout to prevent infinite spinner (MGG-232)

### DIFF
--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -13,6 +13,17 @@ const baseUrl = import.meta.env.VITE_API_URL ?? "";
 
 const client = createClient<paths>({ baseUrl });
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+const timeoutMiddleware: Middleware = {
+  onRequest({ request }) {
+    if (request.signal && !request.signal.aborted) return request;
+    return new Request(request, {
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+    });
+  },
+};
+
 let refreshPromise: Promise<boolean> | null = null;
 
 async function attemptTokenRefresh(): Promise<boolean> {
@@ -24,6 +35,7 @@ async function attemptTokenRefresh(): Promise<boolean> {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ refreshToken }),
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
     });
     if (!res.ok) return false;
 
@@ -77,6 +89,7 @@ const authMiddleware: Middleware = {
   },
 };
 
+client.use(timeoutMiddleware);
 client.use(authMiddleware);
 
 export default client;

--- a/src/client/src/lib/api-errors.test.ts
+++ b/src/client/src/lib/api-errors.test.ts
@@ -1,0 +1,73 @@
+import {
+  isTimeoutError,
+  isNetworkError,
+  getConnectionErrorMessage,
+} from "./api-errors";
+
+describe("isTimeoutError", () => {
+  it("returns true for a DOMException with name TimeoutError", () => {
+    const error = new DOMException("signal timed out", "TimeoutError");
+    expect(isTimeoutError(error)).toBe(true);
+  });
+
+  it("returns false for a DOMException with a different name", () => {
+    const error = new DOMException("aborted", "AbortError");
+    expect(isTimeoutError(error)).toBe(false);
+  });
+
+  it("returns false for a plain Error", () => {
+    expect(isTimeoutError(new Error("timeout"))).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isTimeoutError(null)).toBe(false);
+    expect(isTimeoutError(undefined)).toBe(false);
+    expect(isTimeoutError("TimeoutError")).toBe(false);
+  });
+});
+
+describe("isNetworkError", () => {
+  it("returns true for a TypeError with 'Failed to fetch' message", () => {
+    const error = new TypeError("Failed to fetch");
+    expect(isNetworkError(error)).toBe(true);
+  });
+
+  it("returns false for a TypeError with a different message", () => {
+    const error = new TypeError("something else");
+    expect(isNetworkError(error)).toBe(false);
+  });
+
+  it("returns false for a plain Error with the same message", () => {
+    expect(isNetworkError(new Error("Failed to fetch"))).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isNetworkError(null)).toBe(false);
+    expect(isNetworkError(undefined)).toBe(false);
+  });
+});
+
+describe("getConnectionErrorMessage", () => {
+  it("returns timeout message for TimeoutError", () => {
+    const error = new DOMException("signal timed out", "TimeoutError");
+    expect(getConnectionErrorMessage(error)).toBe(
+      "The server is not responding. Please try again later.",
+    );
+  });
+
+  it("returns network message for Failed to fetch", () => {
+    const error = new TypeError("Failed to fetch");
+    expect(getConnectionErrorMessage(error)).toBe(
+      "Unable to connect to the server. Please check your connection and try again.",
+    );
+  });
+
+  it("returns null for a generic error", () => {
+    expect(getConnectionErrorMessage(new Error("fail"))).toBeNull();
+  });
+
+  it("returns null for non-error values", () => {
+    expect(getConnectionErrorMessage(null)).toBeNull();
+    expect(getConnectionErrorMessage("string error")).toBeNull();
+  });
+});

--- a/src/client/src/lib/api-errors.ts
+++ b/src/client/src/lib/api-errors.ts
@@ -1,0 +1,17 @@
+export function isTimeoutError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "TimeoutError";
+}
+
+export function isNetworkError(error: unknown): boolean {
+  return error instanceof TypeError && error.message === "Failed to fetch";
+}
+
+export function getConnectionErrorMessage(error: unknown): string | null {
+  if (isTimeoutError(error)) {
+    return "The server is not responding. Please try again later.";
+  }
+  if (isNetworkError(error)) {
+    return "Unable to connect to the server. Please check your connection and try again.";
+  }
+  return null;
+}

--- a/src/client/src/pages/ChangePassword.tsx
+++ b/src/client/src/pages/ChangePassword.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/form";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { getConnectionErrorMessage } from "@/lib/api-errors";
 
 const changePasswordSchema = z
   .object({
@@ -63,9 +64,10 @@ function ChangePassword() {
     setError(null);
     try {
       await changePassword(values.currentPassword, values.newPassword);
-    } catch {
+    } catch (err) {
       setError(
-        "Failed to change password. Please check your current password and try again.",
+        getConnectionErrorMessage(err) ??
+          "Failed to change password. Please check your current password and try again.",
       );
     }
   }

--- a/src/client/src/pages/Login.test.tsx
+++ b/src/client/src/pages/Login.test.tsx
@@ -115,4 +115,54 @@ describe("Login", () => {
 
     expect(await screen.findByText(/invalid email or password/i)).toBeInTheDocument();
   });
+
+  it("shows timeout error when server is not responding", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockLogin = vi
+      .fn()
+      .mockRejectedValue(new DOMException("signal timed out", "TimeoutError"));
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      mustResetPassword: false,
+      login: mockLogin,
+      logout: vi.fn(),
+      changePassword: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<Login />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(
+      await screen.findByText(/the server is not responding/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows network error when unable to connect", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockLogin = vi
+      .fn()
+      .mockRejectedValue(new TypeError("Failed to fetch"));
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      mustResetPassword: false,
+      login: mockLogin,
+      logout: vi.fn(),
+      changePassword: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<Login />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(
+      await screen.findByText(/unable to connect to the server/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/Login.tsx
+++ b/src/client/src/pages/Login.tsx
@@ -24,6 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { getConnectionErrorMessage } from "@/lib/api-errors";
 
 const loginSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
@@ -54,8 +55,11 @@ function Login() {
     setError(null);
     try {
       await login(values.email, values.password);
-    } catch {
-      setError("Invalid email or password. Please try again.");
+    } catch (err) {
+      setError(
+        getConnectionErrorMessage(err) ??
+          "Invalid email or password. Please try again.",
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Add 30s `AbortSignal.timeout` middleware to all `openapi-fetch` requests, preventing indefinite hangs when the API backend is unreachable
- Classify timeout and network errors with user-facing messages on Login and ChangePassword pages
- Add `api-errors.ts` utility with `isTimeoutError`, `isNetworkError`, and `getConnectionErrorMessage` helpers

## Test plan
- [x] All 820 existing + new client tests pass (`npx vitest run`)
- [x] New `api-errors.test.ts` covers all three utility functions (timeout, network, null cases)
- [x] New Login.test.tsx cases verify timeout shows "not responding" and network error shows "Unable to connect"
- [ ] Manual: Start Aspire, verify login works normally
- [ ] Manual: Stop API resource, attempt login — should show "The server is not responding" within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)