### PR TITLE
feat(api,client): buffer SignalR broadcasts and aggregate client toasts (MGG-261)

### DIFF
--- a/src/Presentation/API/API.csproj
+++ b/src/Presentation/API/API.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Presentation.API.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/src/Presentation/API/Hubs/EntityChangeNotification.cs
+++ b/src/Presentation/API/Hubs/EntityChangeNotification.cs
@@ -1,3 +1,3 @@
 namespace API.Hubs;
 
-public record EntityChangeNotification(string EntityType, string ChangeType, Guid? Id);
+public record EntityChangeNotification(string EntityType, string ChangeType, Guid? Id, int Count = 1);

--- a/src/Presentation/API/Services/EntityChangeNotifier.cs
+++ b/src/Presentation/API/Services/EntityChangeNotifier.cs
@@ -1,35 +1,120 @@
+using System.Collections.Concurrent;
 using API.Hubs;
 using Microsoft.AspNetCore.SignalR;
 
 namespace API.Services;
 
-public class EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext) : IEntityChangeNotifier
+public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 {
-	public async Task NotifyCreated(string entityType, Guid id)
+	private readonly IHubContext<EntityHub, IEntityHubClient> _hubContext;
+	private readonly ConcurrentDictionary<(string EntityType, string ChangeType), NotificationBucket> _pending = new();
+	private readonly Timer _flushTimer;
+	private readonly TimeSpan _flushInterval;
+	private int _disposed;
+
+	public EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext)
+		: this(hubContext, TimeSpan.FromSeconds(1))
 	{
-		await hubContext.Clients.All.EntityChanged(new EntityChangeNotification(entityType, "created", id));
 	}
 
-	public async Task NotifyUpdated(string entityType, Guid id)
+	internal EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, TimeSpan flushInterval)
 	{
-		await hubContext.Clients.All.EntityChanged(new EntityChangeNotification(entityType, "updated", id));
+		_hubContext = hubContext;
+		_flushInterval = flushInterval;
+		_flushTimer = new Timer(_ => _ = FlushAsync(), null, _flushInterval, _flushInterval);
 	}
 
-	public async Task NotifyDeleted(string entityType, Guid id)
+	public Task NotifyCreated(string entityType, Guid id)
 	{
-		await hubContext.Clients.All.EntityChanged(new EntityChangeNotification(entityType, "deleted", id));
+		Enqueue(entityType, "created", id);
+		return Task.CompletedTask;
 	}
 
-	public async Task NotifyBulkChanged(string entityType, string changeType, IEnumerable<Guid> ids)
+	public Task NotifyUpdated(string entityType, Guid id)
+	{
+		Enqueue(entityType, "updated", id);
+		return Task.CompletedTask;
+	}
+
+	public Task NotifyDeleted(string entityType, Guid id)
+	{
+		Enqueue(entityType, "deleted", id);
+		return Task.CompletedTask;
+	}
+
+	public Task NotifyBulkChanged(string entityType, string changeType, IEnumerable<Guid> ids)
 	{
 		foreach (Guid id in ids)
 		{
-			await hubContext.Clients.All.EntityChanged(new EntityChangeNotification(entityType, changeType, id));
+			Enqueue(entityType, changeType, id);
+		}
+		return Task.CompletedTask;
+	}
+
+	public Task NotifyAllChanged(string entityType, string changeType)
+	{
+		Enqueue(entityType, changeType, id: null);
+		return Task.CompletedTask;
+	}
+
+	private void Enqueue(string entityType, string changeType, Guid? id)
+	{
+		var key = (entityType, changeType);
+		_pending.AddOrUpdate(
+			key,
+			_ => new NotificationBucket(id),
+			(_, bucket) =>
+			{
+				bucket.Add(id);
+				return bucket;
+			});
+	}
+
+	internal async Task FlushAsync()
+	{
+		// Snapshot and remove all pending buckets atomically per key
+		List<(string EntityType, string ChangeType, int Count)> toSend = [];
+		foreach (var key in _pending.Keys)
+		{
+			if (_pending.TryRemove(key, out NotificationBucket? bucket))
+			{
+				toSend.Add((key.EntityType, key.ChangeType, bucket.Count));
+			}
+		}
+
+		foreach (var (entityType, changeType, count) in toSend)
+		{
+			await _hubContext.Clients.All.EntityChanged(
+				new EntityChangeNotification(entityType, changeType, null, count));
 		}
 	}
 
