### PR TITLE
fix(client): align navbar dropdown menus to trigger elements (MGG-241)

### DIFF
--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -251,7 +251,7 @@ export function Layout() {
               Receipts
             </Link>
             <Separator orientation="vertical" className="h-6" />
-            <NavigationMenu>
+            <NavigationMenu viewport={false}>
               <NavigationMenuList>
                 <NavigationMenuItem>
                   <NavigationMenuLink asChild>


### PR DESCRIPTION
## Summary
- Pass `viewport={false}` to `<NavigationMenu>` in `Layout.tsx` so each dropdown renders inside its `NavigationMenuItem` (which has `position: relative`) instead of the shared `NavigationMenuViewport` container
- Fixes dropdown menus all appearing at the left edge of the nav instead of beneath their respective triggers
- The `NavigationMenuContent` component already has `group-data-[viewport=false]` styles for border, shadow, rounded corners, and animations

## Test plan
- [x] Existing Layout tests pass (23/23)
- [ ] Visual verification: each dropdown anchors to its trigger element

🤖 Generated with [Claude Code](https://claude.com/claude-code)