### PR TITLE
feat(client): show pagination controls at top and bottom of tables (MGG-271)

### DIFF
--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -217,6 +217,14 @@ function Accounts() {
         )
       ) : (
         <>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
           <div className="rounded-md border" ref={tableRef}>
             <Table>
               <TableHeader>

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -317,9 +317,13 @@ describe("AdminUsers", () => {
     }));
 
     renderWithProviders(<AdminUsers />);
-    expect(screen.getByText("1/2")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /previous page/i })).toBeDisabled();
-    expect(screen.getByRole("button", { name: /next page/i })).not.toBeDisabled();
+    expect(screen.getAllByText("1/2")).toHaveLength(2);
+    const prevButtons = screen.getAllByRole("button", { name: /previous page/i });
+    const nextButtons = screen.getAllByRole("button", { name: /next page/i });
+    expect(prevButtons).toHaveLength(2);
+    expect(nextButtons).toHaveLength(2);
+    prevButtons.forEach((btn) => expect(btn).toBeDisabled());
+    nextButtons.forEach((btn) => expect(btn).not.toBeDisabled());
   });
 
   it("advances page when Next button is clicked", async () => {
@@ -355,7 +359,8 @@ describe("AdminUsers", () => {
     }));
 
     renderWithProviders(<AdminUsers />);
-    await user.click(screen.getByRole("button", { name: /next page/i }));
+    const nextButtons = screen.getAllByRole("button", { name: /next page/i });
+    await user.click(nextButtons[0]);
 
     expect(mockSetPage).toHaveBeenCalledWith(2, 25);
   });

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -227,6 +227,14 @@ function AdminUsers() {
 
       {!isLoading && items.length > 0 && (
         <>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
           <div className="rounded-md border" ref={tableRef}>
             <Table>
               <TableHeader>

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -177,6 +177,14 @@ function Categories() {
         )
       ) : (
         <>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
           <div className="rounded-md border" ref={tableRef}>
             <Table>
               <TableHeader>

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -173,6 +173,14 @@ function ItemTemplates() {
         )
       ) : (
         <>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
           <div className="rounded-md border" ref={tableRef}>
             <Table>
               <TableHeader>

--- a/src/client/src/pages/ReceiptItems.tsx
+++ b/src/client/src/pages/ReceiptItems.tsx
@@ -275,6 +275,14 @@ function ReceiptItems() {
         )
       ) : (
         <>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
           <div className="rounded-md border" ref={tableRef}>
             <Table>
               <TableHeader>

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -226,6 +226,14 @@ function Receipts() {
         )
       ) : (
         <>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
           <div className="rounded-md border" ref={tableRef}>
             <Table>
               <TableHeader>

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -328,6 +328,14 @@ function Subcategories() {
         )
       ) : (
         <>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
           <div className="rounded-md border" ref={tableRef}>
             <Table>
               <TableHeader>

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -253,6 +253,14 @@ function Transactions() {
         )
       ) : (
         <>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
           <div className="rounded-md border" ref={tableRef}>
             <Table>
               <TableHeader>


### PR DESCRIPTION
## Summary
- Add a duplicate `<Pagination>` component above each data table across all 8 page files, so users can navigate without scrolling to the bottom
- Both top and bottom pagination instances share the same `useServerPagination` state and stay in sync automatically
- Update AdminUsers tests to expect two pagination instances (top and bottom)

Resolves MGG-271

## Test plan
- All 845 client tests pass (`cd src/client && npx vitest run`)
- Pre-commit hooks pass (OpenAPI lint, formatting, build, drift check, all tests)
- Visual check: pagination controls appear above and below every table

🤖 Generated with [Claude Code](https://claude.com/claude-code)