### PR TITLE
fix(api): catch ArgumentException in middleware and add missing validators (MGG-267)

### DIFF
--- a/src/Presentation/API/Filters/FluentValidationActionFilter.cs
+++ b/src/Presentation/API/Filters/FluentValidationActionFilter.cs
@@ -15,6 +15,13 @@ public class FluentValidationActionFilter(IServiceProvider serviceProvider) : IA
 				continue;
 			}
 
+			if (argument is System.Collections.IList { Count: 0 })
+			{
+				throw new ValidationException([
+					new ValidationFailure("", "Request body must contain at least one item.")
+				]);
+			}
+
 			Type validatorType = typeof(IValidator<>).MakeGenericType(argument.GetType());
 
 			if (serviceProvider.GetService(validatorType) is not IValidator validator)

--- a/src/Presentation/API/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/src/Presentation/API/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -41,6 +41,21 @@ public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<Glob
 			context.Response.StatusCode = StatusCodes.Status404NotFound;
 			await context.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: "application/problem+json");
 		}
+		catch (ArgumentException ex)
+		{
+			logger.LogWarning(ex, "Validation error: {Message}", ex.Message);
+
+			ValidationProblemDetails problemDetails = new()
+			{
+				Status = StatusCodes.Status400BadRequest,
+				Title = "Validation Error",
+				Detail = ex.Message,
+				Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+			};
+
+			context.Response.StatusCode = StatusCodes.Status400BadRequest;
+			await context.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: "application/problem+json");
+		}
 		catch (Exception ex)
 		{
 			string errorId = Guid.NewGuid().ToString();

--- a/src/Presentation/API/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/src/Presentation/API/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -41,15 +41,19 @@ public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<Glob
 			context.Response.StatusCode = StatusCodes.Status404NotFound;
 			await context.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: "application/problem+json");
 		}
