### PR TITLE
feat(client): group subcategories by category with expandable sections (MGG-278)

### DIFF
--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import Subcategories from "./Subcategories";
@@ -8,10 +8,16 @@ vi.mock("@/hooks/usePageTitle", () => ({
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategories: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useSubcategories: vi.fn(() => ({
+    data: { data: [], total: 0, offset: 0, limit: 50 },
+    isLoading: false,
+  })),
   useCreateSubcategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateSubcategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
-  useDeleteSubcategories: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDeleteSubcategories: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
@@ -69,6 +75,55 @@ vi.mock("@/hooks/usePagination", () => ({
   })),
 }));
 
+const ITEMS = [
+  { id: "1", name: "Dairy", categoryId: "c1", description: "Dairy products" },
+  { id: "2", name: "Bakery", categoryId: "c1", description: "Baked goods" },
+  { id: "3", name: "Electronics", categoryId: "c2", description: null },
+];
+
+const CATEGORIES = [
+  { id: "c1", name: "Food" },
+  { id: "c2", name: "Goods" },
+];
+
+async function setupWithData(items = ITEMS, categories = CATEGORIES) {
+  const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+  vi.mocked(useFuzzySearch).mockReturnValue(
+    mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({
+        item,
+        matches: [],
+        score: 0,
+        refIndex: 0,
+      })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }),
+  );
+
+  const { useSubcategories } = await import("@/hooks/useSubcategories");
+  vi.mocked(useSubcategories).mockReturnValue(
+    mockQueryResult({
+      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      isLoading: false,
+    }),
+  );
+
+  const { useCategories } = await import("@/hooks/useCategories");
+  // Use Object.assign to create an array with a .data property so both
+  // the page (accesses .data) and SubcategoryForm (iterates directly) work.
+  const catData = Object.assign([...categories], { data: categories });
+  vi.mocked(useCategories).mockReturnValue(
+    mockQueryResult({
+      data: catData,
+      isLoading: false,
+    }),
+  );
+}
+
 describe("Subcategories", () => {
   it("renders the page heading", () => {
     renderWithProviders(<Subcategories />);
@@ -79,26 +134,30 @@ describe("Subcategories", () => {
 
   it("renders loading skeleton when data is loading", async () => {
     const { useSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useSubcategories).mockReturnValue(mockQueryResult({
-      data: undefined,
-      isLoading: true,
-    }));
+    vi.mocked(useSubcategories).mockReturnValue(
+      mockQueryResult({
+        data: undefined,
+        isLoading: true,
+      }),
+    );
 
     const { container } = renderWithProviders(<Subcategories />);
-    expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
+    expect(
+      container.querySelector("[data-slot='skeleton']"),
+    ).toBeInTheDocument();
   });
 
   it("renders empty state when no subcategories exist", async () => {
     const { useSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useSubcategories).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
-      isLoading: false,
-    }));
+    vi.mocked(useSubcategories).mockReturnValue(
+      mockQueryResult({
+        data: { data: [], total: 0, offset: 0, limit: 50 },
+        isLoading: false,
+      }),
+    );
 
     renderWithProviders(<Subcategories />);
-    expect(
-      screen.getByText(/no subcategories yet/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/no subcategories yet/i)).toBeInTheDocument();
   });
 
   it("renders the New Subcategory button", () => {
@@ -115,31 +174,97 @@ describe("Subcategories", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders table with subcategories when data exists", async () => {
-    const items = [
-      { id: "1", name: "Dairy", categoryId: "c1", categoryName: "Food", description: "Dairy products" },
-      { id: "2", name: "Electronics", categoryId: "c2", categoryName: "Goods", description: null },
-    ];
-
-    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
-      search: "",
-      setSearch: vi.fn(),
-      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
-      totalCount: items.length,
-      isSearching: false,
-      clearSearch: vi.fn(),
-    }));
-
-    const { useSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useSubcategories).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
-      isLoading: false,
-    }));
-
+  it("renders category group headers when data exists", async () => {
+    await setupWithData();
     renderWithProviders(<Subcategories />);
+
+    expect(screen.getByText("Food")).toBeInTheDocument();
+    expect(screen.getByText("Goods")).toBeInTheDocument();
+  });
+
+  it("groups are collapsed by default — subcategory rows not visible", async () => {
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    expect(screen.queryByText("Dairy")).not.toBeInTheDocument();
+    expect(screen.queryByText("Electronics")).not.toBeInTheDocument();
+  });
+
+  it("clicking a category header expands its group", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    await user.click(screen.getByTestId("category-header-c1"));
+
     expect(screen.getByText("Dairy")).toBeInTheDocument();
+    expect(screen.getByText("Bakery")).toBeInTheDocument();
+    expect(screen.queryByText("Electronics")).not.toBeInTheDocument();
+  });
+
+  it("clicking an expanded category header collapses it", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    const foodHeader = screen.getByTestId("category-header-c1");
+    await user.click(foodHeader);
+    expect(screen.getByText("Dairy")).toBeInTheDocument();
+
+    await user.click(foodHeader);
+    expect(screen.queryByText("Dairy")).not.toBeInTheDocument();
+  });
+
+  it("Expand All button expands all groups", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    await user.click(screen.getByRole("button", { name: /expand all/i }));
+
+    expect(screen.getByText("Dairy")).toBeInTheDocument();
+    expect(screen.getByText("Bakery")).toBeInTheDocument();
     expect(screen.getByText("Electronics")).toBeInTheDocument();
+  });
+
+  it("Collapse All button collapses all groups", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    await user.click(screen.getByRole("button", { name: /expand all/i }));
+    expect(screen.getByText("Dairy")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /collapse all/i }));
+    expect(screen.queryByText("Dairy")).not.toBeInTheDocument();
+    expect(screen.queryByText("Electronics")).not.toBeInTheDocument();
+  });
+
+  it("category header shows item count", async () => {
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    const foodHeader = screen.getByTestId("category-header-c1");
+    expect(within(foodHeader).getByText("(2)")).toBeInTheDocument();
+
+    const goodsHeader = screen.getByTestId("category-header-c2");
+    expect(within(goodsHeader).getByText("(1)")).toBeInTheDocument();
+  });
+
+  it("select-all only selects visible (expanded) rows", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    await user.click(screen.getByTestId("category-header-c1"));
+    await user.click(screen.getByLabelText("Select all rows"));
+
+    expect(screen.getByLabelText("Select Dairy")).toBeChecked();
+    expect(screen.getByLabelText("Select Bakery")).toBeChecked();
+
+    expect(
+      screen.getByRole("button", { name: /delete \(2\)/i }),
+    ).toBeInTheDocument();
   });
 
   it("opens create dialog when New Subcategory button is clicked", async () => {
@@ -155,27 +280,10 @@ describe("Subcategories", () => {
 
   it("toggles checkbox selection and shows delete button", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
-    const items = [
-      { id: "1", name: "Dairy", categoryId: "c1", categoryName: "Food", description: "Dairy products" },
-    ];
-
-    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
-      search: "",
-      setSearch: vi.fn(),
-      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
-      totalCount: items.length,
-      isSearching: false,
-      clearSearch: vi.fn(),
-    }));
-
-    const { useSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useSubcategories).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
-      isLoading: false,
-    }));
-
+    await setupWithData();
     renderWithProviders(<Subcategories />);
