### PR TITLE
fix(client): resolve type drift from regenerated OpenAPI types

### DIFF
--- a/src/client/src/components/AdminRoute.test.tsx
+++ b/src/client/src/components/AdminRoute.test.tsx
@@ -6,21 +6,21 @@ import { renderWithProviders } from "@/test/test-utils";
 describe("AdminRoute", () => {
   it("renders children when user is admin", () => {
     renderWithProviders(<AdminRoute>Admin page</AdminRoute>, {
-      auth: { user: { email: "admin@test.com", roles: ["Admin"] } },
+      auth: { user: { email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } },
     });
     expect(screen.getByText("Admin page")).toBeInTheDocument();
   });
 
   it("redirects to / when user is not admin", () => {
     renderWithProviders(<AdminRoute>Admin page</AdminRoute>, {
-      auth: { user: { email: "user@test.com", roles: ["User"] } },
+      auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
     });
     expect(screen.queryByText("Admin page")).not.toBeInTheDocument();
   });
 
   it("redirects when user has no roles", () => {
     renderWithProviders(<AdminRoute>Admin page</AdminRoute>, {
-      auth: { user: { email: "user@test.com", roles: [] } },
+      auth: { user: { email: "user@test.com", roles: [], mustResetPassword: false } },
     });
     expect(screen.queryByText("Admin page")).not.toBeInTheDocument();
   });

--- a/src/client/src/components/GlobalSearchDialog.test.tsx
+++ b/src/client/src/components/GlobalSearchDialog.test.tsx
@@ -69,10 +69,10 @@ describe("GlobalSearchDialog", () => {
   it("renders account items when accounts data is available", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: [
+      data: { data: [
         { id: "acc-1", accountCode: "ACC001", name: "Checking" },
         { id: "acc-2", accountCode: "ACC002", name: "Savings" },
-      ],
+      ], total: 2, offset: 0, limit: 50 },
     }));
 
     renderWithQueryClient(
@@ -144,14 +144,14 @@ describe("GlobalSearchDialog", () => {
   it("renders receipt items when receiptItems data is available", async () => {
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
     vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
-      data: [
+      data: { data: [
         {
           id: "ri-1",
           receiptItemCode: "RI001",
           description: "Test Item",
           category: "Food",
         },
-      ],
+      ], total: 1, offset: 0, limit: 50 },
     }));
 
     renderWithQueryClient(
@@ -166,9 +166,9 @@ describe("GlobalSearchDialog", () => {
   it("renders transaction items when transactions data is available", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: [
+      data: { data: [
         { id: "txn-1", amount: 42.5, date: "2024-01-15" },
-      ],
+      ], total: 1, offset: 0, limit: 50 },
     }));
 
     renderWithQueryClient(
@@ -183,10 +183,10 @@ describe("GlobalSearchDialog", () => {
   it("renders receipt items when receipts data is available", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: [
+      data: { data: [
         { id: "r-1", description: "Grocery receipt", location: "Store A" },
         { id: "r-2", description: null, location: "Store B" },
-      ],
+      ], total: 2, offset: 0, limit: 50 },
     }));
 
     renderWithQueryClient(
@@ -199,9 +199,9 @@ describe("GlobalSearchDialog", () => {
   it("selecting an account item closes dialog", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: [
+      data: { data: [
         { id: "acc-1", accountCode: "ACC001", name: "Checking" },
-      ],
+      ], total: 1, offset: 0, limit: 50 },
     }));
 
     const user = userEvent.setup();
@@ -216,9 +216,9 @@ describe("GlobalSearchDialog", () => {
   it("selecting a receipt item closes dialog", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: [
+      data: { data: [
         { id: "r-1", description: "Test Receipt", location: "Downtown" },
-      ],
+      ], total: 1, offset: 0, limit: 50 },
     }));
 
     const user = userEvent.setup();
@@ -233,9 +233,9 @@ describe("GlobalSearchDialog", () => {
   it("selecting a transaction item closes dialog", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: [
+      data: { data: [
         { id: "txn-1", amount: 100, date: "2024-06-01" },
-      ],
+      ], total: 1, offset: 0, limit: 50 },
     }));
 
     const user = userEvent.setup();

--- a/src/client/src/components/GlobalSearchDialog.tsx
+++ b/src/client/src/components/GlobalSearchDialog.tsx
@@ -68,10 +68,15 @@ export function GlobalSearchDialog({
   onOpenChange,
 }: GlobalSearchDialogProps) {
   const navigate = useNavigate();
-  const { data: accounts } = useAccounts();
-  const { data: receipts } = useReceipts();
-  const { data: receiptItems } = useReceiptItems();
-  const { data: transactions } = useTransactions();
+  const { data: accountsResponse } = useAccounts();
+  const { data: receiptsResponse } = useReceipts();
+  const { data: receiptItemsResponse } = useReceiptItems();
+  const { data: transactionsResponse } = useTransactions();
+
+  const accounts = accountsResponse?.data as AccountResponse[] | undefined;
+  const receipts = receiptsResponse?.data as ReceiptResponse[] | undefined;
+  const receiptItems = receiptItemsResponse?.data as ReceiptItemResponse[] | undefined;
+  const transactions = transactionsResponse?.data as TransactionResponse[] | undefined;
 
   const toggleOpen = useCallback(() => {
     onOpenChange(!open);
@@ -103,11 +108,11 @@ export function GlobalSearchDialog({
           ))}
         </CommandGroup>
 
-        {(accounts as AccountResponse[] | undefined)?.length ? (
+        {accounts?.length ? (
           <>
             <CommandSeparator />
             <CommandGroup heading="Accounts">
-              {(accounts as AccountResponse[]).slice(0, 8).map((a) => (
+              {(accounts ?? []).slice(0, 8).map((a) => (
                 <CommandItem
                   key={a.id}
                   value={`account:${a.name} ${a.accountCode}`}
@@ -124,11 +129,11 @@ export function GlobalSearchDialog({
           </>
         ) : null}
 
-        {(receipts as ReceiptResponse[] | undefined)?.length ? (
+        {receipts?.length ? (
           <>
             <CommandSeparator />
             <CommandGroup heading="Receipts">
-              {(receipts as ReceiptResponse[]).slice(0, 8).map((r) => (
+              {(receipts ?? []).slice(0, 8).map((r) => (
                 <CommandItem
                   key={r.id}
                   value={`receipt:${r.description ?? ""} ${r.location}`}
@@ -147,11 +152,11 @@ export function GlobalSearchDialog({
           </>
         ) : null}
 
-        {(receiptItems as ReceiptItemResponse[] | undefined)?.length ? (
+        {receiptItems?.length ? (
           <>
             <CommandSeparator />
             <CommandGroup heading="Receipt Items">
-              {(receiptItems as ReceiptItemResponse[]).slice(0, 8).map((i) => (
+              {(receiptItems ?? []).slice(0, 8).map((i) => (
                 <CommandItem
                   key={i.id}
                   value={`item:${i.description} ${i.receiptItemCode} ${i.category}`}
@@ -168,11 +173,11 @@ export function GlobalSearchDialog({
           </>
         ) : null}
 
-        {(transactions as TransactionResponse[] | undefined)?.length ? (
+        {transactions?.length ? (
           <>
             <CommandSeparator />
             <CommandGroup heading="Transactions">
-              {(transactions as TransactionResponse[]).slice(0, 8).map((t) => (
+              {(transactions ?? []).slice(0, 8).map((t) => (
                 <CommandItem
                   key={t.id}
                   value={`txn:${t.date} ${t.amount}`}

--- a/src/client/src/components/Layout.test.tsx
+++ b/src/client/src/components/Layout.test.tsx
@@ -37,7 +37,7 @@ vi.mock("@/components/ShortcutsHelp", () => ({
 }));
 
 const defaultAuth: AuthContextValue = {
-  user: { email: "test@example.com", roles: ["User"] },
+  user: { email: "test@example.com", roles: ["User"], mustResetPassword: false },
   isLoading: false,
   mustResetPassword: false,
   login: async () => {},
@@ -95,7 +95,7 @@ describe("Layout", () => {
   });
 
   it("shows user email in the header", () => {
-    renderLayout({ user: { email: "admin@test.com", roles: ["Admin"] } });
+    renderLayout({ user: { email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } });
     expect(screen.getByText("admin@test.com")).toBeInTheDocument();
   });
 
@@ -167,13 +167,13 @@ describe("Layout", () => {
   });
 
   it("shows admin nav group when user has Admin role", () => {
-    renderLayout({ user: { email: "admin@test.com", roles: ["Admin"] } });
+    renderLayout({ user: { email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } });
     // Admin group should be rendered in the desktop nav
     expect(screen.getByText("Admin")).toBeInTheDocument();
   });
 
   it("does not show admin nav group for non-admin users", () => {
-    renderLayout({ user: { email: "user@test.com", roles: ["User"] } });
+    renderLayout({ user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } });
     expect(screen.queryByText("Admin")).not.toBeInTheDocument();
   });
 

--- a/src/client/src/components/ProtectedRoute.test.tsx
+++ b/src/client/src/components/ProtectedRoute.test.tsx
@@ -6,7 +6,7 @@ import { renderWithProviders } from "@/test/test-utils";
 describe("ProtectedRoute", () => {
   it("renders children when user is authenticated", () => {
     renderWithProviders(<ProtectedRoute>Dashboard</ProtectedRoute>, {
-      auth: { user: { email: "user@test.com", roles: ["User"] } },
+      auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
     });
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
   });
@@ -29,7 +29,7 @@ describe("ProtectedRoute", () => {
   it("redirects to /change-password when mustResetPassword is true", () => {
     renderWithProviders(<ProtectedRoute>Dashboard</ProtectedRoute>, {
       auth: {
-        user: { email: "user@test.com", roles: ["User"] },
+        user: { email: "user@test.com", roles: ["User"], mustResetPassword: false },
         mustResetPassword: true,
       },
     });

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -93,7 +93,8 @@ export function ReceiptItemForm({
   useFormShortcuts({ formRef });
 
   const { data: receipts, isLoading: receiptsLoading } = useReceipts();
-  const { data: categories } = useCategories();
+  const { data: categoriesResponse } = useCategories();
+  const categories = categoriesResponse?.data as { id: string; name: string }[] | undefined;
   const { data: itemTemplatesData } = useItemTemplates();
   const templates = useMemo(
     () => (itemTemplatesData as ItemTemplate[] | undefined) ?? [],
@@ -118,7 +119,7 @@ export function ReceiptItemForm({
   const categoryOptions = useMemo(
     () =>
       (
-        (categories as { id: string; name: string }[] | undefined) ?? []
+        categories ?? []
       ).map((c) => ({
         value: c.name,
         label: c.name,
@@ -147,8 +148,7 @@ export function ReceiptItemForm({
 
   const selectedCategoryId = useMemo(() => {
     if (!categories || !watchedCategory) return null;
-    return (categories as { id: string; name: string }[])
-      .find((c) => c.name === watchedCategory)?.id ?? null;
+    return categories?.find((c) => c.name === watchedCategory)?.id ?? null;
   }, [categories, watchedCategory]);
 
   const { data: subcategoriesData } =

--- a/src/client/src/components/ReceiptItemsCard.tsx
+++ b/src/client/src/components/ReceiptItemsCard.tsx
@@ -18,12 +18,12 @@ import { formatCurrency } from "@/lib/format";
 
 interface ReceiptItem {
   id: string;
-  receiptItemCode: string | null;
+  receiptItemCode?: string | null;
   description: string;
   quantity: number;
   unitPrice: number;
   category: string;
-  subcategory: string | null;
+  subcategory?: string | null;
 }
 
 interface ReceiptItemsCardProps {

--- a/src/client/src/contexts/AuthContext.test.tsx
+++ b/src/client/src/contexts/AuthContext.test.tsx
@@ -150,6 +150,7 @@ describe("AuthProvider", () => {
     mockedAuth.parseJwtPayload.mockReturnValue({
       email: "a@b.com",
       roles: ["User"],
+      mustResetPassword: false,
     });
 
     render(
@@ -176,6 +177,7 @@ describe("AuthProvider", () => {
     mockedAuth.parseJwtPayload.mockReturnValue({
       email: "user@test.com",
       roles: ["User"],
+      mustResetPassword: false,
     });
     mockedClient.POST.mockResolvedValueOnce({
       data: undefined,
@@ -211,6 +213,7 @@ describe("AuthProvider", () => {
     mockedAuth.parseJwtPayload.mockReturnValue({
       email: "a@b.com",
       roles: ["User"],
+      mustResetPassword: false,
     });
 
     render(

--- a/src/client/src/hooks/useAuth.test.ts
+++ b/src/client/src/hooks/useAuth.test.ts
@@ -7,12 +7,13 @@ describe("useAuth", () => {
   it("returns auth context when inside provider", () => {
     const { result } = renderHook(() => useAuth(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["User"] } },
+        auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
       }),
     });
     expect(result.current.user).toEqual({
       email: "user@test.com",
       roles: ["User"],
+      mustResetPassword: false,
     });
   });
 

--- a/src/client/src/hooks/usePermission.test.ts
+++ b/src/client/src/hooks/usePermission.test.ts
@@ -7,7 +7,7 @@ describe("usePermission", () => {
   it("returns roles from auth context", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["Admin", "User"] } },
+        auth: { user: { email: "user@test.com", roles: ["Admin", "User"], mustResetPassword: false } },
       }),
     });
     expect(result.current.roles).toEqual(["Admin", "User"]);
@@ -16,7 +16,7 @@ describe("usePermission", () => {
   it("hasRole returns true for existing role", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["Admin"] } },
+        auth: { user: { email: "user@test.com", roles: ["Admin"], mustResetPassword: false } },
       }),
     });
     expect(result.current.hasRole("Admin")).toBe(true);
@@ -25,7 +25,7 @@ describe("usePermission", () => {
   it("hasRole returns false for missing role", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["User"] } },
+        auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
       }),
     });
     expect(result.current.hasRole("Admin")).toBe(false);
@@ -34,7 +34,7 @@ describe("usePermission", () => {
   it("isAdmin returns true for Admin role", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "admin@test.com", roles: ["Admin"] } },
+        auth: { user: { email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } },
       }),
     });
     expect(result.current.isAdmin()).toBe(true);
@@ -43,7 +43,7 @@ describe("usePermission", () => {
   it("isAdmin returns false without Admin role", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["User"] } },
+        auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
       }),
     });
     expect(result.current.isAdmin()).toBe(false);

--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -14,12 +14,12 @@ const baseUrl = import.meta.env.VITE_API_URL ?? "";
 
 const client = createClient<paths>({
   baseUrl,
-  fetch: (input, init) => {
+  fetch: (input: Request) => {
     const timeoutSignal = AbortSignal.timeout(30_000);
-    const signal = init?.signal
-      ? AbortSignal.any([timeoutSignal, init.signal])
+    const signal = input.signal
+      ? AbortSignal.any([timeoutSignal, input.signal])
       : timeoutSignal;
-    return fetch(input, { ...init, signal });
+    return fetch(input, { signal });
   },
 });
 

--- a/src/client/src/lib/audit-utils.ts
+++ b/src/client/src/lib/audit-utils.ts
@@ -1,7 +1,7 @@
 import type { components } from "@/generated/api";
 
-export type AuditLog = components["schemas"]["AuditLogResponse"];
-export type AuthAuditLog = components["schemas"]["AuthAuditLogResponse"];
+export type AuditLog = components["schemas"]["AuditLogDto"];
+export type AuthAuditLog = components["schemas"]["AuthAuditEntryDto"];
 
 export interface FieldChange {
   field: string;

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -431,7 +431,7 @@ describe("AdminUsers", () => {
     vi.mocked(useDeleteUser).mockReturnValue({
       mutateAsync: mockMutateAsync,
       isPending: false,
-    } as ReturnType<typeof useDeleteUser>);
+    } as unknown as ReturnType<typeof useDeleteUser>);
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
       data: {
         data: [


### PR DESCRIPTION
## Summary
- Fix client types that silently drifted from the live OpenAPI spec
- Schema renames (`AuditLogDto`, `AuthAuditEntryDto`), paginated response unwrapping, optional nullable fields, openapi-fetch strict mode signature, `mustResetPassword` in test literals
- These only surfaced in Docker builds (which regenerate types at build time); CI used stale checked-in types

## Why this matters
The Phase 6 Docker branch can't build without these fixes. Landing them on main first keeps the Docker branch clean of unrelated client changes.

## Test plan
- [x] `npm run build` passes with regenerated types (`npm run generate:types`)
- [x] 826 client tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)