### PR TITLE
chore(infra): separate CI and Docker Publish workflow triggers (MGG-300)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: ["main"]
     tags: ["v*.*.*"]
-  pull_request:
-    branches: ["main"]
 
 env:
   REGISTRY: ghcr.io
@@ -20,11 +18,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo 'matrix={"include":[{"platform":"linux/amd64","runner":"ubuntu-latest","platform_pair":"linux-amd64"}]}' >> "$GITHUB_OUTPUT"
-          else
-            echo 'matrix={"include":[{"platform":"linux/amd64","runner":"ubuntu-latest","platform_pair":"linux-amd64"},{"platform":"linux/arm64","runner":"ubuntu-latest-arm64","platform_pair":"linux-arm64"}]}' >> "$GITHUB_OUTPUT"
-          fi
+          echo 'matrix={"include":[{"platform":"linux/amd64","runner":"ubuntu-latest","platform_pair":"linux-amd64"},{"platform":"linux/arm64","runner":"ubuntu-latest-arm64","platform_pair":"linux-arm64"}]}' >> "$GITHUB_OUTPUT"
 
   build:
     name: Build (${{ matrix.platform_pair }})
@@ -45,7 +39,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -58,19 +51,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Build (PR only)
-        if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          push: false
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=build-${{ matrix.platform_pair }}
-          cache-to: type=gha,mode=min,scope=build-${{ matrix.platform_pair }}
-
       - name: Build and push by digest
-        if: github.event_name != 'pull_request'
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -82,14 +63,12 @@ jobs:
           cache-to: type=gha,mode=min,scope=build-${{ matrix.platform_pair }}
 
       - name: Export digest
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ matrix.platform_pair }}
@@ -99,7 +78,6 @@ jobs:
 
   merge:
     name: Merge Manifests
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -143,7 +121,6 @@ jobs:
 
   scan:
     name: Security Scan
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: merge
     permissions:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -172,6 +172,25 @@ jobs:
             exit 1
           fi
 
+  docker-build:
+    name: Docker Build Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha,scope=docker-build-check
+          cache-to: type=gha,mode=min,scope=docker-build-check
+
   api-compat:
     name: API Breaking Changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove the pull_request trigger from docker-publish.yml so Docker images are only built/published on pushes to main or version tags (v*.*.*)
- Clean up all PR-specific conditional logic in Docker Publish that is no longer needed: matrix-prep PR branch (amd64-only), PR-only build step, and event_name guards on GHCR login, digest export/upload, merge manifests, and security scan jobs
- Add a new Docker Build Check job to github-ci.yml that runs docker build (without pushing) on PRs, ensuring the Dockerfile still compiles

## Test plan
- [ ] Verify CI workflow runs all existing jobs on PRs plus the new docker-build job
- [ ] Verify Docker Publish workflow no longer triggers on pull requests
- [ ] Verify Docker Publish workflow still triggers on pushes to main and version tags
- [ ] Confirm the new Docker Build Check job in CI uses Buildx with GHA caching and push: false

Closes MGG-300