### PR TITLE
refactor(ci): split PR title check into its own workflow

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -5,9 +5,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-  pull_request_target:
-    types: [opened, edited, synchronize, reopened]
-    branches: ["main"]
 
 env:
   DOTNET_VERSION: "10.0.x"
@@ -19,7 +16,6 @@ jobs:
   build:
     name: Build & Test
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
     permissions:
       pull-requests: write
 
@@ -82,7 +78,6 @@ jobs:
   frontend-test:
     name: Frontend Test & Coverage
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
     permissions:
       pull-requests: write
 
@@ -131,7 +126,6 @@ jobs:
   lint:
     name: Code Formatting
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
 
     steps:
       - uses: actions/checkout@v4
@@ -158,7 +152,6 @@ jobs:
   security:
     name: Vulnerability Scan
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
     steps:
       - uses: actions/checkout@v4
 
@@ -218,44 +211,3 @@ jobs:
 
       - name: Check for breaking API changes
         run: node scripts/check-breaking.mjs origin/${{ github.base_ref }}
-
-  pr-title:
-    name: PR Title (Conventional Commits)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
-    permissions:
-      pull-requests: read
-
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        with:
-          # Types allowed by the project's Conventional Commits convention
-          types: |
-            feat
-            fix
-            docs
-            refactor
-            test
-            chore
-          # Scopes allowed by the project (see AGENTS.md § Commit Convention)
-          scopes: |
-            api
-            client
-            domain
-            application
-            infrastructure
-            infra
-            common
-            shared
-            ci
-            hooks
-          # Require lowercase subject
-          subjectPattern: ^[a-z].*$
-          subjectPatternError: |
-            The PR title subject must start with a lowercase letter.
-            Example: "feat(api): add pagination support"
-          # Skip validation for release-please PRs
-          ignoreLabels: |
-            autorelease: pending
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,48 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+    branches: ["main"]
+
+jobs:
+  pr-title:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        with:
+          # Types allowed by the project's Conventional Commits convention
+          # (see AGENTS.md § Commit Convention)
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            test
+            chore
+          # Scopes allowed by the project (see AGENTS.md § Commit Convention)
+          scopes: |
+            api
+            client
+            domain
+            application
+            infrastructure
+            infra
+            common
+            shared
+            ci
+            hooks
+          # Require lowercase subject
+          subjectPattern: ^[a-z].*$
+          subjectPatternError: |
+            The PR title subject must start with a lowercase letter.
+            Example: "feat(api): add pagination support"
+          # Skip validation for release-please PRs
+          ignoreLabels: |
+            autorelease: pending
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Extract the `pr-title` job from `github-ci.yml` into a new `pr-title.yml` workflow
- Remove the `pull_request_target` trigger from `github-ci.yml`
- Remove all `if: github.event_name != 'pull_request_target'` guards from CI jobs

This eliminates the duplicate check entries that appeared on every PR — previously both `pull_request` and `pull_request_target` triggered the same workflow, creating 14 check entries (7 real + 7 skipped) instead of a clean set.

## Test plan
- [ ] Verify this PR shows one clean set of CI checks (no duplicates)
- [ ] Verify PR Title check runs from the new `pr-title.yml` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)