### PR TITLE
feat(shared): contextual SignalR toast messages based on change origin (MGG-265)

### DIFF
--- a/src/Presentation/API/Hubs/EntityChangeNotification.cs
+++ b/src/Presentation/API/Hubs/EntityChangeNotification.cs
@@ -1,3 +1,10 @@
 namespace API.Hubs;
 
-public record EntityChangeNotification(string EntityType, string ChangeType, Guid? Id, int Count = 1);
+public record EntityChangeNotification(
+	string EntityType,
+	string ChangeType,
+	Guid? Id,
+	int Count = 1,
+	string? UserId = null,
+	string? AuthMethod = null,
+	string? ConnectionId = null);

--- a/src/Presentation/API/Services/EntityChangeNotifier.cs
+++ b/src/Presentation/API/Services/EntityChangeNotifier.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Security.Claims;
+using API.Authentication;
 using API.Hubs;
 using Microsoft.AspNetCore.SignalR;
 
@@ -7,19 +9,21 @@ namespace API.Services;
 public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 {
 	private readonly IHubContext<EntityHub, IEntityHubClient> _hubContext;
-	private readonly ConcurrentDictionary<(string EntityType, string ChangeType), NotificationBucket> _pending = new();
+	private readonly IHttpContextAccessor _httpContextAccessor;
+	private readonly ConcurrentDictionary<(string EntityType, string ChangeType, string? UserId, string? AuthMethod, string? ConnectionId), NotificationBucket> _pending = new();
 	private readonly Timer _flushTimer;
 	private readonly TimeSpan _flushInterval;
 	private int _disposed;
 
-	public EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext)
-		: this(hubContext, TimeSpan.FromSeconds(1))
+	public EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor)
+		: this(hubContext, httpContextAccessor, TimeSpan.FromSeconds(1))
 	{
 	}
 
-	internal EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, TimeSpan flushInterval)
+	internal EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor, TimeSpan flushInterval)
 	{
 		_hubContext = hubContext;
+		_httpContextAccessor = httpContextAccessor;
 		_flushInterval = flushInterval;
 		_flushTimer = new Timer(_ => _ = FlushAsync(), null, _flushInterval, _flushInterval);
 	}
@@ -59,7 +63,8 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 
 	private void Enqueue(string entityType, string changeType, Guid? id)
 	{
-		var key = (entityType, changeType);
+		var origin = CaptureOrigin();
+		var key = (entityType, changeType, origin.UserId, origin.AuthMethod, origin.ConnectionId);
 		_pending.AddOrUpdate(
 			key,
 			_ => new NotificationBucket(id),
@@ -70,22 +75,39 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 			});
 	}
 
+	private NotificationOrigin CaptureOrigin()
+	{
+		var httpContext = _httpContextAccessor.HttpContext;
+		if (httpContext is null)
+		{
+			return new NotificationOrigin(null, null, null);
+		}
+
+		var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+		var authMethod = httpContext.User.Identity?.AuthenticationType == ApiKeyAuthenticationDefaults.AuthenticationScheme
+			? "apikey"
+			: "jwt";
+		var connectionId = httpContext.Request.Headers["X-SignalR-Connection-Id"].FirstOrDefault();
+
+		return new NotificationOrigin(userId, authMethod, connectionId);
+	}
+
 	internal async Task FlushAsync()
 	{
 		// Snapshot and remove all pending buckets atomically per key
-		List<(string EntityType, string ChangeType, int Count)> toSend = [];
+		List<(string EntityType, string ChangeType, string? UserId, string? AuthMethod, string? ConnectionId, int Count)> toSend = [];
 		foreach (var key in _pending.Keys)
 		{
 			if (_pending.TryRemove(key, out NotificationBucket? bucket))
 			{
-				toSend.Add((key.EntityType, key.ChangeType, bucket.Count));
+				toSend.Add((key.EntityType, key.ChangeType, key.UserId, key.AuthMethod, key.ConnectionId, bucket.Count));
 			}
 		}
 
-		foreach (var (entityType, changeType, count) in toSend)
+		foreach (var (entityType, changeType, userId, authMethod, connectionId, count) in toSend)
 		{
 			await _hubContext.Clients.All.EntityChanged(
-				new EntityChangeNotification(entityType, changeType, null, count));
+				new EntityChangeNotification(entityType, changeType, null, count, userId, authMethod, connectionId));
 		}
 	}
 
@@ -98,6 +120,8 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 			FlushAsync().GetAwaiter().GetResult();
 		}
 	}
+
+	private sealed record NotificationOrigin(string? UserId, string? AuthMethod, string? ConnectionId);
 
 	private sealed class NotificationBucket
 	{

--- a/src/Presentation/API/Services/EntityChangeNotifier.cs
+++ b/src/Presentation/API/Services/EntityChangeNotifier.cs
@@ -84,9 +84,14 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 		}
 
 		var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
-		var authMethod = httpContext.User.Identity?.AuthenticationType == ApiKeyAuthenticationDefaults.AuthenticationScheme
+		var authType = httpContext.User.Identity?.AuthenticationType;
+		var authMethod = authType == ApiKeyAuthenticationDefaults.AuthenticationScheme
 			? "apikey"