-		catch (ArgumentException ex)
+		catch (ArgumentException ex) when (ex is not ArgumentNullException and not ArgumentOutOfRangeException)
 		{
 			logger.LogWarning(ex, "Validation error: {Message}", ex.Message);
+
+			string detail = ex.ParamName is not null
+				? ex.Message.Replace($" (Parameter '{ex.ParamName}')", "")
+				: ex.Message;
 
 			ValidationProblemDetails problemDetails = new()
 			{
 				Status = StatusCodes.Status400BadRequest,
 				Title = "Validation Error",
-				Detail = ex.Message,
+				Detail = detail,
 				Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1",
 			};
 

--- a/src/Presentation/API/Validators/CreateAccountRequestValidator.cs
+++ b/src/Presentation/API/Validators/CreateAccountRequestValidator.cs
@@ -1,0 +1,21 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class CreateAccountRequestValidator : AbstractValidator<CreateAccountRequest>
+{
+	public const string AccountCodeMustNotBeEmpty = "Account code must not be empty.";
+	public const string NameMustNotBeEmpty = "Name must not be empty.";
+
+	public CreateAccountRequestValidator()
+	{
+		RuleFor(x => x.AccountCode)
+			.NotEmpty()
+			.WithMessage(AccountCodeMustNotBeEmpty);
+
+		RuleFor(x => x.Name)
+			.NotEmpty()
+			.WithMessage(NameMustNotBeEmpty);
+	}
+}

--- a/src/Presentation/API/Validators/CreateAdjustmentRequestValidator.cs
+++ b/src/Presentation/API/Validators/CreateAdjustmentRequestValidator.cs
@@ -16,6 +16,7 @@ public class CreateAdjustmentRequestValidator : AbstractValidator<CreateAdjustme
 	public CreateAdjustmentRequestValidator()
 	{
 		RuleFor(x => x.Type)
+			.Cascade(CascadeMode.Stop)
 			.NotEmpty()
 			.WithMessage(TypeMustNotBeEmpty)
 			.Must(type => ValidTypeNames.Contains(type, StringComparer.OrdinalIgnoreCase))

--- a/src/Presentation/API/Validators/CreateAdjustmentRequestValidator.cs
+++ b/src/Presentation/API/Validators/CreateAdjustmentRequestValidator.cs
@@ -1,0 +1,33 @@
+using API.Generated.Dtos;
+using Common;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class CreateAdjustmentRequestValidator : AbstractValidator<CreateAdjustmentRequest>
+{
+	public const string TypeMustNotBeEmpty = "Type must not be empty.";
+	public const string TypeMustBeValid = "Type must be a valid adjustment type.";
+	public const string AmountMustBeNonZero = "Amount must be non-zero.";
+	public const string DescriptionRequiredForOtherType = "Description is required when type is 'other'.";
+
+	private static readonly string[] ValidTypeNames = Enum.GetNames<AdjustmentType>();
+
+	public CreateAdjustmentRequestValidator()
+	{
+		RuleFor(x => x.Type)
+			.NotEmpty()
+			.WithMessage(TypeMustNotBeEmpty)
+			.Must(type => ValidTypeNames.Contains(type, StringComparer.OrdinalIgnoreCase))
+			.WithMessage(TypeMustBeValid);
+
+		RuleFor(x => x.Amount)
+			.NotEqual(0)
+			.WithMessage(AmountMustBeNonZero);
+
+		RuleFor(x => x.Description)
+			.NotEmpty()
+			.WithMessage(DescriptionRequiredForOtherType)
+			.When(x => string.Equals(x.Type, nameof(AdjustmentType.Other), StringComparison.OrdinalIgnoreCase));
+	}
+}

--- a/src/Presentation/API/Validators/CreateCategoryRequestValidator.cs
+++ b/src/Presentation/API/Validators/CreateCategoryRequestValidator.cs
@@ -1,0 +1,16 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class CreateCategoryRequestValidator : AbstractValidator<CreateCategoryRequest>
+{
+	public const string NameMustNotBeEmpty = "Name must not be empty.";
+
+	public CreateCategoryRequestValidator()
+	{
+		RuleFor(x => x.Name)
+			.NotEmpty()
+			.WithMessage(NameMustNotBeEmpty);
+	}
+}

--- a/src/Presentation/API/Validators/CreateItemTemplateRequestValidator.cs
+++ b/src/Presentation/API/Validators/CreateItemTemplateRequestValidator.cs
@@ -1,0 +1,28 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class CreateItemTemplateRequestValidator : AbstractValidator<CreateItemTemplateRequest>
+{
+	public const string NameMustNotBeEmpty = "Name must not be empty.";
+	public const string DefaultPricingModeInvalid = "Default pricing mode must be 'quantity' or 'flat'.";
+	public const string DefaultUnitPriceMustBePositive = "Default unit price must be positive.";
+
+	public CreateItemTemplateRequestValidator()
+	{
+		RuleFor(x => x.Name)
+			.NotEmpty()
+			.WithMessage(NameMustNotBeEmpty);
+
+		RuleFor(x => x.DefaultPricingMode)
+			.Must(mode => mode is "quantity" or "flat")
+			.WithMessage(DefaultPricingModeInvalid)
+			.When(x => x.DefaultPricingMode is not null);
+
+		RuleFor(x => x.DefaultUnitPrice)
+			.GreaterThan(0)
+			.WithMessage(DefaultUnitPriceMustBePositive)
+			.When(x => x.DefaultUnitPrice.HasValue);
+	}
+}

--- a/src/Presentation/API/Validators/CreateReceiptItemRequestValidator.cs
+++ b/src/Presentation/API/Validators/CreateReceiptItemRequestValidator.cs
@@ -6,11 +6,26 @@ namespace API.Validators;
 public class CreateReceiptItemRequestValidator : AbstractValidator<CreateReceiptItemRequest>
 {
 	public const string UnitPriceMustBePositive = "Unit price must be positive.";
+	public const string DescriptionMustNotBeEmpty = "Description must not be empty.";
+	public const string QuantityMustBePositive = "Quantity must be positive.";
+	public const string CategoryMustNotBeEmpty = "Category must not be empty.";
 
 	public CreateReceiptItemRequestValidator()
 	{
 		RuleFor(x => x.UnitPrice)
 			.GreaterThan(0)
 			.WithMessage(UnitPriceMustBePositive);
+
+		RuleFor(x => x.Description)
+			.NotEmpty()
+			.WithMessage(DescriptionMustNotBeEmpty);
+
+		RuleFor(x => x.Quantity)
+			.GreaterThan(0)
+			.WithMessage(QuantityMustBePositive);
+
+		RuleFor(x => x.Category)
+			.NotEmpty()
+			.WithMessage(CategoryMustNotBeEmpty);
 	}
 }

--- a/src/Presentation/API/Validators/CreateSubcategoryRequestValidator.cs
+++ b/src/Presentation/API/Validators/CreateSubcategoryRequestValidator.cs
@@ -1,0 +1,21 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class CreateSubcategoryRequestValidator : AbstractValidator<CreateSubcategoryRequest>
+{
+	public const string NameMustNotBeEmpty = "Name must not be empty.";
+	public const string CategoryIdMustNotBeEmpty = "Category ID must not be empty.";
+
+	public CreateSubcategoryRequestValidator()
+	{
+		RuleFor(x => x.Name)
+			.NotEmpty()
+			.WithMessage(NameMustNotBeEmpty);
+
+		RuleFor(x => x.CategoryId)
+			.NotEqual(Guid.Empty)
+			.WithMessage(CategoryIdMustNotBeEmpty);
+	}
+}

--- a/src/Presentation/API/Validators/UpdateAccountRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateAccountRequestValidator.cs
@@ -1,0 +1,26 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class UpdateAccountRequestValidator : AbstractValidator<UpdateAccountRequest>
+{
+	public const string IdMustNotBeEmpty = "ID must not be empty.";
+	public const string AccountCodeMustNotBeEmpty = "Account code must not be empty.";
+	public const string NameMustNotBeEmpty = "Name must not be empty.";
+
+	public UpdateAccountRequestValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEqual(Guid.Empty)
+			.WithMessage(IdMustNotBeEmpty);
+
+		RuleFor(x => x.AccountCode)
+			.NotEmpty()
+			.WithMessage(AccountCodeMustNotBeEmpty);
+
+		RuleFor(x => x.Name)
+			.NotEmpty()
+			.WithMessage(NameMustNotBeEmpty);
+	}
+}

--- a/src/Presentation/API/Validators/UpdateAdjustmentRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateAdjustmentRequestValidator.cs
@@ -21,6 +21,7 @@ public class UpdateAdjustmentRequestValidator : AbstractValidator<UpdateAdjustme
 			.WithMessage(IdMustNotBeEmpty);
 
 		RuleFor(x => x.Type)
+			.Cascade(CascadeMode.Stop)
 			.NotEmpty()
 			.WithMessage(TypeMustNotBeEmpty)
 			.Must(type => ValidTypeNames.Contains(type, StringComparer.OrdinalIgnoreCase))

--- a/src/Presentation/API/Validators/UpdateAdjustmentRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateAdjustmentRequestValidator.cs
@@ -1,0 +1,38 @@
+using API.Generated.Dtos;
+using Common;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class UpdateAdjustmentRequestValidator : AbstractValidator<UpdateAdjustmentRequest>
+{
+	public const string IdMustNotBeEmpty = "ID must not be empty.";
+	public const string TypeMustNotBeEmpty = "Type must not be empty.";
+	public const string TypeMustBeValid = "Type must be a valid adjustment type.";
+	public const string AmountMustBeNonZero = "Amount must be non-zero.";
+	public const string DescriptionRequiredForOtherType = "Description is required when type is 'other'.";
+
+	private static readonly string[] ValidTypeNames = Enum.GetNames<AdjustmentType>();
+
+	public UpdateAdjustmentRequestValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEqual(Guid.Empty)
+			.WithMessage(IdMustNotBeEmpty);
+
+		RuleFor(x => x.Type)
+			.NotEmpty()
+			.WithMessage(TypeMustNotBeEmpty)
+			.Must(type => ValidTypeNames.Contains(type, StringComparer.OrdinalIgnoreCase))
+			.WithMessage(TypeMustBeValid);
+
+		RuleFor(x => x.Amount)
+			.NotEqual(0)
+			.WithMessage(AmountMustBeNonZero);
+
+		RuleFor(x => x.Description)
+			.NotEmpty()
+			.WithMessage(DescriptionRequiredForOtherType)
+			.When(x => string.Equals(x.Type, nameof(AdjustmentType.Other), StringComparison.OrdinalIgnoreCase));
+	}
+}

