### PR TITLE
feat: default accounts table to active filter with segmented tabs (MGG-275)

### DIFF
--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -25,14 +25,6 @@ vi.mock("@/hooks/useFuzzySearch", () => ({
   })),
 }));
 
-vi.mock("@/hooks/useSavedFilters", () => ({
-  useSavedFilters: vi.fn(() => ({
-    filters: [],
-    save: vi.fn(),
-    remove: vi.fn(),
-  })),
-}));
-
 vi.mock("@/hooks/useServerPagination", () => ({
   useServerPagination: vi.fn(() => ({
     offset: 0,
@@ -66,6 +58,10 @@ vi.mock("@/hooks/usePagination", () => ({
 }));
 
 describe("Accounts", () => {
+  beforeEach(() => {
+    localStorage.removeItem("accounts-status-filter");
+  });
+
   it("renders the page heading", () => {
     renderWithProviders(<Accounts />);
     expect(
@@ -114,7 +110,7 @@ describe("Accounts", () => {
   it("renders table with accounts when data exists", async () => {
     const items = [
       { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
-      { id: "2", accountCode: "ACC-002", name: "Savings", isActive: false },
+      { id: "2", accountCode: "ACC-002", name: "Savings", isActive: true },
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -137,8 +133,6 @@ describe("Accounts", () => {
     expect(screen.getByText("Checking")).toBeInTheDocument();
     expect(screen.getByText("Savings")).toBeInTheDocument();
     expect(screen.getByText("ACC-001")).toBeInTheDocument();
-    expect(screen.getByText("Active")).toBeInTheDocument();
-    expect(screen.getByText("Inactive")).toBeInTheDocument();
   });
 
   it("opens create dialog when New Account button is clicked", async () => {
@@ -249,7 +243,7 @@ describe("Accounts", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
       { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
-      { id: "2", accountCode: "ACC-002", name: "Savings", isActive: false },
+      { id: "2", accountCode: "ACC-002", name: "Savings", isActive: true },
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -428,6 +422,85 @@ describe("Accounts", () => {
 
     renderWithProviders(<Accounts />);
     expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
+  });
+
+  it("defaults to showing only active accounts", async () => {
+
+    const items = [
+      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
+      { id: "2", accountCode: "ACC-002", name: "Savings", isActive: false },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Accounts />);
+    expect(screen.getByText("Checking")).toBeInTheDocument();
+    expect(screen.queryByText("Savings")).not.toBeInTheDocument();
+
+    // Active tab should be selected
+    const activeTab = screen.getByRole("tab", { name: "Active" });
+    expect(activeTab).toHaveAttribute("data-state", "active");
+  });
+
+  it("persists status filter in localStorage", async () => {
+
+    const user = (await import("@testing-library/user-event")).default.setup();
+
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+      data: { data: [], total: 0, offset: 0, limit: 50 },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Accounts />);
+    await user.click(screen.getByRole("tab", { name: "All" }));
+
+    expect(localStorage.getItem("accounts-status-filter")).toBe("all");
+  });
+
+  it("shows inactive accounts when Inactive tab is selected", async () => {
+
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
+      { id: "2", accountCode: "ACC-002", name: "Savings", isActive: false },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Accounts />);
+    await user.click(screen.getByRole("tab", { name: "Inactive" }));
+
+    expect(screen.queryByText("Checking")).not.toBeInTheDocument();
+    expect(screen.getByText("Savings")).toBeInTheDocument();
   });
 
   it("calls deleteAccounts.mutate when delete is confirmed", async () => {

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -9,22 +9,18 @@ import {
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useEntityLinkParams } from "@/hooks/useEntityLinkParams";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
-import { useSavedFilters } from "@/hooks/useSavedFilters";
 import { useServerPagination } from "@/hooks/useServerPagination";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
-import type { FuseSearchConfig, FilterDefinition } from "@/lib/search";
-import { applyFilters } from "@/lib/search";
-import type { FilterValues } from "@/components/FilterPanel";
+import type { FuseSearchConfig } from "@/lib/search";
 import { AccountForm } from "@/components/AccountForm";
 import { FuzzySearchInput } from "@/components/FuzzySearchInput";
-import { FilterPanel } from "@/components/FilterPanel";
-import type { FilterField } from "@/components/FilterPanel";
 import { SearchHighlight } from "@/components/SearchHighlight";
 import { getMatchIndices } from "@/lib/search-highlight";
 import { NoResults } from "@/components/NoResults";
 import { Pagination } from "@/components/Pagination";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Dialog,
   DialogContent,
@@ -58,13 +54,8 @@ const SEARCH_CONFIG: FuseSearchConfig<AccountResponse> = {
   ],
 };
 
-const FILTER_FIELDS: FilterField[] = [
-  { type: "boolean", key: "isActive", label: "Active" },
-];
-
-const FILTER_DEFS: FilterDefinition[] = [
-  { key: "isActive", type: "boolean", field: "isActive" },
-];
+const STATUS_STORAGE_KEY = "accounts-status-filter";
+type StatusFilter = "all" | "true" | "false";
 
 const HIGHLIGHT_PARAMS = ["highlight"] as const;
 
@@ -81,8 +72,9 @@ function Accounts() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editAccount, setEditAccount] = useState<AccountResponse | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [filterValues, setFilterValues] = useState<FilterValues>({
-    isActive: "all",
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => {
+    const saved = localStorage.getItem(STATUS_STORAGE_KEY);
+    return saved === "all" || saved === "true" || saved === "false" ? saved : "true";
   });
 
   const anyDialogOpen = createOpen || editAccount !== null || deleteOpen;
@@ -97,19 +89,22 @@ function Accounts() {
 
   const data = (accountsResponse?.data as AccountResponse[] | undefined) ?? [];
   const serverTotal = accountsResponse?.total ?? 0;
-  const {
-    filters: savedFilters,
-    save: saveFilter,
-    remove: removeFilter,
-  } = useSavedFilters("accounts");
 
   const { search, setSearch, results, totalCount, clearSearch } =
     useFuzzySearch({ data, config: SEARCH_CONFIG });
 
+  function handleStatusChange(value: string) {
+    const v = value as StatusFilter;
+    setStatusFilter(v);
+    localStorage.setItem(STATUS_STORAGE_KEY, v);
+  }
+
   const filteredResults = useMemo(() => {
     const items = results.map((r) => r.item);
-    return applyFilters(items, FILTER_DEFS, filterValues);
-  }, [results, filterValues]);
+    if (statusFilter === "all") return items;
+    const expected = statusFilter === "true";
+    return items.filter((a) => a.isActive === expected);
+  }, [results, statusFilter]);
 
   const matchMap = useMemo(() => {
     const map = new Map<string, (typeof results)[number]>();
@@ -182,25 +177,13 @@ function Accounts() {
         </div>
       </div>
 
-      <FilterPanel
-        fields={FILTER_FIELDS}
-        values={filterValues}
-        onChange={setFilterValues}
-        savedFilters={savedFilters}
-        onSaveFilter={(name) =>
-          saveFilter({
-            id: crypto.randomUUID(),
-            name,
-            entityType: "accounts",
-            values: filterValues,
-            createdAt: new Date().toISOString(),
-          })
-        }
-        onDeleteFilter={removeFilter}
-        onLoadFilter={(preset) =>
-          setFilterValues(preset.values as FilterValues)
-        }
-      />
+      <Tabs value={statusFilter} onValueChange={handleStatusChange}>
+        <TabsList>
+          <TabsTrigger value="true">Active</TabsTrigger>
+          <TabsTrigger value="false">Inactive</TabsTrigger>
+          <TabsTrigger value="all">All</TabsTrigger>
+        </TabsList>
+      </Tabs>
 
       {filteredResults.length === 0 ? (
         search ? (


### PR DESCRIPTION
## Summary
- Replace the `FilterPanel` boolean dropdown for `isActive` with a `Tabs` segmented control (Active / Inactive / All) placed above the table
- Default to showing only active accounts instead of all accounts
- Persist the selected filter in `localStorage` so it survives page reloads

Resolves MGG-275

## Test plan
- Verify the Accounts page defaults to the "Active" tab, showing only active accounts
- Click "Inactive" tab → only inactive accounts shown
- Click "All" tab → all accounts shown
- Refresh the page → last selected tab is preserved
- Run `cd src/client && npx vitest run src/pages/Accounts.test.tsx` — all 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)