### PR TITLE
perf(infra): switch GHA cache to mode=min

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Run Trivy vulnerability scanner
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- Switch Docker build GHA cache export from `mode=max` to `mode=min` in `.github/workflows/docker-publish.yml`
- `mode=max` exports all intermediate layers (~10.6 min); `mode=min` only caches final image layers, saving 5-10 minutes per build
- Dockerfile layers don't change frequently, so caching only final layers is sufficient

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Monitor next build on `phase-6/container-architecture` for reduced cache export time
- [ ] Confirm subsequent builds still get cache hits on final layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)