### PR TITLE
fix(client): suppress SignalR query invalidation for off-screen pages (MGG-268)

### DIFF
--- a/src/client/src/hooks/useSignalR.test.ts
+++ b/src/client/src/hooks/useSignalR.test.ts
@@ -145,12 +145,15 @@ describe("useSignalR", () => {
 
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["receipts"],
+        refetchType: "active",
       });
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["receipts-with-items"],
+        refetchType: "active",
       });
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["trips"],
+        refetchType: "active",
       });
       expect(bufferToast).toHaveBeenCalledWith("receipt", "created", 1);
       expect(toast.info).not.toHaveBeenCalled();
@@ -170,9 +173,11 @@ describe("useSignalR", () => {
 
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["accounts"],
+        refetchType: "active",
       });
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["transaction-accounts"],
+        refetchType: "active",
       });
       expect(bufferToast).toHaveBeenCalledWith("account", "updated", 1);
       expect(toast.info).not.toHaveBeenCalled();
@@ -192,15 +197,19 @@ describe("useSignalR", () => {
 
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["transactions"],
+        refetchType: "active",
       });
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["receipts-with-items"],
+        refetchType: "active",
       });
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["trips"],
+        refetchType: "active",
       });
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["transaction-accounts"],
+        refetchType: "active",
       });
       expect(bufferToast).toHaveBeenCalledWith("transaction", "deleted", 1);
       expect(toast.info).not.toHaveBeenCalled();

--- a/src/client/src/hooks/useSignalR.ts
+++ b/src/client/src/hooks/useSignalR.ts
@@ -95,7 +95,7 @@ export function useSignalR(enabled: boolean) {
         const keys = queryKeyMap[notification.entityType];
         if (keys) {
           for (const queryKey of keys) {
-            queryClient.invalidateQueries({ queryKey });
+            queryClient.invalidateQueries({ queryKey, refetchType: "active" });
           }
         }
 


### PR DESCRIPTION
## Summary
- Adds `refetchType: 'active'` to all `invalidateQueries` calls in `useSignalR.ts`
- Only queries observed by mounted components refetch on SignalR `EntityChanged` events
- Stale cached queries (e.g., paginated pages from previously visited routes) are marked invalid but won't refetch until the component remounts

## Test plan
- [x] All 16 existing `useSignalR.test.ts` tests updated and passing
- [ ] Verify in browser: navigate to transactions page, then away, trigger an entity change — no background refetch for transactions

Closes MGG-268

🤖 Generated with [Claude Code](https://claude.com/claude-code)