-	public async Task NotifyAllChanged(string entityType, string changeType)
+	public void Dispose()
 	{
-		await hubContext.Clients.All.EntityChanged(new EntityChangeNotification(entityType, changeType, null));
+		if (Interlocked.Exchange(ref _disposed, 1) == 0)
+		{
+			_flushTimer.Dispose();
+			// Fire one last flush synchronously to drain pending notifications
+			FlushAsync().GetAwaiter().GetResult();
+		}
+	}
+
+	private sealed class NotificationBucket
+	{
+		private int _count;
+
+		public NotificationBucket(Guid? initialId)
+		{
+			_ = initialId; // Individual IDs not needed for aggregated notifications
+			_count = 1;
+		}
+
+		public int Count => _count;
+
+		public void Add(Guid? id)
+		{
+			_ = id;
+			Interlocked.Increment(ref _count);
+		}
 	}
 }

--- a/src/Presentation/API/Services/ProgramService.cs
+++ b/src/Presentation/API/Services/ProgramService.cs
@@ -30,7 +30,7 @@ public static class ProgramService
 		services.AddSingleton<IAuthorizationMiddlewareResultHandler, AuthorizationLoggingHandler>();
 
 		services.AddSignalR();
-		services.AddScoped<IEntityChangeNotifier, EntityChangeNotifier>();
+		services.AddSingleton<IEntityChangeNotifier, EntityChangeNotifier>();
 
 		return services;
 	}

--- a/src/client/src/hooks/useSignalR.test.ts
+++ b/src/client/src/hooks/useSignalR.test.ts
@@ -34,6 +34,10 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
+vi.mock("@/lib/signalr-toast-buffer", () => ({
+  bufferToast: vi.fn(),
+}));
+
 vi.mock("@/lib/auth", () => ({
   getAccessToken: vi.fn().mockReturnValue("mock-token"),
 }));
