### PR TITLE
feat(client): improve Trip search with filterable receipt table (MGG-274)

### DIFF
--- a/src/client/src/pages/Trips.test.tsx
+++ b/src/client/src/pages/Trips.test.tsx
@@ -38,13 +38,13 @@ vi.mock("@/hooks/useSavedFilters", () => ({
   })),
 }));
 
-vi.mock("@/hooks/useServerPagination", () => ({
-  useServerPagination: vi.fn(() => ({
-    offset: 0,
-    limit: 25,
+vi.mock("@/hooks/usePagination", () => ({
+  usePagination: vi.fn(() => ({
+    paginatedItems: [],
     currentPage: 1,
     pageSize: 25,
-    totalPages: vi.fn(() => 1),
+    totalItems: 0,
+    totalPages: 1,
     setPage: vi.fn(),
     setPageSize: vi.fn(),
   })),
@@ -88,9 +88,20 @@ describe("Trips", () => {
       clearSearch: vi.fn(),
     }));
 
+    const { usePagination } = await import("@/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      paginatedItems: items,
+      currentPage: 1,
+      pageSize: 25,
+      totalItems: items.length,
+      totalPages: 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+    });
+
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 25 },
+      data: { data: items, total: items.length, offset: 0, limit: 10000 },
       isLoading: false,
     }));
 
@@ -135,10 +146,31 @@ describe("Trips", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders no-results state when search yields nothing", async () => {
+  it("renders no-results state when search yields nothing but receipts exist", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 25 },
+      data: { data: [{ id: "1", description: "Grocery", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }], total: 1, offset: 0, limit: 10000 },
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "xyz",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 1,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Trips />);
+    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
+  });
+
+  it("shows empty state when searching with zero receipts in database", async () => {
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
+      data: { data: [], total: 0, offset: 0, limit: 10000 },
       isLoading: false,
     }));
 
@@ -153,7 +185,7 @@ describe("Trips", () => {
     }));
 
     renderWithProviders(<Trips />);
-    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
+    expect(screen.getByText(/no receipts found/i)).toBeInTheDocument();
   });
 
   it("does not render trip data when no receipt is selected", () => {

--- a/src/client/src/pages/Trips.test.tsx
+++ b/src/client/src/pages/Trips.test.tsx
@@ -16,13 +16,37 @@ vi.mock("@/hooks/useTrips", () => ({
 }));
 
 vi.mock("@/hooks/useReceipts", () => ({
-  useReceipts: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useReceipts: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 25 }, isLoading: false })),
 }));
 
