### PR TITLE
fix(infrastructure): remove PricingMode database default to fix EF Core sentinel warning (MGG-238)

### DIFF
--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -612,8 +612,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 				.HasConversion(
 					v => v.ToString().ToLowerInvariant(),
 					v => Enum.Parse<PricingMode>(v, ignoreCase: true))
-				.HasMaxLength(8)
-				.HasDefaultValueSql("'quantity'");
+				.HasMaxLength(8);
 
 			entity.Navigation(e => e.Receipt)
 				.AutoInclude();

--- a/src/Infrastructure/Migrations/20260305115230_RemovePricingModeDefaultValue.Designer.cs
+++ b/src/Infrastructure/Migrations/20260305115230_RemovePricingModeDefaultValue.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260305115230_RemovePricingModeDefaultValue")]
+    partial class RemovePricingModeDefaultValue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260305115230_RemovePricingModeDefaultValue.cs
+++ b/src/Infrastructure/Migrations/20260305115230_RemovePricingModeDefaultValue.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class RemovePricingModeDefaultValue : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AlterColumn<string>(
+			name: "PricingMode",
+			table: "ReceiptItems",
+			type: "text",
+			maxLength: 8,
+			nullable: false,
+			oldClrType: typeof(string),
+			oldType: "text",
+			oldMaxLength: 8,
+			oldDefaultValueSql: "'quantity'");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AlterColumn<string>(
+			name: "PricingMode",
+			table: "ReceiptItems",
+			type: "text",
+			maxLength: 8,
+			nullable: false,
+			defaultValueSql: "'quantity'",
+			oldClrType: typeof(string),
+			oldType: "text",
+			oldMaxLength: 8);
+	}
+}


### PR DESCRIPTION
## Summary

- Removes `HasDefaultValueSql("'quantity'")` from the `ReceiptItemEntity.PricingMode` EF Core configuration
- Adds migration `RemovePricingModeDefaultValue` to drop the SQL column default
- Fixes EF Core runtime warning where it couldn't distinguish between an explicitly-set `PricingMode.Quantity` (enum value 0 / CLR default) and "no value set," causing the DB default to silently override application-supplied values

The SQL default was only needed for the initial migration that added the column. The application always supplies PricingMode through the domain model constructor, entity property initializer, and DTO defaults.

## Test plan

- [x] All 949 existing tests pass
- [x] All 8 pre-commit hook checks pass (lint, format, build, DTO staleness, drift, tests, tsc, eslint)
- [x] Verify EF Core sentinel warning no longer appears on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)