### PR TITLE
chore(ci,client): optimize frontend test execution with threads and sharding (MGG-301)

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -76,7 +76,46 @@ jobs:
           path: TestResults/merged/SummaryGithub.md
 
   frontend-test:
-    name: Frontend Test & Coverage
+    name: Frontend Test (Shard ${{ matrix.shard }}/2)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: src/client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: src/client
+
+      - name: Build client
+        run: npm run build
+        working-directory: src/client
+
+      - name: Run tests with coverage
+        run: npx vitest run --shard=${{ matrix.shard }}/2 --reporter=blob --coverage
+        working-directory: src/client
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-test-shard-${{ matrix.shard }}
+          path: src/client/.vitest-reports
+          retention-days: 1
+
+  frontend-test-report:
+    name: Frontend Coverage Report
+    needs: frontend-test
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -95,14 +134,15 @@ jobs:
         run: npm ci
         working-directory: src/client
 
-      - name: Regenerate types and check for drift
-        run: |
-          npm run generate:types
-          npm run build
-        working-directory: src/client
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
+          path: src/client/.vitest-reports
+          pattern: frontend-test-shard-*
+          merge-multiple: true
 
-      - name: Run tests with coverage
-        run: npm run coverage
+      - name: Merge reports and coverage
+        run: npx vitest --merge-reports --coverage
         working-directory: src/client
 
       - name: Generate coverage summary

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -79,6 +79,7 @@ jobs:
     name: Frontend Test (Shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         shard: [1, 2]
 
@@ -103,6 +104,8 @@ jobs:
       - name: Run tests with coverage
         run: npx vitest run --shard=${{ matrix.shard }}/2 --reporter=blob --coverage
         working-directory: src/client
+        env:
+          VITEST_SHARD: "true"
 
       - name: Upload test results
         if: always()
@@ -110,6 +113,7 @@ jobs:
         with:
           name: frontend-test-shard-${{ matrix.shard }}
           path: src/client/.vitest-reports
+          include-hidden-files: true
           retention-days: 1
 
   frontend-test-report:

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    pool: "threads",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
     coverage: {

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -30,12 +30,14 @@ export default defineConfig({
         "src/components/ui/!(combobox|currency-input).{ts,tsx}",
         "src/lib/api-types.ts",
       ],
-      thresholds: {
-        statements: 75,
-        branches: 65,
-        functions: 70,
-        lines: 78,
-      },
+      thresholds: process.env.VITEST_SHARD
+        ? undefined
+        : {
+            statements: 75,
+            branches: 65,
+            functions: 70,
+            lines: 78,
+          },
     },
   },
   server: {


### PR DESCRIPTION
## Summary

- **Switch vitest pool to `threads`** — replaces default `forks` mode so test workers share a single V8 process, eliminating per-worker jsdom startup overhead. All 902 tests pass.
- **Add 2-way test sharding in CI** — splits the `frontend-test` job into a matrix of 2 parallel shards with a `frontend-test-report` merge job that combines blob reports and coverage.
- **Remove redundant `generate:types` call** — the old CI step ran `npm run generate:types` then `npm run build`, but `build` triggers `prebuild` → `generate:types` automatically. Now just runs `npm run build`.

## Deferred items

- **`isolate: false`** — tests fail with shared jsdom due to global state leaks between files. Needs per-test cleanup work before enabling.
- **`fileParallelism: false`** — redundant with sharding; each shard has fewer files, reducing coordination overhead naturally.

## Expected impact

- `pool: 'threads'` should significantly reduce the 84s environment setup cost
- 2-way sharding halves wall-clock time per shard
- Removing redundant `generate:types` saves ~1s + process overhead

## Test plan

- [x] All 902 tests pass locally with `pool: 'threads'`
- [ ] CI sharding produces correct merged coverage report
- [ ] `CodeCoverageSummary` reads merged `cobertura-coverage.xml` successfully
- [ ] Coverage comment posts to PR

Closes MGG-301

🤖 Generated with [Claude Code](https://claude.com/claude-code)