-vi.mock("@/lib/combobox-options", () => ({
-  receiptToOption: vi.fn((r: { id: string }) => ({
-    value: r.id,
-    label: r.id,
+vi.mock("@/hooks/useFuzzySearch", () => ({
+  useFuzzySearch: vi.fn(() => ({
+    search: "",
+    setSearch: vi.fn(),
+    results: [],
+    totalCount: 0,
+    isSearching: false,
+    clearSearch: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/useSavedFilters", () => ({
+  useSavedFilters: vi.fn(() => ({
+    filters: [],
+    save: vi.fn(),
+    remove: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/useServerPagination", () => ({
+  useServerPagination: vi.fn(() => ({
+    offset: 0,
+    limit: 25,
+    currentPage: 1,
+    pageSize: 25,
+    totalPages: vi.fn(() => 1),
+    setPage: vi.fn(),
+    setPageSize: vi.fn(),
   })),
 }));
 
@@ -34,9 +58,102 @@ describe("Trips", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the receipt selection label", () => {
+  it("renders the search input", () => {
     renderWithProviders(<Trips />);
-    expect(screen.getByText(/select a receipt/i)).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/search receipts/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the filter panel", () => {
+    renderWithProviders(<Trips />);
+    expect(
+      screen.getByRole("button", { name: /filters/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders receipt table when receipts exist", async () => {
+    const items = [
+      { id: "1", description: "Grocery", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
+      { id: "2", description: null, location: "Target", date: "2024-01-20", taxAmount: 3.50 },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
+      data: { data: items, total: items.length, offset: 0, limit: 25 },
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Trips />);
+    expect(screen.getByText("Grocery")).toBeInTheDocument();
+    expect(screen.getByText("Walmart")).toBeInTheDocument();
+    expect(screen.getByText("Target")).toBeInTheDocument();
+    expect(screen.getByText(/no description/i)).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton when receipts are loading", async () => {
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
+      data: undefined,
+      isLoading: true,
+    }));
+
+    const { container } = renderWithProviders(<Trips />);
+    expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no receipts found", async () => {
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
+      data: { data: [], total: 0, offset: 0, limit: 25 },
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 0,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Trips />);
+    expect(
+      screen.getByText(/no receipts found/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders no-results state when search yields nothing", async () => {
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
+      data: { data: [], total: 0, offset: 0, limit: 25 },
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "xyz",
+      setSearch: vi.fn(),
+      results: [],
+      totalCount: 0,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Trips />);
+    expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
   });
 
   it("does not render trip data when no receipt is selected", () => {

--- a/src/client/src/pages/Trips.tsx
+++ b/src/client/src/pages/Trips.tsx
@@ -1,13 +1,23 @@
 import { useState, useMemo } from "react";
 import { useTripByReceiptId } from "@/hooks/useTrips";
 import { useReceipts } from "@/hooks/useReceipts";
-import { receiptToOption } from "@/lib/combobox-options";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useFuzzySearch } from "@/hooks/useFuzzySearch";
+import { useSavedFilters } from "@/hooks/useSavedFilters";
+import { useServerPagination } from "@/hooks/useServerPagination";
+import type { FuseSearchConfig, FilterDefinition } from "@/lib/search";
+import { applyFilters } from "@/lib/search";
+import type { FilterValues } from "@/components/FilterPanel";
+import { FuzzySearchInput } from "@/components/FuzzySearchInput";
+import { FilterPanel } from "@/components/FilterPanel";
+import type { FilterField } from "@/components/FilterPanel";
+import { SearchHighlight } from "@/components/SearchHighlight";
+import { getMatchIndices } from "@/lib/search-highlight";
+import { NoResults } from "@/components/NoResults";
+import { Pagination } from "@/components/Pagination";
 import { ValidationWarnings } from "@/components/ValidationWarnings";
 import { BalanceSummaryCard } from "@/components/BalanceSummaryCard";
 import { ReceiptItemsCard } from "@/components/ReceiptItemsCard";
-import { Combobox } from "@/components/ui/combobox";
-import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -26,31 +36,83 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { CardSkeleton } from "@/components/ui/card-skeleton";
+import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { formatCurrency } from "@/lib/format";
+
+interface ReceiptResponse {
+  id: string;
+  description?: string | null;
+  location: string;
+  date: string;
+  taxAmount: number;
+}
+
+const SEARCH_CONFIG: FuseSearchConfig<ReceiptResponse> = {
+  keys: [
+    { name: "description", weight: 2 },
+    { name: "location", weight: 1.5 },
+  ],
+};
+
+const FILTER_FIELDS: FilterField[] = [
+  { type: "dateRange", key: "date", label: "Date" },
+  { type: "numberRange", key: "taxAmount", label: "Tax Amount" },
+];
+
+const FILTER_DEFS: FilterDefinition[] = [
+  { key: "date", type: "dateRange", field: "date" },
+  { key: "taxAmount", type: "numberRange", field: "taxAmount" },
+];
 
 function Trips() {
   usePageTitle("Trips");
   const [receiptId, setReceiptId] = useState<string | null>(null);
-  const { data: trip, isLoading, isError } = useTripByReceiptId(receiptId);
-  const { data: receipts, isLoading: receiptsLoading } = useReceipts();
+  const { data: trip, isLoading: tripLoading, isError } = useTripByReceiptId(receiptId);
 
-  const receiptOptions = useMemo(
-    () =>
-      ((receipts?.data as { id: string; description?: string | null; location: string; date: string }[] | undefined) ?? []).map(receiptToOption),
-    [receipts],
-  );
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination();
+  const { data: receiptsResponse, isLoading: receiptsLoading } = useReceipts(offset, limit);
+
+  const [filterValues, setFilterValues] = useState<FilterValues>({});
+
+  const data = useMemo(() => {
+    const list = (receiptsResponse?.data as ReceiptResponse[] | undefined) ?? [];
+    return [...list].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    );
+  }, [receiptsResponse?.data]);
+  const serverTotal = receiptsResponse?.total ?? 0;
+
+  const {
+    filters: savedFilters,
+    save: saveFilter,
+    remove: removeFilter,
+  } = useSavedFilters("trips");
+
+  const { search, setSearch, results, totalCount, clearSearch } =
+    useFuzzySearch({ data, config: SEARCH_CONFIG });
+
+  const filteredResults = useMemo(() => {
+    const items = results.map((r) => r.item);
+    return applyFilters(items, FILTER_DEFS, filterValues);
+  }, [results, filterValues]);
+
+  const matchMap = useMemo(() => {
+    const map = new Map<string, (typeof results)[number]>();
+    for (const r of results) {
+      map.set(r.item.id, r);
+    }
+    return map;
+  }, [results]);
 
   const transactionsTotal =
     trip?.transactions?.reduce((sum: number, ta: { transaction: { amount: number } }) => sum + ta.transaction.amount, 0) ??
     0;
 
-  // Balance equation values from the server-computed response
   const subtotal = trip?.receipt?.subtotal ?? 0;
   const adjustmentTotal = trip?.receipt?.adjustmentTotal ?? 0;
   const expectedTotal = trip?.receipt?.expectedTotal ?? 0;
   const taxAmount = trip?.receipt?.receipt?.taxAmount ?? 0;
 
-  // Combine warnings from both receipt and trip levels
   const allWarnings = [
     ...(trip?.receipt?.warnings ?? []),
     ...(trip?.warnings ?? []),
@@ -59,20 +121,118 @@ function Trips() {
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold tracking-tight">Trips</h1>
-      <div className="max-w-md space-y-2">
-        <Label>Select a Receipt</Label>
-        <Combobox
-          options={receiptOptions}
-          value={receiptId ?? ""}
-          onValueChange={(value) => setReceiptId(value || null)}
-          placeholder="Search for a receipt..."
-          searchPlaceholder="Search receipts..."
-          emptyMessage="No receipts found."
-          loading={receiptsLoading}
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <FuzzySearchInput
+            aria-label="Search receipts"
+            value={search}
+            onChange={setSearch}
+            placeholder="Search receipts..."
+            resultCount={filteredResults.length}
+            totalCount={totalCount}
+            className="max-w-sm"
+          />
+        </div>
+
+        <FilterPanel
+          fields={FILTER_FIELDS}
+          values={filterValues}
+          onChange={setFilterValues}
+          savedFilters={savedFilters}
+          onSaveFilter={(name) =>
+            saveFilter({
+              id: crypto.randomUUID(),
+              name,
+              entityType: "trips",
+              values: filterValues,
+              createdAt: new Date().toISOString(),
+            })
+          }
+          onDeleteFilter={removeFilter}
+          onLoadFilter={(preset) =>
+            setFilterValues(preset.values as FilterValues)
+          }
         />
+
+        {receiptsLoading ? (
+          <TableSkeleton columns={4} />
+        ) : filteredResults.length === 0 ? (
+          search ? (
+            <NoResults
+              searchTerm={search}
+              onClearSearch={clearSearch}
+              onSelectSuggestion={setSearch}
+              entityName="receipts"
+            />
+          ) : (
+            <div className="py-12 text-center text-muted-foreground">
+              No receipts found.
+            </div>
+          )
+        ) : (
+          <>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Description</TableHead>
+                    <TableHead>Location</TableHead>
+                    <TableHead>Date</TableHead>
+                    <TableHead className="text-right">Tax Amount</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredResults.map((receipt) => {
+                    const result = matchMap.get(receipt.id);
+                    const matches = result?.matches;
+                    return (
+                      <TableRow
+                        key={receipt.id}
+                        className={`cursor-pointer ${receiptId === receipt.id ? "bg-accent" : ""}`}
+                        onClick={() => setReceiptId(receipt.id)}
+                      >
+                        <TableCell>
+                          {receipt.description ? (
+                            <SearchHighlight
+                              text={receipt.description}
+                              indices={getMatchIndices(matches, "description")}
+                            />
+                          ) : (
+                            <span className="text-muted-foreground italic">
+                              No description
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <SearchHighlight
+                            text={receipt.location}
+                            indices={getMatchIndices(matches, "location")}
+                          />
+                        </TableCell>
+                        <TableCell>{receipt.date}</TableCell>
+                        <TableCell className="text-right">
+                          {formatCurrency(receipt.taxAmount)}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+            <Pagination
+              currentPage={currentPage}
+              totalItems={serverTotal}
+              pageSize={pageSize}
+              totalPages={totalPages(serverTotal)}
+              onPageChange={(page) => setPage(page, serverTotal)}
+              onPageSizeChange={setPageSize}
+            />
+          </>
+        )}
       </div>
 
-      {isLoading && (
+      {tripLoading && (
         <div className="space-y-4">
           <CardSkeleton lines={1} />
           <CardSkeleton lines={3} />

--- a/src/client/src/pages/Trips.tsx
+++ b/src/client/src/pages/Trips.tsx
@@ -4,7 +4,7 @@ import { useReceipts } from "@/hooks/useReceipts";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
-import { useServerPagination } from "@/hooks/useServerPagination";
+import { usePagination } from "@/hooks/usePagination";
 import type { FuseSearchConfig, FilterDefinition } from "@/lib/search";
 import { applyFilters } from "@/lib/search";
 import type { FilterValues } from "@/components/FilterPanel";
@@ -69,8 +69,7 @@ function Trips() {
   const [receiptId, setReceiptId] = useState<string | null>(null);
   const { data: trip, isLoading: tripLoading, isError } = useTripByReceiptId(receiptId);
 
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination();
-  const { data: receiptsResponse, isLoading: receiptsLoading } = useReceipts(offset, limit);
+  const { data: receiptsResponse, isLoading: receiptsLoading } = useReceipts(0, 10000);
 
   const [filterValues, setFilterValues] = useState<FilterValues>({});
 
@@ -80,7 +79,6 @@ function Trips() {
       (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
     );
   }, [receiptsResponse?.data]);
-  const serverTotal = receiptsResponse?.total ?? 0;
 
   const {
     filters: savedFilters,
@@ -95,6 +93,19 @@ function Trips() {
     const items = results.map((r) => r.item);
     return applyFilters(items, FILTER_DEFS, filterValues);
   }, [results, filterValues]);
+
+  const { paginatedItems, currentPage, pageSize, totalItems, totalPages, setPage, setPageSize } =
+    usePagination({ items: filteredResults });
+
+  const hasActiveFilters = useMemo(() => {
+    return Object.values(filterValues).some((v) => {
+      if (v == null) return false;
+      if (typeof v === "object") {
+        return Object.values(v as Record<string, unknown>).some((inner) => inner != null);
+      }
+      return v !== "" && v !== "all";
+    });
+  }, [filterValues]);
 
   const matchMap = useMemo(() => {
     const map = new Map<string, (typeof results)[number]>();
@@ -158,9 +169,9 @@ function Trips() {
         {receiptsLoading ? (
           <TableSkeleton columns={4} />
         ) : filteredResults.length === 0 ? (
-          search ? (
+          (search || hasActiveFilters) && totalCount > 0 ? (
             <NoResults
-              searchTerm={search}
+              searchTerm={search || "current filters"}
               onClearSearch={clearSearch}
               onSelectSuggestion={setSearch}
               entityName="receipts"
@@ -183,7 +194,7 @@ function Trips() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {filteredResults.map((receipt) => {
+                  {paginatedItems.map((receipt) => {
                     const result = matchMap.get(receipt.id);
                     const matches = result?.matches;
                     return (
@@ -222,10 +233,10 @@ function Trips() {
             </div>
             <Pagination
               currentPage={currentPage}
-              totalItems={serverTotal}
+              totalItems={totalItems}
               pageSize={pageSize}
-              totalPages={totalPages(serverTotal)}
-              onPageChange={(page) => setPage(page, serverTotal)}
+              totalPages={totalPages}
+              onPageChange={setPage}
               onPageSizeChange={setPageSize}
             />
           </>


### PR DESCRIPTION
## Summary
- Replace the Combobox dropdown on the Trips page with a searchable, filterable receipt table
- Reuse existing search/filter infrastructure from the Receipts page (fuzzy search, date/amount filters, saved filter presets, pagination)
- Clicking a table row selects that receipt and displays the trip detail below with selected row highlighted

Resolves MGG-274

## Test plan
- `cd src/client && npx vitest run src/pages/Trips.test.tsx` — 15 tests pass
- `dotnet test Receipts.slnx` — all 1033 backend tests pass
- Pre-commit hooks pass
- Manual: navigate to Trips page, verify search/filter/select/pagination flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)