### PR TITLE
feat(client): show receipt detail columns in transactions table (MGG-272)

### DIFF
--- a/src/client/src/pages/Transactions.test.tsx
+++ b/src/client/src/pages/Transactions.test.tsx
@@ -54,13 +54,31 @@ vi.mock("@/hooks/useListKeyboardNav", () => ({
   })),
 }));
 
-// Mocks needed by TransactionForm (rendered inside dialogs)
+// Mocks needed by TransactionForm (rendered inside dialogs) and receipt/account lookups
 vi.mock("@/hooks/useReceipts", () => ({
-  useReceipts: vi.fn(() => ({ data: [], isLoading: false })),
+  useReceipts: vi.fn(() => ({
+    data: {
+      data: [
+        { id: "r1", description: "Grocery Run", location: "Whole Foods", date: "2024-01-14" },
+        { id: "r2", description: null, location: "Target Store", date: "2024-01-19" },
+      ],
+      total: 2, offset: 0, limit: 1000,
+    },
+    isLoading: false,
+  })),
 }));
 
 vi.mock("@/hooks/useAccounts", () => ({
-  useAccounts: vi.fn(() => ({ data: [], isLoading: false })),
+  useAccounts: vi.fn(() => ({
+    data: {
+      data: [
+        { id: "a1", name: "Chase Checking" },
+        { id: "a2", name: "Amex Gold" },
+      ],
+      total: 2, offset: 0, limit: 1000,
+    },
+    isLoading: false,
+  })),
 }));
 
 vi.mock("@/hooks/usePagination", () => ({
@@ -146,6 +164,49 @@ describe("Transactions", () => {
     renderWithProviders(<Transactions />);
     expect(screen.getByText("2024-01-15")).toBeInTheDocument();
     expect(screen.getByText("2024-01-20")).toBeInTheDocument();
+    // Verify account names are resolved
+    expect(screen.getByText("Chase Checking")).toBeInTheDocument();
+    expect(screen.getByText("Amex Gold")).toBeInTheDocument();
+    // Verify receipt description is shown for r1
+    expect(screen.getByText("Grocery Run")).toBeInTheDocument();
+    // r2 has null description so location "Target Store" appears in both Receipt and Location columns
+    expect(screen.getAllByText("Target Store").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders receipt location and receipt date columns", async () => {
+    const items = [
+      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
+      { id: "t2", receiptId: "r2", accountId: "a2", amount: 100.00, date: "2024-01-20" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />);
+    // Verify location column values
+    expect(screen.getByText("Whole Foods")).toBeInTheDocument();
+    // "Target Store" appears in both Receipt (fallback) and Location columns
+    expect(screen.getAllByText("Target Store")).toHaveLength(2);
+    // Verify receipt date column values
+    expect(screen.getByText("2024-01-14")).toBeInTheDocument();
+    expect(screen.getByText("2024-01-19")).toBeInTheDocument();
+    // Verify column headers
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByText("Receipt Date")).toBeInTheDocument();
+    expect(screen.getByText("Transaction Date")).toBeInTheDocument();
   });
 
   it("opens create dialog when New Transaction button is clicked", async () => {

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -55,8 +55,25 @@ interface TransactionResponse {
   date: string;
 }
 
-const SEARCH_CONFIG: FuseSearchConfig<TransactionResponse> = {
-  keys: [{ name: "date", weight: 1 }],
+interface ReceiptInfo {
+  description: string | null | undefined;
+  location: string;
+  date: string;
+}
+
+interface EnrichedTransaction extends TransactionResponse {
+  accountName?: string;
+  receiptDescription?: string;
+  receiptLocation?: string;
+}
+
+const SEARCH_CONFIG: FuseSearchConfig<EnrichedTransaction> = {
+  keys: [
+    { name: "date", weight: 1 },
+    { name: "accountName", weight: 2 },
+    { name: "receiptDescription", weight: 2 },
+    { name: "receiptLocation", weight: 1 },
+  ],
 };
 
 const FILTER_FIELDS: FilterField[] = [
@@ -102,12 +119,6 @@ function Transactions() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const data = useMemo(() => {
-    const list = (transactionsResponse?.data as TransactionResponse[] | undefined) ?? [];
-    return [...list].sort(
-      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
-    );
-  }, [transactionsResponse?.data]);
   const serverTotal = transactionsResponse?.total ?? 0;
 
   const accountMap = useMemo(() => {
@@ -118,11 +129,26 @@ function Transactions() {
   }, [accountsResponse?.data]);
 
   const receiptMap = useMemo(() => {
-    const map = new Map<string, string>();
-    const list = (receiptsResponse?.data as { id: string; description?: string | null; location: string }[] | undefined) ?? [];
-    for (const r of list) map.set(r.id, r.description || r.location);
+    const map = new Map<string, ReceiptInfo>();
+    const list = (receiptsResponse?.data as { id: string; description?: string | null; location: string; date: string }[] | undefined) ?? [];
+    for (const r of list) map.set(r.id, { description: r.description, location: r.location, date: r.date });
     return map;
   }, [receiptsResponse?.data]);
+
+  const data: EnrichedTransaction[] = useMemo(() => {
+    const list = (transactionsResponse?.data as TransactionResponse[] | undefined) ?? [];
+    return [...list]
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+      .map((txn) => {
+        const receipt = receiptMap.get(txn.receiptId);
+        return {
+          ...txn,
+          accountName: accountMap.get(txn.accountId),
+          receiptDescription: receipt?.description ?? undefined,
+          receiptLocation: receipt?.location,
+        };
+      });
+  }, [transactionsResponse?.data, accountMap, receiptMap]);
 
   const {
     filters: savedFilters,
@@ -181,7 +207,7 @@ function Transactions() {
   });
 
   if (isLoading) {
-    return <TableSkeleton columns={3} />;
+    return <TableSkeleton columns={8} />;
   }
 
   return (
@@ -231,7 +257,7 @@ function Transactions() {
         <ActiveFilterBanner
           message={
             linkParams.receiptId
-              ? `Showing transactions for receipt: ${receiptMap.get(linkParams.receiptId) ?? linkParams.receiptId}`
+              ? `Showing transactions for receipt: ${receiptMap.get(linkParams.receiptId)?.description || receiptMap.get(linkParams.receiptId)?.location || linkParams.receiptId}`
               : `Showing transactions for account: ${accountMap.get(linkParams.accountId!) ?? linkParams.accountId}`
           }
           onClear={clearParams}
@@ -271,8 +297,10 @@ function Transactions() {
                   </TableHead>
                   <TableHead>Account</TableHead>
                   <TableHead>Receipt</TableHead>
+                  <TableHead>Location</TableHead>
                   <TableHead className="text-right">Amount</TableHead>
-                  <TableHead>Date</TableHead>
+                  <TableHead>Receipt Date</TableHead>
+                  <TableHead>Transaction Date</TableHead>
                   <TableHead className="w-24">Actions</TableHead>
                 </TableRow>
               </TableHeader>
@@ -305,11 +333,17 @@ function Transactions() {
                       </TableCell>
                       <TableCell>
                         <Link to={`/receipts?highlight=${txn.receiptId}`} className="text-sm text-primary hover:underline">
-                          Receipt
+                          {receiptMap.get(txn.receiptId)?.description || receiptMap.get(txn.receiptId)?.location || "Receipt"}
                         </Link>
+                      </TableCell>
+                      <TableCell>
+                        {receiptMap.get(txn.receiptId)?.location ?? ""}
                       </TableCell>
                       <TableCell className="text-right">
                         {formatCurrency(txn.amount)}
+                      </TableCell>
+                      <TableCell>
+                        {receiptMap.get(txn.receiptId)?.date ?? ""}
                       </TableCell>
                       <TableCell>
                         <SearchHighlight


### PR DESCRIPTION
## Summary
- Expanded the transactions table with Receipt Description, Location, and Receipt Date columns alongside the existing Transaction Date
- Updated receipt link text from generic "Receipt" to the receipt's description (or location as fallback)
- Added account name and receipt description/location as searchable fields in fuzzy search
- Updated skeleton columns count and all related tests

## Test plan
- [x] `cd src/client && npx vitest run src/pages/Transactions.test.tsx` — all 16 tests pass
- [x] Pre-commit hooks pass (lint, format, build, drift check, all tests)
- [ ] Visual: verify transactions table shows account name, receipt description, location, receipt date, transaction date

🤖 Generated with [Claude Code](https://claude.com/claude-code)