### PR TITLE
docs: add React custom hook stability convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,16 @@ See **[docs/architecture.md](docs/architecture.md)** for full layer structure, k
 
 C# conventions, Mapperly rules, EF Core query guidelines, and LSP validation workflow. See **[docs/coding-standards.md](docs/coding-standards.md)** for full details.
 
+### React Custom Hook Conventions
+
+All functions, objects, and arrays returned from custom hooks (`use*`) **must** be referentially stable:
+
+- Wrap returned functions in `useCallback`
+- Wrap returned objects/arrays in `useMemo`
+- Ensure reducers return the same state reference when values haven't changed (bail out with `return state`)
+
+**Why:** Consumers may place hook return values in `useEffect`/`useMemo`/`useCallback` dependency arrays. Unstable references cause infinite render loops that are invisible in static review and pass individual test files but hang the full test suite.
+
 ## Agent Workflow Rules
 
 ### Tests and Code Review


### PR DESCRIPTION
## Summary
- Adds a convention to AGENTS.md requiring all functions/objects/arrays returned from custom React hooks to be memoized (`useCallback`/`useMemo`)
- Also requires reducers to bail out (return same state reference) when values haven't changed
- Motivated by MGG-286 where an unstable `resetPage` function in `useServerPagination` caused an infinite render loop when used in a `useEffect` dependency array

## Test plan
- Documentation-only change, no runtime impact