### PR TITLE
feat(client): add timeout warning to loading buttons (MGG-236)

### DIFF
--- a/src/client/src/components/AccountForm.tsx
+++ b/src/client/src/components/AccountForm.tsx
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import {
   Form,
@@ -13,7 +14,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Spinner } from "@/components/ui/spinner";
 
 const accountSchema = z.object({
   accountCode: z.string().min(1, "Account code is required"),
@@ -106,14 +106,11 @@ export function AccountForm({
           <Button type="button" variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting && <Spinner size="sm" />}
-            {isSubmitting
-              ? "Saving..."
-              : mode === "create"
-                ? "Create Account"
-                : "Update Account"}
-          </Button>
+          <SubmitButton
+            isSubmitting={isSubmitting ?? false}
+            label={mode === "create" ? "Create Account" : "Update Account"}
+            loadingLabel="Saving..."
+          />
         </div>
       </form>
     </Form>

--- a/src/client/src/components/CategoryForm.tsx
+++ b/src/client/src/components/CategoryForm.tsx
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import {
   Form,
@@ -13,7 +14,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Spinner } from "@/components/ui/spinner";
 
 const categorySchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -84,14 +84,11 @@ export function CategoryForm({
           <Button type="button" variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting && <Spinner size="sm" />}
-            {isSubmitting
-              ? "Saving..."
-              : mode === "create"
-                ? "Create Category"
-                : "Update Category"}
-          </Button>
+          <SubmitButton
+            isSubmitting={isSubmitting ?? false}
+            label={mode === "create" ? "Create Category" : "Update Category"}
+            loadingLabel="Saving..."
+          />
         </div>
       </form>
     </Form>

--- a/src/client/src/components/ReceiptForm.tsx
+++ b/src/client/src/components/ReceiptForm.tsx
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import {
@@ -14,7 +15,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Spinner } from "@/components/ui/spinner";
 
 const receiptSchema = z.object({
   description: z.string().optional(),
@@ -117,14 +117,11 @@ export function ReceiptForm({
           <Button type="button" variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting && <Spinner size="sm" />}
-            {isSubmitting
-              ? "Saving..."
-              : mode === "create"
-                ? "Create Receipt"
-                : "Update Receipt"}
-          </Button>
+          <SubmitButton
+            isSubmitting={isSubmitting ?? false}
+            label={mode === "create" ? "Create Receipt" : "Update Receipt"}
+            loadingLabel="Saving..."
+          />
         </div>
       </form>
     </Form>

--- a/src/client/src/components/SubcategoryForm.tsx
+++ b/src/client/src/components/SubcategoryForm.tsx
@@ -6,6 +6,7 @@ import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useCategories } from "@/hooks/useCategories";
 import { Combobox } from "@/components/ui/combobox";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import {
   Form,
@@ -15,7 +16,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Spinner } from "@/components/ui/spinner";
 
 const subcategorySchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -121,14 +121,11 @@ export function SubcategoryForm({
           <Button type="button" variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting && <Spinner size="sm" />}
-            {isSubmitting
-              ? "Saving..."
-              : mode === "create"
-                ? "Create Subcategory"
-                : "Update Subcategory"}
-          </Button>
+          <SubmitButton
+            isSubmitting={isSubmitting ?? false}
+            label={mode === "create" ? "Create Subcategory" : "Update Subcategory"}
+            loadingLabel="Saving..."
+          />
         </div>
       </form>
     </Form>

--- a/src/client/src/components/ui/submit-button.tsx
+++ b/src/client/src/components/ui/submit-button.tsx
@@ -1,0 +1,33 @@
+import { TriangleAlertIcon } from "lucide-react";
+import { useSubmitTimeout } from "@/hooks/useSubmitTimeout";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+
+interface SubmitButtonProps
+  extends Omit<React.ComponentProps<typeof Button>, "type" | "children"> {
+  isSubmitting: boolean;
+  label: string;
+  loadingLabel: string;
+}
+
+export function SubmitButton({
+  isSubmitting,
+  label,
+  loadingLabel,
+  disabled,
+  ...props
+}: SubmitButtonProps) {
+  const { isWarning } = useSubmitTimeout(isSubmitting);
+
+  return (
+    <Button type="submit" disabled={disabled ?? isSubmitting} {...props}>
+      {isSubmitting &&
+        (isWarning ? (
+          <TriangleAlertIcon className="size-4 text-amber-500" />
+        ) : (
+          <Spinner size="sm" />
+        ))}
+      {isSubmitting ? (isWarning ? "Still working..." : loadingLabel) : label}
+    </Button>
+  );
+}

--- a/src/client/src/components/ui/submit-button.tsx
+++ b/src/client/src/components/ui/submit-button.tsx
@@ -20,7 +20,7 @@ export function SubmitButton({
   const { isWarning } = useSubmitTimeout(isSubmitting);
 
   return (
-    <Button type="submit" disabled={disabled ?? isSubmitting} {...props}>
+    <Button type="submit" disabled={disabled || isSubmitting} {...props}>
       {isSubmitting &&
         (isWarning ? (
           <TriangleAlertIcon className="size-4 text-amber-500" />

--- a/src/client/src/hooks/useSubmitTimeout.test.ts
+++ b/src/client/src/hooks/useSubmitTimeout.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, act } from "@testing-library/react";
+import { useSubmitTimeout } from "./useSubmitTimeout";
+
+describe("useSubmitTimeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns isWarning: false when not submitting", () => {
+    const { result } = renderHook(() => useSubmitTimeout(false));
+    expect(result.current.isWarning).toBe(false);
+  });
+
+  it("returns isWarning: false immediately when submitting starts", () => {
+    const { result } = renderHook(() => useSubmitTimeout(true));
+    expect(result.current.isWarning).toBe(false);
+  });
+
+  it("returns isWarning: true after 5 seconds of submitting", () => {
+    const { result } = renderHook(() => useSubmitTimeout(true));
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+
+    expect(result.current.isWarning).toBe(true);
+  });
+
+  it("resets isWarning to false when submitting ends", () => {
+    const { result, rerender } = renderHook(
+      ({ isSubmitting }) => useSubmitTimeout(isSubmitting),
+      { initialProps: { isSubmitting: true } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(result.current.isWarning).toBe(true);
+
+    rerender({ isSubmitting: false });
+    expect(result.current.isWarning).toBe(false);
+  });
+
+  it("cleans up timer on unmount", () => {
+    const { unmount } = renderHook(() => useSubmitTimeout(true));
+    unmount();
+
+    // Advancing timers after unmount should not cause errors
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+  });
+});

--- a/src/client/src/hooks/useSubmitTimeout.ts
+++ b/src/client/src/hooks/useSubmitTimeout.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+const WARNING_DELAY_MS = 5_000;
+
+export function useSubmitTimeout(isSubmitting: boolean): {
+  isWarning: boolean;
+} {
+  const [isWarning, setIsWarning] = useState(false);
+
+  useEffect(() => {
+    if (!isSubmitting) {
+      setIsWarning(false);
+      return;
+    }
+
+    const timer = setTimeout(() => setIsWarning(true), WARNING_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [isSubmitting]);
+
+  return { isWarning };
+}

--- a/src/client/src/hooks/useSubmitTimeout.ts
+++ b/src/client/src/hooks/useSubmitTimeout.ts
@@ -5,17 +5,31 @@ const WARNING_DELAY_MS = 5_000;
 export function useSubmitTimeout(isSubmitting: boolean): {
   isWarning: boolean;
 } {
-  const [isWarning, setIsWarning] = useState(false);
+  const [warningGeneration, setWarningGeneration] = useState<number | null>(
+    null,
+  );
+  const [submitGeneration, setSubmitGeneration] = useState(0);
+
+  // Track submission transitions: increment generation each time isSubmitting becomes true
+  const [wasSubmitting, setWasSubmitting] = useState(false);
+  if (isSubmitting && !wasSubmitting) {
+    setSubmitGeneration((g) => g + 1);
+    setWasSubmitting(true);
+  } else if (!isSubmitting && wasSubmitting) {
+    setWasSubmitting(false);
+  }
 
   useEffect(() => {
     if (!isSubmitting) {
-      setIsWarning(false);
       return;
     }
 
-    const timer = setTimeout(() => setIsWarning(true), WARNING_DELAY_MS);
+    const timer = setTimeout(
+      () => setWarningGeneration(submitGeneration),
+      WARNING_DELAY_MS,
+    );
     return () => clearTimeout(timer);
-  }, [isSubmitting]);
+  }, [isSubmitting, submitGeneration]);
 
-  return { isWarning };
+  return { isWarning: isSubmitting && warningGeneration === submitGeneration };
 }

--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -13,15 +13,17 @@ const baseUrl = import.meta.env.VITE_API_URL ?? "";
 
 const client = createClient<paths>({
   baseUrl,
-  fetch: (input, init) =>
-    fetch(input, { ...init, signal: AbortSignal.timeout(30_000) }),
+  fetch: (input, init) => {
+    const timeoutSignal = AbortSignal.timeout(30_000);
+    const signal = init?.signal
+      ? AbortSignal.any([timeoutSignal, init.signal])
+      : timeoutSignal;
+    return fetch(input, { ...init, signal });
+  },
 });
 
 export function isTimeoutError(error: unknown): boolean {
-  return (
-    error instanceof DOMException &&
-    (error.name === "TimeoutError" || error.name === "AbortError")
-  );
+  return error instanceof DOMException && error.name === "TimeoutError";
 }
 
 let refreshPromise: Promise<boolean> | null = null;

--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -11,7 +11,18 @@ import {
 
 const baseUrl = import.meta.env.VITE_API_URL ?? "";
 
-const client = createClient<paths>({ baseUrl });
+const client = createClient<paths>({
+  baseUrl,
+  fetch: (input, init) =>
+    fetch(input, { ...init, signal: AbortSignal.timeout(30_000) }),
+});
+
+export function isTimeoutError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+  );
+}
 
 let refreshPromise: Promise<boolean> | null = null;
 

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -7,7 +7,9 @@ import {
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { showApiError, showNetworkError } from "@/lib/toast";
+import { isTimeoutError } from "@/lib/api-client";
 import { ThemeProvider } from "next-themes";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/contexts/AuthContext";
@@ -18,6 +20,11 @@ import "./index.css";
 const router = createBrowserRouter(routeConfig);
 
 function handleGlobalError(error: unknown) {
+  if (isTimeoutError(error)) {
+    toast.error("Request timed out. Please try again.");
+    return;
+  }
+
   if (
     error &&
     typeof error === "object" &&

--- a/src/client/src/pages/ChangePassword.tsx
+++ b/src/client/src/pages/ChangePassword.tsx
@@ -5,8 +5,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
+import { isTimeoutError } from "@/lib/api-client";
+import { SubmitButton } from "@/components/ui/submit-button";
 import {
   Card,
   CardContent,
@@ -63,10 +63,14 @@ function ChangePassword() {
     setError(null);
     try {
       await changePassword(values.currentPassword, values.newPassword);
-    } catch {
-      setError(
-        "Failed to change password. Please check your current password and try again.",
-      );
+    } catch (err) {
+      if (isTimeoutError(err)) {
+        setError("Request timed out. Please try again.");
+      } else {
+        setError(
+          "Failed to change password. Please check your current password and try again.",
+        );
+      }
     }
   }
 
@@ -139,16 +143,12 @@ function ChangePassword() {
                 </FormItem>
               )}
             />
-            <Button
-              type="submit"
+            <SubmitButton
+              isSubmitting={form.formState.isSubmitting}
+              label="Change Password"
+              loadingLabel="Changing password..."
               className="w-full"
-              disabled={form.formState.isSubmitting}
-            >
-              {form.formState.isSubmitting && <Spinner size="sm" />}
-              {form.formState.isSubmitting
-                ? "Changing password..."
-                : "Change Password"}
-            </Button>
+            />
           </form>
         </Form>
       </CardContent>

--- a/src/client/src/pages/Login.tsx
+++ b/src/client/src/pages/Login.tsx
@@ -5,8 +5,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
+import { isTimeoutError } from "@/lib/api-client";
+import { SubmitButton } from "@/components/ui/submit-button";
 import {
   Card,
   CardContent,
@@ -54,8 +54,12 @@ function Login() {
     setError(null);
     try {
       await login(values.email, values.password);
-    } catch {
-      setError("Invalid email or password. Please try again.");
+    } catch (err) {
+      if (isTimeoutError(err)) {
+        setError("Request timed out. Please try again.");
+      } else {
+        setError("Invalid email or password. Please try again.");
+      }
     }
   }
 
@@ -110,14 +114,12 @@ function Login() {
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
+              <SubmitButton
+                isSubmitting={form.formState.isSubmitting}
+                label="Sign In"
+                loadingLabel="Signing in..."
                 className="w-full"
-                disabled={form.formState.isSubmitting}
-              >
-                {form.formState.isSubmitting && <Spinner size="sm" />}
-                {form.formState.isSubmitting ? "Signing in..." : "Sign In"}
-              </Button>
+              />
             </form>
           </Form>
         </CardContent>


### PR DESCRIPTION
## Summary
- Add `useSubmitTimeout` hook and `SubmitButton` component that shows an amber warning icon + "Still working..." text after 5 seconds of loading
- Add 30-second API timeout via `AbortSignal.timeout()` on all requests with specific timeout error messaging
- Replace inline loading button patterns across all 6 forms (Login, ChangePassword, Account, Category, Receipt, Subcategory) with the new `SubmitButton` component

Resolves MGG-236

## Test plan
- `npx tsc --noEmit` passes with no type errors
- `npx vitest run src/hooks/useSubmitTimeout.test.ts` — all 5 tests pass (timer behavior, reset, cleanup)
- Manual: throttle network in DevTools to "Slow 3G", submit any form, verify warning state appears after 5s
- Manual: block network entirely, verify timeout toast appears after 30s