### PR TITLE
ci: skip arm64 build on pull requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Skip the arm64 QEMU build on pull request events to save ~18 min of CI time
- PR builds never push images, so the multi-arch build is unnecessary
- Arm64 builds still run on pushes to main and tag events

## Test plan
- [ ] CI validates workflow syntax when this PR is opened
- [ ] Verify PR build only targets `linux/amd64`
- [ ] Verify merge-to-main build targets both `linux/amd64` and `linux/arm64`

Resolves MGG-245

🤖 Generated with [Claude Code](https://claude.com/claude-code)