+
+    await user.click(screen.getByTestId("category-header-c1"));
     await user.click(screen.getByLabelText("Select Dairy"));
 
     expect(
@@ -186,33 +294,20 @@ describe("Subcategories", () => {
   it("opens delete dialog and confirms deletion", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();
-    const { useDeleteSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useDeleteSubcategories).mockReturnValue(mockMutationResult({
-      mutate: mockMutate,
-      isPending: false,
-    }));
+    const { useDeleteSubcategories } = await import(
+      "@/hooks/useSubcategories"
+    );
+    vi.mocked(useDeleteSubcategories).mockReturnValue(
+      mockMutationResult({
+        mutate: mockMutate,
+        isPending: false,
+      }),
+    );
 
-    const items = [
-      { id: "1", name: "Dairy", categoryId: "c1", categoryName: "Food", description: "Dairy products" },
-    ];
-
-    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
-      search: "",
-      setSearch: vi.fn(),
-      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
-      totalCount: items.length,
-      isSearching: false,
-      clearSearch: vi.fn(),
-    }));
-
-    const { useSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useSubcategories).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
-      isLoading: false,
-    }));
-
+    await setupWithData();
     renderWithProviders(<Subcategories />);
+
+    await user.click(screen.getByTestId("category-header-c1"));
     await user.click(screen.getByLabelText("Select Dairy"));
     await user.click(screen.getByRole("button", { name: /delete/i }));
 