@@ -41,6 +45,7 @@ vi.mock("@/lib/auth", () => ({
 import { useSignalR } from "./useSignalR";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { bufferToast } from "@/lib/signalr-toast-buffer";
 import { act } from "@testing-library/react";
 
 beforeEach(() => {
@@ -126,7 +131,7 @@ describe("useSignalR", () => {
   });
 
   describe("EntityChanged handler", () => {
-    it("invalidates receipt query keys and shows toast for receipt created", async () => {
+    it("invalidates receipt query keys and buffers toast for receipt created", async () => {
       const mockQueryClient = vi.mocked(useQueryClient)();
 
       await renderEnabled();
@@ -135,7 +140,7 @@ describe("useSignalR", () => {
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "receipt", changeType: "created", id: "abc-123" });
+        handler!({ entityType: "receipt", changeType: "created", id: "abc-123", count: 1 });
       });
 
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -147,12 +152,11 @@ describe("useSignalR", () => {
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["trips"],
       });
-      expect(toast.info).toHaveBeenCalledWith(
-        "A receipt was created by another user",
-      );
+      expect(bufferToast).toHaveBeenCalledWith("receipt", "created", 1);
+      expect(toast.info).not.toHaveBeenCalled();
     });
 
-    it("invalidates account query keys and shows toast for account updated", async () => {
+    it("invalidates account query keys and buffers toast for account updated", async () => {
       const mockQueryClient = vi.mocked(useQueryClient)();
 
       await renderEnabled();
@@ -161,7 +165,7 @@ describe("useSignalR", () => {
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "account", changeType: "updated", id: "abc-123" });
+        handler!({ entityType: "account", changeType: "updated", id: "abc-123", count: 1 });
       });
 
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -170,12 +174,11 @@ describe("useSignalR", () => {
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["transaction-accounts"],
       });
-      expect(toast.info).toHaveBeenCalledWith(
-        "A account was updated by another user",
-      );
+      expect(bufferToast).toHaveBeenCalledWith("account", "updated", 1);
+      expect(toast.info).not.toHaveBeenCalled();
     });
 
-    it("invalidates transaction query keys for transaction deleted", async () => {
+    it("invalidates transaction query keys and buffers toast for transaction deleted", async () => {
       const mockQueryClient = vi.mocked(useQueryClient)();
 
       await renderEnabled();
@@ -184,7 +187,7 @@ describe("useSignalR", () => {
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "transaction", changeType: "deleted", id: "abc-123" });
+        handler!({ entityType: "transaction", changeType: "deleted", id: "abc-123", count: 1 });
       });
 
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -199,39 +202,36 @@ describe("useSignalR", () => {
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["transaction-accounts"],
       });
-      expect(toast.info).toHaveBeenCalledWith(
-        "A transaction was deleted by another user",
-      );
+      expect(bufferToast).toHaveBeenCalledWith("transaction", "deleted", 1);
+      expect(toast.info).not.toHaveBeenCalled();
     });
 
-    it("shows toast with display name for receipt-item", async () => {
+    it("buffers toast with display name for receipt-item", async () => {
       await renderEnabled();
 
       const handler = getOnHandler("EntityChanged");
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "receipt-item", changeType: "created", id: "abc" });
+        handler!({ entityType: "receipt-item", changeType: "created", id: "abc", count: 1 });
       });
 
-      expect(toast.info).toHaveBeenCalledWith(
-        "A receipt item was created by another user",
-      );
+      expect(bufferToast).toHaveBeenCalledWith("receipt item", "created", 1);
+      expect(toast.info).not.toHaveBeenCalled();
     });
 
-    it("shows toast with display name for item-template", async () => {
+    it("buffers toast with display name for item-template", async () => {
       await renderEnabled();
 
       const handler = getOnHandler("EntityChanged");
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "item-template", changeType: "updated", id: "abc" });
+        handler!({ entityType: "item-template", changeType: "updated", id: "abc", count: 1 });
       });
 
-      expect(toast.info).toHaveBeenCalledWith(
-        "A item template was updated by another user",
-      );
+      expect(bufferToast).toHaveBeenCalledWith("item template", "updated", 1);
+      expect(toast.info).not.toHaveBeenCalled();
     });
   });
 

--- a/src/client/src/hooks/useSignalR.ts
+++ b/src/client/src/hooks/useSignalR.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import * as signalR from "@microsoft/signalr";
 import { useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
 import { getAccessToken } from "@/lib/auth";
+import { bufferToast } from "@/lib/signalr-toast-buffer";
 
 export type SignalRConnectionState =
   | "connected"
@@ -13,6 +13,7 @@ interface EntityChangeNotification {
   entityType: string;
   changeType: string;
   id: string | null;
+  count?: number;
 }
 
 const queryKeyMap: Record<string, string[][]> = {
@@ -100,13 +101,7 @@ export function useSignalR(enabled: boolean) {
 
         const displayName =
           displayNameMap[notification.entityType] ?? notification.entityType;
-        const action =
-          notification.changeType === "created"
-            ? "created"
-            : notification.changeType === "deleted"
-              ? "deleted"
-              : "updated";
-        toast.info(`A ${displayName} was ${action} by another user`);
+        bufferToast(displayName, notification.changeType, notification.count ?? 1);
       },
     );
 

--- a/src/client/src/lib/signalr-toast-buffer.test.ts
+++ b/src/client/src/lib/signalr-toast-buffer.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: { info: vi.fn() },
+}));
+
+import { toast } from "sonner";
+import {
+  bufferToast,
+  _resetForTesting,
+  _flushForTesting,
+} from "./signalr-toast-buffer";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetForTesting();
+  vi.useFakeTimers();
+});
+
+describe("signalr-toast-buffer", () => {
+  it("single event flushes as singular message", () => {
+    bufferToast("receipt", "created", 1);
+    _flushForTesting();
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "A receipt was created by another user",
+    );
+    expect(toast.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("multiple events of same key accumulate count", () => {
+    bufferToast("receipt", "created", 1);
+    bufferToast("receipt", "created", 1);
+    bufferToast("receipt", "created", 1);
+    _flushForTesting();
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "3 receipts were created by another user",
+    );
+    expect(toast.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("different keys produce separate toasts", () => {
+    bufferToast("receipt", "created", 1);
+    bufferToast("account", "updated", 1);
+    _flushForTesting();
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "A receipt was created by another user",
+    );
+    expect(toast.info).toHaveBeenCalledWith(
+      "A account was updated by another user",
+    );
+    expect(toast.info).toHaveBeenCalledTimes(2);
+  });
+
+  it('pluralizes "category" to "categories"', () => {
+    bufferToast("category", "deleted", 1);
+    bufferToast("category", "deleted", 1);
+    bufferToast("category", "deleted", 1);
+    _flushForTesting();
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "3 categories were deleted by another user",
+    );
+  });
+
+  it('pluralizes "receipt" to "receipts"', () => {
+    bufferToast("receipt", "updated", 1);
+    bufferToast("receipt", "updated", 1);
+    bufferToast("receipt", "updated", 1);
+    bufferToast("receipt", "updated", 1);
+    bufferToast("receipt", "updated", 1);
+    _flushForTesting();
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "5 receipts were updated by another user",
+    );
+  });
+
+  it("count parameter adds to existing count", () => {
+    bufferToast("receipt", "deleted", 3);
+    bufferToast("receipt", "deleted", 2);
+    _flushForTesting();
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "5 receipts were deleted by another user",
+    );
+    expect(toast.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("_resetForTesting clears without flushing", () => {
+    bufferToast("receipt", "created", 1);
+    bufferToast("account", "updated", 1);
+    _resetForTesting();
+    _flushForTesting();
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  it("flush with no buffered items produces no toasts", () => {
+    _flushForTesting();
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+});

--- a/src/client/src/lib/signalr-toast-buffer.ts
+++ b/src/client/src/lib/signalr-toast-buffer.ts
@@ -1,0 +1,86 @@
+import { toast } from "sonner";
+
+const FLUSH_DELAY_MS = 5_000;
+
+interface BufferEntry {
+  count: number;
+}
+
+const buffer = new Map<string, BufferEntry>();
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+const pluralExceptions: Record<string, string> = {
+  category: "categories",
+  subcategory: "subcategories",
+};
+
+function pluralize(name: string, count: number): string {
+  if (count === 1) return name;
+  return pluralExceptions[name] ?? `${name}s`;
+}
+
+function makeKey(entityType: string, changeType: string): string {
+  return `${entityType}::${changeType}`;
+}
+
+function flush(): void {
+  flushTimer = null;
+
+  for (const [key, entry] of buffer) {
+    const [entityType, changeType] = key.split("::");
+    const displayName = pluralize(entityType, entry.count);
+    const action =
+      changeType === "created"
+        ? "created"
+        : changeType === "deleted"
+          ? "deleted"
+          : "updated";
+
+    if (entry.count === 1) {
+      toast.info(`A ${displayName} was ${action} by another user`);
+    } else {
+      toast.info(
+        `${entry.count} ${displayName} were ${action} by another user`,
+      );
+    }
+  }
+
+  buffer.clear();
+}
+
+export function bufferToast(
+  entityType: string,
+  changeType: string,
+  count: number,
+): void {
+  const key = makeKey(entityType, changeType);
+  const existing = buffer.get(key);
+
+  if (existing) {
+    existing.count += count;
+  } else {
+    buffer.set(key, { count });
+  }
+
+  if (flushTimer === null) {
+    flushTimer = setTimeout(flush, FLUSH_DELAY_MS);
+  }
+}
+
+/** Exposed for testing — clears pending state without flushing. */
+export function _resetForTesting(): void {
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  buffer.clear();
+}
+
+/** Exposed for testing — triggers an immediate flush. */
+export function _flushForTesting(): void {
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  flush();
+}

--- a/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
+++ b/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
@@ -1,11 +1,12 @@
 using API.Hubs;
 using API.Services;
+using FluentAssertions;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
 
 namespace Presentation.API.Tests.Services;
 
-public class EntityChangeNotifierTests
+public class EntityChangeNotifierTests : IDisposable
 {
 	private readonly Mock<IHubContext<EntityHub, IEntityHubClient>> _hubContextMock;
 	private readonly Mock<IEntityHubClient> _clientMock;
@@ -14,89 +15,191 @@ public class EntityChangeNotifierTests
 	public EntityChangeNotifierTests()
 	{
 		_clientMock = new Mock<IEntityHubClient>();
+		_clientMock.Setup(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()))
+			.Returns(Task.CompletedTask);
+
 		Mock<IHubClients<IEntityHubClient>> hubClientsMock = new();
 		hubClientsMock.Setup(c => c.All).Returns(_clientMock.Object);
+
 		_hubContextMock = new Mock<IHubContext<EntityHub, IEntityHubClient>>();
 		_hubContextMock.Setup(h => h.Clients).Returns(hubClientsMock.Object);
 
-		_notifier = new EntityChangeNotifier(_hubContextMock.Object);
+		// Use a very long flush interval so the timer never fires during tests
+		_notifier = new EntityChangeNotifier(_hubContextMock.Object, TimeSpan.FromHours(1));
+	}
+
+	public void Dispose()
+	{
+		_notifier.Dispose();
+		GC.SuppressFinalize(this);
 	}
 
 	[Fact]
-	public async Task NotifyCreated_SendsEntityChangedWithCreatedChangeType()
+	public async Task NotifyCreated_EnqueuesAndFlushSendsNotificationWithCount1()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
 
 		// Act
 		await _notifier.NotifyCreated("receipt", id);
+		await _notifier.FlushAsync();
 
 		// Assert
 		_clientMock.Verify(c => c.EntityChanged(
-			It.Is<EntityChangeNotification>(n => n.EntityType == "receipt" && n.ChangeType == "created" && n.Id == id)),
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "receipt" &&
+				n.ChangeType == "created" &&
+				n.Count == 1)),
 			Times.Once);
 	}
 
 	[Fact]
-	public async Task NotifyUpdated_SendsEntityChangedWithUpdatedChangeType()
+	public async Task NotifyUpdated_EnqueuesAndFlushSendsNotificationWithCount1()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
 
 		// Act
 		await _notifier.NotifyUpdated("account", id);
+		await _notifier.FlushAsync();
 
 		// Assert
 		_clientMock.Verify(c => c.EntityChanged(
-			It.Is<EntityChangeNotification>(n => n.EntityType == "account" && n.ChangeType == "updated" && n.Id == id)),
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "account" &&
+				n.ChangeType == "updated" &&
+				n.Count == 1)),
 			Times.Once);
 	}
 
 	[Fact]
-	public async Task NotifyDeleted_SendsEntityChangedWithDeletedChangeType()
+	public async Task NotifyDeleted_EnqueuesAndFlushSendsNotificationWithCount1()
 	{
 		// Arrange
 		Guid id = Guid.NewGuid();
 
 		// Act
 		await _notifier.NotifyDeleted("category", id);
+		await _notifier.FlushAsync();
 
 		// Assert
 		_clientMock.Verify(c => c.EntityChanged(
-			It.Is<EntityChangeNotification>(n => n.EntityType == "category" && n.ChangeType == "deleted" && n.Id == id)),
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "category" &&
+				n.ChangeType == "deleted" &&
+				n.Count == 1)),
 			Times.Once);
 	}
 
 	[Fact]
