### PR TITLE
fix(client): distinguish network errors from auth failures on login (MGG-232)

### DIFF
--- a/src/client/src/contexts/AuthContext.test.tsx
+++ b/src/client/src/contexts/AuthContext.test.tsx
@@ -200,6 +200,46 @@ describe("AuthProvider", () => {
     expect(screen.getByTestId("user")).toHaveTextContent("null");
   });
 
+  it("login propagates timeout error to caller", async () => {
+    const timeoutError = new DOMException("Signal timed out", "TimeoutError");
+    mockedClient.POST.mockRejectedValueOnce(timeoutError);
+
+    const ref: { login?: (email: string, password: string) => Promise<void> } = {};
+    function CaptureFn() {
+      const ctx = useContext(AuthContext);
+      ref.login = ctx!.login;
+      return null;
+    }
+
+    render(
+      <AuthProvider>
+        <CaptureFn />
+      </AuthProvider>,
+    );
+
+    await expect(ref.login!("a@b.com", "pw")).rejects.toBe(timeoutError);
+  });
+
+  it("login propagates network error to caller", async () => {
+    const networkError = new TypeError("Failed to fetch");
+    mockedClient.POST.mockRejectedValueOnce(networkError);
+
+    const ref: { login?: (email: string, password: string) => Promise<void> } = {};
+    function CaptureFn() {
+      const ctx = useContext(AuthContext);
+      ref.login = ctx!.login;
+      return null;
+    }
+
+    render(
+      <AuthProvider>
+        <CaptureFn />
+      </AuthProvider>,
+    );
+
+    await expect(ref.login!("a@b.com", "pw")).rejects.toThrow(networkError);
+  });
+
   it("changePassword calls POST /api/auth/change-password and updates user", async () => {
     const newToken = makeJwt("a@b.com", "User");
     mockedClient.POST.mockResolvedValueOnce({

--- a/src/client/src/contexts/AuthContext.test.tsx
+++ b/src/client/src/contexts/AuthContext.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { AuthProvider } from "./AuthContext";
 import { AuthContext } from "./auth-context";
 
@@ -204,40 +204,66 @@ describe("AuthProvider", () => {
     const timeoutError = new DOMException("Signal timed out", "TimeoutError");
     mockedClient.POST.mockRejectedValueOnce(timeoutError);
 
-    const ref: { login?: (email: string, password: string) => Promise<void> } = {};
-    function CaptureFn() {
+    function ErrorCapture() {
       const ctx = useContext(AuthContext);
-      ref.login = ctx!.login;
-      return null;
+      const [error, setError] = useState<string>("none");
+      return (
+        <div>
+          <span data-testid="error-type">{error}</span>
+          <button
+            data-testid="login-catch"
+            onClick={() => ctx!.login("a@b.com", "pw").catch((e: unknown) =>
+              setError(e instanceof DOMException ? e.name : "other"),
+            )}
+          />
+        </div>
+      );
     }
 
     render(
       <AuthProvider>
-        <CaptureFn />
+        <ErrorCapture />
       </AuthProvider>,
     );
 
-    await expect(ref.login!("a@b.com", "pw")).rejects.toBe(timeoutError);
+    await act(async () => {
+      screen.getByTestId("login-catch").click();
+    });
+
+    expect(screen.getByTestId("error-type")).toHaveTextContent("TimeoutError");
   });
 
   it("login propagates network error to caller", async () => {
     const networkError = new TypeError("Failed to fetch");
     mockedClient.POST.mockRejectedValueOnce(networkError);
 
-    const ref: { login?: (email: string, password: string) => Promise<void> } = {};
-    function CaptureFn() {
+    function ErrorCapture() {
       const ctx = useContext(AuthContext);
-      ref.login = ctx!.login;
-      return null;
+      const [error, setError] = useState<string>("none");
+      return (
+        <div>
+          <span data-testid="error-type">{error}</span>
+          <button
+            data-testid="login-catch"
+            onClick={() => ctx!.login("a@b.com", "pw").catch((e: unknown) =>
+              setError(e instanceof TypeError ? e.message : "other"),
+            )}
+          />
+        </div>
+      );
     }
 
     render(
       <AuthProvider>
-        <CaptureFn />
+        <ErrorCapture />
       </AuthProvider>,
     );
 
-    await expect(ref.login!("a@b.com", "pw")).rejects.toThrow(networkError);
+    await act(async () => {
+      screen.getByTestId("login-catch").click();
+    });
+
+    expect(screen.getByTestId("error-type")).toHaveTextContent("Failed to fetch");
   });
 
   it("changePassword calls POST /api/auth/change-password and updates user", async () => {

--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -11,11 +11,12 @@ import {
 } from "@/lib/auth";
 
 const baseUrl = import.meta.env.VITE_API_URL ?? "";
+const API_TIMEOUT_MS = 30_000;
 
 const client = createClient<paths>({
   baseUrl,
   fetch: (input: Request) => {
-    const timeoutSignal = AbortSignal.timeout(30_000);
+    const timeoutSignal = AbortSignal.timeout(API_TIMEOUT_MS);
     const signal = input.signal
       ? AbortSignal.any([timeoutSignal, input.signal])
       : timeoutSignal;
@@ -25,6 +26,10 @@ const client = createClient<paths>({
 
 export function isTimeoutError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "TimeoutError";
+}
+
+export function isNetworkError(error: unknown): boolean {
+  return error instanceof TypeError;
 }
 
 let refreshPromise: Promise<boolean> | null = null;
@@ -38,6 +43,7 @@ async function attemptTokenRefresh(): Promise<boolean> {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ refreshToken }),
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
     });
     if (!res.ok) return false;
 
@@ -100,7 +106,7 @@ const authMiddleware: Middleware = {
     if (newToken) {
       retryRequest.headers.set("Authorization", `Bearer ${newToken}`);
     }
-    return fetch(retryRequest);
+    return fetch(retryRequest, { signal: AbortSignal.timeout(API_TIMEOUT_MS) });
   },
 };
 

--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -29,7 +29,7 @@ export function isTimeoutError(error: unknown): boolean {
 }
 
 export function isNetworkError(error: unknown): boolean {
-  return error instanceof TypeError;
+  return error instanceof TypeError && error.message.includes("fetch");
 }
 
 let refreshPromise: Promise<boolean> | null = null;
@@ -106,7 +106,11 @@ const authMiddleware: Middleware = {
     if (newToken) {
       retryRequest.headers.set("Authorization", `Bearer ${newToken}`);
     }
-    return fetch(retryRequest, { signal: AbortSignal.timeout(API_TIMEOUT_MS) });
+    const timeoutSignal = AbortSignal.timeout(API_TIMEOUT_MS);
+    const retrySignal = retryRequest.signal
+      ? AbortSignal.any([timeoutSignal, retryRequest.signal])
+      : timeoutSignal;
+    return fetch(retryRequest, { signal: retrySignal });
   },
 };
 

--- a/src/client/src/pages/Login.test.tsx
+++ b/src/client/src/pages/Login.test.tsx
@@ -115,4 +115,48 @@ describe("Login", () => {
 
     expect(await screen.findByText(/invalid email or password/i)).toBeInTheDocument();
   });
+
+  it("shows timeout message when login times out", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const timeoutError = new DOMException("Signal timed out", "TimeoutError");
+    const mockLogin = vi.fn().mockRejectedValue(timeoutError);
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      mustResetPassword: false,
+      login: mockLogin,
+      logout: vi.fn(),
+      changePassword: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<Login />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(await screen.findByText(/request timed out/i)).toBeInTheDocument();
+  });
+
+  it("shows network error message when server is unreachable", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const networkError = new TypeError("Failed to fetch");
+    const mockLogin = vi.fn().mockRejectedValue(networkError);
+    const { useAuth } = await import("@/hooks/useAuth");
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      mustResetPassword: false,
+      login: mockLogin,
+      logout: vi.fn(),
+      changePassword: vi.fn(),
+      isLoading: false,
+    });
+
+    renderWithProviders(<Login />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(await screen.findByText(/unable to reach the server/i)).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/Login.tsx
+++ b/src/client/src/pages/Login.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { isTimeoutError } from "@/lib/api-client";
+import { isTimeoutError, isNetworkError } from "@/lib/api-client";
 import { SubmitButton } from "@/components/ui/submit-button";
 import {
   Card,
@@ -56,7 +56,9 @@ function Login() {
       await login(values.email, values.password);
     } catch (err) {
       if (isTimeoutError(err)) {
-        setError("Request timed out. Please try again.");
+        setError("Request timed out. Please check your connection and try again.");
+      } else if (isNetworkError(err)) {
+        setError("Unable to reach the server. Please check your connection and try again.");
       } else {
         setError("Invalid email or password. Please try again.");
       }


### PR DESCRIPTION
## Summary
- Add `isNetworkError` helper and `API_TIMEOUT_MS` constant to `api-client.ts`; apply `AbortSignal.timeout` to raw `fetch()` calls in `attemptTokenRefresh()` and the 401-retry path so they no longer hang indefinitely when the backend is unreachable
- Update `Login.tsx` catch block to show distinct messages for timeout errors ("Request timed out…"), network errors ("Unable to reach the server…"), and actual auth failures ("Invalid email or password…")
- Add test coverage for timeout and network error paths in both `Login.test.tsx` and `AuthContext.test.tsx`

Resolves MGG-232

## Test plan
- `cd src/client && npx vitest run` — all 830 tests pass
- `dotnet build Receipts.slnx` — builds with zero warnings
- Pre-commit hooks pass
- Manual: stop the API backend, attempt login → should show "Unable to reach the server" instead of "Invalid email or password"