### PR TITLE
fix(hooks): add prerequisite checks and quick mode to pre-commit (MGG-285)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,31 +3,52 @@ set -e
 
 echo "=== Pre-commit hook ==="
 
-echo "[1/8] Linting OpenAPI spec..."
-NODE_OPTIONS="--disable-warning=DEP0040" npx spectral lint openapi/spec.yaml --fail-severity warn
+# Determine mode and step count
+if [ "${PRECOMMIT_QUICK:-}" = "1" ]; then
+  TOTAL=4
+  echo "(quick mode — set PRECOMMIT_QUICK=0 or unset for full checks)"
+else
+  TOTAL=9
+fi
+STEP=0
 
-echo "[2/8] Checking code formatting..."
+next_step() {
+  STEP=$((STEP + 1))
+  echo "[$STEP/$TOTAL] $1"
+}
+
+next_step "Checking prerequisites..."
+bash scripts/worktree-setup.sh --check
+
+if [ "${PRECOMMIT_QUICK:-}" != "1" ]; then
+  next_step "Linting OpenAPI spec..."
+  NODE_OPTIONS="--disable-warning=DEP0040" npx spectral lint openapi/spec.yaml --fail-severity warn
+fi
+
+next_step "Checking code formatting..."
 dotnet format Receipts.slnx --verify-no-changes
 
-echo "[3/8] Building with warnings-as-errors..."
-# Provide a build-time JWT key so GenerateOpenApiDocuments can start the host.
-# At runtime the real key is required via appsettings/Aspire configuration.
-Jwt__Key=build-time-spec-extraction-only-not-for-runtime \
-dotnet build Receipts.slnx -p:TreatWarningsAsErrors=true --no-restore
+if [ "${PRECOMMIT_QUICK:-}" != "1" ]; then
+  next_step "Building with warnings-as-errors..."
+  # Provide a build-time JWT key so GenerateOpenApiDocuments can start the host.
+  # At runtime the real key is required via appsettings/Aspire configuration.
+  Jwt__Key=build-time-spec-extraction-only-not-for-runtime \
+  dotnet build Receipts.slnx -p:TreatWarningsAsErrors=true --no-restore
 
-echo "[4/8] Checking DTO staleness..."
-git diff --exit-code -- src/Presentation/API/Generated/
+  next_step "Checking DTO staleness..."
+  git diff --exit-code -- src/Presentation/API/Generated/
 
-echo "[5/8] Checking spec drift..."
-node scripts/check-drift.mjs
+  next_step "Checking spec drift..."
+  node scripts/check-drift.mjs
 
-echo "[6/8] Running .NET tests..."
-dotnet test Receipts.slnx --no-build --verbosity normal
+  next_step "Running .NET tests..."
+  dotnet test Receipts.slnx --no-build --verbosity normal
+fi
 
-echo "[7/8] Checking TypeScript types..."
+next_step "Checking TypeScript types..."
 npx tsc --noEmit --project src/client/tsconfig.json
 
-echo "[8/8] Linting React client..."
+next_step "Linting React client..."
 npx eslint src/client/src
 
 echo "=== All checks passed ==="

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,14 +91,22 @@ dotnet ef migrations add MigrationName --project src/Infrastructure/Infrastructu
 Native Git hooks via `core.hooksPath`. Install automatically on `dotnet restore` (or `bash .githooks/setup.sh`).
 
 **Pipeline (runs on every `git commit`):**
+0. `bash scripts/worktree-setup.sh --check` — prerequisite verification
 1. `npx spectral lint openapi/spec.yaml` — OpenAPI spec linting
 2. `dotnet format --verify-no-changes` — code formatting check
 3. `dotnet build -p:TreatWarningsAsErrors=true` — build (also generates `openapi/generated/API.json`)
 4. `git diff --exit-code -- src/Presentation/API/Generated/` — DTO staleness check
 5. `node scripts/check-drift.mjs` — semantic drift detection
 6. `dotnet test --no-build` — run all tests
+7. `npx tsc --noEmit` — TypeScript type checking
+8. `npx eslint src/client/src` — React client linting
 
-Skip with `git commit --no-verify -m "message"` (use sparingly).
+**Quick mode** runs only steps 0, 2, 7, 8 (prerequisites, format, tsc, eslint):
+```bash
+PRECOMMIT_QUICK=1 git commit -m "message"
+```
+
+`git commit --no-verify` skips all hooks — use only as a last resort.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -148,19 +148,22 @@ The OpenAPI spec is generated at build time to `openapi/generated/API.json`. Thi
 
 ## Pre-commit Hooks
 
-Native Git hooks (`.githooks/`) run a six-stage pipeline on every `git commit`:
+Native Git hooks (`.githooks/`) run a nine-step pipeline on every `git commit`:
 