--- a/src/Presentation/API/Validators/UpdateCategoryRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateCategoryRequestValidator.cs
@@ -1,0 +1,21 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class UpdateCategoryRequestValidator : AbstractValidator<UpdateCategoryRequest>
+{
+	public const string IdMustNotBeEmpty = "ID must not be empty.";
+	public const string NameMustNotBeEmpty = "Name must not be empty.";
+
+	public UpdateCategoryRequestValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEqual(Guid.Empty)
+			.WithMessage(IdMustNotBeEmpty);
+
+		RuleFor(x => x.Name)
+			.NotEmpty()
+			.WithMessage(NameMustNotBeEmpty);
+	}
+}

--- a/src/Presentation/API/Validators/UpdateItemTemplateRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateItemTemplateRequestValidator.cs
@@ -1,0 +1,33 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class UpdateItemTemplateRequestValidator : AbstractValidator<UpdateItemTemplateRequest>
+{
+	public const string IdMustNotBeEmpty = "ID must not be empty.";
+	public const string NameMustNotBeEmpty = "Name must not be empty.";
+	public const string DefaultPricingModeInvalid = "Default pricing mode must be 'quantity' or 'flat'.";
+	public const string DefaultUnitPriceMustBePositive = "Default unit price must be positive.";
+
+	public UpdateItemTemplateRequestValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEqual(Guid.Empty)
+			.WithMessage(IdMustNotBeEmpty);
+
+		RuleFor(x => x.Name)
+			.NotEmpty()
+			.WithMessage(NameMustNotBeEmpty);
+
+		RuleFor(x => x.DefaultPricingMode)
+			.Must(mode => mode is "quantity" or "flat")
+			.WithMessage(DefaultPricingModeInvalid)
+			.When(x => x.DefaultPricingMode is not null);
+
+		RuleFor(x => x.DefaultUnitPrice)
+			.GreaterThan(0)
+			.WithMessage(DefaultUnitPriceMustBePositive)
+			.When(x => x.DefaultUnitPrice.HasValue);
+	}
+}

--- a/src/Presentation/API/Validators/UpdateReceiptItemRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateReceiptItemRequestValidator.cs
@@ -6,11 +6,31 @@ namespace API.Validators;
 public class UpdateReceiptItemRequestValidator : AbstractValidator<UpdateReceiptItemRequest>
 {
 	public const string UnitPriceMustBePositive = "Unit price must be positive.";
+	public const string IdMustNotBeEmpty = "ID must not be empty.";
+	public const string DescriptionMustNotBeEmpty = "Description must not be empty.";
+	public const string QuantityMustBePositive = "Quantity must be positive.";
+	public const string CategoryMustNotBeEmpty = "Category must not be empty.";
 
 	public UpdateReceiptItemRequestValidator()
 	{
+		RuleFor(x => x.Id)
+			.NotEqual(Guid.Empty)
+			.WithMessage(IdMustNotBeEmpty);
+
 		RuleFor(x => x.UnitPrice)
 			.GreaterThan(0)
 			.WithMessage(UnitPriceMustBePositive);
+
+		RuleFor(x => x.Description)
+			.NotEmpty()
+			.WithMessage(DescriptionMustNotBeEmpty);
+
+		RuleFor(x => x.Quantity)
+			.GreaterThan(0)
+			.WithMessage(QuantityMustBePositive);
+
+		RuleFor(x => x.Category)
+			.NotEmpty()
+			.WithMessage(CategoryMustNotBeEmpty);
 	}
 }

--- a/src/Presentation/API/Validators/UpdateReceiptRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateReceiptRequestValidator.cs
@@ -3,16 +3,20 @@ using FluentValidation;
 
 namespace API.Validators;
 
