### PR TITLE
fix: normalize DateTimeOffset to UTC via global EF Core converter (MGG-258)

### DIFF
--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -360,6 +360,15 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
 		if (columnTypes.TryGetValue(baseType, out string? columnType))
 		{
+			// Npgsql rejects DateTimeOffset with non-zero offset for timestamptz columns.
+			// Normalize all DateTimeOffset values to UTC before persisting.
+			if (baseType == typeof(DateTimeOffset))
+			{
+				property.SetValueConverter(new ValueConverter<DateTimeOffset, DateTimeOffset>(
+					v => v.ToUniversalTime(),
+					v => v.ToUniversalTime()));
+			}
+
 			return columnType;
 		}
 

--- a/tests/Infrastructure.Tests/DateTimeOffsetUtcConverterTests.cs
+++ b/tests/Infrastructure.Tests/DateTimeOffsetUtcConverterTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Infrastructure.Tests;
+
+public class DateTimeOffsetUtcConverterTests
+{
+	[Fact]
+	public void NpgsqlModel_DateTimeOffsetProperties_HaveUtcConverter()
+	{
+		// Arrange — use the DesignTimeDbContextFactory which configures Npgsql
+		DesignTimeDbContextFactory factory = new();
+		Environment.SetEnvironmentVariable("POSTGRES_CONNECTION_STRING",
+			"Host=localhost;Database=testdb;Username=testuser;Password=testpass");
+
+		using ApplicationDbContext context = factory.CreateDbContext([]);
+		IModel model = context.Model;
+
+		// Act + Assert — every DateTimeOffset property should have a value converter
+		foreach (IEntityType entityType in model.GetEntityTypes())
+		{
+			foreach (IProperty property in entityType.GetProperties())
+			{
+				Type baseType = Nullable.GetUnderlyingType(property.ClrType) ?? property.ClrType;
+				if (baseType != typeof(DateTimeOffset))
+				{
+					continue;
+				}
+
+				ValueConverter? converter = property.GetValueConverter();
+				Assert.True(converter is not null,
+					$"{entityType.ClrType.Name}.{property.Name} (DateTimeOffset) is missing a UTC value converter");
+			}
+		}
+	}
+
+	[Fact]
+	public void UtcConverter_ConvertsNonUtcOffset_ToUtc()
+	{
+		// Arrange — use the DesignTimeDbContextFactory which configures Npgsql
+		DesignTimeDbContextFactory factory = new();
+		Environment.SetEnvironmentVariable("POSTGRES_CONNECTION_STRING",
+			"Host=localhost;Database=testdb;Username=testuser;Password=testpass");
+
+		using ApplicationDbContext context = factory.CreateDbContext([]);
+
+		// Find a DateTimeOffset property and get its converter
+		IProperty dtoProperty = context.Model
+			.GetEntityTypes()
+			.SelectMany(e => e.GetProperties())
+			.First(p => (Nullable.GetUnderlyingType(p.ClrType) ?? p.ClrType) == typeof(DateTimeOffset));
+
+		ValueConverter converter = dtoProperty.GetValueConverter()!;
+
+		// Act — convert a DateTimeOffset with -05:00 offset
+		DateTimeOffset eastern = new(2026, 3, 6, 12, 0, 0, TimeSpan.FromHours(-5));
+		object? result = converter.ConvertToProvider(eastern);
+
+		// Assert — should be normalized to UTC (offset = 0, time adjusted)
+		DateTimeOffset utcResult = Assert.IsType<DateTimeOffset>(result);
+		Assert.Equal(TimeSpan.Zero, utcResult.Offset);
+		Assert.Equal(new DateTimeOffset(2026, 3, 6, 17, 0, 0, TimeSpan.Zero), utcResult);
+	}
+}


### PR DESCRIPTION
## Summary

- Add a global `ValueConverter<DateTimeOffset, DateTimeOffset>` in `ApplicationDbContext.GetColumnType()` that normalizes all `DateTimeOffset` values to UTC before persisting
- Fixes `POST /api/apikeys` returning 500 when the client sends an `ExpiresAt` with a non-UTC offset (e.g., `-05:00`)
- Future-proofs all entities: any `DateTimeOffset` property will be automatically UTC-normalized, preventing Npgsql's `ArgumentException` for non-zero offsets on `timestamptz` columns

## Test plan

- [x] New test: `NpgsqlModel_DateTimeOffsetProperties_HaveUtcConverter` — verifies every `DateTimeOffset` property in the model has a UTC converter
- [x] New test: `UtcConverter_ConvertsNonUtcOffset_ToUtc` — verifies a `-05:00` offset is normalized to `+00:00`
- [ ] Manual: `POST /api/apikeys` with a non-UTC `ExpiresAt` no longer returns 500

Closes MGG-258

🤖 Generated with [Claude Code](https://claude.com/claude-code)