### PR TITLE
chore(client): wire up eslint-plugin-react-hook-stability

### DIFF
--- a/src/client/eslint.config.js
+++ b/src/client/eslint.config.js
@@ -1,6 +1,7 @@
 import js from "@eslint/js";
 import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
+import reactHookStability from "@mggarofalo/eslint-plugin-react-hook-stability";
 import reactRefresh from "eslint-plugin-react-refresh";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import tseslint from "typescript-eslint";
@@ -15,6 +16,7 @@ export default defineConfig([
       js.configs.recommended,
       tseslint.configs.recommended,
       reactHooks.configs.flat.recommended,
+      reactHookStability.configs.recommended,
       reactRefresh.configs.vite,
       jsxA11y.flatConfigs.recommended,
     ],

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@mggarofalo/eslint-plugin-react-hook-stability": "^0.1.4",
         "@tailwindcss/vite": "^4.2.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1840,6 +1841,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mggarofalo/eslint-plugin-react-hook-stability": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@mggarofalo/eslint-plugin-react-hook-stability/-/eslint-plugin-react-hook-stability-0.1.4.tgz",
+      "integrity": "sha512-vJQG33I632nS0HsEgpKVqYlXgneHa1jMg2vwu9vjEaxWsr2W32jlgf+fYxM3ecm+87RfoFZrzlqQII7muHRCKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@microsoft/signalr": {

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@mggarofalo/eslint-plugin-react-hook-stability": "^0.1.4",
     "@tailwindcss/vite": "^4.2.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/src/client/src/hooks/useFuzzySearch.ts
+++ b/src/client/src/hooks/useFuzzySearch.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import type { FuseSearchConfig, SearchResult } from "@/lib/search";
 import { createFuseInstance, addSearchHistoryEntry } from "@/lib/search";
 
@@ -53,10 +53,10 @@ export function useFuzzySearch<T>({
 
   const isSearching = search !== debouncedSearch;
 
-  function clearSearch() {
+  const clearSearch = useCallback(() => {
     setSearch("");
     setDebouncedSearch("");
-  }
+  }, []);
 
   return {
     search,

--- a/src/client/src/hooks/usePagination.ts
+++ b/src/client/src/hooks/usePagination.ts
@@ -1,4 +1,4 @@
-import { useReducer, useMemo } from "react";
+import { useReducer, useMemo, useCallback } from "react";
 import { getPersistedPageSize, persistPageSize } from "@/lib/page-size";
 
 interface UsePaginationOptions<T> {
@@ -53,17 +53,20 @@ export function usePagination<T>({
     return items.slice(start, start + state.pageSize);
   }, [items, safePage, state.pageSize]);
 
-  function setPage(page: number) {
-    dispatch({
-      type: "SET_PAGE",
-      page: Math.max(1, Math.min(page, totalPages)),
-    });
-  }
+  const setPage = useCallback(
+    (page: number) => {
+      dispatch({
+        type: "SET_PAGE",
+        page: Math.max(1, Math.min(page, totalPages)),
+      });
+    },
+    [totalPages],
+  );
 
-  function setPageSize(size: number) {
+  const setPageSize = useCallback((size: number) => {
     persistPageSize(size);
     dispatch({ type: "SET_PAGE_SIZE", size });
-  }
+  }, []);
 
   return {
     paginatedItems,


### PR DESCRIPTION
## Summary
- Install `@mggarofalo/eslint-plugin-react-hook-stability` and add its recommended config to the ESLint flat config alongside existing plugins
- Fix 3 new `require-stable-hook-returns` warnings: wrap `clearSearch` in `useFuzzySearch` and `setPage`/`setPageSize` in `usePagination` with `useCallback` for referential stability
- No behavioral changes — hook return values are now stable references, preventing potential infinite render loops when consumers use them in dependency arrays

Resolves MGG-302

## Test plan
- `npx eslint src/client/src` shows zero `react-hook-stability` warnings (4 pre-existing `react-hooks/exhaustive-deps` warnings remain, unrelated)
- `npm test` in `src/client/` passes all 902 tests across 102 files
- TypeScript compiles cleanly (`npx tsc --noEmit`)
- Pre-commit hooks pass in quick mode