@@ -231,38 +326,20 @@ describe("Subcategories", () => {
 
   it("closes edit dialog when dismissed", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
-    const items = [
-      { id: "1", name: "Dairy", categoryId: "c1", categoryName: "Food", description: "Dairy products" },
-    ];
-
-    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
-      search: "",
-      setSearch: vi.fn(),
-      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
-      totalCount: items.length,
-      isSearching: false,
-      clearSearch: vi.fn(),
-    }));
-
-    const { usePagination } = await import("@/hooks/usePagination");
-    vi.mocked(usePagination).mockReturnValue({
-      paginatedItems: items,
-      currentPage: 1,
-      pageSize: 10,
-      totalItems: items.length,
-      totalPages: 1,
-      setPage: vi.fn(),
-      setPageSize: vi.fn(),
-    });
-
+    await setupWithData();
     renderWithProviders(<Subcategories />);
-    await user.click(screen.getByRole("button", { name: /edit/i }));
-    expect(screen.getByRole("heading", { name: /edit subcategory/i })).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("category-header-c1"));
+    await user.click(screen.getAllByRole("button", { name: /edit/i })[0]);
+    expect(
+      screen.getByRole("heading", { name: /edit subcategory/i }),
+    ).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
     await vi.waitFor(() => {
-      expect(screen.queryByRole("heading", { name: /edit subcategory/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: /edit subcategory/i }),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -270,30 +347,45 @@ describe("Subcategories", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithProviders(<Subcategories />);
     await user.click(screen.getByRole("button", { name: /new subcategory/i }));
-    expect(screen.getByRole("heading", { name: /create subcategory/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /create subcategory/i }),
+    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /cancel/i }));
     await vi.waitFor(() => {
-      expect(screen.queryByRole("heading", { name: /create subcategory/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: /create subcategory/i }),
+      ).not.toBeInTheDocument();
     });
   });
 
   it("renders NoResults when search returns no matches", async () => {
     const { useSubcategories } = await import("@/hooks/useSubcategories");
-    vi.mocked(useSubcategories).mockReturnValue(mockQueryResult({
-      data: [{ id: "1", name: "Dairy", categoryId: "c1", description: "Dairy products" }],
-      isLoading: false,
-    }));
+    vi.mocked(useSubcategories).mockReturnValue(
+      mockQueryResult({
+        data: [
+          {
+            id: "1",
+            name: "Dairy",
+            categoryId: "c1",
+            description: "Dairy products",
+          },
+        ],
+        isLoading: false,
+      }),
+    );
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
-      search: "xyz",
-      setSearch: vi.fn(),
-      results: [],
-      totalCount: 0,
-      isSearching: false,
-      clearSearch: vi.fn(),
-    }));
+    vi.mocked(useFuzzySearch).mockReturnValue(
+      mockQueryResult({
+        search: "xyz",
+        setSearch: vi.fn(),
+        results: [],
+        totalCount: 0,
+        isSearching: false,
+        clearSearch: vi.fn(),
+      }),
+    );
 
     renderWithProviders(<Subcategories />);
     expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
@@ -301,33 +393,11 @@ describe("Subcategories", () => {
 
   it("opens edit dialog when Edit button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
-    const items = [
-      { id: "1", name: "Dairy", categoryId: "c1", categoryName: "Food", description: "Dairy products" },
-    ];
-
-    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
-    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
-      search: "",
-      setSearch: vi.fn(),
-      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
-      totalCount: items.length,
-      isSearching: false,
-      clearSearch: vi.fn(),
-    }));
-
-    const { usePagination } = await import("@/hooks/usePagination");
-    vi.mocked(usePagination).mockReturnValue({
-      paginatedItems: items,
-      currentPage: 1,
-      pageSize: 10,
-      totalItems: items.length,
-      totalPages: 1,
-      setPage: vi.fn(),
-      setPageSize: vi.fn(),
-    });
-
+    await setupWithData();
     renderWithProviders(<Subcategories />);
