### PR TITLE
feat(client): persist table page size preference (MGG-270)

### DIFF
--- a/src/client/src/hooks/usePagination.test.ts
+++ b/src/client/src/hooks/usePagination.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { usePagination } from "./usePagination";
 
 const items = Array.from({ length: 50 }, (_, i) => i + 1);
 
 describe("usePagination", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("returns first page by default", () => {
     const { result } = renderHook(() =>
       usePagination({ items, defaultPageSize: 10 }),
@@ -69,5 +73,30 @@ describe("usePagination", () => {
     );
     expect(result.current.totalPages).toBe(1);
     expect(result.current.paginatedItems).toEqual([]);
+  });
+
+  it("uses persisted page size from localStorage when available", () => {
+    localStorage.setItem("table-page-size", "50");
+    const { result } = renderHook(() =>
+      usePagination({ items, defaultPageSize: 10 }),
+    );
+    expect(result.current.pageSize).toBe(50);
+    expect(result.current.totalPages).toBe(1);
+  });
+
+  it("falls back to defaultPageSize when nothing is persisted", () => {
+    const { result } = renderHook(() =>
+      usePagination({ items, defaultPageSize: 10 }),
+    );
+    expect(result.current.pageSize).toBe(10);
+  });
+
+  it("persists new page size to localStorage via setPageSize", () => {
+    const { result } = renderHook(() =>
+      usePagination({ items, defaultPageSize: 10 }),
+    );
+    act(() => result.current.setPageSize(50));
+    expect(localStorage.getItem("table-page-size")).toBe("50");
+    expect(result.current.pageSize).toBe(50);
   });
 });

--- a/src/client/src/hooks/usePagination.ts
+++ b/src/client/src/hooks/usePagination.ts
@@ -1,4 +1,5 @@
 import { useReducer, useMemo } from "react";
+import { getPersistedPageSize, persistPageSize } from "@/lib/page-size";
 
 interface UsePaginationOptions<T> {
   items: T[];
@@ -39,7 +40,7 @@ export function usePagination<T>({
 }: UsePaginationOptions<T>): UsePaginationReturn<T> {
   const [state, dispatch] = useReducer(reducer, {
     currentPage: 1,
-    pageSize: defaultPageSize,
+    pageSize: getPersistedPageSize() ?? defaultPageSize,
   });
 
   const totalItems = items.length;
@@ -60,6 +61,7 @@ export function usePagination<T>({
   }
 
   function setPageSize(size: number) {
+    persistPageSize(size);
     dispatch({ type: "SET_PAGE_SIZE", size });
   }
 

--- a/src/client/src/hooks/useServerPagination.test.ts
+++ b/src/client/src/hooks/useServerPagination.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useServerPagination } from "./useServerPagination";
+
+describe("useServerPagination", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns offset 0 and default page size on mount", () => {
+    const { result } = renderHook(() => useServerPagination());
+    expect(result.current.offset).toBe(0);
+    expect(result.current.limit).toBe(25);
+    expect(result.current.pageSize).toBe(25);
+    expect(result.current.currentPage).toBe(1);
+  });
+
+  it("respects custom defaultPageSize", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 20 }),
+    );
+    expect(result.current.limit).toBe(20);
+  });
+
+  it("navigates to a specific page", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10 }),
+    );
+    act(() => result.current.setPage(3, 100));
+    expect(result.current.currentPage).toBe(3);
+    expect(result.current.offset).toBe(20);
+  });
+
+  it("clamps page to minimum of 1", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10 }),
+    );
+    act(() => result.current.setPage(0, 100));
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.offset).toBe(0);
+  });
+
+  it("clamps page to maximum", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10 }),
+    );
+    act(() => result.current.setPage(999, 50));
+    expect(result.current.currentPage).toBe(5);
+    expect(result.current.offset).toBe(40);
+  });
+
+  it("calculates totalPages correctly", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10 }),
+    );
+    expect(result.current.totalPages(50)).toBe(5);
+    expect(result.current.totalPages(51)).toBe(6);
+    expect(result.current.totalPages(0)).toBe(1);
+  });
+
+  it("resets to offset 0 when page size changes", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10 }),
+    );
+    act(() => result.current.setPage(3, 100));
+    expect(result.current.offset).toBe(20);
+
+    act(() => result.current.setPageSize(25));
+    expect(result.current.offset).toBe(0);
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.limit).toBe(25);
+  });
+
+  it("uses persisted page size from localStorage when available", () => {
+    localStorage.setItem("table-page-size", "50");
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10 }),
+    );
+    expect(result.current.limit).toBe(50);
+    expect(result.current.pageSize).toBe(50);
+  });
+
+  it("falls back to defaultPageSize when nothing is persisted", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10 }),
+    );
+    expect(result.current.limit).toBe(10);
+  });
+
+  it("persists new page size to localStorage via setPageSize", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10 }),
+    );
+    act(() => result.current.setPageSize(50));
+    expect(localStorage.getItem("table-page-size")).toBe("50");
+    expect(result.current.limit).toBe(50);
+  });
+});

