### PR TITLE
fix(ci): lowercase Docker image name to fix GHCR push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: mggarofalo/receipts
 
 jobs:
   matrix-prep:


### PR DESCRIPTION
## Summary

- Fix Docker Publish workflow failing with `invalid reference format: repository name (mggarofalo/Receipts) must be lowercase`
- `github.repository` returns `mggarofalo/Receipts` with uppercase R, but Docker/GHCR requires all-lowercase
- Hardcode `mggarofalo/receipts` as the image name

## Test plan

- [ ] Docker Publish workflow passes on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)