-public class CreateReceiptRequestValidator : AbstractValidator<CreateReceiptRequest>
+public class UpdateReceiptRequestValidator : AbstractValidator<UpdateReceiptRequest>
 {
+	public const string IdMustNotBeEmpty = "ID must not be empty.";
 	public const string DescriptionMustNotExceed256Characters = "Description must not exceed 256 characters.";
+	public const string LocationMustNotBeEmpty = "Location must not be empty.";
 	public const string LocationMustNotExceed200Characters = "Location must not exceed 200 characters.";
 	public const string DateMustBePriorToCurrentDate = "Date must be prior to the current date";
 
-	public const string LocationMustNotBeEmpty = "Location must not be empty.";
-
-	public CreateReceiptRequestValidator()
+	public UpdateReceiptRequestValidator()
 	{
+		RuleFor(x => x.Id)
+			.NotEqual(Guid.Empty)
+			.WithMessage(IdMustNotBeEmpty);
+
 		RuleFor(x => x.Description)
 			.MaximumLength(256)
 			.WithMessage(DescriptionMustNotExceed256Characters);

--- a/src/Presentation/API/Validators/UpdateSubcategoryRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateSubcategoryRequestValidator.cs
@@ -1,0 +1,26 @@
+using API.Generated.Dtos;
+using FluentValidation;
+
+namespace API.Validators;
+
+public class UpdateSubcategoryRequestValidator : AbstractValidator<UpdateSubcategoryRequest>
+{
+	public const string IdMustNotBeEmpty = "ID must not be empty.";
+	public const string NameMustNotBeEmpty = "Name must not be empty.";
+	public const string CategoryIdMustNotBeEmpty = "Category ID must not be empty.";
+
+	public UpdateSubcategoryRequestValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEqual(Guid.Empty)
+			.WithMessage(IdMustNotBeEmpty);
+
+		RuleFor(x => x.Name)
+			.NotEmpty()
+			.WithMessage(NameMustNotBeEmpty);
+
+		RuleFor(x => x.CategoryId)
+			.NotEqual(Guid.Empty)
+			.WithMessage(CategoryIdMustNotBeEmpty);
+	}
+}

--- a/src/Presentation/API/Validators/UpdateTransactionRequestValidator.cs
+++ b/src/Presentation/API/Validators/UpdateTransactionRequestValidator.cs
@@ -3,15 +3,19 @@ using FluentValidation;
 
 namespace API.Validators;
 
-public class CreateTransactionRequestValidator : AbstractValidator<CreateTransactionRequest>
+public class UpdateTransactionRequestValidator : AbstractValidator<UpdateTransactionRequest>
 {
+	public const string IdMustNotBeEmpty = "ID must not be empty.";
 	public const string AmountMustBeNonZero = "Amount must be non-zero.";
 	public const string DateMustBePriorToCurrentDate = "Date must be prior to the current date";
-
 	public const string AccountIdMustNotBeEmpty = "Account ID must not be empty.";
 
-	public CreateTransactionRequestValidator()
+	public UpdateTransactionRequestValidator()
 	{
+		RuleFor(x => x.Id)
+			.NotEqual(Guid.Empty)
+			.WithMessage(IdMustNotBeEmpty);
+
 		RuleFor(x => x.Amount)
 			.NotEqual(0)
 			.WithMessage(AmountMustBeNonZero);

--- a/tests/Presentation.API.Tests/Filters/FluentValidationActionFilterTests.cs
+++ b/tests/Presentation.API.Tests/Filters/FluentValidationActionFilterTests.cs
@@ -110,6 +110,26 @@ public class FluentValidationActionFilterTests
 	}
 
 	[Fact]
+	public async Task OnActionExecutionAsync_EmptyList_ThrowsValidationException()
+	{
+		// Arrange
+		ServiceCollection services = new();
+		ServiceProvider provider = services.BuildServiceProvider();
+		FluentValidationActionFilter filter = new(provider);
+		ActionExecutingContext context = CreateContext(new Dictionary<string, object?>
+		{
+			["model"] = new List<TestModel>()
+		});
+
+		// Act
+		Func<Task> act = () => filter.OnActionExecutionAsync(context, () =>
+			Task.FromResult<ActionExecutedContext>(null!));
+
+		// Assert
+		await act.Should().ThrowAsync<ValidationException>();
+	}
+
+	[Fact]
 	public async Task OnActionExecutionAsync_NullArgument_SkipsValidation()
 	{
 		// Arrange

--- a/tests/Presentation.API.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
+++ b/tests/Presentation.API.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
@@ -153,6 +153,30 @@ public class GlobalExceptionHandlerMiddlewareTests
 			Times.Once);
 	}
 
+	[Fact]
+	public async Task InvokeAsync_ArgumentException_Returns400ValidationProblemDetails()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+
+		GlobalExceptionHandlerMiddleware middleware = new(
+			_ => throw new ArgumentException("Name cannot be empty"),
+			_loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(400);
+		context.Response.ContentType.Should().Be("application/problem+json");
+
+		ProblemDetails? problemDetails = await DeserializeProblemDetails(context.Response);
+		problemDetails.Should().NotBeNull();
+		problemDetails!.Status.Should().Be(400);
+		problemDetails.Title.Should().Be("Validation Error");
+	}
+
 	private static async Task<ProblemDetails?> DeserializeProblemDetails(HttpResponse response)
 	{
 		response.Body.Position = 0;

--- a/tests/Presentation.API.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
+++ b/tests/Presentation.API.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
@@ -177,6 +177,65 @@ public class GlobalExceptionHandlerMiddlewareTests
 		problemDetails.Title.Should().Be("Validation Error");
 	}
 
+	[Fact]
+	public async Task InvokeAsync_ArgumentException_StripsParameterNameFromDetail()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+
+		GlobalExceptionHandlerMiddleware middleware = new(
+			_ => throw new ArgumentException("Amount must be non-zero", "amount"),
+			_loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		ProblemDetails? problemDetails = await DeserializeProblemDetails(context.Response);
+		problemDetails.Should().NotBeNull();
+		problemDetails!.Detail.Should().Be("Amount must be non-zero");
+		problemDetails.Detail.Should().NotContain("Parameter");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_ArgumentNullException_Returns500NotCaughtAsValidation()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+		context.Items[CorrelationIdMiddleware.ItemKey] = "test-correlation-id";
+
+		GlobalExceptionHandlerMiddleware middleware = new(
+			_ => throw new ArgumentNullException("connectionString"),
+			_loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(500);
+	}
+
+	[Fact]
+	public async Task InvokeAsync_ArgumentOutOfRangeException_Returns500NotCaughtAsValidation()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Response.Body = new MemoryStream();
+		context.Items[CorrelationIdMiddleware.ItemKey] = "test-correlation-id";
+
+		GlobalExceptionHandlerMiddleware middleware = new(
+			_ => throw new ArgumentOutOfRangeException("index"),
+			_loggerMock.Object);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(500);
+	}
+
 	private static async Task<ProblemDetails?> DeserializeProblemDetails(HttpResponse response)
 	{
 		response.Body.Position = 0;

--- a/tests/Presentation.API.Tests/Validators/CreateAccountRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/CreateAccountRequestValidatorTests.cs
@@ -1,0 +1,50 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class CreateAccountRequestValidatorTests
+{
+	private readonly CreateAccountRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		CreateAccountRequest request = new() { AccountCode = "ABC", Name = "Test" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_AccountCodeIsEmpty()
+	{
+		// Arrange
+		CreateAccountRequest request = new() { AccountCode = "", Name = "Test" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateAccountRequestValidator.AccountCodeMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_NameIsEmpty()
+	{
+		// Arrange
+		CreateAccountRequest request = new() { AccountCode = "ABC", Name = "" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateAccountRequestValidator.NameMustNotBeEmpty);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/CreateAdjustmentRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/CreateAdjustmentRequestValidatorTests.cs
@@ -32,6 +32,7 @@ public class CreateAdjustmentRequestValidatorTests
 		// Assert
 		Assert.False(result.IsValid);
 		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateAdjustmentRequestValidator.TypeMustNotBeEmpty);
+		Assert.DoesNotContain(result.Errors, e => e.ErrorMessage == CreateAdjustmentRequestValidator.TypeMustBeValid);
 	}
 
 	[Fact]

--- a/tests/Presentation.API.Tests/Validators/CreateAdjustmentRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/CreateAdjustmentRequestValidatorTests.cs
@@ -1,0 +1,104 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class CreateAdjustmentRequestValidatorTests
+{
+	private readonly CreateAdjustmentRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		CreateAdjustmentRequest request = new() { Type = "Tip", Amount = 5.0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_TypeIsEmpty()
+	{
+		// Arrange
+		CreateAdjustmentRequest request = new() { Type = "", Amount = 5.0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateAdjustmentRequestValidator.TypeMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_TypeIsInvalid()
+	{
+		// Arrange
+		CreateAdjustmentRequest request = new() { Type = "Invalid", Amount = 5.0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateAdjustmentRequestValidator.TypeMustBeValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_AmountIsZero()
+	{
+		// Arrange
+		CreateAdjustmentRequest request = new() { Type = "Tip", Amount = 0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateAdjustmentRequestValidator.AmountMustBeNonZero);
+	}
+
+	[Fact]
+	public void Should_Fail_When_TypeIsOtherAndDescriptionIsNull()
+	{
+		// Arrange
+		CreateAdjustmentRequest request = new() { Type = "Other", Amount = 5.0, Description = null };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateAdjustmentRequestValidator.DescriptionRequiredForOtherType);
+	}
+
+	[Fact]
+	public void Should_Pass_When_TypeIsOtherAndDescriptionIsProvided()
+	{
+		// Arrange
+		CreateAdjustmentRequest request = new() { Type = "Other", Amount = 5.0, Description = "Reason" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_TypeIsTipAndDescriptionIsNull()
+	{
+		// Arrange
+		CreateAdjustmentRequest request = new() { Type = "Tip", Amount = 5.0, Description = null };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/CreateCategoryRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/CreateCategoryRequestValidatorTests.cs
@@ -1,0 +1,36 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class CreateCategoryRequestValidatorTests
+{
+	private readonly CreateCategoryRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_NameIsValid()
+	{
+		// Arrange
+		CreateCategoryRequest request = new() { Name = "Food" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_NameIsEmpty()
+	{
+		// Arrange
+		CreateCategoryRequest request = new() { Name = "" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateCategoryRequestValidator.NameMustNotBeEmpty);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/CreateItemTemplateRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/CreateItemTemplateRequestValidatorTests.cs
@@ -1,0 +1,143 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class CreateItemTemplateRequestValidatorTests
+{
+	private readonly CreateItemTemplateRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_NameIsValid()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "Template" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_NameIsEmpty()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateItemTemplateRequestValidator.NameMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DefaultPricingModeIsInvalid()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "Template", DefaultPricingMode = "invalid" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateItemTemplateRequestValidator.DefaultPricingModeInvalid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultPricingModeIsQuantity()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "Template", DefaultPricingMode = "quantity" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultPricingModeIsFlat()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "Template", DefaultPricingMode = "flat" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultPricingModeIsNull()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "Template", DefaultPricingMode = null };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DefaultUnitPriceIsNegative()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "Template", DefaultUnitPrice = -1 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateItemTemplateRequestValidator.DefaultUnitPriceMustBePositive);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DefaultUnitPriceIsZero()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "Template", DefaultUnitPrice = 0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateItemTemplateRequestValidator.DefaultUnitPriceMustBePositive);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultUnitPriceIsPositive()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "Template", DefaultUnitPrice = 5.0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultUnitPriceIsNull()
+	{
+		// Arrange
+		CreateItemTemplateRequest request = new() { Name = "Template", DefaultUnitPrice = null };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/CreateReceiptItemRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/CreateReceiptItemRequestValidatorTests.cs
@@ -8,10 +8,10 @@ public class CreateReceiptItemRequestValidatorTests
 	private readonly CreateReceiptItemRequestValidator _validator = new();
 
 	[Fact]
-	public void Should_Pass_When_UnitPriceIsPositive()
+	public void Should_Pass_When_AllFieldsValid()
 	{
 		// Arrange
-		CreateReceiptItemRequest request = new() { UnitPrice = 9.99 };
+		CreateReceiptItemRequest request = new() { UnitPrice = 9.99, Description = "Test", Quantity = 1, Category = "Food" };
 
 		// Act
 		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
@@ -46,5 +46,61 @@ public class CreateReceiptItemRequestValidatorTests
 		// Assert
 		Assert.False(result.IsValid);
 		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateReceiptItemRequestValidator.UnitPriceMustBePositive);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DescriptionIsEmpty()
+	{
+		// Arrange
+		CreateReceiptItemRequest request = new() { UnitPrice = 9.99, Description = "", Quantity = 1, Category = "Food" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateReceiptItemRequestValidator.DescriptionMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_QuantityIsZero()
+	{
+		// Arrange
+		CreateReceiptItemRequest request = new() { UnitPrice = 9.99, Description = "Test", Quantity = 0, Category = "Food" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateReceiptItemRequestValidator.QuantityMustBePositive);
+	}
+
+	[Fact]
+	public void Should_Fail_When_QuantityIsNegative()
+	{
+		// Arrange
+		CreateReceiptItemRequest request = new() { UnitPrice = 9.99, Description = "Test", Quantity = -1, Category = "Food" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateReceiptItemRequestValidator.QuantityMustBePositive);
+	}
+
+	[Fact]
+	public void Should_Fail_When_CategoryIsEmpty()
+	{
+		// Arrange
+		CreateReceiptItemRequest request = new() { UnitPrice = 9.99, Description = "Test", Quantity = 1, Category = "" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateReceiptItemRequestValidator.CategoryMustNotBeEmpty);
 	}
 }

--- a/tests/Presentation.API.Tests/Validators/CreateReceiptRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/CreateReceiptRequestValidatorTests.cs
@@ -81,4 +81,23 @@ public class CreateReceiptRequestValidatorTests
 		Assert.False(result.IsValid);
 		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateReceiptRequestValidator.DateMustBePriorToCurrentDate);
 	}
+
+	[Fact]
+	public void Should_Fail_When_LocationIsEmpty()
+	{
+		// Arrange
+		CreateReceiptRequest receipt = new()
+		{
+			Description = "Valid Description",
+			Location = "",
+			Date = DateOnly.FromDateTime(DateTime.Today)
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(receipt);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateReceiptRequestValidator.LocationMustNotBeEmpty);
+	}
 }

--- a/tests/Presentation.API.Tests/Validators/CreateSubcategoryRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/CreateSubcategoryRequestValidatorTests.cs
@@ -1,0 +1,50 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class CreateSubcategoryRequestValidatorTests
+{
+	private readonly CreateSubcategoryRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		CreateSubcategoryRequest request = new() { Name = "Fruits", CategoryId = Guid.NewGuid() };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_NameIsEmpty()
+	{
+		// Arrange
+		CreateSubcategoryRequest request = new() { Name = "", CategoryId = Guid.NewGuid() };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateSubcategoryRequestValidator.NameMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_CategoryIdIsEmpty()
+	{
+		// Arrange
+		CreateSubcategoryRequest request = new() { Name = "Fruits", CategoryId = Guid.Empty };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateSubcategoryRequestValidator.CategoryIdMustNotBeEmpty);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/CreateTransactionRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/CreateTransactionRequestValidatorTests.cs
@@ -15,6 +15,7 @@ public class CreateTransactionRequestValidatorTests
 		{
 			Amount = 100,
 			Date = DateOnly.FromDateTime(DateTime.Today),
+			AccountId = Guid.NewGuid(),
 		};
 
 		// Act
@@ -50,7 +51,8 @@ public class CreateTransactionRequestValidatorTests
 		CreateTransactionRequest transaction = new()
 		{
 			Amount = 100,
-			Date = pastDate
+			Date = pastDate,
+			AccountId = Guid.NewGuid(),
 		};
 
 		// Act
@@ -68,7 +70,8 @@ public class CreateTransactionRequestValidatorTests
 		CreateTransactionRequest transaction = new()
 		{
 			Amount = 100,
-			Date = today
+			Date = today,
+			AccountId = Guid.NewGuid(),
 		};
 
 		// Act
@@ -94,5 +97,24 @@ public class CreateTransactionRequestValidatorTests
 		// Assert
 		Assert.False(result.IsValid);
 		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateTransactionRequestValidator.DateMustBePriorToCurrentDate);
+	}
+
+	[Fact]
+	public void Should_Fail_When_AccountIdIsEmpty()
+	{
+		// Arrange
+		CreateTransactionRequest transaction = new()
+		{
+			Amount = 100,
+			Date = DateOnly.FromDateTime(DateTime.Today),
+			AccountId = Guid.Empty,
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(transaction);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == CreateTransactionRequestValidator.AccountIdMustNotBeEmpty);
 	}
 }

--- a/tests/Presentation.API.Tests/Validators/UpdateAccountRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/UpdateAccountRequestValidatorTests.cs
@@ -1,0 +1,64 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class UpdateAccountRequestValidatorTests
+{
+	private readonly UpdateAccountRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		UpdateAccountRequest request = new() { Id = Guid.NewGuid(), AccountCode = "ABC", Name = "Test" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_IdIsEmpty()
+	{
+		// Arrange
+		UpdateAccountRequest request = new() { Id = Guid.Empty, AccountCode = "ABC", Name = "Test" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateAccountRequestValidator.IdMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_AccountCodeIsEmpty()
+	{
+		// Arrange
+		UpdateAccountRequest request = new() { Id = Guid.NewGuid(), AccountCode = "", Name = "Test" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateAccountRequestValidator.AccountCodeMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_NameIsEmpty()
+	{
+		// Arrange
+		UpdateAccountRequest request = new() { Id = Guid.NewGuid(), AccountCode = "ABC", Name = "" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateAccountRequestValidator.NameMustNotBeEmpty);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/UpdateAdjustmentRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/UpdateAdjustmentRequestValidatorTests.cs
@@ -1,0 +1,118 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class UpdateAdjustmentRequestValidatorTests
+{
+	private readonly UpdateAdjustmentRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		UpdateAdjustmentRequest request = new() { Id = Guid.NewGuid(), Type = "Tip", Amount = 5.0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_IdIsEmpty()
+	{
+		// Arrange
+		UpdateAdjustmentRequest request = new() { Id = Guid.Empty, Type = "Tip", Amount = 5.0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateAdjustmentRequestValidator.IdMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_TypeIsEmpty()
+	{
+		// Arrange
+		UpdateAdjustmentRequest request = new() { Id = Guid.NewGuid(), Type = "", Amount = 5.0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateAdjustmentRequestValidator.TypeMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_TypeIsInvalid()
+	{
+		// Arrange
+		UpdateAdjustmentRequest request = new() { Id = Guid.NewGuid(), Type = "Invalid", Amount = 5.0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateAdjustmentRequestValidator.TypeMustBeValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_AmountIsZero()
+	{
+		// Arrange
+		UpdateAdjustmentRequest request = new() { Id = Guid.NewGuid(), Type = "Tip", Amount = 0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateAdjustmentRequestValidator.AmountMustBeNonZero);
+	}
+
+	[Fact]
+	public void Should_Fail_When_TypeIsOtherAndDescriptionIsNull()
+	{
+		// Arrange
+		UpdateAdjustmentRequest request = new() { Id = Guid.NewGuid(), Type = "Other", Amount = 5.0, Description = null };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateAdjustmentRequestValidator.DescriptionRequiredForOtherType);
+	}
+
+	[Fact]
+	public void Should_Pass_When_TypeIsOtherAndDescriptionIsProvided()
+	{
+		// Arrange
+		UpdateAdjustmentRequest request = new() { Id = Guid.NewGuid(), Type = "Other", Amount = 5.0, Description = "Reason" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_TypeIsTipAndDescriptionIsNull()
+	{
+		// Arrange
+		UpdateAdjustmentRequest request = new() { Id = Guid.NewGuid(), Type = "Tip", Amount = 5.0, Description = null };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/UpdateAdjustmentRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/UpdateAdjustmentRequestValidatorTests.cs
@@ -46,6 +46,7 @@ public class UpdateAdjustmentRequestValidatorTests
 		// Assert
 		Assert.False(result.IsValid);
 		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateAdjustmentRequestValidator.TypeMustNotBeEmpty);
+		Assert.DoesNotContain(result.Errors, e => e.ErrorMessage == UpdateAdjustmentRequestValidator.TypeMustBeValid);
 	}
 
 	[Fact]

--- a/tests/Presentation.API.Tests/Validators/UpdateCategoryRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/UpdateCategoryRequestValidatorTests.cs
@@ -1,0 +1,50 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class UpdateCategoryRequestValidatorTests
+{
+	private readonly UpdateCategoryRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		UpdateCategoryRequest request = new() { Id = Guid.NewGuid(), Name = "Food" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_IdIsEmpty()
+	{
+		// Arrange
+		UpdateCategoryRequest request = new() { Id = Guid.Empty, Name = "Food" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateCategoryRequestValidator.IdMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_NameIsEmpty()
+	{
+		// Arrange
+		UpdateCategoryRequest request = new() { Id = Guid.NewGuid(), Name = "" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateCategoryRequestValidator.NameMustNotBeEmpty);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/UpdateItemTemplateRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/UpdateItemTemplateRequestValidatorTests.cs
@@ -1,0 +1,157 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class UpdateItemTemplateRequestValidatorTests
+{
+	private readonly UpdateItemTemplateRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "Template" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_IdIsEmpty()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.Empty, Name = "Template" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateItemTemplateRequestValidator.IdMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_NameIsEmpty()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateItemTemplateRequestValidator.NameMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DefaultPricingModeIsInvalid()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "Template", DefaultPricingMode = "invalid" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateItemTemplateRequestValidator.DefaultPricingModeInvalid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultPricingModeIsQuantity()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "Template", DefaultPricingMode = "quantity" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultPricingModeIsFlat()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "Template", DefaultPricingMode = "flat" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultPricingModeIsNull()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "Template", DefaultPricingMode = null };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DefaultUnitPriceIsNegative()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "Template", DefaultUnitPrice = -1 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateItemTemplateRequestValidator.DefaultUnitPriceMustBePositive);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DefaultUnitPriceIsZero()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "Template", DefaultUnitPrice = 0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateItemTemplateRequestValidator.DefaultUnitPriceMustBePositive);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultUnitPriceIsPositive()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "Template", DefaultUnitPrice = 5.0 };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Pass_When_DefaultUnitPriceIsNull()
+	{
+		// Arrange
+		UpdateItemTemplateRequest request = new() { Id = Guid.NewGuid(), Name = "Template", DefaultUnitPrice = null };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/UpdateReceiptItemRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/UpdateReceiptItemRequestValidatorTests.cs
@@ -8,10 +8,10 @@ public class UpdateReceiptItemRequestValidatorTests
 	private readonly UpdateReceiptItemRequestValidator _validator = new();
 
 	[Fact]
-	public void Should_Pass_When_UnitPriceIsPositive()
+	public void Should_Pass_When_AllFieldsValid()
 	{
 		// Arrange
-		UpdateReceiptItemRequest request = new() { UnitPrice = 9.99 };
+		UpdateReceiptItemRequest request = new() { Id = Guid.NewGuid(), UnitPrice = 9.99, Description = "Test", Quantity = 1, Category = "Food" };
 
 		// Act
 		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
@@ -46,5 +46,61 @@ public class UpdateReceiptItemRequestValidatorTests
 		// Assert
 		Assert.False(result.IsValid);
 		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptItemRequestValidator.UnitPriceMustBePositive);
+	}
+
+	[Fact]
+	public void Should_Fail_When_IdIsEmpty()
+	{
+		// Arrange
+		UpdateReceiptItemRequest request = new() { Id = Guid.Empty, UnitPrice = 9.99, Description = "Test", Quantity = 1, Category = "Food" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptItemRequestValidator.IdMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DescriptionIsEmpty()
+	{
+		// Arrange
+		UpdateReceiptItemRequest request = new() { Id = Guid.NewGuid(), UnitPrice = 9.99, Description = "", Quantity = 1, Category = "Food" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptItemRequestValidator.DescriptionMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_QuantityIsZero()
+	{
+		// Arrange
+		UpdateReceiptItemRequest request = new() { Id = Guid.NewGuid(), UnitPrice = 9.99, Description = "Test", Quantity = 0, Category = "Food" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptItemRequestValidator.QuantityMustBePositive);
+	}
+
+	[Fact]
+	public void Should_Fail_When_CategoryIsEmpty()
+	{
+		// Arrange
+		UpdateReceiptItemRequest request = new() { Id = Guid.NewGuid(), UnitPrice = 9.99, Description = "Test", Quantity = 1, Category = "" };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptItemRequestValidator.CategoryMustNotBeEmpty);
 	}
 }

--- a/tests/Presentation.API.Tests/Validators/UpdateReceiptRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/UpdateReceiptRequestValidatorTests.cs
@@ -1,0 +1,123 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class UpdateReceiptRequestValidatorTests
+{
+	private readonly UpdateReceiptRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		UpdateReceiptRequest request = new()
+		{
+			Id = Guid.NewGuid(),
+			Location = "Store",
+			Date = DateOnly.FromDateTime(DateTime.Today)
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_IdIsEmpty()
+	{
+		// Arrange
+		UpdateReceiptRequest request = new()
+		{
+			Id = Guid.Empty,
+			Location = "Store",
+			Date = DateOnly.FromDateTime(DateTime.Today)
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptRequestValidator.IdMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DescriptionExceeds256Characters()
+	{
+		// Arrange
+		UpdateReceiptRequest request = new()
+		{
+			Id = Guid.NewGuid(),
+			Description = new string('a', 257),
+			Location = "Store",
+			Date = DateOnly.FromDateTime(DateTime.Today)
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptRequestValidator.DescriptionMustNotExceed256Characters);
+	}
+
+	[Fact]
+	public void Should_Fail_When_LocationIsEmpty()
+	{
+		// Arrange
+		UpdateReceiptRequest request = new()
+		{
+			Id = Guid.NewGuid(),
+			Location = "",
+			Date = DateOnly.FromDateTime(DateTime.Today)
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptRequestValidator.LocationMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_LocationExceeds200Characters()
+	{
+		// Arrange
+		UpdateReceiptRequest request = new()
+		{
+			Id = Guid.NewGuid(),
+			Location = new string('a', 201),
+			Date = DateOnly.FromDateTime(DateTime.Today)
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptRequestValidator.LocationMustNotExceed200Characters);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DateIsInTheFuture()
+	{
+		// Arrange
+		UpdateReceiptRequest request = new()
+		{
+			Id = Guid.NewGuid(),
+			Location = "Store",
+			Date = DateOnly.FromDateTime(DateTime.Today.AddDays(1))
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateReceiptRequestValidator.DateMustBePriorToCurrentDate);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/UpdateSubcategoryRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/UpdateSubcategoryRequestValidatorTests.cs
@@ -1,0 +1,64 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class UpdateSubcategoryRequestValidatorTests
+{
+	private readonly UpdateSubcategoryRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		UpdateSubcategoryRequest request = new() { Id = Guid.NewGuid(), Name = "Fruits", CategoryId = Guid.NewGuid() };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_IdIsEmpty()
+	{
+		// Arrange
+		UpdateSubcategoryRequest request = new() { Id = Guid.Empty, Name = "Fruits", CategoryId = Guid.NewGuid() };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateSubcategoryRequestValidator.IdMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_NameIsEmpty()
+	{
+		// Arrange
+		UpdateSubcategoryRequest request = new() { Id = Guid.NewGuid(), Name = "", CategoryId = Guid.NewGuid() };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateSubcategoryRequestValidator.NameMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_CategoryIdIsEmpty()
+	{
+		// Arrange
+		UpdateSubcategoryRequest request = new() { Id = Guid.NewGuid(), Name = "Fruits", CategoryId = Guid.Empty };
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateSubcategoryRequestValidator.CategoryIdMustNotBeEmpty);
+	}
+}

--- a/tests/Presentation.API.Tests/Validators/UpdateTransactionRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/UpdateTransactionRequestValidatorTests.cs
@@ -1,0 +1,108 @@
+using API.Generated.Dtos;
+using API.Validators;
+
+namespace Presentation.API.Tests.Validators;
+
+public class UpdateTransactionRequestValidatorTests
+{
+	private readonly UpdateTransactionRequestValidator _validator = new();
+
+	[Fact]
+	public void Should_Pass_When_AllFieldsValid()
+	{
+		// Arrange
+		UpdateTransactionRequest request = new()
+		{
+			Id = Guid.NewGuid(),
+			Amount = 100,
+			Date = DateOnly.FromDateTime(DateTime.Today),
+			AccountId = Guid.NewGuid()
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.True(result.IsValid);
+	}
+
+	[Fact]
+	public void Should_Fail_When_IdIsEmpty()
+	{
+		// Arrange
+		UpdateTransactionRequest request = new()
+		{
+			Id = Guid.Empty,
+			Amount = 100,
+			Date = DateOnly.FromDateTime(DateTime.Today),
+			AccountId = Guid.NewGuid()
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateTransactionRequestValidator.IdMustNotBeEmpty);
+	}
+
+	[Fact]
+	public void Should_Fail_When_AmountIsZero()
+	{
+		// Arrange
+		UpdateTransactionRequest request = new()
+		{
+			Id = Guid.NewGuid(),
+			Amount = 0,
+			Date = DateOnly.FromDateTime(DateTime.Today),
+			AccountId = Guid.NewGuid()
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateTransactionRequestValidator.AmountMustBeNonZero);
+	}
+
+	[Fact]
+	public void Should_Fail_When_DateIsInTheFuture()
+	{
+		// Arrange
+		UpdateTransactionRequest request = new()
+		{
+			Id = Guid.NewGuid(),
+			Amount = 100,
+			Date = DateOnly.FromDateTime(DateTime.Today.AddDays(1)),
+			AccountId = Guid.NewGuid()
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateTransactionRequestValidator.DateMustBePriorToCurrentDate);
+	}
+
+	[Fact]
+	public void Should_Fail_When_AccountIdIsEmpty()
+	{
+		// Arrange
+		UpdateTransactionRequest request = new()
+		{
+			Id = Guid.NewGuid(),
+			Amount = 100,
+			Date = DateOnly.FromDateTime(DateTime.Today),
+			AccountId = Guid.Empty
+		};
+
+		// Act
+		FluentValidation.Results.ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		Assert.False(result.IsValid);
+		Assert.Contains(result.Errors, e => e.ErrorMessage == UpdateTransactionRequestValidator.AccountIdMustNotBeEmpty);
+	}
+}


### PR DESCRIPTION
## Summary
- **Safety net:** Add `ArgumentException` catch in `GlobalExceptionHandlerMiddleware` returning 400 instead of 500, so domain validation errors never surface as internal server errors
- **Missing validators:** Create 12 new FluentValidation validators for Account, Adjustment, Category, Subcategory, ItemTemplate, UpdateReceipt, and UpdateTransaction request DTOs
- **Strengthened existing validators:** Add Description/Quantity/Category rules to receipt item validators, Location NotEmpty to receipt validator, AccountId to transaction validator
- **Empty batch guard:** Add empty-collection check in `FluentValidationActionFilter` returning 400 for all batch endpoints uniformly

Resolves MGG-267

## Test plan
- [x] All 1,012 tests pass (`dotnet test Receipts.slnx`)
- [x] Pre-commit hooks pass (build, format, spec lint, drift check, tests, client lint)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)