### PR TITLE
Fix .map is not a function on /trips and TransactionForm (MGG-246)

### DIFF
--- a/src/client/src/components/TransactionForm.test.tsx
+++ b/src/client/src/components/TransactionForm.test.tsx
@@ -8,18 +8,28 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
 
 vi.mock("@/hooks/useReceipts", () => ({
   useReceipts: vi.fn(() => ({
-    data: [
-      { id: "r-1", description: "Walmart Trip", location: "Walmart", date: "2024-01-15" },
-    ],
+    data: {
+      data: [
+        { id: "r-1", description: "Walmart Trip", location: "Walmart", date: "2024-01-15" },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    },
     isLoading: false,
   })),
 }));
 
 vi.mock("@/hooks/useAccounts", () => ({
   useAccounts: vi.fn(() => ({
-    data: [
-      { id: "a-1", name: "Checking", accountCode: "CHK-001" },
-    ],
+    data: {
+      data: [
+        { id: "a-1", name: "Checking", accountCode: "CHK-001" },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    },
     isLoading: false,
   })),
 }));

--- a/src/client/src/components/TransactionForm.tsx
+++ b/src/client/src/components/TransactionForm.tsx
@@ -52,13 +52,13 @@ export function TransactionForm({
 
   const receiptOptions = useMemo(
     () =>
-      ((receipts as { id: string; description?: string | null; location: string; date: string }[] | undefined) ?? []).map(receiptToOption),
+      ((receipts?.data as { id: string; description?: string | null; location: string; date: string }[] | undefined) ?? []).map(receiptToOption),
     [receipts],
   );
 
   const accountOptions = useMemo(
     () =>
-      ((accounts as { id: string; name: string; accountCode: string }[] | undefined) ?? []).map(accountToOption),
+      ((accounts?.data as { id: string; name: string; accountCode: string }[] | undefined) ?? []).map(accountToOption),
     [accounts],
   );
 

--- a/src/client/src/pages/Trips.test.tsx
+++ b/src/client/src/pages/Trips.test.tsx
@@ -16,7 +16,7 @@ vi.mock("@/hooks/useTrips", () => ({
 }));
 
 vi.mock("@/hooks/useReceipts", () => ({
-  useReceipts: vi.fn(() => ({ data: [], isLoading: false })),
+  useReceipts: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
 }));
 
 vi.mock("@/lib/combobox-options", () => ({

--- a/src/client/src/pages/Trips.tsx
+++ b/src/client/src/pages/Trips.tsx
@@ -36,7 +36,7 @@ function Trips() {
 
   const receiptOptions = useMemo(
     () =>
-      ((receipts as { id: string; description?: string | null; location: string; date: string }[] | undefined) ?? []).map(receiptToOption),
+      ((receipts?.data as { id: string; description?: string | null; location: string; date: string }[] | undefined) ?? []).map(receiptToOption),
     [receipts],
   );
 


### PR DESCRIPTION
## Summary
- `useReceipts()` and `useAccounts()` return paginated response objects `{ data: T[], total, ... }`, not arrays
- Three locations cast the full response object to an array type and called `.map()` on it, causing a runtime crash
- Fixed `Trips.tsx:39`, `TransactionForm.tsx:55`, and `TransactionForm.tsx:61` to access `.data` before mapping

## Test plan
- [ ] Navigate to /trips — receipt combobox loads without error
- [ ] Open the create transaction form — receipt and account comboboxes load without error
- [ ] Verify selecting items in all three comboboxes works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)