### PR TITLE
feat(client): replace Edit text buttons with Pencil icons (MGG-277)

### DIFF
--- a/src/client/src/components/AdjustmentsCard.tsx
+++ b/src/client/src/components/AdjustmentsCard.tsx
@@ -37,6 +37,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { formatCurrency } from "@/lib/format";
+import { Pencil } from "lucide-react";
 
 interface AdjustmentRow {
   id: string;
@@ -199,13 +200,14 @@ export function AdjustmentsCard({
                       <TableCell>
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon"
+                          aria-label="Edit"
                           onClick={() => {
                             setServerErrors({});
                             setEditAdj(adj);
                           }}
                         >
-                          Edit
+                          <Pencil className="h-4 w-4" />
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Pencil } from "lucide-react";
 
 interface AccountResponse {
   id: string;
@@ -270,10 +271,11 @@ function Accounts() {
                       <TableCell>
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon"
+                          aria-label="Edit"
                           onClick={() => setEditAccount(account)}
                         >
-                          Edit
+                          <Pencil className="h-4 w-4" />
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -62,6 +62,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
+import { Pencil } from "lucide-react";
 
 const AVAILABLE_ROLES = ["Admin", "User"];
 
@@ -288,10 +289,11 @@ function AdminUsers() {
                         <div className="flex gap-1">
                           <Button
                             variant="outline"
-                            size="sm"
+                            size="icon"
+                            aria-label="Edit"
                             onClick={() => openEdit(user)}
                           >
-                            Edit
+                            <Pencil className="h-4 w-4" />
                           </Button>
                           <Button
                             variant="outline"

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Pencil } from "lucide-react";
 
 interface CategoryResponse {
   id: string;
@@ -231,10 +232,11 @@ function Categories() {
                       <TableCell>
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon"
+                          aria-label="Edit"
                           onClick={() => setEditCategory(category)}
                         >
-                          Edit
+                          <Pencil className="h-4 w-4" />
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Pencil } from "lucide-react";
 
 interface ItemTemplateResponse {
   id: string;
@@ -262,10 +263,11 @@ function ItemTemplates() {
                       <TableCell>
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon"
+                          aria-label="Edit"
                           onClick={() => setEditTemplate(template)}
                         >
-                          Edit
+                          <Pencil className="h-4 w-4" />
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/src/client/src/pages/ReceiptItems.tsx
+++ b/src/client/src/pages/ReceiptItems.tsx
@@ -40,6 +40,7 @@ import {
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
+import { Pencil } from "lucide-react";
 
 interface ReceiptItemResponse {
   id: string;
@@ -327,12 +328,13 @@ function ReceiptItems() {
                       <TableCell>
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon"
+                          aria-label="Edit"
                           onClick={() => {
                             setEditItem(item);
                           }}
                         >
-                          Edit
+                          <Pencil className="h-4 w-4" />
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -39,6 +39,7 @@ import {
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
+import { Pencil } from "lucide-react";
 
 interface ReceiptResponse {
   id: string;
@@ -283,10 +284,11 @@ function Receipts() {
                       <TableCell>
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon"
+                          aria-label="Edit"
                           onClick={() => setEditReceipt(receipt)}
                         >
-                          Edit
+                          <Pencil className="h-4 w-4" />
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Pencil } from "lucide-react";
 
 interface SubcategoryResponse {
   id: string;
@@ -320,10 +321,11 @@ function Subcategories() {
                       <TableCell>
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon"
+                          aria-label="Edit"
                           onClick={() => setEditSubcategory(subcategory)}
                         >
-                          Edit
+                          <Pencil className="h-4 w-4" />
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -39,6 +39,7 @@ import {
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
+import { Pencil } from "lucide-react";
 
 interface TransactionResponse {
   id: string;
@@ -266,12 +267,13 @@ function Transactions() {
                       <TableCell>
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon"
+                          aria-label="Edit"
                           onClick={() => {
                             setEditTransaction(txn);
                           }}
                         >
-                          Edit
+                          <Pencil className="h-4 w-4" />
                         </Button>
                       </TableCell>
                     </TableRow>


### PR DESCRIPTION
## Summary
- Replace "Edit" text in all table action buttons with a `Pencil` icon from `lucide-react` for a cleaner, more compact UI
- Use `size="icon"` instead of `size="sm"` for proper icon button sizing
- Add `aria-label="Edit"` to maintain accessibility — existing tests pass unchanged since they use `getByRole("button", { name: /edit/i })`

## Files changed (9)
- `src/client/src/pages/Transactions.tsx`
- `src/client/src/pages/Subcategories.tsx`
- `src/client/src/pages/ItemTemplates.tsx`
- `src/client/src/pages/Receipts.tsx`
- `src/client/src/pages/Categories.tsx`
- `src/client/src/pages/AdminUsers.tsx`
- `src/client/src/pages/Accounts.tsx`
- `src/client/src/pages/ReceiptItems.tsx`
- `src/client/src/components/AdjustmentsCard.tsx`

## Test plan
- [x] All 830 client tests pass (96 test files)
- [x] Pre-commit hooks pass (lint, format, build, tests)
- [ ] Visual check: all table Edit buttons show pencil icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)