-    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    await user.click(screen.getByTestId("category-header-c1"));
+    await user.click(screen.getAllByRole("button", { name: /edit/i })[0]);
 
     expect(
       screen.getByRole("heading", { name: /edit subcategory/i }),

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { Fragment, useState, useMemo, useEffect } from "react";
 import {
   useSubcategories,
   useCreateSubcategory,
@@ -39,7 +39,7 @@ import {
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { Pencil } from "lucide-react";
+import { ChevronDown, ChevronRight, Pencil } from "lucide-react";
 
 interface SubcategoryResponse {
   id: string;
@@ -80,6 +80,9 @@ function Subcategories() {
   const [filterValues, setFilterValues] = useState<FilterValues>({
     categoryId: "all",
   });
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
+    new Set(),
+  );
 
   const anyDialogOpen = createOpen || editSubcategory !== null || deleteOpen;
 
@@ -154,6 +157,51 @@ function Subcategories() {
     return map;
   }, [results]);
 
+  const groupedByCategory = useMemo(() => {
+    const groups = new Map<string, SubcategoryResponse[]>();
+    for (const item of filteredResults) {
+      const existing = groups.get(item.categoryId);
+      if (existing) {
+        existing.push(item);
+      } else {
+        groups.set(item.categoryId, [item]);
+      }
+    }
+    const sorted = [...groups.entries()].sort((a, b) => {
+      const nameA = categoryMap.get(a[0]) ?? "";
+      const nameB = categoryMap.get(b[0]) ?? "";
+      return nameA.localeCompare(nameB);
+    });
+    return sorted;
+  }, [filteredResults, categoryMap]);
+
+  const visibleSubcategories = useMemo(
+    () =>
+      groupedByCategory.flatMap(([categoryId, items]) =>
+        expandedCategories.has(categoryId) ? items : [],
+      ),
+    [groupedByCategory, expandedCategories],
+  );
+
+  function toggleCategory(categoryId: string) {
+    setExpandedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(categoryId)) next.delete(categoryId);
+      else next.add(categoryId);
+      return next;
+    });
+  }
+
+  function expandAll() {
+    setExpandedCategories(
+      new Set(groupedByCategory.map(([categoryId]) => categoryId)),
+    );
+  }
+
+  function collapseAll() {
+    setExpandedCategories(new Set());
+  }
+
   function toggleSelect(id: string) {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -163,22 +211,34 @@ function Subcategories() {
     });
   }
 
+  const allVisibleSelected =
+    visibleSubcategories.length > 0 &&
+    visibleSubcategories.every((a) => selected.has(a.id));
+
   function toggleAll() {
-    if (selected.size === filteredResults.length) {
-      setSelected(new Set());
+    if (allVisibleSelected) {
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const a of visibleSubcategories) next.delete(a.id);
+        return next;
+      });
     } else {
-      setSelected(new Set(filteredResults.map((a) => a.id)));
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const a of visibleSubcategories) next.add(a.id);
+        return next;
+      });
     }
   }
 
   const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
-    items: filteredResults,
+    items: visibleSubcategories,
     getId: (a) => a.id,
     enabled: !anyDialogOpen,
     onOpen: (a) => setEditSubcategory(a),
     onDelete: () => setDeleteOpen(true),
     onSelectAll: () =>
-      setSelected(new Set(filteredResults.map((a) => a.id))),
+      setSelected(new Set(visibleSubcategories.map((a) => a.id))),
     onDeselectAll: () => setSelected(new Set()),
     onToggleSelect: (a) => toggleSelect(a.id),
     selected,