+0. **Prerequisites** - `bash scripts/worktree-setup.sh --check`
 1. **OpenAPI spec lint** - `npx spectral lint openapi/spec.yaml`
 2. **Format check** - `dotnet format --verify-no-changes`
 3. **Build** - `dotnet build -p:TreatWarningsAsErrors=true`
 4. **DTO staleness check** - `git diff --exit-code -- src/Presentation/API/Generated/`
 5. **Spec drift check** - `node scripts/check-drift.mjs`
 6. **Test** - `dotnet test --no-build`
+7. **TypeScript types** - `npx tsc --noEmit`
+8. **ESLint** - `npx eslint src/client/src`
 
-Hooks install automatically on `dotnet restore`. To skip temporarily:
+Hooks install automatically on `dotnet restore`. For faster iteration, use quick mode (runs only steps 0, 2, 7, 8):
 
 ```bash
-git commit --no-verify -m "message"
+PRECOMMIT_QUICK=1 git commit -m "message"
 ```
 
 ## CI/CD

--- a/docs/development.md
+++ b/docs/development.md
@@ -108,15 +108,19 @@ dotnet test tests/Application.Tests/Application.Tests.csproj
 
 Every `git commit` runs the full quality pipeline automatically:
 
+0. **Prerequisites** — `bash scripts/worktree-setup.sh --check`
 1. **OpenAPI spec lint** — `npx spectral lint openapi/spec.yaml`
 2. **Code format check** — `dotnet format --verify-no-changes`
 3. **Build with warnings-as-errors** — also regenerates `openapi/generated/API.json`
-4. **Semantic drift check** — compares spec vs generated output for structural differences
-5. **Tests** — `dotnet test --no-build`
+4. **DTO staleness check** — `git diff --exit-code -- src/Presentation/API/Generated/`
+5. **Semantic drift check** — compares spec vs generated output for structural differences
+6. **Tests** — `dotnet test --no-build`
+7. **TypeScript types** — `npx tsc --noEmit`
+8. **ESLint** — `npx eslint src/client/src`
 
-To skip hooks temporarily (use sparingly):
+For faster iteration, quick mode runs only prerequisites, format, tsc, and eslint:
 ```bash
-git commit --no-verify -m "message"
+PRECOMMIT_QUICK=1 git commit -m "message"
 ```
 
 ## OpenAPI Spec-First Workflow

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,11 +1,39 @@
 #!/usr/bin/env bash
 # Bootstrap a git worktree with all dependencies and generated files.
-# Usage: bash scripts/worktree-setup.sh
+# Usage: bash scripts/worktree-setup.sh          # full setup
+#        bash scripts/worktree-setup.sh --check   # verify prerequisites only
 
 set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
+
+if [ "${1:-}" = "--check" ]; then
+  missing=()
+
+  [ ! -d "node_modules" ] && missing+=("node_modules/ — run: npm install")
+  [ ! -d "src/client/node_modules" ] && missing+=("src/client/node_modules/ — run: cd src/client && npm install")
+
+  if ! find src/ -maxdepth 3 -type d -name obj -print -quit 2>/dev/null | grep -q .; then
+    missing+=("src/*/obj/ — run: dotnet restore Receipts.slnx")
+  fi
+
+  [ ! -f "openapi/generated/API.json" ] && missing+=("openapi/generated/API.json — run: dotnet build Receipts.slnx")
+  [ ! -f "src/client/src/generated/api.d.ts" ] && missing+=("src/client/src/generated/api.d.ts — run: cd src/client && npm run generate:types")
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "Pre-commit prerequisites missing:"
+    for item in "${missing[@]}"; do
+      echo "  - $item"
+    done
+    echo ""
+    echo "Run 'bash scripts/worktree-setup.sh' to fix all at once."
+    exit 1
+  fi
+
+  echo "All prerequisites present."
+  exit 0
+fi
 
 echo "==> Restoring NuGet packages and configuring git hooks..."
 dotnet restore Receipts.slnx


### PR DESCRIPTION
## Summary
- Add `--check` flag to `scripts/worktree-setup.sh` that verifies all prerequisites (node_modules, obj dirs, generated files) without network calls
- Add step 0 (prerequisite verification) to pre-commit hook so missing dependencies fail fast with clear fix instructions
- Add `PRECOMMIT_QUICK=1` mode that runs only 4 steps (prerequisites, dotnet format, tsc, eslint) instead of all 9, giving developers a fast alternative to `--no-verify`
- Update pipeline docs in AGENTS.md, README.md, and docs/development.md to show all 9 steps (was missing tsc + eslint) and document quick mode

## Test plan
- [x] `bash scripts/worktree-setup.sh --check` exits 0 in bootstrapped worktree
- [x] `bash scripts/worktree-setup.sh --check` exits 1 with clear messages when prerequisites missing
- [x] Full commit runs all 9 pre-commit steps successfully
- [ ] `PRECOMMIT_QUICK=1 git commit` runs only 4 steps
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)