-	public async Task NotifyBulkChanged_SendsEntityChangedForEachId()
+	public async Task NotifyBulkChanged_With3Ids_SendsOneNotificationWithCount3()
+	{
+		// Arrange
+		List<Guid> ids = [Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()];
+
+		// Act
+		await _notifier.NotifyBulkChanged("transaction", "created", ids);
+		await _notifier.FlushAsync();
+
+		// Assert
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "transaction" &&
+				n.ChangeType == "created" &&
+				n.Count == 3)),
+			Times.Once);
+		_clientMock.Verify(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task NotifyBulkChanged_WithEmptyIds_SendsNothingOnFlush()
+	{
+		// Act
+		await _notifier.NotifyBulkChanged("receipt", "deleted", []);
+		await _notifier.FlushAsync();
+
+		// Assert
+		_clientMock.Verify(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task NotifyAllChanged_SendsNotificationWithCount1AndNullId()
+	{
+		// Act
+		await _notifier.NotifyAllChanged("category", "updated");
+		await _notifier.FlushAsync();
+
+		// Assert
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "category" &&
+				n.ChangeType == "updated" &&
+				n.Id == null &&
+				n.Count == 1)),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task MultipleDifferentPairs_ProduceSeparateNotificationsOnFlush()
 	{
 		// Arrange
 		Guid id1 = Guid.NewGuid();
 		Guid id2 = Guid.NewGuid();
-		Guid id3 = Guid.NewGuid();
-		List<Guid> ids = [id1, id2, id3];
 
 		// Act
-		await _notifier.NotifyBulkChanged("transaction", "created", ids);
+		await _notifier.NotifyCreated("receipt", id1);
+		await _notifier.NotifyDeleted("category", id2);
+		await _notifier.FlushAsync();
 
 		// Assert
 		_clientMock.Verify(c => c.EntityChanged(
-			It.Is<EntityChangeNotification>(n => n.EntityType == "transaction" && n.ChangeType == "created" && n.Id == id1)),
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "receipt" &&
+				n.ChangeType == "created" &&
+				n.Count == 1)),
 			Times.Once);
 		_clientMock.Verify(c => c.EntityChanged(
-			It.Is<EntityChangeNotification>(n => n.EntityType == "transaction" && n.ChangeType == "created" && n.Id == id2)),
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "category" &&
+				n.ChangeType == "deleted" &&
+				n.Count == 1)),
 			Times.Once);
