### PR TITLE
feat(infra): move database seeding from API to Infrastructure (MGG-204)

### DIFF
--- a/src/Infrastructure/Services/DatabaseSeederService.cs
+++ b/src/Infrastructure/Services/DatabaseSeederService.cs
@@ -1,0 +1,56 @@
+using Common;
+using Infrastructure.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.Services;
+
+public static class DatabaseSeederService
+{
+	public static async Task SeedRolesAndAdminAsync(IServiceProvider services)
+	{
+		using IServiceScope scope = services.CreateScope();
+		RoleManager<IdentityRole> roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+		UserManager<ApplicationUser> userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+		IConfiguration configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
+
+		foreach (string role in AppRoles.All)
+		{
+			if (!await roleManager.RoleExistsAsync(role))
+			{
+				await roleManager.CreateAsync(new IdentityRole(role));
+			}
+		}
+
+		string? adminEmail = configuration[ConfigurationVariables.AdminSeedEmail];
+		string? adminPassword = configuration[ConfigurationVariables.AdminSeedPassword];
+
+		if (string.IsNullOrWhiteSpace(adminEmail) || string.IsNullOrWhiteSpace(adminPassword))
+		{
+			return;
+		}
+
+		ApplicationUser? existingAdmin = await userManager.FindByEmailAsync(adminEmail);
+		if (existingAdmin is not null)
+		{
+			return;
+		}
+
+		ApplicationUser adminUser = new()
+		{
+			UserName = adminEmail,
+			Email = adminEmail,
+			FirstName = configuration[ConfigurationVariables.AdminSeedFirstName],
+			LastName = configuration[ConfigurationVariables.AdminSeedLastName],
+			MustResetPassword = true,
+		};
+
+		IdentityResult result = await userManager.CreateAsync(adminUser, adminPassword);
+		if (result.Succeeded)
+		{
+			await userManager.AddToRoleAsync(adminUser, AppRoles.Admin);
+			await userManager.AddToRoleAsync(adminUser, AppRoles.User);
+		}
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -33,7 +33,7 @@ public static class InfrastructureService
 			&& !string.IsNullOrEmpty(configuration[ConfigurationVariables.PostgresDb]);
 	}
 
-	private static string GetConnectionString(IConfiguration configuration)
+	public static string GetConnectionString(IConfiguration configuration)
 	{
 		// Aspire-injected connection string (set by WithReference(db) in AppHost)
 		string? aspireConnectionString = configuration[$"ConnectionStrings:{ConfigurationVariables.AspireConnectionStringName}"];

--- a/src/Presentation/API/Configuration/AuthConfiguration.cs
+++ b/src/Presentation/API/Configuration/AuthConfiguration.cs
@@ -2,9 +2,7 @@ using System.Text;
 using API.Authentication;
 using API.Middleware;
 using Common;
-using Infrastructure.Entities;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
 
 namespace API.Configuration;
@@ -110,51 +108,5 @@ public static class AuthConfiguration
 		app.UseMiddleware<MustResetPasswordMiddleware>();
 		app.UseAuthorization();
 		return app;
-	}
-
-	public static async Task SeedRolesAndAdminAsync(this IServiceProvider services)
-	{
-		using IServiceScope scope = services.CreateScope();
-		RoleManager<IdentityRole> roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
-		UserManager<ApplicationUser> userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
-		IConfiguration configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
-
-		foreach (string role in AppRoles.All)
-		{
-			if (!await roleManager.RoleExistsAsync(role))
-			{
-				await roleManager.CreateAsync(new IdentityRole(role));
-			}
-		}
-
-		string? adminEmail = configuration[ConfigurationVariables.AdminSeedEmail];
-		string? adminPassword = configuration[ConfigurationVariables.AdminSeedPassword];
-
-		if (string.IsNullOrWhiteSpace(adminEmail) || string.IsNullOrWhiteSpace(adminPassword))
-		{
-			return;
-		}
-
-		ApplicationUser? existingAdmin = await userManager.FindByEmailAsync(adminEmail);
-		if (existingAdmin is not null)
-		{
-			return;
-		}
-
-		ApplicationUser adminUser = new()
-		{
-			UserName = adminEmail,
-			Email = adminEmail,
-			FirstName = configuration[ConfigurationVariables.AdminSeedFirstName],
-			LastName = configuration[ConfigurationVariables.AdminSeedLastName],
-			MustResetPassword = true,
-		};
-
-		IdentityResult result = await userManager.CreateAsync(adminUser, adminPassword);
-		if (result.Succeeded)
-		{
-			await userManager.AddToRoleAsync(adminUser, AppRoles.Admin);
-			await userManager.AddToRoleAsync(adminUser, AppRoles.User);
-		}
 	}
 }

--- a/src/Presentation/API/Program.cs
+++ b/src/Presentation/API/Program.cs
@@ -46,7 +46,7 @@ if (Infrastructure.Services.InfrastructureService.IsDatabaseConfigured(builder.C
 {
 	using IServiceScope scope = app.Services.CreateScope();
 	await scope.ServiceProvider.GetRequiredService<IDatabaseMigratorService>().MigrateAsync();
-	await app.Services.SeedRolesAndAdminAsync();
+	await DatabaseSeederService.SeedRolesAndAdminAsync(app.Services);
 }
 
 // Serve SPA static files in production (Vite dev server handles this in development)


### PR DESCRIPTION
## Summary
- Move `SeedRolesAndAdminAsync` from `AuthConfiguration` (Presentation layer) into a new `DatabaseSeederService` in Infrastructure, enabling reuse by the future standalone DbSeeder CLI tool without an API dependency
- Make `GetConnectionString` public in `InfrastructureService` for the same reuse purpose
- Update `Program.cs` to call the new static method instead of the removed extension method

## Test plan
- [x] `dotnet build Receipts.slnx` — compiles with zero warnings
- [x] `dotnet test Receipts.slnx` — all 934 tests pass
- [x] Pre-commit hooks pass (all 8 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)