@@ -202,6 +262,12 @@ function Subcategories() {
           className="max-w-sm"
         />
         <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={expandAll}>
+            Expand All
+          </Button>
+          <Button variant="outline" size="sm" onClick={collapseAll}>
+            Collapse All
+          </Button>
           {selected.size > 0 && (
             <Button variant="destructive" onClick={() => setDeleteOpen(true)}>
               Delete ({selected.size})
@@ -254,10 +320,7 @@ function Subcategories() {
                     <input
                       type="checkbox"
                       aria-label="Select all rows"
-                      checked={
-                        selected.size === filteredResults.length &&
-                        filteredResults.length > 0
-                      }
+                      checked={allVisibleSelected}
                       onChange={toggleAll}
                       className="h-4 w-4 rounded border-gray-300"
                     />
@@ -269,66 +332,102 @@ function Subcategories() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredResults.map((subcategory, index) => {
-                  const result = matchMap.get(subcategory.id);
-                  const matches = result?.matches;
+                {groupedByCategory.map(([categoryId, items]) => {
+                  const isExpanded = expandedCategories.has(categoryId);
+                  const categoryName =
+                    categoryMap.get(categoryId) ?? "Unknown";
                   return (
-                    <TableRow
-                      key={subcategory.id}
-                      className={`cursor-pointer ${focusedId === subcategory.id ? "bg-accent" : ""}`}
-                      onClick={(e) => {
-                        if (
-                          (e.target as HTMLElement).closest(
-                            "button, input, a, [role='button']",
-                          )
-                        )
-                          return;
-                        setFocusedIndex(index);
-                      }}
-                    >
-                      <TableCell>
-                        <input
-                          type="checkbox"
-                          aria-label={`Select ${subcategory.name}`}
-                          checked={selected.has(subcategory.id)}
-                          onChange={() => toggleSelect(subcategory.id)}
-                          className="h-4 w-4 rounded border-gray-300"
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <SearchHighlight
-                          text={subcategory.name}
-                          indices={getMatchIndices(matches, "name")}
-                        />
-                      </TableCell>
-                      <TableCell>
-                        {categoryMap.get(subcategory.categoryId) ?? (
-                          <span className="italic text-muted-foreground">
-                            Unknown
-                          </span>
-                        )}
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">
-                        {subcategory.description ? (
-                          <SearchHighlight
-                            text={subcategory.description}
-                            indices={getMatchIndices(matches, "description")}
-                          />
-                        ) : (
-                          <span className="italic">--</span>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          aria-label="Edit"
-                          onClick={() => setEditSubcategory(subcategory)}
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                      </TableCell>
-                    </TableRow>
+                    <Fragment key={categoryId}>
+                      <TableRow
+                        className="cursor-pointer bg-muted/50 hover:bg-muted"
+                        onClick={() => toggleCategory(categoryId)}
+                        data-testid={`category-header-${categoryId}`}
+                      >
+                        <TableCell colSpan={5}>
+                          <div className="flex items-center gap-2 font-medium">
+                            {isExpanded ? (
+                              <ChevronDown className="h-4 w-4" />
+                            ) : (
+                              <ChevronRight className="h-4 w-4" />
+                            )}
+                            {categoryName}
+                            <span className="ml-1 text-xs text-muted-foreground">
+                              ({items.length})
+                            </span>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                      {isExpanded &&
+                        items.map((subcategory) => {
+                          const visibleIndex =
+                            visibleSubcategories.indexOf(subcategory);
+                          const result = matchMap.get(subcategory.id);
+                          const matches = result?.matches;
+                          return (
+                            <TableRow
+                              key={subcategory.id}
+                              className={`cursor-pointer ${focusedId === subcategory.id ? "bg-accent" : ""}`}
+                              onClick={(e) => {
+                                if (
+                                  (e.target as HTMLElement).closest(
+                                    "button, input, a, [role='button']",
+                                  )
+                                )
+                                  return;
+                                setFocusedIndex(visibleIndex);
+                              }}
+                            >
+                              <TableCell>
+                                <input
+                                  type="checkbox"
+                                  aria-label={`Select ${subcategory.name}`}
+                                  checked={selected.has(subcategory.id)}
+                                  onChange={() => toggleSelect(subcategory.id)}
+                                  className="h-4 w-4 rounded border-gray-300"
+                                />
+                              </TableCell>
+                              <TableCell>
+                                <SearchHighlight
+                                  text={subcategory.name}
+                                  indices={getMatchIndices(matches, "name")}
+                                />
+                              </TableCell>
+                              <TableCell>
+                                {categoryMap.get(subcategory.categoryId) ?? (
+                                  <span className="italic text-muted-foreground">
+                                    Unknown
+                                  </span>
+                                )}
+                              </TableCell>
+                              <TableCell className="text-muted-foreground">
+                                {subcategory.description ? (
+                                  <SearchHighlight
+                                    text={subcategory.description}
+                                    indices={getMatchIndices(
+                                      matches,
+                                      "description",
+                                    )}
+                                  />
+                                ) : (
+                                  <span className="italic">--</span>
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  aria-label="Edit"
+                                  onClick={() =>
+                                    setEditSubcategory(subcategory)
+                                  }
+                                >
+                                  <Pencil className="h-4 w-4" />
+                                </Button>
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                    </Fragment>
                   );
                 })}
               </TableBody>


### PR DESCRIPTION
## Summary
- Group subcategories under their parent category with collapsible header rows (chevron + name + count badge)
- All groups start collapsed; Expand All / Collapse All buttons in toolbar
- Select-all checkbox and keyboard navigation operate only on visible (expanded) rows

## Test plan
- [x] `cd src/client && npx vitest run src/pages/Subcategories.test.tsx` — 21 tests pass
- [x] `dotnet build Receipts.slnx` — solution builds
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)