### PR TITLE
fix(ci): skip PR title lint for release-please PRs

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -249,13 +249,13 @@ jobs:
             shared
             ci
             hooks
-          # Allow multiple scopes separated by commas (e.g., "api,client")
-          enableMultipleScopes: true
-          scopeDelimiter: ","
           # Require lowercase subject
           subjectPattern: ^[a-z].*$
           subjectPatternError: |
             The PR title subject must start with a lowercase letter.
             Example: "feat(api): add pagination support"
+          # Skip validation for release-please PRs
+          ignoreLabels: |
+            autorelease: pending
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `ignoreLabels: autorelease: pending` to the PR title linter so release-please PRs (e.g., `chore(main): release 0.1.1`) bypass scope validation
- Remove `enableMultipleScopes` and `scopeDelimiter` inputs that are not supported by `amannn/action-semantic-pull-request@v5`

## Test plan
- [ ] Verify this PR's own CI passes the pr-title check
- [ ] After merge, verify the release-please PR #130 CI re-runs and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)