### PR TITLE
ci: remove Snyk security scan from CI pipeline

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -152,9 +152,6 @@ jobs:
   security:
     name: Vulnerability Scan
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-
     steps:
       - uses: actions/checkout@v4
 
@@ -174,38 +171,6 @@ jobs:
             echo "::error::Vulnerable packages detected!"
             exit 1
           fi
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Run Snyk Code analysis
-        uses: snyk/actions/node@master
-        continue-on-error: true
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          command: code test
-          args: --severity-threshold=medium --sarif-file-output=snyk.sarif
-
-      - name: Upload Snyk results to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: snyk.sarif
-        continue-on-error: true
-
-      - name: Sync Snyk findings to Linear
-        if: always()
-        run: node scripts/create-linear-issues.mjs snyk.sarif
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-        continue-on-error: true
 
   api-compat:
     name: API Breaking Changes


### PR DESCRIPTION
## Summary
- Remove Snyk Code analysis, SARIF upload, and Linear issue sync steps from the `security` CI job
- Remove the now-unnecessary Node.js setup and `npm ci` steps from that job
- Remove `security-events: write` permission (was only needed for SARIF upload)
- The `dotnet list package --vulnerable` check is retained

## Motivation
Snyk's monthly scan limit is exhausted. Removing it avoids CI noise from a non-functional step.

## Test plan
- [ ] CI passes without Snyk steps
- [ ] `security` job still runs the dotnet vulnerable-packages check

🤖 Generated with [Claude Code](https://claude.com/claude-code)