--- a/src/client/src/hooks/useServerPagination.ts
+++ b/src/client/src/hooks/useServerPagination.ts
@@ -1,4 +1,5 @@
 import { useReducer, useMemo } from "react";
+import { getPersistedPageSize, persistPageSize } from "@/lib/page-size";
 
 interface UseServerPaginationOptions {
   defaultPageSize?: number;
@@ -37,7 +38,7 @@ export function useServerPagination({
 }: UseServerPaginationOptions = {}): UseServerPaginationReturn {
   const [state, dispatch] = useReducer(reducer, {
     offset: 0,
-    limit: defaultPageSize,
+    limit: getPersistedPageSize() ?? defaultPageSize,
   });
 
   const currentPage = useMemo(
@@ -56,6 +57,7 @@ export function useServerPagination({
   }
 
   function setPageSize(size: number) {
+    persistPageSize(size);
     dispatch({ type: "SET_LIMIT", limit: size });
   }
 

--- a/src/client/src/lib/page-size.test.ts
+++ b/src/client/src/lib/page-size.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { getPersistedPageSize, persistPageSize } from "./page-size";
+
+describe("getPersistedPageSize", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(getPersistedPageSize()).toBeNull();
+  });
+
+  it.each([10, 25, 50, 100])("returns %i when stored", (size) => {
+    localStorage.setItem("table-page-size", String(size));
+    expect(getPersistedPageSize()).toBe(size);
+  });
+
+  it.each(["abc", "15", "0", "-1", "999", ""])(
+    'returns null for invalid stored value "%s"',
+    (value) => {
+      localStorage.setItem("table-page-size", value);
+      expect(getPersistedPageSize()).toBeNull();
+    },
+  );
+
+  it("returns null when localStorage.getItem throws", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+    expect(getPersistedPageSize()).toBeNull();
+    vi.restoreAllMocks();
+  });
+});
+
+describe("persistPageSize", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("writes the size to localStorage", () => {
+    persistPageSize(50);
+    expect(localStorage.getItem("table-page-size")).toBe("50");
+  });
+
+  it("overwrites a previously stored size", () => {
+    persistPageSize(10);
+    persistPageSize(100);
+    expect(localStorage.getItem("table-page-size")).toBe("100");
+  });
+
+  it("does not throw when localStorage.setItem throws", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    expect(() => persistPageSize(25)).not.toThrow();
+    vi.restoreAllMocks();
+  });
+});

--- a/src/client/src/lib/page-size.test.ts
+++ b/src/client/src/lib/page-size.test.ts
@@ -48,6 +48,11 @@ describe("persistPageSize", () => {
     expect(localStorage.getItem("table-page-size")).toBe("100");
   });
 
+  it("does not write an invalid size", () => {
+    persistPageSize(15);
+    expect(localStorage.getItem("table-page-size")).toBeNull();
+  });
+
   it("does not throw when localStorage.setItem throws", () => {
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new Error("quota exceeded");

--- a/src/client/src/lib/page-size.ts
+++ b/src/client/src/lib/page-size.ts
@@ -1,0 +1,21 @@
+const PAGE_SIZE_KEY = "table-page-size";
+const VALID_PAGE_SIZES = [10, 25, 50, 100];
+
+export function getPersistedPageSize(): number | null {
+  try {
+    const raw = localStorage.getItem(PAGE_SIZE_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return VALID_PAGE_SIZES.includes(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function persistPageSize(size: number): void {
+  try {
+    localStorage.setItem(PAGE_SIZE_KEY, String(size));
+  } catch {
+    // Ignore storage errors (full, disabled, etc.)
+  }
+}

--- a/src/client/src/lib/page-size.ts
+++ b/src/client/src/lib/page-size.ts
@@ -13,6 +13,7 @@ export function getPersistedPageSize(): number | null {
 }
 
 export function persistPageSize(size: number): void {
+  if (!VALID_PAGE_SIZES.includes(size)) return;
   try {
     localStorage.setItem(PAGE_SIZE_KEY, String(size));
   } catch {


### PR DESCRIPTION
## Summary

- Add localStorage persistence for table page size preference across all data tables
- Both `useServerPagination` and `usePagination` hooks read/write a shared `table-page-size` key
- User's chosen page size (10/25/50/100) is restored on subsequent visits
- Invalid or missing stored values fall back to the hook's `defaultPageSize`

Closes MGG-270

## Test plan

- [x] Unit tests for `page-size.ts` (valid sizes, invalid values, localStorage errors)
- [x] Updated `usePagination.test.ts` (persistence read/write, fallback behavior)
- [x] Full client test suite passes (873 tests)
- [ ] Manual: change page size on one table, navigate away, return — size is preserved
- [ ] Manual: change page size, open a different table — same size is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)