### PR TITLE
fix(client): persist forced password change across refreshes (MGG-240)

### DIFF
--- a/src/client/src/contexts/AuthContext.test.tsx
+++ b/src/client/src/contexts/AuthContext.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/lib/auth", () => ({
   setTokens: vi.fn(),
   clearTokens: vi.fn(),
   addTokenRefreshListener: vi.fn(() => vi.fn()),
+  addPasswordChangeRequiredListener: vi.fn(() => vi.fn()),
 }));
 
 import client from "@/lib/api-client";
@@ -83,6 +84,7 @@ describe("AuthProvider", () => {
     mockedAuth.parseJwtPayload.mockReturnValue({
       email: "user@test.com",
       roles: ["User"],
+      mustResetPassword: false,
     });
 
     render(
@@ -92,6 +94,47 @@ describe("AuthProvider", () => {
     );
 
     expect(screen.getByTestId("user")).toHaveTextContent("user@test.com");
+  });
+
+  it("initializes mustResetPassword from JWT claim", () => {
+    const token = makeJwt("admin@test.com", "Admin");
+    mockedAuth.isAuthenticated.mockReturnValue(true);
+    mockedAuth.getAccessToken.mockReturnValue(token);
+    mockedAuth.parseJwtPayload.mockReturnValue({
+      email: "admin@test.com",
+      roles: ["Admin"],
+      mustResetPassword: true,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId("must-reset")).toHaveTextContent("true");
+  });
+
+  it("sets mustResetPassword when password-change-required listener fires", () => {
+    let capturedListener: (() => void) | undefined;
+    mockedAuth.addPasswordChangeRequiredListener.mockImplementation((cb: () => void) => {
+      capturedListener = cb;
+      return vi.fn();
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId("must-reset")).toHaveTextContent("false");
+
+    act(() => {
+      capturedListener!();
+    });
+
+    expect(screen.getByTestId("must-reset")).toHaveTextContent("true");
   });
 
   it("login calls POST /api/auth/login, stores tokens, and sets user", async () => {

--- a/src/client/src/contexts/AuthContext.tsx
+++ b/src/client/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ import {
   parseJwtPayload,
   setTokens,
   addTokenRefreshListener,
+  addPasswordChangeRequiredListener,
 } from "@/lib/auth";
 import type { JwtPayload } from "@/lib/auth";
 import { AuthContext } from "@/contexts/auth-context";
@@ -20,13 +21,24 @@ function getInitialUser(): JwtPayload | null {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<JwtPayload | null>(getInitialUser);
-  const [mustResetPassword, setMustResetPassword] = useState(false);
+  const [mustResetPassword, setMustResetPassword] = useState(
+    () => getInitialUser()?.mustResetPassword ?? false,
+  );
 
   useEffect(() => {
-    return addTokenRefreshListener(() => {
+    const unsubRefresh = addTokenRefreshListener(() => {
       const token = getAccessToken();
-      setUser(token ? parseJwtPayload(token) : null);
+      const parsed = token ? parseJwtPayload(token) : null;
+      setUser(parsed);
+      setMustResetPassword(parsed?.mustResetPassword ?? false);
     });
+    const unsubPasswordChange = addPasswordChangeRequiredListener(() => {
+      setMustResetPassword(true);
+    });
+    return () => {
+      unsubRefresh();
+      unsubPasswordChange();
+    };
   }, []);
 
   const login = useCallback(async (email: string, password: string) => {

--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -7,6 +7,7 @@ import {
   setTokens,
   clearTokens,
   notifyTokenRefresh,
+  notifyPasswordChangeRequired,
 } from "@/lib/auth";
 
 const baseUrl = import.meta.env.VITE_API_URL ?? "";
@@ -58,6 +59,19 @@ const authMiddleware: Middleware = {
     return request;
   },
   async onResponse({ request, response }) {
+    if (response.status === 403) {
+      const cloned = response.clone();
+      try {
+        const body = await cloned.json();
+        if (body?.detail === "Password change required") {
+          notifyPasswordChangeRequired();
+        }
+      } catch {
+        // Not JSON — ignore
+      }
+      return response;
+    }
+
     if (response.status !== 401) return response;
 
     // Avoid refresh loop for auth endpoints

--- a/src/client/src/lib/auth.test.ts
+++ b/src/client/src/lib/auth.test.ts
@@ -8,6 +8,8 @@ import {
   parseJwtPayload,
   addTokenRefreshListener,
   notifyTokenRefresh,
+  addPasswordChangeRequiredListener,
+  notifyPasswordChangeRequired,
 } from "./auth";
 
 describe("token storage", () => {
@@ -62,6 +64,7 @@ describe("parseJwtPayload", () => {
     expect(result).toEqual({
       email: "user@example.com",
       roles: ["Admin", "User"],
+      mustResetPassword: false,
     });
   });
 
@@ -75,7 +78,25 @@ describe("parseJwtPayload", () => {
     expect(result).toEqual({
       email: "ms@example.com",
       roles: ["Admin"],
+      mustResetPassword: false,
     });
+  });
+
+  it("parses must_reset_password claim as true", () => {
+    const token = encodePayload({
+      email: "user@example.com",
+      must_reset_password: "true",
+    });
+    const result = parseJwtPayload(token);
+    expect(result?.mustResetPassword).toBe(true);
+  });
+
+  it("parses must_reset_password claim as false when absent", () => {
+    const token = encodePayload({
+      email: "user@example.com",
+    });
+    const result = parseJwtPayload(token);
+    expect(result?.mustResetPassword).toBe(false);
   });
 
   it("wraps a single role string into an array", () => {
@@ -134,6 +155,33 @@ describe("token refresh listeners", () => {
 
     unsub();
     notifyTokenRefresh();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("password change required listeners", () => {
+  it("calls all registered listeners on notify", () => {
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
+    const unsub1 = addPasswordChangeRequiredListener(listener1);
+    const unsub2 = addPasswordChangeRequiredListener(listener2);
+
+    notifyPasswordChangeRequired();
+
+    expect(listener1).toHaveBeenCalledOnce();
+    expect(listener2).toHaveBeenCalledOnce();
+
+    unsub1();
+    unsub2();
+  });
+
+  it("unsubscribe prevents future calls", () => {
+    const listener = vi.fn();
+    const unsub = addPasswordChangeRequiredListener(listener);
+
+    unsub();
+    notifyPasswordChangeRequired();
 
     expect(listener).not.toHaveBeenCalled();
   });

--- a/src/client/src/lib/auth.ts
+++ b/src/client/src/lib/auth.ts
@@ -13,6 +13,18 @@ export function notifyTokenRefresh(): void {
   tokenRefreshListeners.forEach((cb) => cb());
 }
 
+type PasswordChangeRequiredListener = () => void;
+const passwordChangeRequiredListeners = new Set<PasswordChangeRequiredListener>();
+
+export function addPasswordChangeRequiredListener(cb: PasswordChangeRequiredListener): () => void {
+  passwordChangeRequiredListeners.add(cb);
+  return () => passwordChangeRequiredListeners.delete(cb);
+}
+
+export function notifyPasswordChangeRequired(): void {
+  passwordChangeRequiredListeners.forEach((cb) => cb());
+}
+
 export function getAccessToken(): string | null {
   return localStorage.getItem(LS_ACCESS_KEY);
 }
@@ -38,6 +50,7 @@ export function isAuthenticated(): boolean {
 export interface JwtPayload {
   email: string;
   roles: string[];
+  mustResetPassword: boolean;
 }
 
 export function parseJwtPayload(token: string): JwtPayload | null {
@@ -59,7 +72,8 @@ export function parseJwtPayload(token: string): JwtPayload | null {
       : roleClaim
         ? [roleClaim]
         : [];
-    return { email, roles };
+    const mustResetPassword = payload.must_reset_password === "true" || payload.must_reset_password === true;
+    return { email, roles, mustResetPassword };
   } catch {
     return null;
   }

--- a/src/client/src/pages/ChangePassword.test.tsx
+++ b/src/client/src/pages/ChangePassword.test.tsx
@@ -121,4 +121,32 @@ describe("ChangePassword", () => {
 
     expect(await screen.findByText(/failed to change password/i)).toBeInTheDocument();
   });
+
+  it("shows backend error_description when available", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const backendError = {
+      error: "invalid_request",
+      error_description: "Passwords must have at least one uppercase ('A'-'Z').",
+    };
+    const mockChangePassword = vi.fn().mockRejectedValue(backendError);
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: { email: "test@example.com" } as ReturnType<typeof useAuth>["user"],
+      mustResetPassword: true,
+      changePassword: mockChangePassword,
+      login: vi.fn(),
+      logout: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<ChangePassword />);
+    await user.type(screen.getByLabelText(/^current password$/i), "OldPass123");
+    await user.type(screen.getByLabelText(/^new password$/i), "weakpass");
+    await user.type(screen.getByLabelText(/^confirm new password$/i), "weakpass");
+    await user.click(screen.getByRole("button", { name: /change password/i }));
+
+    expect(
+      await screen.findByText("Passwords must have at least one uppercase ('A'-'Z')."),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/ChangePassword.tsx
+++ b/src/client/src/pages/ChangePassword.tsx
@@ -63,12 +63,20 @@ function ChangePassword() {
     setError(null);
     try {
       await changePassword(values.currentPassword, values.newPassword);
-    } catch (err) {
+    } catch (err: unknown) {
       if (isTimeoutError(err)) {
         setError("Request timed out. Please try again.");
       } else {
+        const description =
+          err != null &&
+          typeof err === "object" &&
+          "error_description" in err &&
+          typeof (err as Record<string, unknown>).error_description === "string"
+            ? (err as Record<string, string>).error_description
+            : null;
         setError(
-          "Failed to change password. Please check your current password and try again.",
+          description ??
+            "Failed to change password. Please check your current password and try again.",
         );
       }
     }


### PR DESCRIPTION
## Summary
- Parse `must_reset_password` JWT claim so `mustResetPassword` survives page refreshes instead of being lost in React state
- Intercept 403 "Password change required" responses in API middleware to prevent bypassing the change-password screen via navigation
- Surface backend `error_description` (e.g., Identity password policy violations) on the change-password page instead of a generic fallback message

## Test plan
- [x] All 813 client tests pass (`npx vitest run`)
- [x] All 927 backend tests pass (`dotnet test`)
- [x] All pre-commit hooks pass (lint, typecheck, build, format)
- [ ] Manual: log in as seeded admin → refresh page → still redirected to change-password
- [ ] Manual: log in as seeded admin → navigate to another route → redirected back to change-password
- [ ] Manual: submit weak password → see specific backend error (e.g., "must have uppercase")

🤖 Generated with [Claude Code](https://claude.com/claude-code)