-		_clientMock.Verify(c => c.EntityChanged(
-			It.Is<EntityChangeNotification>(n => n.EntityType == "transaction" && n.ChangeType == "created" && n.Id == id3)),
-			Times.Once);
-		_clientMock.Verify(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()), Times.Exactly(3));
+		_clientMock.Verify(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()), Times.Exactly(2));
 	}
 
 	[Fact]
-	public async Task NotifyBulkChanged_WithEmptyIds_DoesNotSendAnyNotifications()
+	public async Task Dispose_FlushesPendingNotifications()
+	{
+		// Arrange — use a separate notifier for this test so Dispose actually flushes
+		var clientMock = new Mock<IEntityHubClient>();
+		clientMock.Setup(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()))
+			.Returns(Task.CompletedTask);
+		Mock<IHubClients<IEntityHubClient>> hubClientsMock = new();
+		hubClientsMock.Setup(c => c.All).Returns(clientMock.Object);
+		Mock<IHubContext<EntityHub, IEntityHubClient>> hubContextMock = new();
+		hubContextMock.Setup(h => h.Clients).Returns(hubClientsMock.Object);
+		var notifier = new EntityChangeNotifier(hubContextMock.Object, TimeSpan.FromHours(1));
+
+		Guid id = Guid.NewGuid();
+		await notifier.NotifyCreated("receipt", id);
+
+		// Act
+		notifier.Dispose();
+
+		// Assert
+		clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "receipt" &&
+				n.ChangeType == "created" &&
+				n.Count == 1)),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task FlushAsync_WithNoPendingItems_SendsNothing()
 	{
 		// Act
-		await _notifier.NotifyBulkChanged("receipt", "deleted", []);
+		await _notifier.FlushAsync();
 
 		// Assert
 		_clientMock.Verify(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()), Times.Never);


### PR DESCRIPTION
## Summary

- **Server**: Rewrote `EntityChangeNotifier` as a buffered singleton that accumulates notifications in a `ConcurrentDictionary` and flushes once per second, sending one `EntityChanged` message per unique `(entityType, changeType)` pair with an aggregated `Count` field
- **Client**: New `signalr-toast-buffer.ts` module collects toast events for 5 seconds then shows a single summary toast (e.g. "3 receipts were deleted by another user") instead of N individual toasts
- Query invalidation remains immediate — only toast display is batched

## Test plan

- [x] `dotnet build Receipts.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Receipts.slnx` — 955 backend tests pass (9 new buffer tests)
- [x] `npx vitest run` — 826 client tests pass (8 new toast buffer tests, 5 updated hook tests)
- [ ] Manual: Run Aspire, bulk delete transactions, confirm single aggregated toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)