-			: "jwt";
+			: authType is not null
+				? "jwt"
+				: null;
+		// connectionId is client-supplied and untrusted; spoofing suppresses a toast
+		// but does not affect data integrity or query invalidation.
 		var connectionId = httpContext.Request.Headers["X-SignalR-Connection-Id"].FirstOrDefault();
 
 		return new NotificationOrigin(userId, authMethod, connectionId);

--- a/src/client/src/components/AdminRoute.test.tsx
+++ b/src/client/src/components/AdminRoute.test.tsx
@@ -6,21 +6,21 @@ import { renderWithProviders } from "@/test/test-utils";
 describe("AdminRoute", () => {
   it("renders children when user is admin", () => {
     renderWithProviders(<AdminRoute>Admin page</AdminRoute>, {
-      auth: { user: { email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } },
+      auth: { user: { userId: "admin-id", email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } },
     });
     expect(screen.getByText("Admin page")).toBeInTheDocument();
   });
 
   it("redirects to / when user is not admin", () => {
     renderWithProviders(<AdminRoute>Admin page</AdminRoute>, {
-      auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
+      auth: { user: { userId: "user-id", email: "user@test.com", roles: ["User"], mustResetPassword: false } },
     });
     expect(screen.queryByText("Admin page")).not.toBeInTheDocument();
   });
 
   it("redirects when user has no roles", () => {
     renderWithProviders(<AdminRoute>Admin page</AdminRoute>, {
-      auth: { user: { email: "user@test.com", roles: [], mustResetPassword: false } },
+      auth: { user: { userId: "user-id", email: "user@test.com", roles: [], mustResetPassword: false } },
     });
     expect(screen.queryByText("Admin page")).not.toBeInTheDocument();
   });

--- a/src/client/src/components/Layout.test.tsx
+++ b/src/client/src/components/Layout.test.tsx
@@ -37,7 +37,7 @@ vi.mock("@/components/ShortcutsHelp", () => ({
 }));
 
 const defaultAuth: AuthContextValue = {
-  user: { email: "test@example.com", roles: ["User"], mustResetPassword: false },
+  user: { userId: "test-user-id", email: "test@example.com", roles: ["User"], mustResetPassword: false },
   isLoading: false,
   mustResetPassword: false,
   login: async () => {},
@@ -95,7 +95,7 @@ describe("Layout", () => {
   });
 
   it("shows user email in the header", () => {
-    renderLayout({ user: { email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } });
+    renderLayout({ user: { userId: "admin-id", email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } });
     expect(screen.getByText("admin@test.com")).toBeInTheDocument();
   });
 
@@ -167,13 +167,13 @@ describe("Layout", () => {
   });
 
   it("shows admin nav group when user has Admin role", () => {
-    renderLayout({ user: { email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } });
+    renderLayout({ user: { userId: "admin-id", email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } });
     // Admin group should be rendered in the desktop nav
     expect(screen.getByText("Admin")).toBeInTheDocument();
   });
 
   it("does not show admin nav group for non-admin users", () => {
-    renderLayout({ user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } });
+    renderLayout({ user: { userId: "user-id", email: "user@test.com", roles: ["User"], mustResetPassword: false } });
     expect(screen.queryByText("Admin")).not.toBeInTheDocument();
   });
 

--- a/src/client/src/components/ProtectedRoute.test.tsx
+++ b/src/client/src/components/ProtectedRoute.test.tsx
@@ -6,7 +6,7 @@ import { renderWithProviders } from "@/test/test-utils";
 describe("ProtectedRoute", () => {
   it("renders children when user is authenticated", () => {
     renderWithProviders(<ProtectedRoute>Dashboard</ProtectedRoute>, {
-      auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
+      auth: { user: { userId: "user-id", email: "user@test.com", roles: ["User"], mustResetPassword: false } },
     });
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
   });
@@ -29,7 +29,7 @@ describe("ProtectedRoute", () => {
   it("redirects to /change-password when mustResetPassword is true", () => {
     renderWithProviders(<ProtectedRoute>Dashboard</ProtectedRoute>, {
       auth: {
-        user: { email: "user@test.com", roles: ["User"], mustResetPassword: false },
+        user: { userId: "user-id", email: "user@test.com", roles: ["User"], mustResetPassword: false },
         mustResetPassword: true,
       },
     });

--- a/src/client/src/contexts/AuthContext.test.tsx
+++ b/src/client/src/contexts/AuthContext.test.tsx
@@ -82,6 +82,7 @@ describe("AuthProvider", () => {
     mockedAuth.isAuthenticated.mockReturnValue(true);
     mockedAuth.getAccessToken.mockReturnValue(token);
     mockedAuth.parseJwtPayload.mockReturnValue({
+      userId: "user-id",
       email: "user@test.com",
       roles: ["User"],
       mustResetPassword: false,
@@ -101,6 +102,7 @@ describe("AuthProvider", () => {
     mockedAuth.isAuthenticated.mockReturnValue(true);
     mockedAuth.getAccessToken.mockReturnValue(token);
     mockedAuth.parseJwtPayload.mockReturnValue({
+      userId: "admin-id",
       email: "admin@test.com",
       roles: ["Admin"],
       mustResetPassword: true,
@@ -148,6 +150,7 @@ describe("AuthProvider", () => {
       error: undefined,
     });
     mockedAuth.parseJwtPayload.mockReturnValue({
+      userId: "user-id",
       email: "a@b.com",
       roles: ["User"],
       mustResetPassword: false,
@@ -175,6 +178,7 @@ describe("AuthProvider", () => {
     mockedAuth.isAuthenticated.mockReturnValue(true);
     mockedAuth.getAccessToken.mockReturnValue(token);
     mockedAuth.parseJwtPayload.mockReturnValue({
+      userId: "user-id",
       email: "user@test.com",
       roles: ["User"],
       mustResetPassword: false,
@@ -277,6 +281,7 @@ describe("AuthProvider", () => {
       error: undefined,
     });
     mockedAuth.parseJwtPayload.mockReturnValue({
+      userId: "user-id",
       email: "a@b.com",
       roles: ["User"],
       mustResetPassword: false,

--- a/src/client/src/hooks/useAuth.test.ts
+++ b/src/client/src/hooks/useAuth.test.ts
@@ -7,10 +7,11 @@ describe("useAuth", () => {
   it("returns auth context when inside provider", () => {
     const { result } = renderHook(() => useAuth(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
+        auth: { user: { userId: "user-id", email: "user@test.com", roles: ["User"], mustResetPassword: false } },
       }),
     });
     expect(result.current.user).toEqual({
+      userId: "user-id",
       email: "user@test.com",
       roles: ["User"],
       mustResetPassword: false,

--- a/src/client/src/hooks/usePermission.test.ts
+++ b/src/client/src/hooks/usePermission.test.ts
@@ -7,7 +7,7 @@ describe("usePermission", () => {
   it("returns roles from auth context", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["Admin", "User"], mustResetPassword: false } },
+        auth: { user: { userId: "user-id", email: "user@test.com", roles: ["Admin", "User"], mustResetPassword: false } },
       }),
     });
     expect(result.current.roles).toEqual(["Admin", "User"]);
@@ -16,7 +16,7 @@ describe("usePermission", () => {
   it("hasRole returns true for existing role", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["Admin"], mustResetPassword: false } },
+        auth: { user: { userId: "user-id", email: "user@test.com", roles: ["Admin"], mustResetPassword: false } },
       }),
     });
     expect(result.current.hasRole("Admin")).toBe(true);
@@ -25,7 +25,7 @@ describe("usePermission", () => {
   it("hasRole returns false for missing role", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
+        auth: { user: { userId: "user-id", email: "user@test.com", roles: ["User"], mustResetPassword: false } },
       }),
     });
     expect(result.current.hasRole("Admin")).toBe(false);
@@ -34,7 +34,7 @@ describe("usePermission", () => {
   it("isAdmin returns true for Admin role", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } },
+        auth: { user: { userId: "admin-id", email: "admin@test.com", roles: ["Admin"], mustResetPassword: false } },
       }),
     });
     expect(result.current.isAdmin()).toBe(true);
@@ -43,7 +43,7 @@ describe("usePermission", () => {
   it("isAdmin returns false without Admin role", () => {
     const { result } = renderHook(() => usePermission(), {
       wrapper: createWrapper({
-        auth: { user: { email: "user@test.com", roles: ["User"], mustResetPassword: false } },
+        auth: { user: { userId: "user-id", email: "user@test.com", roles: ["User"], mustResetPassword: false } },
       }),
     });
     expect(result.current.isAdmin()).toBe(false);

--- a/src/client/src/hooks/useSignalR.test.ts
+++ b/src/client/src/hooks/useSignalR.test.ts
@@ -60,6 +60,7 @@ import { toast } from "sonner";
 import { bufferToast } from "@/lib/signalr-toast-buffer";
 import { act } from "@testing-library/react";
 import { setConnectionId, getConnectionId } from "@/lib/signalr-connection";
+import { parseJwtPayload } from "@/lib/auth";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -311,6 +312,21 @@ describe("useSignalR", () => {
       });
 
       expect(bufferToast).toHaveBeenCalledWith("receipt", "deleted", 1, "other-user");
+    });
+
+    it("classifies as other-user when parseJwtPayload returns null", async () => {
+      vi.mocked(parseJwtPayload).mockReturnValueOnce(null);
+
+      await renderEnabled();
+
+      const handler = getOnHandler("EntityChanged");
+      expect(handler).toBeDefined();
+
+      act(() => {
+        handler!({ entityType: "receipt", changeType: "created", id: "abc", count: 1, userId: "current-user-id", authMethod: "jwt", connectionId: "different-conn" });
+      });
+
+      expect(bufferToast).toHaveBeenCalledWith("receipt", "created", 1, "other-user");
     });
   });
 

--- a/src/client/src/hooks/useSignalR.test.ts
+++ b/src/client/src/hooks/useSignalR.test.ts
@@ -8,6 +8,7 @@ const mockConnection = {
   onreconnecting: vi.fn(),
   onreconnected: vi.fn(),
   onclose: vi.fn(),
+  connectionId: "mock-conn-id",
 };
 
 const mockBuilder = {
@@ -40,6 +41,17 @@ vi.mock("@/lib/signalr-toast-buffer", () => ({
 
 vi.mock("@/lib/auth", () => ({
   getAccessToken: vi.fn().mockReturnValue("mock-token"),
+  parseJwtPayload: vi.fn().mockReturnValue({
+    userId: "current-user-id",
+    email: "user@example.com",
+    roles: [],
+    mustResetPassword: false,
+  }),
+}));
+
+vi.mock("@/lib/signalr-connection", () => ({
+  setConnectionId: vi.fn(),
+  getConnectionId: vi.fn().mockReturnValue("mock-conn-id"),
 }));
 
 import { useSignalR } from "./useSignalR";
@@ -47,11 +59,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { bufferToast } from "@/lib/signalr-toast-buffer";
 import { act } from "@testing-library/react";
+import { setConnectionId, getConnectionId } from "@/lib/signalr-connection";
 
 beforeEach(() => {
   vi.clearAllMocks();
   // Restore start to resolve by default (individual tests may override)
   mockConnection.start.mockResolvedValue(undefined);
+  mockConnection.connectionId = "mock-conn-id";
+  vi.mocked(getConnectionId).mockReturnValue("mock-conn-id");
 });
 
 /** Helper: render the hook, flush the start() promise, and return the result. */
@@ -122,12 +137,19 @@ describe("useSignalR", () => {
     expect(result.current.connectionState).toBe("connected");
   });
 
+  it("sets connectionId on connect", async () => {
+    await renderEnabled();
+
+    expect(setConnectionId).toHaveBeenCalledWith("mock-conn-id");
+  });
+
   it("clears connectionRef on cleanup", () => {
     const { unmount } = renderHook(() => useSignalR(true));
 
     unmount();
 
     expect(mockConnection.stop).toHaveBeenCalled();
+    expect(setConnectionId).toHaveBeenCalledWith(null);
   });
 
   describe("EntityChanged handler", () => {
@@ -140,7 +162,7 @@ describe("useSignalR", () => {
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "receipt", changeType: "created", id: "abc-123", count: 1 });
+        handler!({ entityType: "receipt", changeType: "created", id: "abc-123", count: 1, userId: "other-user-id", authMethod: "jwt", connectionId: "other-conn" });
       });
 
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -152,7 +174,7 @@ describe("useSignalR", () => {
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["trips"],
       });
-      expect(bufferToast).toHaveBeenCalledWith("receipt", "created", 1);
+      expect(bufferToast).toHaveBeenCalledWith("receipt", "created", 1, "other-user");
       expect(toast.info).not.toHaveBeenCalled();
     });
 
@@ -165,7 +187,7 @@ describe("useSignalR", () => {
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "account", changeType: "updated", id: "abc-123", count: 1 });
+        handler!({ entityType: "account", changeType: "updated", id: "abc-123", count: 1, userId: "other-user-id", authMethod: "jwt", connectionId: "other-conn" });
       });
 
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -174,7 +196,7 @@ describe("useSignalR", () => {
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["transaction-accounts"],
       });
-      expect(bufferToast).toHaveBeenCalledWith("account", "updated", 1);
+      expect(bufferToast).toHaveBeenCalledWith("account", "updated", 1, "other-user");
       expect(toast.info).not.toHaveBeenCalled();
     });
 
@@ -187,7 +209,7 @@ describe("useSignalR", () => {
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "transaction", changeType: "deleted", id: "abc-123", count: 1 });
+        handler!({ entityType: "transaction", changeType: "deleted", id: "abc-123", count: 1, userId: "other-user-id", authMethod: "jwt", connectionId: "other-conn" });
       });
 
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -202,7 +224,7 @@ describe("useSignalR", () => {
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["transaction-accounts"],
       });
-      expect(bufferToast).toHaveBeenCalledWith("transaction", "deleted", 1);
+      expect(bufferToast).toHaveBeenCalledWith("transaction", "deleted", 1, "other-user");
       expect(toast.info).not.toHaveBeenCalled();
     });
 
@@ -213,10 +235,10 @@ describe("useSignalR", () => {
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "receipt-item", changeType: "created", id: "abc", count: 1 });
+        handler!({ entityType: "receipt-item", changeType: "created", id: "abc", count: 1, userId: "other-user-id", authMethod: "jwt", connectionId: "other-conn" });
       });
 
-      expect(bufferToast).toHaveBeenCalledWith("receipt item", "created", 1);
+      expect(bufferToast).toHaveBeenCalledWith("receipt item", "created", 1, "other-user");
       expect(toast.info).not.toHaveBeenCalled();
     });
 
@@ -227,11 +249,68 @@ describe("useSignalR", () => {
       expect(handler).toBeDefined();
 
       act(() => {
-        handler!({ entityType: "item-template", changeType: "updated", id: "abc", count: 1 });
+        handler!({ entityType: "item-template", changeType: "updated", id: "abc", count: 1, userId: "other-user-id", authMethod: "jwt", connectionId: "other-conn" });
       });
 
-      expect(bufferToast).toHaveBeenCalledWith("item template", "updated", 1);
+      expect(bufferToast).toHaveBeenCalledWith("item template", "updated", 1, "other-user");
       expect(toast.info).not.toHaveBeenCalled();
+    });
+
+    it("suppresses toast when notification.connectionId matches own connectionId", async () => {
+      const mockQueryClient = vi.mocked(useQueryClient)();
+
+      await renderEnabled();
+
+      const handler = getOnHandler("EntityChanged");
+      expect(handler).toBeDefined();
+
+      act(() => {
+        handler!({ entityType: "receipt", changeType: "created", id: "abc", count: 1, userId: "current-user-id", authMethod: "jwt", connectionId: "mock-conn-id" });
+      });
+
+      // Queries still invalidated
+      expect(mockQueryClient.invalidateQueries).toHaveBeenCalled();
+      // But no toast
+      expect(bufferToast).not.toHaveBeenCalled();
+    });
+
+    it("calls bufferToast with api-key origin when authMethod=apikey and userId matches", async () => {
+      await renderEnabled();
+
+      const handler = getOnHandler("EntityChanged");
+      expect(handler).toBeDefined();
+
+      act(() => {
+        handler!({ entityType: "receipt", changeType: "updated", id: "abc", count: 1, userId: "current-user-id", authMethod: "apikey", connectionId: null });
+      });
+
+      expect(bufferToast).toHaveBeenCalledWith("receipt", "updated", 1, "api-key");
+    });
+
+    it("calls bufferToast with other-session origin when same userId, different connectionId", async () => {
+      await renderEnabled();
+
+      const handler = getOnHandler("EntityChanged");
+      expect(handler).toBeDefined();
+
+      act(() => {
+        handler!({ entityType: "receipt", changeType: "created", id: "abc", count: 1, userId: "current-user-id", authMethod: "jwt", connectionId: "different-conn" });
+      });
+
+      expect(bufferToast).toHaveBeenCalledWith("receipt", "created", 1, "other-session");
+    });
+
+    it("calls bufferToast with other-user origin when different userId", async () => {
+      await renderEnabled();
+
+      const handler = getOnHandler("EntityChanged");
+      expect(handler).toBeDefined();
+
+      act(() => {
+        handler!({ entityType: "receipt", changeType: "deleted", id: "abc", count: 1, userId: "someone-else", authMethod: "jwt", connectionId: "other-conn" });
+      });
+
+      expect(bufferToast).toHaveBeenCalledWith("receipt", "deleted", 1, "other-user");
     });
   });
 

--- a/src/client/src/hooks/useSignalR.ts
+++ b/src/client/src/hooks/useSignalR.ts
@@ -1,8 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import * as signalR from "@microsoft/signalr";
 import { useQueryClient } from "@tanstack/react-query";
-import { getAccessToken } from "@/lib/auth";
-import { bufferToast } from "@/lib/signalr-toast-buffer";
+import { getAccessToken, parseJwtPayload } from "@/lib/auth";
+import { bufferToast, type ToastOrigin } from "@/lib/signalr-toast-buffer";
+import {
+  setConnectionId,
+  getConnectionId,
+} from "@/lib/signalr-connection";
 
 export type SignalRConnectionState =
   | "connected"
@@ -14,6 +18,9 @@ interface EntityChangeNotification {
   changeType: string;
   id: string | null;
   count?: number;
+  userId?: string | null;
+  authMethod?: string | null;
+  connectionId?: string | null;
 }
 
 const queryKeyMap: Record<string, string[][]> = {
@@ -42,6 +49,26 @@ const displayNameMap: Record<string, string> = {
   subcategory: "subcategory",
   "item-template": "item template",
 };
+
+function classifyOrigin(
+  notification: EntityChangeNotification,
+  myConnectionId: string | null,
+  myUserId: string | null,
+): ToastOrigin | null {
+  // Same session — suppress toast entirely
+  if (notification.connectionId && notification.connectionId === myConnectionId) {
+    return null;
+  }
+
+  if (notification.userId && notification.userId === myUserId) {
+    if (notification.authMethod === "apikey") {
+      return "api-key";
+    }
+    return "other-session";
+  }
+
+  return "other-user";
+}
 
 export function useSignalR(enabled: boolean) {
   const queryClient = useQueryClient();
@@ -73,6 +100,7 @@ export function useSignalR(enabled: boolean) {
 
     connection.onreconnected(() => {
       setConnectionState("connected");
+      setConnectionId(connection.connectionId ?? null);
       if (import.meta.env.DEV) {
         console.debug("[SignalR] Reconnected.");
       }
@@ -80,6 +108,7 @@ export function useSignalR(enabled: boolean) {
 
     connection.onclose(() => {
       setConnectionState("disconnected");
+      setConnectionId(null);
       if (import.meta.env.DEV) {
         console.debug("[SignalR] Connection closed.");
       }
@@ -99,9 +128,20 @@ export function useSignalR(enabled: boolean) {
           }
         }
 
+        const token = getAccessToken();
+        const jwt = token ? parseJwtPayload(token) : null;
+        const myUserId = jwt?.userId ?? null;
+        const myConnectionId = getConnectionId();
+
+        const origin = classifyOrigin(notification, myConnectionId, myUserId);
+        if (origin === null) {
+          // Same session — suppress toast, query invalidation already done
+          return;
+        }
+
         const displayName =
           displayNameMap[notification.entityType] ?? notification.entityType;
-        bufferToast(displayName, notification.changeType, notification.count ?? 1);
+        bufferToast(displayName, notification.changeType, notification.count ?? 1, origin);
       },
     );
 
@@ -111,6 +151,7 @@ export function useSignalR(enabled: boolean) {
       .start()
       .then(() => {
         setConnectionState("connected");
+        setConnectionId(connection.connectionId ?? null);
         if (import.meta.env.DEV) {
           console.debug("[SignalR] Connected to /entities hub.");
         }
@@ -124,6 +165,7 @@ export function useSignalR(enabled: boolean) {
 
     return () => {
       connectionRef.current = null;
+      setConnectionId(null);
       connection.stop();
     };
   }, [enabled, queryClient]);

--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -9,6 +9,7 @@ import {
   notifyTokenRefresh,
   notifyPasswordChangeRequired,
 } from "@/lib/auth";
+import { getConnectionId } from "@/lib/signalr-connection";
 
 const baseUrl = import.meta.env.VITE_API_URL ?? "";
 const API_TIMEOUT_MS = 30_000;
@@ -114,6 +115,17 @@ const authMiddleware: Middleware = {
   },
 };
 
+const signalRConnectionMiddleware: Middleware = {
+  async onRequest({ request }) {
+    const connId = getConnectionId();
+    if (connId) {
+      request.headers.set("X-SignalR-Connection-Id", connId);
+    }
+    return request;
+  },
+};
+
 client.use(authMiddleware);
+client.use(signalRConnectionMiddleware);
 
 export default client;

--- a/src/client/src/lib/auth.test.ts
+++ b/src/client/src/lib/auth.test.ts
@@ -62,6 +62,7 @@ describe("parseJwtPayload", () => {
     });
     const result = parseJwtPayload(token);
     expect(result).toEqual({
+      userId: "",
       email: "user@example.com",
       roles: ["Admin", "User"],
       mustResetPassword: false,
@@ -76,6 +77,7 @@ describe("parseJwtPayload", () => {
     });
     const result = parseJwtPayload(token);
     expect(result).toEqual({
+      userId: "",
       email: "ms@example.com",
       roles: ["Admin"],
       mustResetPassword: false,
@@ -130,6 +132,25 @@ describe("parseJwtPayload", () => {
 
   it("returns null for token with invalid base64", () => {
     expect(parseJwtPayload("a.!!!invalid!!!.c")).toBeNull();
+  });
+
+  it("parses userId from NameIdentifier claim URI", () => {
+    const token = encodePayload({
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":
+        "user-id-123",
+      email: "user@example.com",
+    });
+    const result = parseJwtPayload(token);
+    expect(result?.userId).toBe("user-id-123");
+  });
+
+  it("parses userId from sub claim", () => {
+    const token = encodePayload({
+      sub: "sub-user-456",
+      email: "user@example.com",
+    });
+    const result = parseJwtPayload(token);
+    expect(result?.userId).toBe("sub-user-456");
   });
 });
 

--- a/src/client/src/lib/auth.ts
+++ b/src/client/src/lib/auth.ts
@@ -48,6 +48,7 @@ export function isAuthenticated(): boolean {
 }
 
 export interface JwtPayload {
+  userId: string;
   email: string;
   roles: string[];
   mustResetPassword: boolean;
@@ -58,6 +59,12 @@ export function parseJwtPayload(token: string): JwtPayload | null {
     const parts = token.split(".");
     if (parts.length !== 3) return null;
     const payload = JSON.parse(atob(parts[1]));
+    const userId =
+      payload.sub ??
+      payload[
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
+      ] ??
+      "";
     const email =
       payload.email ??
       payload[
@@ -73,7 +80,7 @@ export function parseJwtPayload(token: string): JwtPayload | null {
         ? [roleClaim]
         : [];
     const mustResetPassword = payload.must_reset_password === "true" || payload.must_reset_password === true;
-    return { email, roles, mustResetPassword };
+    return { userId, email, roles, mustResetPassword };
   } catch {
     return null;
   }

--- a/src/client/src/lib/signalr-connection.test.ts
+++ b/src/client/src/lib/signalr-connection.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getConnectionId, setConnectionId } from "./signalr-connection";
+
+describe("signalr-connection", () => {
+  beforeEach(() => {
+    setConnectionId(null);
+  });
+
+  it("returns null by default", () => {
+    expect(getConnectionId()).toBeNull();
+  });
+
+  it("stores and retrieves a connection ID", () => {
+    setConnectionId("conn-123");
+    expect(getConnectionId()).toBe("conn-123");
+  });
+
+  it("clears the connection ID when set to null", () => {
+    setConnectionId("conn-123");
+    setConnectionId(null);
+    expect(getConnectionId()).toBeNull();
+  });
+});

--- a/src/client/src/lib/signalr-connection.ts
+++ b/src/client/src/lib/signalr-connection.ts
@@ -1,0 +1,9 @@
+let connectionId: string | null = null;
+
+export function setConnectionId(id: string | null): void {
+  connectionId = id;
+}
+
+export function getConnectionId(): string | null {
+  return connectionId;
+}

--- a/src/client/src/lib/signalr-toast-buffer.test.ts
+++ b/src/client/src/lib/signalr-toast-buffer.test.ts
@@ -103,4 +103,36 @@ describe("signalr-toast-buffer", () => {
 
     expect(toast.info).not.toHaveBeenCalled();
   });
+
+  it("shows 'via your API key' for api-key origin", () => {
+    bufferToast("receipt", "created", 1, "api-key");
+    _flushForTesting();
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "A receipt was created via your API key",
+    );
+  });
+
+  it("shows 'in another of your sessions' for other-session origin", () => {
+    bufferToast("account", "updated", 1, "other-session");
+    _flushForTesting();
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "A account was updated in another of your sessions",
+    );
+  });
+
+  it("different origins for same entity/change produce separate toasts", () => {
+    bufferToast("receipt", "created", 1, "api-key");
+    bufferToast("receipt", "created", 1, "other-user");
+    _flushForTesting();
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "A receipt was created via your API key",
+    );
+    expect(toast.info).toHaveBeenCalledWith(
+      "A receipt was created by another user",
+    );
+    expect(toast.info).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/client/src/lib/signalr-toast-buffer.ts
+++ b/src/client/src/lib/signalr-toast-buffer.ts
@@ -2,6 +2,8 @@ import { toast } from "sonner";
 
 const FLUSH_DELAY_MS = 5_000;
 
+export type ToastOrigin = "api-key" | "other-session" | "other-user";
+
 interface BufferEntry {
   count: number;
 }
@@ -19,16 +21,27 @@ function pluralize(name: string, count: number): string {
   return pluralExceptions[name] ?? `${name}s`;
 }
 
-function makeKey(entityType: string, changeType: string): string {
-  return `${entityType}::${changeType}`;
+function makeKey(
+  entityType: string,
+  changeType: string,
+  origin: ToastOrigin,
+): string {
+  return `${entityType}::${changeType}::${origin}`;
 }
+
+const originSuffix: Record<ToastOrigin, string> = {
+  "api-key": "via your API key",
+  "other-session": "in another of your sessions",
+  "other-user": "by another user",
+};
 
 function flush(): void {
   flushTimer = null;
 
   for (const [key, entry] of buffer) {
-    const [entityType, changeType] = key.split("::");
+    const [entityType, changeType, origin] = key.split("::");
     const displayName = pluralize(entityType, entry.count);
+    const suffix = originSuffix[origin as ToastOrigin] ?? "by another user";
     const action =
       changeType === "created"
         ? "created"
@@ -37,11 +50,9 @@ function flush(): void {
           : "updated";
 
     if (entry.count === 1) {
-      toast.info(`A ${displayName} was ${action} by another user`);
+      toast.info(`A ${displayName} was ${action} ${suffix}`);
     } else {
-      toast.info(
-        `${entry.count} ${displayName} were ${action} by another user`,
-      );
+      toast.info(`${entry.count} ${displayName} were ${action} ${suffix}`);
     }
   }
 
@@ -52,8 +63,9 @@ export function bufferToast(
   entityType: string,
   changeType: string,
   count: number,
+  origin: ToastOrigin = "other-user",
 ): void {
-  const key = makeKey(entityType, changeType);
+  const key = makeKey(entityType, changeType, origin);
   const existing = buffer.get(key);
 
   if (existing) {

--- a/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
+++ b/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
@@ -309,6 +309,25 @@ public class EntityChangeNotifierTests : IDisposable
 	}
 
 	[Fact]
+	public async Task NotifyCreated_WithUnauthenticatedIdentity_SetsAuthMethodToNull()
+	{
+		// Arrange — HttpContext exists but identity has no AuthenticationType
+		var context = new DefaultHttpContext();
+		_httpContextAccessorMock.Setup(a => a.HttpContext).Returns(context);
+
+		// Act
+		await _notifier.NotifyCreated("receipt", Guid.NewGuid());
+		await _notifier.FlushAsync();
+
+		// Assert
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.UserId == null &&
+				n.AuthMethod == null)),
+			Times.Once);
+	}
+
+	[Fact]
 	public async Task SameEntityAndChange_DifferentOrigin_ProducesSeparateNotifications()
 	{
 		// Arrange — first call with user A

--- a/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
+++ b/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
@@ -1,6 +1,9 @@
+using System.Security.Claims;
+using API.Authentication;
 using API.Hubs;
 using API.Services;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
 
@@ -10,6 +13,7 @@ public class EntityChangeNotifierTests : IDisposable
 {
 	private readonly Mock<IHubContext<EntityHub, IEntityHubClient>> _hubContextMock;
 	private readonly Mock<IEntityHubClient> _clientMock;
+	private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock;
 	private readonly EntityChangeNotifier _notifier;
 
 	public EntityChangeNotifierTests()
@@ -24,14 +28,53 @@ public class EntityChangeNotifierTests : IDisposable
 		_hubContextMock = new Mock<IHubContext<EntityHub, IEntityHubClient>>();
 		_hubContextMock.Setup(h => h.Clients).Returns(hubClientsMock.Object);
 
+		_httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+		_httpContextAccessorMock.Setup(a => a.HttpContext).Returns((HttpContext?)null);
+
 		// Use a very long flush interval so the timer never fires during tests
-		_notifier = new EntityChangeNotifier(_hubContextMock.Object, TimeSpan.FromHours(1));
+		_notifier = new EntityChangeNotifier(_hubContextMock.Object, _httpContextAccessorMock.Object, TimeSpan.FromHours(1));
 	}
 
 	public void Dispose()
 	{
 		_notifier.Dispose();
 		GC.SuppressFinalize(this);
+	}
+
+	private static DefaultHttpContext CreateJwtHttpContext(string userId, string? connectionId = null)
+	{
+		var claims = new List<Claim>
+		{
+			new(ClaimTypes.NameIdentifier, userId),
+		};
+		var identity = new ClaimsIdentity(claims, "Bearer");
+		var context = new DefaultHttpContext
+		{
+			User = new ClaimsPrincipal(identity),
+		};
+		if (connectionId is not null)
+		{
+			context.Request.Headers["X-SignalR-Connection-Id"] = connectionId;
+		}
+		return context;
+	}
+
+	private static DefaultHttpContext CreateApiKeyHttpContext(string userId, string? connectionId = null)
+	{
+		var claims = new List<Claim>
+		{
+			new(ClaimTypes.NameIdentifier, userId),
+		};
+		var identity = new ClaimsIdentity(claims, ApiKeyAuthenticationDefaults.AuthenticationScheme);
+		var context = new DefaultHttpContext
+		{
+			User = new ClaimsPrincipal(identity),
+		};
+		if (connectionId is not null)
+		{
+			context.Request.Headers["X-SignalR-Connection-Id"] = connectionId;
+		}
+		return context;
 	}
 
 	[Fact]
@@ -178,7 +221,9 @@ public class EntityChangeNotifierTests : IDisposable
 		hubClientsMock.Setup(c => c.All).Returns(clientMock.Object);
 		Mock<IHubContext<EntityHub, IEntityHubClient>> hubContextMock = new();
 		hubContextMock.Setup(h => h.Clients).Returns(hubClientsMock.Object);
-		var notifier = new EntityChangeNotifier(hubContextMock.Object, TimeSpan.FromHours(1));
+		Mock<IHttpContextAccessor> httpContextAccessorMock = new();
+		httpContextAccessorMock.Setup(a => a.HttpContext).Returns((HttpContext?)null);
+		var notifier = new EntityChangeNotifier(hubContextMock.Object, httpContextAccessorMock.Object, TimeSpan.FromHours(1));
 
 		Guid id = Guid.NewGuid();
 		await notifier.NotifyCreated("receipt", id);
@@ -203,5 +248,95 @@ public class EntityChangeNotifierTests : IDisposable
 
 		// Assert
 		_clientMock.Verify(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task NotifyCreated_WithJwtContext_SetsOriginFields()
+	{
+		// Arrange
+		var context = CreateJwtHttpContext("user-123", "conn-abc");
+		_httpContextAccessorMock.Setup(a => a.HttpContext).Returns(context);
+
+		// Act
+		await _notifier.NotifyCreated("receipt", Guid.NewGuid());
+		await _notifier.FlushAsync();
+
+		// Assert
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.UserId == "user-123" &&
+				n.AuthMethod == "jwt" &&
+				n.ConnectionId == "conn-abc")),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task NotifyCreated_WithApiKeyContext_SetsAuthMethodToApikey()
+	{
+		// Arrange
+		var context = CreateApiKeyHttpContext("user-456");
+		_httpContextAccessorMock.Setup(a => a.HttpContext).Returns(context);
+
+		// Act
+		await _notifier.NotifyCreated("account", Guid.NewGuid());
+		await _notifier.FlushAsync();
+
+		// Assert
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.UserId == "user-456" &&
+				n.AuthMethod == "apikey" &&
+				n.ConnectionId == null)),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task NotifyCreated_WithNoHttpContext_SetsNullOriginFields()
+	{
+		// Arrange — default mock already returns null HttpContext
+
+		// Act
+		await _notifier.NotifyCreated("receipt", Guid.NewGuid());
+		await _notifier.FlushAsync();
+
+		// Assert
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.UserId == null &&
+				n.AuthMethod == null &&
+				n.ConnectionId == null)),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task SameEntityAndChange_DifferentOrigin_ProducesSeparateNotifications()
+	{
+		// Arrange — first call with user A
+		var contextA = CreateJwtHttpContext("user-A", "conn-1");
+		_httpContextAccessorMock.Setup(a => a.HttpContext).Returns(contextA);
+		await _notifier.NotifyCreated("receipt", Guid.NewGuid());
+
+		// Second call with user B
+		var contextB = CreateJwtHttpContext("user-B", "conn-2");
+		_httpContextAccessorMock.Setup(a => a.HttpContext).Returns(contextB);
+		await _notifier.NotifyCreated("receipt", Guid.NewGuid());
+
+		// Act
+		await _notifier.FlushAsync();
+
+		// Assert — two separate notifications for the same entity/change but different origins
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "receipt" &&
+				n.ChangeType == "created" &&
+				n.UserId == "user-A")),
+			Times.Once);
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.EntityType == "receipt" &&
+				n.ChangeType == "created" &&
+				n.UserId == "user-B")),
+			Times.Once);
+		_clientMock.Verify(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()), Times.Exactly(2));
 	}
 }


### PR DESCRIPTION
## Summary
- Thread origin metadata (`userId`, `authMethod`, `connectionId`) through the SignalR notification pipeline so the client can show contextual toast messages
- Same session → suppress toast (still invalidate queries), same user via API key → "via your API key", same user different session → "in another of your sessions", different user → "by another user"
- Server: `EntityChangeNotifier` captures origin from `HttpContext` (user claims, auth scheme, `X-SignalR-Connection-Id` header) and batches separately per origin
- Client: new `signalr-connection.ts` singleton, `api-client.ts` sends connectionId header, `useSignalR` classifies origin, `signalr-toast-buffer` renders origin-aware messages

## Test plan
- [x] `dotnet build Receipts.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Receipts.slnx` — 1,037 server tests pass (4 new origin tests in `EntityChangeNotifierTests`)
- [x] `vitest run` — 865 client tests pass (2 new auth tests, 3 new toast buffer tests, 4 new useSignalR origin tests)
- [ ] Manual: open two browser tabs, create a receipt in tab A, verify tab B shows "in another of your sessions"

Closes MGG-265

🤖 Generated with [Claude Code](https://claude.com/claude-code)