### PR TITLE
feat(client): add dashboard with charts and statistics (MGG-279)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -2548,8 +2548,279 @@ paths:
         "404":
           description: Not Found
 
+  # ──────────────────────────────────────────────
+  # Dashboard
+  # ──────────────────────────────────────────────
+
+  /api/dashboard/summary:
+    get:
+      operationId: GetDashboardSummary
+      tags: [Dashboard]
+      summary: Get dashboard summary statistics
+      description: Returns high-level stats for a date range including total receipts, total spent, average trip amount, and most-used account/category.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Start date (ISO date string). Defaults to 30 days ago.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: End date (ISO date string). Defaults to today.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DashboardSummaryResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/dashboard/spending-over-time:
+    get:
+      operationId: GetSpendingOverTime
+      tags: [Dashboard]
+      summary: Get spending over time
+      description: Returns time-series spending data bucketed by the specified granularity.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Start date (ISO date string). Defaults to 30 days ago.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: End date (ISO date string). Defaults to today.
+        - name: granularity
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [daily, weekly, monthly]
+            default: monthly
+          description: Time bucket granularity.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpendingOverTimeResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/dashboard/spending-by-category:
+    get:
+      operationId: GetSpendingByCategory
+      tags: [Dashboard]
+      summary: Get spending grouped by category
+      description: Returns spending amounts grouped by receipt item category.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Start date (ISO date string). Defaults to 30 days ago.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: End date (ISO date string). Defaults to today.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 10
+          description: Maximum number of categories to return (top N).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpendingByCategoryResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/dashboard/spending-by-account:
+    get:
+      operationId: GetSpendingByAccount
+      tags: [Dashboard]
+      summary: Get spending grouped by account
+      description: Returns spending amounts grouped by payment account.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Start date (ISO date string). Defaults to 30 days ago.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: End date (ISO date string). Defaults to today.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpendingByAccountResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
 components:
   schemas:
+    # ── Dashboard ──────────────────────────────────
+
+    DashboardSummaryResponse:
+      type: object
+      required: [totalReceipts, totalSpent, averageTripAmount, mostUsedAccount, mostUsedCategory]
+      properties:
+        totalReceipts:
+          type: integer
+          format: int32
+        totalSpent:
+          type: number
+          format: double
+        averageTripAmount:
+          type: number
+          format: double
+        mostUsedAccount:
+          $ref: "#/components/schemas/NameCountPair"
+        mostUsedCategory:
+          $ref: "#/components/schemas/NameCountPair"
+
+    NameCountPair:
+      type: object
+      required: [count]
+      properties:
+        name:
+          type:
+            - string
+            - "null"
+        count:
+          type: integer
+          format: int32
+
+    SpendingOverTimeResponse:
+      type: object
+      required: [buckets]
+      properties:
+        buckets:
+          type: array
+          items:
+            $ref: "#/components/schemas/SpendingBucket"
+
+    SpendingBucket:
+      type: object
+      required: [period, amount]
+      properties:
+        period:
+          type: string
+        amount:
+          type: number
+          format: double
+
+    SpendingByCategoryResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SpendingCategoryItem"
+
+    SpendingCategoryItem:
+      type: object
+      required: [categoryName, amount, percentage]
+      properties:
+        categoryName:
+          type: string
+        amount:
+          type: number
+          format: double
+        percentage:
+          type: number
+          format: double
+
+    SpendingByAccountResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SpendingAccountItem"
+
+    SpendingAccountItem:
+      type: object
+      required: [accountId, accountName, amount, percentage]
+      properties:
+        accountId:
+          type: string
+          format: uuid
+        accountName:
+          type: string
+        amount:
+          type: number
+          format: double
+        percentage:
+          type: number
+          format: double
+
     # ── Account ──────────────────────────────────
 
     CreateAccountRequest:

--- a/src/Application/Interfaces/Services/IDashboardService.cs
+++ b/src/Application/Interfaces/Services/IDashboardService.cs
@@ -1,0 +1,11 @@
+using Application.Models.Dashboard;
+
+namespace Application.Interfaces.Services;
+
+public interface IDashboardService
+{
+	Task<DashboardSummaryResult> GetSummaryAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken);
+	Task<SpendingOverTimeResult> GetSpendingOverTimeAsync(DateOnly startDate, DateOnly endDate, string granularity, CancellationToken cancellationToken);
+	Task<SpendingByCategoryResult> GetSpendingByCategoryAsync(DateOnly startDate, DateOnly endDate, int limit, CancellationToken cancellationToken);
+	Task<SpendingByAccountResult> GetSpendingByAccountAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken);
+}

--- a/src/Application/Models/Dashboard/DashboardSummaryResult.cs
+++ b/src/Application/Models/Dashboard/DashboardSummaryResult.cs
@@ -1,0 +1,10 @@
+namespace Application.Models.Dashboard;
+
+public record DashboardSummaryResult(
+	int TotalReceipts,
+	decimal TotalSpent,
+	decimal AverageTripAmount,
+	NameCountResult MostUsedAccount,
+	NameCountResult MostUsedCategory);
+
+public record NameCountResult(string? Name, int Count);

--- a/src/Application/Models/Dashboard/SpendingByAccountResult.cs
+++ b/src/Application/Models/Dashboard/SpendingByAccountResult.cs
@@ -1,0 +1,5 @@
+namespace Application.Models.Dashboard;
+
+public record SpendingByAccountResult(List<SpendingAccountItemResult> Items);
+
+public record SpendingAccountItemResult(Guid AccountId, string AccountName, decimal Amount, decimal Percentage);

--- a/src/Application/Models/Dashboard/SpendingByCategoryResult.cs
+++ b/src/Application/Models/Dashboard/SpendingByCategoryResult.cs
@@ -1,0 +1,5 @@
+namespace Application.Models.Dashboard;
+
+public record SpendingByCategoryResult(List<SpendingCategoryItemResult> Items);
+
+public record SpendingCategoryItemResult(string CategoryName, decimal Amount, decimal Percentage);

--- a/src/Application/Models/Dashboard/SpendingOverTimeResult.cs
+++ b/src/Application/Models/Dashboard/SpendingOverTimeResult.cs
@@ -1,0 +1,5 @@
+namespace Application.Models.Dashboard;
+
+public record SpendingOverTimeResult(List<SpendingBucketResult> Buckets);
+
+public record SpendingBucketResult(string Period, decimal Amount);

--- a/src/Application/Queries/Aggregates/Dashboard/GetDashboardSummaryQuery.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetDashboardSummaryQuery.cs
@@ -1,0 +1,6 @@
+using Application.Interfaces;
+using Application.Models.Dashboard;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public record GetDashboardSummaryQuery(DateOnly StartDate, DateOnly EndDate) : IQuery<DashboardSummaryResult>;

--- a/src/Application/Queries/Aggregates/Dashboard/GetDashboardSummaryQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetDashboardSummaryQueryHandler.cs
@@ -1,0 +1,14 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public class GetDashboardSummaryQueryHandler(IDashboardService dashboardService)
+	: IRequestHandler<GetDashboardSummaryQuery, DashboardSummaryResult>
+{
+	public async Task<DashboardSummaryResult> Handle(GetDashboardSummaryQuery request, CancellationToken cancellationToken)
+	{
+		return await dashboardService.GetSummaryAsync(request.StartDate, request.EndDate, cancellationToken);
+	}
+}

--- a/src/Application/Queries/Aggregates/Dashboard/GetSpendingByAccountQuery.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetSpendingByAccountQuery.cs
@@ -1,0 +1,6 @@
+using Application.Interfaces;
+using Application.Models.Dashboard;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public record GetSpendingByAccountQuery(DateOnly StartDate, DateOnly EndDate) : IQuery<SpendingByAccountResult>;

--- a/src/Application/Queries/Aggregates/Dashboard/GetSpendingByAccountQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetSpendingByAccountQueryHandler.cs
@@ -1,0 +1,14 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public class GetSpendingByAccountQueryHandler(IDashboardService dashboardService)
+	: IRequestHandler<GetSpendingByAccountQuery, SpendingByAccountResult>
+{
+	public async Task<SpendingByAccountResult> Handle(GetSpendingByAccountQuery request, CancellationToken cancellationToken)
+	{
+		return await dashboardService.GetSpendingByAccountAsync(request.StartDate, request.EndDate, cancellationToken);
+	}
+}

--- a/src/Application/Queries/Aggregates/Dashboard/GetSpendingByCategoryQuery.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetSpendingByCategoryQuery.cs
@@ -1,0 +1,6 @@
+using Application.Interfaces;
+using Application.Models.Dashboard;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public record GetSpendingByCategoryQuery(DateOnly StartDate, DateOnly EndDate, int Limit) : IQuery<SpendingByCategoryResult>;

--- a/src/Application/Queries/Aggregates/Dashboard/GetSpendingByCategoryQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetSpendingByCategoryQueryHandler.cs
@@ -1,0 +1,14 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public class GetSpendingByCategoryQueryHandler(IDashboardService dashboardService)
+	: IRequestHandler<GetSpendingByCategoryQuery, SpendingByCategoryResult>
+{
+	public async Task<SpendingByCategoryResult> Handle(GetSpendingByCategoryQuery request, CancellationToken cancellationToken)
+	{
+		return await dashboardService.GetSpendingByCategoryAsync(request.StartDate, request.EndDate, request.Limit, cancellationToken);
+	}
+}

--- a/src/Application/Queries/Aggregates/Dashboard/GetSpendingOverTimeQuery.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetSpendingOverTimeQuery.cs
@@ -1,0 +1,6 @@
+using Application.Interfaces;
+using Application.Models.Dashboard;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public record GetSpendingOverTimeQuery(DateOnly StartDate, DateOnly EndDate, string Granularity) : IQuery<SpendingOverTimeResult>;

--- a/src/Application/Queries/Aggregates/Dashboard/GetSpendingOverTimeQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetSpendingOverTimeQueryHandler.cs
@@ -1,0 +1,14 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public class GetSpendingOverTimeQueryHandler(IDashboardService dashboardService)
+	: IRequestHandler<GetSpendingOverTimeQuery, SpendingOverTimeResult>
+{
+	public async Task<SpendingOverTimeResult> Handle(GetSpendingOverTimeQuery request, CancellationToken cancellationToken)
+	{
+		return await dashboardService.GetSpendingOverTimeAsync(request.StartDate, request.EndDate, request.Granularity, cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/DashboardService.cs
+++ b/src/Infrastructure/Services/DashboardService.cs
@@ -1,0 +1,204 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using Infrastructure.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Services;
+
+public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFactory) : IDashboardService
+{
+	public async Task<DashboardSummaryResult> GetSummaryAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		IQueryable<ReceiptEntity> receiptsInRange = context.Receipts
+			.AsNoTracking()
+			.Where(r => r.Date >= startDate && r.Date <= endDate);
+
+		int totalReceipts = await receiptsInRange.CountAsync(cancellationToken);
+
+		if (totalReceipts == 0)
+		{
+			return new DashboardSummaryResult(0, 0, 0, new NameCountResult(null, 0), new NameCountResult(null, 0));
+		}
+
+		// Get receipt IDs in range for joining with transactions/items
+		IQueryable<Guid> receiptIds = receiptsInRange.Select(r => r.Id);
+
+		// Total spent = sum of all transaction amounts for receipts in range
+		decimal totalSpent = await context.Transactions
+			.AsNoTracking()
+			.Where(t => receiptIds.Contains(t.ReceiptId))
+			.SumAsync(t => t.Amount, cancellationToken);
+
+		decimal averageTripAmount = totalReceipts > 0 ? Math.Round(totalSpent / totalReceipts, 2) : 0;
+
+		// Most-used account = account with the most transactions in range
+		var mostUsedAccountData = await context.Transactions
+			.AsNoTracking()
+			.Where(t => receiptIds.Contains(t.ReceiptId))
+			.GroupBy(t => t.AccountId)
+			.Select(g => new { AccountId = g.Key, Count = g.Count() })
+			.OrderByDescending(g => g.Count)
+			.FirstOrDefaultAsync(cancellationToken);
+
+		NameCountResult mostUsedAccount;
+		if (mostUsedAccountData != null)
+		{
+			string? accountName = await context.Accounts
+				.AsNoTracking()
+				.Where(a => a.Id == mostUsedAccountData.AccountId)
+				.Select(a => a.Name)
+				.FirstOrDefaultAsync(cancellationToken);
+			mostUsedAccount = new NameCountResult(accountName, mostUsedAccountData.Count);
+		}
+		else
+		{
+			mostUsedAccount = new NameCountResult(null, 0);
+		}
+
+		// Most-used category = category with the most receipt items in range
+		var mostUsedCategoryData = await context.ReceiptItems
+			.AsNoTracking()
+			.Where(ri => receiptIds.Contains(ri.ReceiptId))
+			.GroupBy(ri => ri.Category)
+			.Select(g => new { Category = g.Key, Count = g.Count() })
+			.OrderByDescending(g => g.Count)
+			.FirstOrDefaultAsync(cancellationToken);
+
+		NameCountResult mostUsedCategory = mostUsedCategoryData != null
+			? new NameCountResult(mostUsedCategoryData.Category, mostUsedCategoryData.Count)
+			: new NameCountResult(null, 0);
+
+		return new DashboardSummaryResult(totalReceipts, totalSpent, averageTripAmount, mostUsedAccount, mostUsedCategory);
+	}
+
+	public async Task<SpendingOverTimeResult> GetSpendingOverTimeAsync(DateOnly startDate, DateOnly endDate, string granularity, CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		IQueryable<Guid> receiptIds = context.Receipts
+			.AsNoTracking()
+			.Where(r => r.Date >= startDate && r.Date <= endDate)
+			.Select(r => r.Id);
+
+		// Get all transactions for receipts in range, joined with receipt date
+		var transactionsWithDate = context.Transactions
+			.AsNoTracking()
+			.Where(t => receiptIds.Contains(t.ReceiptId))
+			.Join(
+				context.Receipts.AsNoTracking(),
+				t => t.ReceiptId,
+				r => r.Id,
+				(t, r) => new { t.Amount, r.Date });
+
+		List<SpendingBucketResult> buckets;
+
+		switch (granularity.ToLowerInvariant())
+		{
+			case "daily":
+				buckets = await transactionsWithDate
+					.GroupBy(x => x.Date)
+					.Select(g => new SpendingBucketResult(g.Key.ToString("yyyy-MM-dd"), g.Sum(x => x.Amount)))
+					.OrderBy(b => b.Period)
+					.ToListAsync(cancellationToken);
+				break;
+
+			case "weekly":
+				// Materialize first — DayOfWeek arithmetic cannot be translated to SQL by EF Core.
+				// Then group by the Monday of each ISO week in memory.
+				var weeklyRaw = await transactionsWithDate.ToListAsync(cancellationToken);
+				buckets = weeklyRaw
+					.GroupBy(x => x.Date.AddDays(-(((int)x.Date.DayOfWeek + 6) % 7)))
+					.OrderBy(g => g.Key)
+					.Select(g => new SpendingBucketResult(g.Key.ToString("yyyy-MM-dd"), g.Sum(x => x.Amount)))
+					.ToList();
+				break;
+
+			case "monthly":
+			default:
+				var monthlyRaw = await transactionsWithDate
+					.GroupBy(x => new { x.Date.Year, x.Date.Month })
+					.Select(g => new { g.Key.Year, g.Key.Month, Amount = g.Sum(x => x.Amount) })
+					.OrderBy(g => g.Year)
+					.ThenBy(g => g.Month)
+					.ToListAsync(cancellationToken);
+				buckets = monthlyRaw
+					.Select(m => new SpendingBucketResult($"{m.Year}-{m.Month:D2}", m.Amount))
+					.ToList();
+				break;
+		}
+
+		return new SpendingOverTimeResult(buckets);
+	}
+
+	public async Task<SpendingByCategoryResult> GetSpendingByCategoryAsync(DateOnly startDate, DateOnly endDate, int limit, CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		IQueryable<Guid> receiptIds = context.Receipts
+			.AsNoTracking()
+			.Where(r => r.Date >= startDate && r.Date <= endDate)
+			.Select(r => r.Id);
+
+		var allCategorySpending = context.ReceiptItems
+			.AsNoTracking()
+			.Where(ri => receiptIds.Contains(ri.ReceiptId))
+			.GroupBy(ri => ri.Category)
+			.Select(g => new { Category = g.Key, Amount = g.Sum(ri => ri.TotalAmount) })
+			.OrderByDescending(g => g.Amount);
+
+		// Compute total from ALL categories before applying the limit
+		decimal total = await allCategorySpending.SumAsync(g => g.Amount, cancellationToken);
+
+		var categorySpending = await allCategorySpending
+			.Take(limit)
+			.ToListAsync(cancellationToken);
+
+		List<SpendingCategoryItemResult> items = categorySpending
+			.Select(c => new SpendingCategoryItemResult(
+				c.Category,
+				c.Amount,
+				total > 0 ? Math.Round(c.Amount / total * 100, 2) : 0))
+			.ToList();
+
+		return new SpendingByCategoryResult(items);
+	}
+
+	public async Task<SpendingByAccountResult> GetSpendingByAccountAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		IQueryable<Guid> receiptIds = context.Receipts
+			.AsNoTracking()
+			.Where(r => r.Date >= startDate && r.Date <= endDate)
+			.Select(r => r.Id);
+
+		var accountSpending = await context.Transactions
+			.AsNoTracking()
+			.Where(t => receiptIds.Contains(t.ReceiptId))
+			.GroupBy(t => t.AccountId)
+			.Select(g => new { AccountId = g.Key, Amount = g.Sum(t => t.Amount) })
+			.OrderByDescending(g => g.Amount)
+			.ToListAsync(cancellationToken);
+
+		decimal total = accountSpending.Sum(a => a.Amount);
+
+		// Fetch account names in a single query
+		List<Guid> accountIds = accountSpending.Select(a => a.AccountId).ToList();
+		Dictionary<Guid, string> accountNames = await context.Accounts
+			.AsNoTracking()
+			.Where(a => accountIds.Contains(a.Id))
+			.ToDictionaryAsync(a => a.Id, a => a.Name, cancellationToken);
+
+		List<SpendingAccountItemResult> items = accountSpending
+			.Select(a => new SpendingAccountItemResult(
+				a.AccountId,
+				accountNames.GetValueOrDefault(a.AccountId, "Unknown"),
+				a.Amount,
+				total > 0 ? Math.Round(a.Amount / total * 100, 2) : 0))
+			.ToList();
+
+		return new SpendingByAccountResult(items);
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -124,7 +124,8 @@ public static class InfrastructureService
 			.AddScoped<IAuditService, AuditService>()
 			.AddScoped<IAuthAuditService, AuthAuditService>()
 			.AddScoped<IUserService, UserService>()
-			.AddScoped<ITrashService, TrashService>();
+			.AddScoped<ITrashService, TrashService>()
+			.AddScoped<IDashboardService, DashboardService>();
 
 		services.AddHostedService<AuthAuditCleanupService>();
 

--- a/src/Presentation/API/Controllers/Aggregates/DashboardController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/DashboardController.cs
@@ -1,0 +1,159 @@
+using API.Generated.Dtos;
+using Application.Models.Dashboard;
+using Application.Queries.Aggregates.Dashboard;
+using Asp.Versioning;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers.Aggregates;
+
+[ApiVersion("1.0")]
+[ApiController]
+[Route("api/dashboard")]
+[Produces("application/json")]
+[Authorize]
+public class DashboardController(IMediator mediator) : ControllerBase
+{
+	[HttpGet("summary")]
+	[EndpointSummary("Get dashboard summary statistics")]
+	[EndpointDescription("Returns high-level stats for a date range including total receipts, total spent, average trip amount, and most-used account/category.")]
+	public async Task<Results<Ok<DashboardSummaryResponse>, BadRequest<string>>> GetDashboardSummary(
+		[FromQuery] DateOnly? startDate,
+		[FromQuery] DateOnly? endDate,
+		CancellationToken cancellationToken)
+	{
+		DateOnly start = startDate ?? DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly end = endDate ?? DateOnly.FromDateTime(DateTime.Today);
+
+		if (start > end)
+		{
+			return TypedResults.BadRequest("startDate must be before or equal to endDate");
+		}
+
+		GetDashboardSummaryQuery query = new(start, end);
+		DashboardSummaryResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new DashboardSummaryResponse
+		{
+			TotalReceipts = result.TotalReceipts,
+			TotalSpent = (double)result.TotalSpent,
+			AverageTripAmount = (double)result.AverageTripAmount,
+			MostUsedAccount = new NameCountPair
+			{
+				Name = result.MostUsedAccount.Name,
+				Count = result.MostUsedAccount.Count
+			},
+			MostUsedCategory = new NameCountPair
+			{
+				Name = result.MostUsedCategory.Name,
+				Count = result.MostUsedCategory.Count
+			}
+		});
+	}
+
+	[HttpGet("spending-over-time")]
+	[EndpointSummary("Get spending over time")]
+	[EndpointDescription("Returns time-series spending data bucketed by the specified granularity.")]
+	public async Task<Results<Ok<SpendingOverTimeResponse>, BadRequest<string>>> GetSpendingOverTime(
+		[FromQuery] DateOnly? startDate,
+		[FromQuery] DateOnly? endDate,
+		[FromQuery] string? granularity,
+		CancellationToken cancellationToken)
+	{
+		DateOnly start = startDate ?? DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly end = endDate ?? DateOnly.FromDateTime(DateTime.Today);
+		string gran = granularity ?? "monthly";
+
+		if (start > end)
+		{
+			return TypedResults.BadRequest("startDate must be before or equal to endDate");
+		}
+
+		string[] validGranularities = ["daily", "weekly", "monthly"];
+		if (!validGranularities.Contains(gran.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid granularity '{gran}'. Allowed: daily, weekly, monthly");
+		}
+
+		GetSpendingOverTimeQuery query = new(start, end, gran);
+		SpendingOverTimeResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new SpendingOverTimeResponse
+		{
+			Buckets = result.Buckets.Select(b => new SpendingBucket
+			{
+				Period = b.Period,
+				Amount = (double)b.Amount
+			}).ToList()
+		});
+	}
+
+	[HttpGet("spending-by-category")]
+	[EndpointSummary("Get spending grouped by category")]
+	[EndpointDescription("Returns spending amounts grouped by receipt item category.")]
+	public async Task<Results<Ok<SpendingByCategoryResponse>, BadRequest<string>>> GetSpendingByCategory(
+		[FromQuery] DateOnly? startDate,
+		[FromQuery] DateOnly? endDate,
+		[FromQuery] int limit = 10,
+		CancellationToken cancellationToken = default)
+	{
+		DateOnly start = startDate ?? DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly end = endDate ?? DateOnly.FromDateTime(DateTime.Today);
+
+		if (start > end)
+		{
+			return TypedResults.BadRequest("startDate must be before or equal to endDate");
+		}
+
+		if (limit <= 0 || limit > 100)
+		{
+			return TypedResults.BadRequest("limit must be between 1 and 100");
+		}
+
+		GetSpendingByCategoryQuery query = new(start, end, limit);
+		SpendingByCategoryResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new SpendingByCategoryResponse
+		{
+			Items = result.Items.Select(i => new SpendingCategoryItem
+			{
+				CategoryName = i.CategoryName,
+				Amount = (double)i.Amount,
+				Percentage = (double)i.Percentage
+			}).ToList()
+		});
+	}
+
+	[HttpGet("spending-by-account")]
+	[EndpointSummary("Get spending grouped by account")]
+	[EndpointDescription("Returns spending amounts grouped by payment account.")]
+	public async Task<Results<Ok<SpendingByAccountResponse>, BadRequest<string>>> GetSpendingByAccount(
+		[FromQuery] DateOnly? startDate,
+		[FromQuery] DateOnly? endDate,
+		CancellationToken cancellationToken)
+	{
+		DateOnly start = startDate ?? DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly end = endDate ?? DateOnly.FromDateTime(DateTime.Today);
+
+		if (start > end)
+		{
+			return TypedResults.BadRequest("startDate must be before or equal to endDate");
+		}
+
+		GetSpendingByAccountQuery query = new(start, end);
+		SpendingByAccountResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new SpendingByAccountResponse
+		{
+			Items = result.Items.Select(i => new SpendingAccountItem
+			{
+				AccountId = i.AccountId,
+				AccountName = i.AccountName,
+				Amount = (double)i.Amount,
+				Percentage = (double)i.Percentage
+			}).ToList()
+		});
+	}
+}

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",
@@ -27,6 +27,7 @@
         "react-hook-form": "^7.71.2",
         "react-hotkeys-hook": "^5.2.4",
         "react-router": "^7.13.0",
+        "recharts": "^3.8.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
@@ -3630,6 +3631,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -4011,7 +4048,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -4598,6 +4634,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4661,6 +4760,12 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -6146,6 +6251,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6308,6 +6534,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6762,6 +6994,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -7113,6 +7355,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "2.0.2",
@@ -8074,6 +8322,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8144,6 +8402,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -10799,9 +11066,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -10921,6 +11210,36 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -10933,6 +11252,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -11003,6 +11337,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -11893,7 +12233,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -12425,6 +12764,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -37,6 +37,7 @@
     "react-hook-form": "^7.71.2",
     "react-hotkeys-hook": "^5.2.4",
     "react-router": "^7.13.0",
+    "recharts": "^3.8.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"

--- a/src/client/src/App.test.tsx
+++ b/src/client/src/App.test.tsx
@@ -4,8 +4,8 @@ import { createMemoryRouter, RouterProvider, Outlet } from "react-router";
 import type { ReactNode } from "react";
 
 // Mock all page components to simple stubs
-vi.mock("@/pages/Home", () => ({
-  default: () => <div data-testid="page-home">Home Page</div>,
+vi.mock("@/pages/Dashboard", () => ({
+  default: () => <div data-testid="page-dashboard">Dashboard Page</div>,
 }));
 vi.mock("@/pages/Login", () => ({
   default: () => <div data-testid="page-login">Login Page</div>,
@@ -110,9 +110,9 @@ function renderRoute(path: string) {
 }
 
 describe("App router", () => {
-  it('renders Home page at "/" route', async () => {
+  it('renders Dashboard page at "/" route', async () => {
     renderRoute("/");
-    expect(await screen.findByTestId("page-home")).toBeInTheDocument();
+    expect(await screen.findByTestId("page-dashboard")).toBeInTheDocument();
   });
 
   it('renders Accounts page at "/accounts" route', async () => {

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -3,7 +3,7 @@ import { AdminRoute } from "@/components/AdminRoute";
 import { Layout } from "@/components/Layout";
 import { PublicLayout } from "@/components/PublicLayout";
 import { RootLayout } from "@/components/RootLayout";
-import Home from "@/pages/Home";
+import Dashboard from "@/pages/Dashboard";
 import Login from "@/pages/Login";
 import ChangePassword from "@/pages/ChangePassword";
 import ApiKeys from "@/pages/ApiKeys";
@@ -41,7 +41,7 @@ export const routeConfig = [
           </ProtectedRoute>
         ),
         children: [
-          { path: "/", element: <Home /> },
+          { path: "/", element: <Dashboard /> },
           { path: "/accounts", element: <Accounts /> },
           { path: "/categories", element: <Categories /> },
           { path: "/subcategories", element: <Subcategories /> },

--- a/src/client/src/components/Layout.test.tsx
+++ b/src/client/src/components/Layout.test.tsx
@@ -177,14 +177,14 @@ describe("Layout", () => {
     expect(screen.queryByText("Admin")).not.toBeInTheDocument();
   });
 
-  it("applies active styling to Home link when on root route", () => {
+  it("applies active styling to Dashboard link when on root route", () => {
     renderLayout();
-    // The desktop nav contains the NavigationMenu with a Home link
+    // The desktop nav contains the NavigationMenu with a Dashboard link
     const desktopNav = screen.getByRole("navigation", { name: /main navigation/i });
     const homeLinks = desktopNav.querySelectorAll("a[href='/']");
-    // Find the Home link (not the brand link) -- it should contain "Home" text
+    // Find the Dashboard link (not the brand link) -- it should contain "Dashboard" text
     const homeNavLink = Array.from(homeLinks).find((link) =>
-      link.textContent?.includes("Home"),
+      link.textContent?.includes("Dashboard"),
     );
     expect(homeNavLink).toBeDefined();
     expect(homeNavLink!.className).toContain("bg-accent");

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -201,7 +201,7 @@ export function Layout() {
   }
 
   const navLinks = [
-    { to: "/", label: "Home" },
+    { to: "/", label: "Dashboard" },
     { to: "/accounts", label: "Accounts" },
     { to: "/categories", label: "Categories" },
     { to: "/subcategories", label: "Subcategories" },
@@ -263,7 +263,7 @@ export function Layout() {
                           "bg-accent/50 text-accent-foreground",
                       )}
                     >
-                      Home
+                      Dashboard
                     </Link>
                   </NavigationMenuLink>
                 </NavigationMenuItem>

--- a/src/client/src/components/charts/AreaTimeChart.test.tsx
+++ b/src/client/src/components/charts/AreaTimeChart.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { AreaTimeChart } from "./AreaTimeChart";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  AreaChart: ({ children, data }: { children: React.ReactNode; data: unknown[] }) => (
+    <div data-testid="area-chart" data-count={data.length}>
+      {children}
+    </div>
+  ),
+  Area: () => <div data-testid="area" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+}));
+
+const mockData = [
+  { period: "Jan", amount: 100 },
+  { period: "Feb", amount: 200 },
+  { period: "Mar", amount: 150 },
+];
+
+describe("AreaTimeChart", () => {
+  it("renders the chart with data", () => {
+    render(<AreaTimeChart data={mockData} />);
+    expect(screen.getByTestId("responsive-container")).toBeInTheDocument();
+    expect(screen.getByTestId("area-chart")).toHaveAttribute("data-count", "3");
+    expect(screen.getByTestId("area")).toBeInTheDocument();
+  });
+
+  it("renders axis and grid elements", () => {
+    render(<AreaTimeChart data={mockData} />);
+    expect(screen.getByTestId("x-axis")).toBeInTheDocument();
+    expect(screen.getByTestId("y-axis")).toBeInTheDocument();
+    expect(screen.getByTestId("cartesian-grid")).toBeInTheDocument();
+  });
+
+  it("renders with empty data", () => {
+    render(<AreaTimeChart data={[]} />);
+    expect(screen.getByTestId("area-chart")).toHaveAttribute("data-count", "0");
+  });
+});

--- a/src/client/src/components/charts/AreaTimeChart.tsx
+++ b/src/client/src/components/charts/AreaTimeChart.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import {
   ResponsiveContainer,
   AreaChart,
@@ -22,11 +23,13 @@ export function AreaTimeChart({
   color = CHART_COLORS[0],
   formatValue = (v) => v.toLocaleString(),
 }: AreaTimeChartProps) {
+  const gradientId = useId();
+
   return (
     <ResponsiveContainer width="100%" height={height}>
       <AreaChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
         <defs>
-          <linearGradient id="areaGradient" x1="0" y1="0" x2="0" y2="1">
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
             <stop offset="5%" stopColor={color} stopOpacity={0.3} />
             <stop offset="95%" stopColor={color} stopOpacity={0} />
           </linearGradient>
@@ -43,7 +46,7 @@ export function AreaTimeChart({
           tickFormatter={formatValue}
         />
         <Tooltip
-          formatter={(value: number) => [formatValue(value), "Amount"]}
+          formatter={(value) => [formatValue(Number(value)), "Amount"]}
           contentStyle={{
             backgroundColor: "hsl(var(--popover))",
             border: "1px solid hsl(var(--border))",
@@ -55,7 +58,7 @@ export function AreaTimeChart({
           type="monotone"
           dataKey="amount"
           stroke={color}
-          fill="url(#areaGradient)"
+          fill={`url(#${gradientId})`}
           strokeWidth={2}
         />
       </AreaChart>

--- a/src/client/src/components/charts/AreaTimeChart.tsx
+++ b/src/client/src/components/charts/AreaTimeChart.tsx
@@ -1,0 +1,64 @@
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+import { CHART_COLORS } from "./chart-colors";
+
+interface AreaTimeChartProps {
+  data: Array<{ period: string; amount: number }>;
+  height?: number;
+  color?: string;
+  formatValue?: (value: number) => string;
+}
+
+export function AreaTimeChart({
+  data,
+  height = 300,
+  color = CHART_COLORS[0],
+  formatValue = (v) => v.toLocaleString(),
+}: AreaTimeChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <AreaChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+        <defs>
+          <linearGradient id="areaGradient" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor={color} stopOpacity={0.3} />
+            <stop offset="95%" stopColor={color} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+        <XAxis
+          dataKey="period"
+          tick={{ fontSize: 12 }}
+          className="fill-muted-foreground"
+        />
+        <YAxis
+          tick={{ fontSize: 12 }}
+          className="fill-muted-foreground"
+          tickFormatter={formatValue}
+        />
+        <Tooltip
+          formatter={(value: number) => [formatValue(value), "Amount"]}
+          contentStyle={{
+            backgroundColor: "hsl(var(--popover))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: "var(--radius)",
+            color: "hsl(var(--popover-foreground))",
+          }}
+        />
+        <Area
+          type="monotone"
+          dataKey="amount"
+          stroke={color}
+          fill="url(#areaGradient)"
+          strokeWidth={2}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/client/src/components/charts/BarChart.test.tsx
+++ b/src/client/src/components/charts/BarChart.test.tsx
@@ -42,7 +42,7 @@ describe("BarChart", () => {
     expect(screen.getByTestId("bar")).toBeInTheDocument();
   });
 
-  it("renders vertical layout by default", () => {
+  it("passes horizontal recharts layout for default vertical bar orientation", () => {
     render(<BarChart data={mockData} />);
     expect(screen.getByTestId("bar-chart")).toHaveAttribute(
       "data-layout",
@@ -50,7 +50,7 @@ describe("BarChart", () => {
     );
   });
 
-  it("renders horizontal layout when specified", () => {
+  it("passes vertical recharts layout for horizontal bar orientation", () => {
     render(<BarChart data={mockData} layout="horizontal" />);
     expect(screen.getByTestId("bar-chart")).toHaveAttribute(
       "data-layout",

--- a/src/client/src/components/charts/BarChart.test.tsx
+++ b/src/client/src/components/charts/BarChart.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { BarChart } from "./BarChart";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  BarChart: ({
+    children,
+    data,
+    layout,
+  }: {
+    children: React.ReactNode;
+    data: unknown[];
+    layout?: string;
+  }) => (
+    <div data-testid="bar-chart" data-count={data.length} data-layout={layout}>
+      {children}
+    </div>
+  ),
+  Bar: () => <div data-testid="bar" />,
+  XAxis: ({ type }: { type?: string }) => (
+    <div data-testid="x-axis" data-type={type} />
+  ),
+  YAxis: ({ type }: { type?: string }) => (
+    <div data-testid="y-axis" data-type={type} />
+  ),
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+}));
+
+const mockData = [
+  { name: "Account A", value: 500 },
+  { name: "Account B", value: 300 },
+];
+
+describe("BarChart", () => {
+  it("renders the chart with data", () => {
+    render(<BarChart data={mockData} />);
+    expect(screen.getByTestId("responsive-container")).toBeInTheDocument();
+    expect(screen.getByTestId("bar-chart")).toHaveAttribute("data-count", "2");
+    expect(screen.getByTestId("bar")).toBeInTheDocument();
+  });
+
+  it("renders vertical layout by default", () => {
+    render(<BarChart data={mockData} />);
+    expect(screen.getByTestId("bar-chart")).toHaveAttribute(
+      "data-layout",
+      "horizontal",
+    );
+  });
+
+  it("renders horizontal layout when specified", () => {
+    render(<BarChart data={mockData} layout="horizontal" />);
+    expect(screen.getByTestId("bar-chart")).toHaveAttribute(
+      "data-layout",
+      "vertical",
+    );
+    expect(screen.getByTestId("x-axis")).toHaveAttribute("data-type", "number");
+    expect(screen.getByTestId("y-axis")).toHaveAttribute(
+      "data-type",
+      "category",
+    );
+  });
+
+  it("renders with empty data", () => {
+    render(<BarChart data={[]} />);
+    expect(screen.getByTestId("bar-chart")).toHaveAttribute("data-count", "0");
+  });
+});

--- a/src/client/src/components/charts/BarChart.tsx
+++ b/src/client/src/components/charts/BarChart.tsx
@@ -65,7 +65,7 @@ export function BarChart({
           </>
         )}
         <Tooltip
-          formatter={(value: number) => [formatValue(value), "Amount"]}
+          formatter={(value) => [formatValue(Number(value)), "Amount"]}
           contentStyle={{
             backgroundColor: "hsl(var(--popover))",
             border: "1px solid hsl(var(--border))",

--- a/src/client/src/components/charts/BarChart.tsx
+++ b/src/client/src/components/charts/BarChart.tsx
@@ -73,7 +73,7 @@ export function BarChart({
             color: "hsl(var(--popover-foreground))",
           }}
         />
-        <Bar dataKey="value" fill={color} radius={[4, 4, 0, 0]} />
+        <Bar dataKey="value" fill={color} radius={isHorizontal ? [0, 4, 4, 0] : [4, 4, 0, 0]} />
       </RechartsBarChart>
     </ResponsiveContainer>
   );

--- a/src/client/src/components/charts/BarChart.tsx
+++ b/src/client/src/components/charts/BarChart.tsx
@@ -1,0 +1,80 @@
+import {
+  ResponsiveContainer,
+  BarChart as RechartsBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+import { CHART_COLORS } from "./chart-colors";
+
+interface BarChartProps {
+  data: Array<{ name: string; value: number }>;
+  height?: number;
+  color?: string;
+  layout?: "horizontal" | "vertical";
+  formatValue?: (value: number) => string;
+}
+
+export function BarChart({
+  data,
+  height = 300,
+  color = CHART_COLORS[0],
+  layout = "vertical",
+  formatValue = (v) => v.toLocaleString(),
+}: BarChartProps) {
+  const isHorizontal = layout === "horizontal";
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <RechartsBarChart
+        data={data}
+        layout={isHorizontal ? "vertical" : "horizontal"}
+        margin={{ top: 5, right: 20, bottom: 5, left: isHorizontal ? 80 : 0 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+        {isHorizontal ? (
+          <>
+            <XAxis
+              type="number"
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+              tickFormatter={formatValue}
+            />
+            <YAxis
+              type="category"
+              dataKey="name"
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+              width={75}
+            />
+          </>
+        ) : (
+          <>
+            <XAxis
+              dataKey="name"
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+            />
+            <YAxis
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+              tickFormatter={formatValue}
+            />
+          </>
+        )}
+        <Tooltip
+          formatter={(value: number) => [formatValue(value), "Amount"]}
+          contentStyle={{
+            backgroundColor: "hsl(var(--popover))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: "var(--radius)",
+            color: "hsl(var(--popover-foreground))",
+          }}
+        />
+        <Bar dataKey="value" fill={color} radius={[4, 4, 0, 0]} />
+      </RechartsBarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/client/src/components/charts/ChartCard.test.tsx
+++ b/src/client/src/components/charts/ChartCard.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/test-utils";
+import { ChartCard } from "./ChartCard";
+
+describe("ChartCard", () => {
+  it("renders title and children", () => {
+    renderWithProviders(
+      <ChartCard title="Test Title">
+        <div>Chart content</div>
+      </ChartCard>,
+    );
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.getByText("Chart content")).toBeInTheDocument();
+  });
+
+  it("renders subtitle when provided", () => {
+    renderWithProviders(
+      <ChartCard title="Title" subtitle="Subtitle text">
+        <div>Content</div>
+      </ChartCard>,
+    );
+    expect(screen.getByText("Subtitle text")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderWithProviders(
+      <ChartCard title="Title" loading>
+        <div>Content</div>
+      </ChartCard>,
+    );
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+    expect(screen.queryByText("Content")).not.toBeInTheDocument();
+  });
+
+  it("renders empty message when empty", () => {
+    renderWithProviders(
+      <ChartCard title="Title" empty>
+        <div>Content</div>
+      </ChartCard>,
+    );
+    expect(screen.getByText("No data available")).toBeInTheDocument();
+    expect(screen.queryByText("Content")).not.toBeInTheDocument();
+  });
+
+  it("renders custom empty message", () => {
+    renderWithProviders(
+      <ChartCard title="Title" empty emptyMessage="Nothing here">
+        <div>Content</div>
+      </ChartCard>,
+    );
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+
+  it("renders action slot", () => {
+    renderWithProviders(
+      <ChartCard title="Title" action={<button>Action</button>}>
+        <div>Content</div>
+      </ChartCard>,
+    );
+    expect(
+      screen.getByRole("button", { name: "Action" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/charts/ChartCard.tsx
+++ b/src/client/src/components/charts/ChartCard.tsx
@@ -1,0 +1,60 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  CardAction,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface ChartCardProps {
+  title: string;
+  subtitle?: string;
+  loading?: boolean;
+  empty?: boolean;
+  emptyMessage?: string;
+  action?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function ChartCard({
+  title,
+  subtitle,
+  loading,
+  empty,
+  emptyMessage = "No data available",
+  action,
+  children,
+  className,
+}: ChartCardProps) {
+  return (
+    <Card className={cn("flex flex-col", className)}>
+      <CardHeader>
+        <div>
+          <CardTitle>{title}</CardTitle>
+          {subtitle && <CardDescription>{subtitle}</CardDescription>}
+        </div>
+        {action && <CardAction>{action}</CardAction>}
+      </CardHeader>
+      <CardContent className="flex-1">
+        {loading ? (
+          <div className="space-y-3" aria-label="Loading">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-32 w-full" />
+          </div>
+        ) : empty ? (
+          <div className="flex items-center justify-center h-32 text-muted-foreground text-sm">
+            {emptyMessage}
+          </div>
+        ) : (
+          children
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/client/src/components/charts/DonutChart.test.tsx
+++ b/src/client/src/components/charts/DonutChart.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { DonutChart } from "./DonutChart";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: ({
+    children,
+    data,
+  }: {
+    children: React.ReactNode;
+    data: unknown[];
+  }) => (
+    <div data-testid="pie" data-count={data.length}>
+      {children}
+    </div>
+  ),
+  Cell: ({ fill }: { fill: string }) => (
+    <div data-testid="cell" data-fill={fill} />
+  ),
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+const mockData = [
+  { name: "Food", value: 300 },
+  { name: "Transport", value: 200 },
+  { name: "Entertainment", value: 100 },
+];
+
+describe("DonutChart", () => {
+  it("renders the chart with data", () => {
+    render(<DonutChart data={mockData} />);
+    expect(screen.getByTestId("responsive-container")).toBeInTheDocument();
+    expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("pie")).toHaveAttribute("data-count", "3");
+  });
+
+  it("renders cells for each data item", () => {
+    render(<DonutChart data={mockData} />);
+    expect(screen.getAllByTestId("cell")).toHaveLength(3);
+  });
+
+  it("renders legend", () => {
+    render(<DonutChart data={mockData} />);
+    expect(screen.getByTestId("legend")).toBeInTheDocument();
+  });
+
+  it("renders with empty data", () => {
+    render(<DonutChart data={[]} />);
+    expect(screen.getByTestId("pie")).toHaveAttribute("data-count", "0");
+  });
+});

--- a/src/client/src/components/charts/DonutChart.tsx
+++ b/src/client/src/components/charts/DonutChart.tsx
@@ -1,0 +1,79 @@
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { CHART_COLORS } from "./chart-colors";
+
+interface DonutChartItem {
+  name: string;
+  value: number;
+}
+
+interface DonutChartProps {
+  data: DonutChartItem[];
+  height?: number;
+  centerLabel?: string;
+  formatValue?: (value: number) => string;
+}
+
+export function DonutChart({
+  data,
+  height = 300,
+  centerLabel,
+  formatValue = (v) => v.toLocaleString(),
+}: DonutChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <PieChart>
+        <Pie
+          data={data}
+          cx="50%"
+          cy="50%"
+          innerRadius="55%"
+          outerRadius="80%"
+          paddingAngle={2}
+          dataKey="value"
+          nameKey="name"
+          label={false}
+        >
+          {data.map((_entry, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={CHART_COLORS[index % CHART_COLORS.length]}
+            />
+          ))}
+        </Pie>
+        {centerLabel && (
+          <text
+            x="50%"
+            y="50%"
+            textAnchor="middle"
+            dominantBaseline="middle"
+            className="fill-foreground text-lg font-semibold"
+          >
+            {centerLabel}
+          </text>
+        )}
+        <Tooltip
+          formatter={(value: number) => [formatValue(value)]}
+          contentStyle={{
+            backgroundColor: "hsl(var(--popover))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: "var(--radius)",
+            color: "hsl(var(--popover-foreground))",
+          }}
+        />
+        <Legend
+          verticalAlign="bottom"
+          iconType="circle"
+          iconSize={8}
+          wrapperStyle={{ fontSize: "12px" }}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/client/src/components/charts/DonutChart.tsx
+++ b/src/client/src/components/charts/DonutChart.tsx
@@ -59,7 +59,7 @@ export function DonutChart({
           </text>
         )}
         <Tooltip
-          formatter={(value: number) => [formatValue(value)]}
+          formatter={(value) => [formatValue(Number(value))]}
           contentStyle={{
             backgroundColor: "hsl(var(--popover))",
             border: "1px solid hsl(var(--border))",

--- a/src/client/src/components/charts/chart-colors.ts
+++ b/src/client/src/components/charts/chart-colors.ts
@@ -1,0 +1,7 @@
+export const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+] as const;

--- a/src/client/src/components/charts/index.ts
+++ b/src/client/src/components/charts/index.ts
@@ -1,0 +1,5 @@
+export { ChartCard } from "./ChartCard";
+export { AreaTimeChart } from "./AreaTimeChart";
+export { DonutChart } from "./DonutChart";
+export { BarChart } from "./BarChart";
+export { CHART_COLORS } from "./chart-colors";

--- a/src/client/src/components/dashboard/DateRangeSelector.test.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.test.tsx
@@ -56,7 +56,7 @@ describe("DateRangeSelector", () => {
     );
   });
 
-  it("calls onChange with empty object for All time", async () => {
+  it("calls onChange with early start date for All time", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     renderWithProviders(
@@ -64,6 +64,11 @@ describe("DateRangeSelector", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "All time" }));
-    expect(onChange).toHaveBeenCalledWith({});
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: "2000-01-01",
+        endDate: expect.any(String),
+      }),
+    );
   });
 });

--- a/src/client/src/components/dashboard/DateRangeSelector.test.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { DateRangeSelector } from "./DateRangeSelector";
+import type { DateRange } from "@/hooks/useDashboard";
+
+const defaultRange: DateRange = {
+  startDate: "2024-01-01",
+  endDate: "2024-01-31",
+};
+
+describe("DateRangeSelector", () => {
+  it("renders all preset buttons", () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <DateRangeSelector value={defaultRange} onChange={onChange} />,
+    );
+    expect(screen.getByRole("button", { name: "7 days" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "30 days" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "90 days" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Year to date" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "All time" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders custom date button", () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <DateRangeSelector value={defaultRange} onChange={onChange} />,
+    );
+    expect(
+      screen.getByRole("button", { name: /custom/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange when a preset is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <DateRangeSelector value={defaultRange} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "7 days" }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: expect.any(String),
+        endDate: expect.any(String),
+      }),
+    );
+  });
+
+  it("calls onChange with empty object for All time", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <DateRangeSelector value={defaultRange} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "All time" }));
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+});

--- a/src/client/src/components/dashboard/DateRangeSelector.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.tsx
@@ -49,7 +49,10 @@ const presets: Record<PresetKey, Preset> = {
   },
   all: {
     label: "All time",
-    getRange: () => ({}),
+    getRange: () => ({
+      startDate: "2000-01-01",
+      endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
   },
 };
 

--- a/src/client/src/components/dashboard/DateRangeSelector.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.tsx
@@ -1,0 +1,144 @@
+import { useState, useCallback, useMemo } from "react";
+import { format, subDays, startOfYear } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import type { DateRange } from "@/hooks/useDashboard";
+import type { DateRange as DayPickerDateRange } from "react-day-picker";
+
+type PresetKey = "7d" | "30d" | "90d" | "ytd" | "all";
+
+interface Preset {
+  label: string;
+  getRange: () => DateRange;
+}
+
+const presets: Record<PresetKey, Preset> = {
+  "7d": {
+    label: "7 days",
+    getRange: () => ({
+      startDate: format(subDays(new Date(), 7), "yyyy-MM-dd"),
+      endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
+  },
+  "30d": {
+    label: "30 days",
+    getRange: () => ({
+      startDate: format(subDays(new Date(), 30), "yyyy-MM-dd"),
+      endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
+  },
+  "90d": {
+    label: "90 days",
+    getRange: () => ({
+      startDate: format(subDays(new Date(), 90), "yyyy-MM-dd"),
+      endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
+  },
+  ytd: {
+    label: "Year to date",
+    getRange: () => ({
+      startDate: format(startOfYear(new Date()), "yyyy-MM-dd"),
+      endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
+  },
+  all: {
+    label: "All time",
+    getRange: () => ({}),
+  },
+};
+
+interface DateRangeSelectorProps {
+  value: DateRange;
+  onChange: (range: DateRange) => void;
+}
+
+export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
+  const [activePreset, setActivePreset] = useState<PresetKey | "custom">("30d");
+  const [calendarOpen, setCalendarOpen] = useState(false);
+
+  const handlePreset = useCallback(
+    (key: PresetKey) => {
+      setActivePreset(key);
+      onChange(presets[key].getRange());
+    },
+    [onChange],
+  );
+
+  const handleCalendarSelect = useCallback(
+    (range: DayPickerDateRange | undefined) => {
+      if (range?.from) {
+        setActivePreset("custom");
+        onChange({
+          startDate: format(range.from, "yyyy-MM-dd"),
+          endDate: range.to
+            ? format(range.to, "yyyy-MM-dd")
+            : format(range.from, "yyyy-MM-dd"),
+        });
+        if (range.to) {
+          setCalendarOpen(false);
+        }
+      }
+    },
+    [onChange],
+  );
+
+  const calendarSelected = useMemo<DayPickerDateRange | undefined>(() => {
+    if (!value.startDate) return undefined;
+    return {
+      from: new Date(value.startDate + "T00:00:00"),
+      to: value.endDate ? new Date(value.endDate + "T00:00:00") : undefined,
+    };
+  }, [value.startDate, value.endDate]);
+
+  const displayLabel = useMemo(() => {
+    if (activePreset !== "custom" && activePreset in presets) {
+      return presets[activePreset].label;
+    }
+    if (value.startDate && value.endDate) {
+      return `${value.startDate} – ${value.endDate}`;
+    }
+    return "Select range";
+  }, [activePreset, value.startDate, value.endDate]);
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {(Object.keys(presets) as PresetKey[]).map((key) => (
+        <Button
+          key={key}
+          variant={activePreset === key ? "default" : "outline"}
+          size="sm"
+          onClick={() => handlePreset(key)}
+        >
+          {presets[key].label}
+        </Button>
+      ))}
+      <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant={activePreset === "custom" ? "default" : "outline"}
+            size="sm"
+            className="gap-1.5"
+          >
+            <CalendarIcon className="h-3.5 w-3.5" />
+            {activePreset === "custom" ? displayLabel : "Custom"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="end">
+          <Calendar
+            mode="range"
+            selected={calendarSelected}
+            onSelect={handleCalendarSelect}
+            numberOfMonths={2}
+            disabled={{ after: new Date() }}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/client/src/components/dashboard/RecentReceiptsWidget.test.tsx
+++ b/src/client/src/components/dashboard/RecentReceiptsWidget.test.tsx
@@ -39,8 +39,8 @@ describe("RecentReceiptsWidget", () => {
     renderWithQueryClient(<RecentReceiptsWidget />);
     expect(screen.getByText("Grocery Store")).toBeInTheDocument();
     expect(screen.getByText("Gas Station")).toBeInTheDocument();
-    expect(screen.getByText("$45.99")).toBeInTheDocument();
-    expect(screen.getByText("$32.50")).toBeInTheDocument();
+    expect(screen.getByText("Tax: $45.99")).toBeInTheDocument();
+    expect(screen.getByText("Tax: $32.50")).toBeInTheDocument();
   });
 
   it("renders View all link", () => {

--- a/src/client/src/components/dashboard/RecentReceiptsWidget.test.tsx
+++ b/src/client/src/components/dashboard/RecentReceiptsWidget.test.tsx
@@ -1,0 +1,75 @@
+import { screen } from "@testing-library/react";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { RecentReceiptsWidget } from "./RecentReceiptsWidget";
+
+vi.mock("@/hooks/useReceipts", () => ({
+  useReceipts: vi.fn(),
+}));
+
+import { useReceipts } from "@/hooks/useReceipts";
+const mockUseReceipts = vi.mocked(useReceipts);
+
+describe("RecentReceiptsWidget", () => {
+  it("renders recent receipts", () => {
+    mockUseReceipts.mockReturnValue({
+      data: {
+        data: [
+          {
+            id: "1",
+            location: "Grocery Store",
+            date: "2024-01-15",
+            taxAmount: 45.99,
+            description: null,
+          },
+          {
+            id: "2",
+            location: "Gas Station",
+            date: "2024-01-14",
+            taxAmount: 32.5,
+            description: null,
+          },
+        ],
+        total: 2,
+        offset: 0,
+        limit: 5,
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useReceipts>);
+
+    renderWithQueryClient(<RecentReceiptsWidget />);
+    expect(screen.getByText("Grocery Store")).toBeInTheDocument();
+    expect(screen.getByText("Gas Station")).toBeInTheDocument();
+    expect(screen.getByText("$45.99")).toBeInTheDocument();
+    expect(screen.getByText("$32.50")).toBeInTheDocument();
+  });
+
+  it("renders View all link", () => {
+    mockUseReceipts.mockReturnValue({
+      data: { data: [], total: 0, offset: 0, limit: 5 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useReceipts>);
+
+    renderWithQueryClient(<RecentReceiptsWidget />);
+    expect(screen.getByText("View all")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockUseReceipts.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useReceipts>);
+
+    renderWithQueryClient(<RecentReceiptsWidget />);
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no receipts", () => {
+    mockUseReceipts.mockReturnValue({
+      data: { data: [], total: 0, offset: 0, limit: 5 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useReceipts>);
+
+    renderWithQueryClient(<RecentReceiptsWidget />);
+    expect(screen.getByText("No receipts yet")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
+++ b/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
@@ -1,0 +1,13 @@
+import { ChartCard } from "@/components/charts";
+
+interface RecentReceiptsWidgetProps {
+  className?: string;
+}
+
+export function RecentReceiptsWidget({ className }: RecentReceiptsWidgetProps) {
+  return (
+    <ChartCard title="Recent Receipts" className={className}>
+      <p className="text-muted-foreground text-sm">Recent receipts will appear here.</p>
+    </ChartCard>
+  );
+}

--- a/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
+++ b/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
@@ -52,8 +52,8 @@ export function RecentReceiptsWidget({ className }: RecentReceiptsWidgetProps) {
                   {format(new Date(receipt.date), "MMM d, yyyy")}
                 </p>
               </div>
-              <span className="ml-4 text-sm font-medium tabular-nums">
-                {formatCurrency(receipt.taxAmount)}
+              <span className="ml-4 text-xs text-muted-foreground tabular-nums">
+                Tax: {formatCurrency(receipt.taxAmount)}
               </span>
             </Link>
           </li>

--- a/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
+++ b/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
@@ -1,13 +1,64 @@
+import { useMemo } from "react";
+import { format } from "date-fns";
+import { Link } from "react-router";
 import { ChartCard } from "@/components/charts";
+import { useReceipts } from "@/hooks/useReceipts";
 
 interface RecentReceiptsWidgetProps {
   className?: string;
 }
 
+function formatCurrency(value: number | string | undefined): string {
+  const num = Number(value ?? 0);
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(num);
+}
+
 export function RecentReceiptsWidget({ className }: RecentReceiptsWidgetProps) {
+  const { data, isLoading } = useReceipts(0, 5, "date", "desc");
+
+  const receipts = useMemo(() => data?.data ?? [], [data?.data]);
+
   return (
-    <ChartCard title="Recent Receipts" className={className}>
-      <p className="text-muted-foreground text-sm">Recent receipts will appear here.</p>
+    <ChartCard
+      title="Recent Receipts"
+      loading={isLoading}
+      empty={receipts.length === 0 && !isLoading}
+      emptyMessage="No receipts yet"
+      className={className}
+      action={
+        <Link
+          to="/receipts"
+          className="text-sm text-primary hover:underline"
+        >
+          View all
+        </Link>
+      }
+    >
+      <ul className="space-y-3">
+        {receipts.map((receipt) => (
+          <li key={receipt.id}>
+            <Link
+              to={`/receipt-detail?id=${receipt.id}`}
+              className="flex items-center justify-between rounded-md px-2 py-1.5 transition-colors hover:bg-accent"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium truncate">
+                  {receipt.location}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {format(new Date(receipt.date), "MMM d, yyyy")}
+                </p>
+              </div>
+              <span className="ml-4 text-sm font-medium tabular-nums">
+                {formatCurrency(receipt.taxAmount)}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
     </ChartCard>
   );
 }

--- a/src/client/src/components/dashboard/SpendingByAccountWidget.test.tsx
+++ b/src/client/src/components/dashboard/SpendingByAccountWidget.test.tsx
@@ -1,0 +1,83 @@
+import { screen } from "@testing-library/react";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { SpendingByAccountWidget } from "./SpendingByAccountWidget";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  BarChart: ({
+    children,
+    data,
+  }: {
+    children: React.ReactNode;
+    data: unknown[];
+  }) => (
+    <div data-testid="bar-chart" data-count={data.length}>
+      {children}
+    </div>
+  ),
+  Bar: () => <div data-testid="bar" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+}));
+
+vi.mock("@/hooks/useDashboard", () => ({
+  useDashboardSpendingByAccount: vi.fn(),
+}));
+
+import { useDashboardSpendingByAccount } from "@/hooks/useDashboard";
+const mockHook = vi.mocked(useDashboardSpendingByAccount);
+
+const dateRange = { startDate: "2024-01-01", endDate: "2024-01-31" };
+
+describe("SpendingByAccountWidget", () => {
+  it("renders chart with account data sorted descending", () => {
+    mockHook.mockReturnValue({
+      data: {
+        items: [
+          { accountId: "1", accountName: "Visa", amount: 300, percentage: 60 },
+          {
+            accountId: "2",
+            accountName: "Amex",
+            amount: 500,
+            percentage: 40,
+          },
+        ],
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByAccount>);
+
+    renderWithQueryClient(
+      <SpendingByAccountWidget dateRange={dateRange} />,
+    );
+    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("bar-chart")).toHaveAttribute("data-count", "2");
+  });
+
+  it("shows loading state", () => {
+    mockHook.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useDashboardSpendingByAccount>);
+
+    renderWithQueryClient(
+      <SpendingByAccountWidget dateRange={dateRange} />,
+    );
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no data", () => {
+    mockHook.mockReturnValue({
+      data: { items: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByAccount>);
+
+    renderWithQueryClient(
+      <SpendingByAccountWidget dateRange={dateRange} />,
+    );
+    expect(screen.getByText("No data available")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/dashboard/SpendingByAccountWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingByAccountWidget.tsx
@@ -1,4 +1,6 @@
-import { ChartCard } from "@/components/charts";
+import { useMemo } from "react";
+import { ChartCard, BarChart } from "@/components/charts";
+import { useDashboardSpendingByAccount } from "@/hooks/useDashboard";
 import type { DateRange } from "@/hooks/useDashboard";
 
 interface SpendingByAccountWidgetProps {
@@ -6,13 +8,44 @@ interface SpendingByAccountWidgetProps {
   className?: string;
 }
 
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
 export function SpendingByAccountWidget({
-  dateRange: _dateRange,
+  dateRange,
   className,
 }: SpendingByAccountWidgetProps) {
+  const { data, isLoading } = useDashboardSpendingByAccount(dateRange);
+
+  const chartData = useMemo(
+    () =>
+      (data?.items ?? [])
+        .map((item) => ({
+          name: item.accountName,
+          value: Number(item.amount ?? 0),
+        }))
+        .sort((a, b) => b.value - a.value),
+    [data?.items],
+  );
+
   return (
-    <ChartCard title="Spending by Account" className={className}>
-      <p className="text-muted-foreground text-sm">Account breakdown chart will appear here.</p>
+    <ChartCard
+      title="Spending by Account"
+      loading={isLoading}
+      empty={chartData.length === 0 && !isLoading}
+      className={className}
+    >
+      <BarChart
+        data={chartData}
+        layout="horizontal"
+        formatValue={formatCurrency}
+      />
     </ChartCard>
   );
 }

--- a/src/client/src/components/dashboard/SpendingByAccountWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingByAccountWidget.tsx
@@ -1,0 +1,18 @@
+import { ChartCard } from "@/components/charts";
+import type { DateRange } from "@/hooks/useDashboard";
+
+interface SpendingByAccountWidgetProps {
+  dateRange: DateRange;
+  className?: string;
+}
+
+export function SpendingByAccountWidget({
+  dateRange: _dateRange,
+  className,
+}: SpendingByAccountWidgetProps) {
+  return (
+    <ChartCard title="Spending by Account" className={className}>
+      <p className="text-muted-foreground text-sm">Account breakdown chart will appear here.</p>
+    </ChartCard>
+  );
+}

--- a/src/client/src/components/dashboard/SpendingByCategoryWidget.test.tsx
+++ b/src/client/src/components/dashboard/SpendingByCategoryWidget.test.tsx
@@ -1,0 +1,97 @@
+import { screen } from "@testing-library/react";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { SpendingByCategoryWidget } from "./SpendingByCategoryWidget";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: ({
+    children,
+    data,
+  }: {
+    children: React.ReactNode;
+    data: unknown[];
+  }) => (
+    <div data-testid="pie" data-count={data.length}>
+      {children}
+    </div>
+  ),
+  Cell: () => <div data-testid="cell" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+vi.mock("@/hooks/useDashboard", () => ({
+  useDashboardSpendingByCategory: vi.fn(),
+}));
+
+import { useDashboardSpendingByCategory } from "@/hooks/useDashboard";
+const mockHook = vi.mocked(useDashboardSpendingByCategory);
+
+const dateRange = { startDate: "2024-01-01", endDate: "2024-01-31" };
+
+describe("SpendingByCategoryWidget", () => {
+  it("renders chart with category data", () => {
+    mockHook.mockReturnValue({
+      data: {
+        items: [
+          { categoryName: "Food", amount: 300, percentage: 60 },
+          { categoryName: "Transport", amount: 200, percentage: 40 },
+        ],
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByCategory>);
+
+    renderWithQueryClient(
+      <SpendingByCategoryWidget dateRange={dateRange} />,
+    );
+    expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("pie")).toHaveAttribute("data-count", "2");
+  });
+
+  it("groups excess categories into Other", () => {
+    const items = Array.from({ length: 7 }, (_, i) => ({
+      categoryName: `Cat${i}`,
+      amount: 100 - i * 10,
+      percentage: 14,
+    }));
+    mockHook.mockReturnValue({
+      data: { items },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByCategory>);
+
+    renderWithQueryClient(
+      <SpendingByCategoryWidget dateRange={dateRange} />,
+    );
+    // 4 top + 1 "Other" = 5
+    expect(screen.getByTestId("pie")).toHaveAttribute("data-count", "5");
+  });
+
+  it("shows loading state", () => {
+    mockHook.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useDashboardSpendingByCategory>);
+
+    renderWithQueryClient(
+      <SpendingByCategoryWidget dateRange={dateRange} />,
+    );
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no data", () => {
+    mockHook.mockReturnValue({
+      data: { items: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByCategory>);
+
+    renderWithQueryClient(
+      <SpendingByCategoryWidget dateRange={dateRange} />,
+    );
+    expect(screen.getByText("No data available")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/dashboard/SpendingByCategoryWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingByCategoryWidget.tsx
@@ -1,18 +1,71 @@
-import { ChartCard } from "@/components/charts";
+import { useMemo } from "react";
+import { ChartCard, DonutChart } from "@/components/charts";
+import { useDashboardSpendingByCategory } from "@/hooks/useDashboard";
 import type { DateRange } from "@/hooks/useDashboard";
+
+const MAX_SLICES = 5;
 
 interface SpendingByCategoryWidgetProps {
   dateRange: DateRange;
   className?: string;
 }
 
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
 export function SpendingByCategoryWidget({
-  dateRange: _dateRange,
+  dateRange,
   className,
 }: SpendingByCategoryWidgetProps) {
+  const { data, isLoading } = useDashboardSpendingByCategory(dateRange);
+
+  const chartData = useMemo(() => {
+    const items = data?.items ?? [];
+    if (items.length <= MAX_SLICES) {
+      return items.map((item) => ({
+        name: item.categoryName,
+        value: Number(item.amount ?? 0),
+      }));
+    }
+    const top = items.slice(0, MAX_SLICES - 1);
+    const rest = items.slice(MAX_SLICES - 1);
+    const otherTotal = rest.reduce(
+      (sum, item) => sum + Number(item.amount ?? 0),
+      0,
+    );
+    return [
+      ...top.map((item) => ({
+        name: item.categoryName,
+        value: Number(item.amount ?? 0),
+      })),
+      { name: "Other", value: otherTotal },
+    ];
+  }, [data?.items]);
+
+  const totalSpent = useMemo(
+    () =>
+      chartData.reduce((sum, item) => sum + item.value, 0),
+    [chartData],
+  );
+
   return (
-    <ChartCard title="Spending by Category" className={className}>
-      <p className="text-muted-foreground text-sm">Category breakdown chart will appear here.</p>
+    <ChartCard
+      title="Spending by Category"
+      loading={isLoading}
+      empty={chartData.length === 0 && !isLoading}
+      className={className}
+    >
+      <DonutChart
+        data={chartData}
+        centerLabel={formatCurrency(totalSpent)}
+        formatValue={formatCurrency}
+      />
     </ChartCard>
   );
 }

--- a/src/client/src/components/dashboard/SpendingByCategoryWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingByCategoryWidget.tsx
@@ -1,0 +1,18 @@
+import { ChartCard } from "@/components/charts";
+import type { DateRange } from "@/hooks/useDashboard";
+
+interface SpendingByCategoryWidgetProps {
+  dateRange: DateRange;
+  className?: string;
+}
+
+export function SpendingByCategoryWidget({
+  dateRange: _dateRange,
+  className,
+}: SpendingByCategoryWidgetProps) {
+  return (
+    <ChartCard title="Spending by Category" className={className}>
+      <p className="text-muted-foreground text-sm">Category breakdown chart will appear here.</p>
+    </ChartCard>
+  );
+}

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.test.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.test.tsx
@@ -1,0 +1,78 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { SpendingOverTimeWidget } from "./SpendingOverTimeWidget";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  AreaChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="area-chart">{children}</div>
+  ),
+  Area: () => <div data-testid="area" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+}));
+
+vi.mock("@/hooks/useDashboard", () => ({
+  useDashboardSpendingOverTime: vi.fn(),
+}));
+
+import { useDashboardSpendingOverTime } from "@/hooks/useDashboard";
+const mockHook = vi.mocked(useDashboardSpendingOverTime);
+
+const dateRange = { startDate: "2024-01-01", endDate: "2024-01-31" };
+
+describe("SpendingOverTimeWidget", () => {
+  it("renders granularity toggle buttons", () => {
+    mockHook.mockReturnValue({
+      data: { buckets: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    expect(screen.getByRole("button", { name: "Day" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Week" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Month" })).toBeInTheDocument();
+  });
+
+  it("renders chart with data", () => {
+    mockHook.mockReturnValue({
+      data: {
+        buckets: [
+          { period: "2024-01", amount: 100 },
+          { period: "2024-02", amount: 200 },
+        ],
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    expect(screen.getByTestId("area-chart")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockHook.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+  });
+
+  it("changes granularity on button click", async () => {
+    const user = userEvent.setup();
+    mockHook.mockReturnValue({
+      data: { buckets: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    await user.click(screen.getByRole("button", { name: "Day" }));
+    expect(mockHook).toHaveBeenCalledWith(dateRange, "daily");
+  });
+});

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
@@ -1,0 +1,18 @@
+import { ChartCard } from "@/components/charts";
+import type { DateRange } from "@/hooks/useDashboard";
+
+interface SpendingOverTimeWidgetProps {
+  dateRange: DateRange;
+  className?: string;
+}
+
+export function SpendingOverTimeWidget({
+  dateRange: _dateRange,
+  className,
+}: SpendingOverTimeWidgetProps) {
+  return (
+    <ChartCard title="Spending Over Time" className={className}>
+      <p className="text-muted-foreground text-sm">Spending over time chart will appear here.</p>
+    </ChartCard>
+  );
+}

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
@@ -1,18 +1,76 @@
-import { ChartCard } from "@/components/charts";
+import { useState, useCallback, useMemo } from "react";
+import { ChartCard, AreaTimeChart } from "@/components/charts";
+import { useDashboardSpendingOverTime } from "@/hooks/useDashboard";
 import type { DateRange } from "@/hooks/useDashboard";
+import { Button } from "@/components/ui/button";
+
+type Granularity = "daily" | "weekly" | "monthly";
 
 interface SpendingOverTimeWidgetProps {
   dateRange: DateRange;
   className?: string;
 }
 
+const granularityOptions: { value: Granularity; label: string }[] = [
+  { value: "daily", label: "Day" },
+  { value: "weekly", label: "Week" },
+  { value: "monthly", label: "Month" },
+];
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
 export function SpendingOverTimeWidget({
-  dateRange: _dateRange,
+  dateRange,
   className,
 }: SpendingOverTimeWidgetProps) {
+  const [granularity, setGranularity] = useState<Granularity>("monthly");
+  const { data, isLoading } = useDashboardSpendingOverTime(
+    dateRange,
+    granularity,
+  );
+
+  const handleGranularity = useCallback((g: Granularity) => {
+    setGranularity(g);
+  }, []);
+
+  const chartData = useMemo(
+    () =>
+      (data?.buckets ?? []).map((b) => ({
+        period: b.period,
+        amount: Number(b.amount ?? 0),
+      })),
+    [data?.buckets],
+  );
+
   return (
-    <ChartCard title="Spending Over Time" className={className}>
-      <p className="text-muted-foreground text-sm">Spending over time chart will appear here.</p>
+    <ChartCard
+      title="Spending Over Time"
+      loading={isLoading}
+      empty={chartData.length === 0 && !isLoading}
+      className={className}
+      action={
+        <div className="flex gap-1">
+          {granularityOptions.map(({ value, label }) => (
+            <Button
+              key={value}
+              variant={granularity === value ? "default" : "outline"}
+              size="sm"
+              onClick={() => handleGranularity(value)}
+            >
+              {label}
+            </Button>
+          ))}
+        </div>
+      }
+    >
+      <AreaTimeChart data={chartData} formatValue={formatCurrency} />
     </ChartCard>
   );
 }

--- a/src/client/src/components/dashboard/StatCard.tsx
+++ b/src/client/src/components/dashboard/StatCard.tsx
@@ -1,0 +1,45 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react";
+
+interface StatCardProps {
+  title: string;
+  value: string;
+  subtitle?: string;
+  icon: LucideIcon;
+  loading?: boolean;
+  className?: string;
+}
+
+export function StatCard({
+  title,
+  value,
+  subtitle,
+  icon: Icon,
+  loading,
+  className,
+}: StatCardProps) {
+  return (
+    <Card className={cn("py-4", className)}>
+      <CardContent className="flex items-center gap-4">
+        <div className="rounded-lg bg-primary/10 p-2.5">
+          <Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-muted-foreground">{title}</p>
+          {loading ? (
+            <Skeleton className="h-7 w-24 mt-1" />
+          ) : (
+            <p className="text-2xl font-bold tracking-tight truncate">
+              {value}
+            </p>
+          )}
+          {subtitle && !loading && (
+            <p className="text-xs text-muted-foreground truncate">{subtitle}</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/client/src/components/dashboard/SummaryStats.test.tsx
+++ b/src/client/src/components/dashboard/SummaryStats.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from "@testing-library/react";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { SummaryStats } from "./SummaryStats";
+
+vi.mock("@/hooks/useDashboard", () => ({
+  useDashboardSummary: vi.fn(),
+}));
+
+import { useDashboardSummary } from "@/hooks/useDashboard";
+const mockUseDashboardSummary = vi.mocked(useDashboardSummary);
+
+const dateRange = { startDate: "2024-01-01", endDate: "2024-01-31" };
+
+describe("SummaryStats", () => {
+  it("renders loading state", () => {
+    mockUseDashboardSummary.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useDashboardSummary>);
+
+    renderWithQueryClient(<SummaryStats dateRange={dateRange} />);
+    expect(screen.getByText("Total Receipts")).toBeInTheDocument();
+    expect(screen.getByText("Total Spent")).toBeInTheDocument();
+    expect(screen.getByText("Avg Trip Amount")).toBeInTheDocument();
+    expect(screen.getByText("Top Category")).toBeInTheDocument();
+  });
+
+  it("renders data when loaded", () => {
+    mockUseDashboardSummary.mockReturnValue({
+      data: {
+        totalReceipts: 42,
+        totalSpent: 1234.56,
+        averageTripAmount: 29.39,
+        mostUsedAccount: { name: "Visa", count: 20 },
+        mostUsedCategory: { name: "Food", count: 15 },
+      },
+      isLoading: false,
+    } as ReturnType<typeof useDashboardSummary>);
+
+    renderWithQueryClient(<SummaryStats dateRange={dateRange} />);
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("$1,234.56")).toBeInTheDocument();
+    expect(screen.getByText("$29.39")).toBeInTheDocument();
+    expect(screen.getByText("Food")).toBeInTheDocument();
+    expect(screen.getByText("15 receipts")).toBeInTheDocument();
+  });
+
+  it("renders dash when no category data", () => {
+    mockUseDashboardSummary.mockReturnValue({
+      data: {
+        totalReceipts: 0,
+        totalSpent: 0,
+        averageTripAmount: 0,
+        mostUsedAccount: { name: null, count: 0 },
+        mostUsedCategory: { name: null, count: 0 },
+      },
+      isLoading: false,
+    } as ReturnType<typeof useDashboardSummary>);
+
+    renderWithQueryClient(<SummaryStats dateRange={dateRange} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/dashboard/SummaryStats.tsx
+++ b/src/client/src/components/dashboard/SummaryStats.tsx
@@ -1,0 +1,15 @@
+import { ChartCard } from "@/components/charts";
+import type { DateRange } from "@/hooks/useDashboard";
+
+interface SummaryStatsProps {
+  dateRange: DateRange;
+  className?: string;
+}
+
+export function SummaryStats({ dateRange: _dateRange, className }: SummaryStatsProps) {
+  return (
+    <ChartCard title="Summary" className={className}>
+      <p className="text-muted-foreground text-sm">Summary statistics will appear here.</p>
+    </ChartCard>
+  );
+}

--- a/src/client/src/components/dashboard/SummaryStats.tsx
+++ b/src/client/src/components/dashboard/SummaryStats.tsx
@@ -1,15 +1,57 @@
-import { ChartCard } from "@/components/charts";
+import { Receipt, DollarSign, TrendingUp, Tag } from "lucide-react";
+import { useDashboardSummary } from "@/hooks/useDashboard";
 import type { DateRange } from "@/hooks/useDashboard";
+import { StatCard } from "./StatCard";
 
 interface SummaryStatsProps {
   dateRange: DateRange;
   className?: string;
 }
 
-export function SummaryStats({ dateRange: _dateRange, className }: SummaryStatsProps) {
+function formatCurrency(value: number | string | undefined): string {
+  const num = Number(value ?? 0);
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(num);
+}
+
+export function SummaryStats({ dateRange, className }: SummaryStatsProps) {
+  const { data, isLoading } = useDashboardSummary(dateRange);
+
   return (
-    <ChartCard title="Summary" className={className}>
-      <p className="text-muted-foreground text-sm">Summary statistics will appear here.</p>
-    </ChartCard>
+    <div
+      className={`grid gap-4 sm:grid-cols-2 lg:grid-cols-4 ${className ?? ""}`}
+    >
+      <StatCard
+        title="Total Receipts"
+        value={String(Number(data?.totalReceipts ?? 0))}
+        icon={Receipt}
+        loading={isLoading}
+      />
+      <StatCard
+        title="Total Spent"
+        value={formatCurrency(data?.totalSpent)}
+        icon={DollarSign}
+        loading={isLoading}
+      />
+      <StatCard
+        title="Avg Trip Amount"
+        value={formatCurrency(data?.averageTripAmount)}
+        icon={TrendingUp}
+        loading={isLoading}
+      />
+      <StatCard
+        title="Top Category"
+        value={data?.mostUsedCategory?.name ?? "—"}
+        subtitle={
+          data?.mostUsedCategory?.count
+            ? `${Number(data.mostUsedCategory.count)} receipts`
+            : undefined
+        }
+        icon={Tag}
+        loading={isLoading}
+      />
+    </div>
   );
 }

--- a/src/client/src/hooks/useDashboard.test.ts
+++ b/src/client/src/hooks/useDashboard.test.ts
@@ -1,0 +1,109 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import {
+  useDashboardSummary,
+  useDashboardSpendingOverTime,
+  useDashboardSpendingByCategory,
+  useDashboardSpendingByAccount,
+} from "./useDashboard";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useDashboard hooks", () => {
+  const dateRange = { startDate: "2024-01-01", endDate: "2024-01-31" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useDashboardSummary", () => {
+    it("fetches summary data", async () => {
+      const mockData = {
+        totalReceipts: 10,
+        totalSpent: 500,
+        averageTripAmount: 50,
+        mostUsedAccount: { name: "Visa", count: 5 },
+        mostUsedCategory: { name: "Food", count: 7 },
+      };
+      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response });
+
+      const { result } = renderHook(() => useDashboardSummary(dateRange), {
+        wrapper: createQueryWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(mockData);
+      expect(mockClient.GET).toHaveBeenCalledWith("/api/dashboard/summary", {
+        params: { query: dateRange },
+      });
+    });
+  });
+
+  describe("useDashboardSpendingOverTime", () => {
+    it("fetches spending over time data", async () => {
+      const mockData = {
+        buckets: [
+          { period: "2024-01", amount: 100 },
+          { period: "2024-02", amount: 200 },
+        ],
+      };
+      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response });
+
+      const { result } = renderHook(
+        () => useDashboardSpendingOverTime(dateRange, "monthly"),
+        { wrapper: createQueryWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(mockData);
+    });
+  });
+
+  describe("useDashboardSpendingByCategory", () => {
+    it("fetches spending by category data", async () => {
+      const mockData = {
+        items: [{ categoryName: "Food", amount: 300, percentage: 60 }],
+      };
+      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response });
+
+      const { result } = renderHook(
+        () => useDashboardSpendingByCategory(dateRange),
+        { wrapper: createQueryWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(mockData);
+    });
+  });
+
+  describe("useDashboardSpendingByAccount", () => {
+    it("fetches spending by account data", async () => {
+      const mockData = {
+        items: [
+          {
+            accountId: "abc",
+            accountName: "Visa",
+            amount: 500,
+            percentage: 100,
+          },
+        ],
+      };
+      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response });
+
+      const { result } = renderHook(
+        () => useDashboardSpendingByAccount(dateRange),
+        { wrapper: createQueryWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(mockData);
+    });
+  });
+});

--- a/src/client/src/hooks/useDashboard.test.ts
+++ b/src/client/src/hooks/useDashboard.test.ts
@@ -32,7 +32,8 @@ describe("useDashboard hooks", () => {
         mostUsedAccount: { name: "Visa", count: 5 },
         mostUsedCategory: { name: "Food", count: 7 },
       };
-      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response } as any);
 
       const { result } = renderHook(() => useDashboardSummary(dateRange), {
         wrapper: createQueryWrapper(),
@@ -54,7 +55,8 @@ describe("useDashboard hooks", () => {
           { period: "2024-02", amount: 200 },
         ],
       };
-      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response } as any);
 
       const { result } = renderHook(
         () => useDashboardSpendingOverTime(dateRange, "monthly"),
@@ -71,7 +73,8 @@ describe("useDashboard hooks", () => {
       const mockData = {
         items: [{ categoryName: "Food", amount: 300, percentage: 60 }],
       };
-      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response } as any);
 
       const { result } = renderHook(
         () => useDashboardSpendingByCategory(dateRange),
@@ -95,7 +98,8 @@ describe("useDashboard hooks", () => {
           },
         ],
       };
-      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockClient.GET.mockResolvedValue({ data: mockData, error: undefined, response: {} as Response } as any);
 
       const { result } = renderHook(
         () => useDashboardSpendingByAccount(dateRange),

--- a/src/client/src/hooks/useDashboard.ts
+++ b/src/client/src/hooks/useDashboard.ts
@@ -1,0 +1,108 @@
+import { useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export interface DateRange {
+  startDate?: string;
+  endDate?: string;
+}
+
+export function useDashboardSummary(dateRange: DateRange) {
+  return useQuery({
+    queryKey: ["dashboard", "summary", dateRange.startDate, dateRange.endDate],
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/dashboard/summary", {
+        params: {
+          query: {
+            startDate: dateRange.startDate,
+            endDate: dateRange.endDate,
+          },
+        },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useDashboardSpendingOverTime(
+  dateRange: DateRange,
+  granularity?: string,
+) {
+  return useQuery({
+    queryKey: [
+      "dashboard",
+      "spending-over-time",
+      dateRange.startDate,
+      dateRange.endDate,
+      granularity,
+    ],
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/dashboard/spending-over-time",
+        {
+          params: {
+            query: {
+              startDate: dateRange.startDate,
+              endDate: dateRange.endDate,
+              granularity,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useDashboardSpendingByCategory(dateRange: DateRange) {
+  return useQuery({
+    queryKey: [
+      "dashboard",
+      "spending-by-category",
+      dateRange.startDate,
+      dateRange.endDate,
+    ],
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/dashboard/spending-by-category",
+        {
+          params: {
+            query: {
+              startDate: dateRange.startDate,
+              endDate: dateRange.endDate,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useDashboardSpendingByAccount(dateRange: DateRange) {
+  return useQuery({
+    queryKey: [
+      "dashboard",
+      "spending-by-account",
+      dateRange.startDate,
+      dateRange.endDate,
+    ],
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/dashboard/spending-by-account",
+        {
+          params: {
+            query: {
+              startDate: dateRange.startDate,
+              endDate: dateRange.endDate,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/src/client/src/hooks/useDashboard.ts
+++ b/src/client/src/hooks/useDashboard.ts
@@ -26,7 +26,7 @@ export function useDashboardSummary(dateRange: DateRange) {
 
 export function useDashboardSpendingOverTime(
   dateRange: DateRange,
-  granularity?: string,
+  granularity?: "daily" | "weekly" | "monthly",
 ) {
   return useQuery({
     queryKey: [

--- a/src/client/src/hooks/useDashboard.ts
+++ b/src/client/src/hooks/useDashboard.ts
@@ -55,13 +55,17 @@ export function useDashboardSpendingOverTime(
   });
 }
 
-export function useDashboardSpendingByCategory(dateRange: DateRange) {
+export function useDashboardSpendingByCategory(
+  dateRange: DateRange,
+  limit = 100,
+) {
   return useQuery({
     queryKey: [
       "dashboard",
       "spending-by-category",
       dateRange.startDate,
       dateRange.endDate,
+      limit,
     ],
     queryFn: async () => {
       const { data, error } = await client.GET(
@@ -71,6 +75,7 @@ export function useDashboardSpendingByCategory(dateRange: DateRange) {
             query: {
               startDate: dateRange.startDate,
               endDate: dateRange.endDate,
+              limit,
             },
           },
         },

--- a/src/client/src/pages/Dashboard.test.tsx
+++ b/src/client/src/pages/Dashboard.test.tsx
@@ -1,0 +1,60 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/test-utils";
+import Dashboard from "./Dashboard";
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@/components/dashboard/DateRangeSelector", () => ({
+  DateRangeSelector: () => <div data-testid="date-range-selector" />,
+}));
+
+vi.mock("@/components/dashboard/SummaryStats", () => ({
+  SummaryStats: () => <div data-testid="summary-stats" />,
+}));
+
+vi.mock("@/components/dashboard/SpendingOverTimeWidget", () => ({
+  SpendingOverTimeWidget: () => <div data-testid="spending-over-time" />,
+}));
+
+vi.mock("@/components/dashboard/SpendingByCategoryWidget", () => ({
+  SpendingByCategoryWidget: () => <div data-testid="spending-by-category" />,
+}));
+
+vi.mock("@/components/dashboard/SpendingByAccountWidget", () => ({
+  SpendingByAccountWidget: () => <div data-testid="spending-by-account" />,
+}));
+
+vi.mock("@/components/dashboard/RecentReceiptsWidget", () => ({
+  RecentReceiptsWidget: () => <div data-testid="recent-receipts" />,
+}));
+
+describe("Dashboard", () => {
+  it("renders the page heading", () => {
+    renderWithProviders(<Dashboard />);
+    expect(
+      screen.getByRole("heading", { name: /dashboard/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the date range selector", () => {
+    renderWithProviders(<Dashboard />);
+    expect(screen.getByTestId("date-range-selector")).toBeInTheDocument();
+  });
+
+  it("renders all widget sections", () => {
+    renderWithProviders(<Dashboard />);
+    expect(screen.getByTestId("summary-stats")).toBeInTheDocument();
+    expect(screen.getByTestId("spending-over-time")).toBeInTheDocument();
+    expect(screen.getByTestId("spending-by-category")).toBeInTheDocument();
+    expect(screen.getByTestId("spending-by-account")).toBeInTheDocument();
+    expect(screen.getByTestId("recent-receipts")).toBeInTheDocument();
+  });
+
+  it("calls usePageTitle with Dashboard", async () => {
+    const { usePageTitle } = await import("@/hooks/usePageTitle");
+    renderWithProviders(<Dashboard />);
+    expect(usePageTitle).toHaveBeenCalledWith("Dashboard");
+  });
+});

--- a/src/client/src/pages/Dashboard.tsx
+++ b/src/client/src/pages/Dashboard.tsx
@@ -9,14 +9,17 @@ import { SpendingByCategoryWidget } from "@/components/dashboard/SpendingByCateg
 import { SpendingByAccountWidget } from "@/components/dashboard/SpendingByAccountWidget";
 import { RecentReceiptsWidget } from "@/components/dashboard/RecentReceiptsWidget";
 
-const defaultRange: DateRange = {
-  startDate: format(subDays(new Date(), 30), "yyyy-MM-dd"),
-  endDate: format(new Date(), "yyyy-MM-dd"),
-};
+function getDefaultRange(): DateRange {
+  const now = new Date();
+  return {
+    startDate: format(subDays(now, 30), "yyyy-MM-dd"),
+    endDate: format(now, "yyyy-MM-dd"),
+  };
+}
 
 function Dashboard() {
   usePageTitle("Dashboard");
-  const [dateRange, setDateRange] = useState<DateRange>(defaultRange);
+  const [dateRange, setDateRange] = useState<DateRange>(getDefaultRange);
 
   const handleDateRangeChange = useCallback((range: DateRange) => {
     setDateRange(range);

--- a/src/client/src/pages/Dashboard.tsx
+++ b/src/client/src/pages/Dashboard.tsx
@@ -1,0 +1,50 @@
+import { useState, useCallback } from "react";
+import { format, subDays } from "date-fns";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import type { DateRange } from "@/hooks/useDashboard";
+import { DateRangeSelector } from "@/components/dashboard/DateRangeSelector";
+import { SummaryStats } from "@/components/dashboard/SummaryStats";
+import { SpendingOverTimeWidget } from "@/components/dashboard/SpendingOverTimeWidget";
+import { SpendingByCategoryWidget } from "@/components/dashboard/SpendingByCategoryWidget";
+import { SpendingByAccountWidget } from "@/components/dashboard/SpendingByAccountWidget";
+import { RecentReceiptsWidget } from "@/components/dashboard/RecentReceiptsWidget";
+
+const defaultRange: DateRange = {
+  startDate: format(subDays(new Date(), 30), "yyyy-MM-dd"),
+  endDate: format(new Date(), "yyyy-MM-dd"),
+};
+
+function Dashboard() {
+  usePageTitle("Dashboard");
+  const [dateRange, setDateRange] = useState<DateRange>(defaultRange);
+
+  const handleDateRangeChange = useCallback((range: DateRange) => {
+    setDateRange(range);
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
+        <DateRangeSelector value={dateRange} onChange={handleDateRangeChange} />
+      </div>
+
+      <SummaryStats dateRange={dateRange} />
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <SpendingOverTimeWidget
+          dateRange={dateRange}
+          className="md:col-span-2"
+        />
+        <SpendingByCategoryWidget dateRange={dateRange} />
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <SpendingByAccountWidget dateRange={dateRange} />
+        <RecentReceiptsWidget />
+      </div>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetDashboardSummaryQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetDashboardSummaryQueryHandlerTests.cs
@@ -1,0 +1,62 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using Application.Queries.Aggregates.Dashboard;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetDashboardSummaryQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ShouldReturnSummary()
+	{
+		// Arrange
+		DateOnly startDate = DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly endDate = DateOnly.FromDateTime(DateTime.Today);
+
+		DashboardSummaryResult expected = new(
+			TotalReceipts: 5,
+			TotalSpent: 250.50m,
+			AverageTripAmount: 50.10m,
+			MostUsedAccount: new NameCountResult("Visa", 3),
+			MostUsedCategory: new NameCountResult("Groceries", 10));
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSummaryAsync(startDate, endDate, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetDashboardSummaryQueryHandler handler = new(mockService.Object);
+		GetDashboardSummaryQuery query = new(startDate, endDate);
+
+		// Act
+		DashboardSummaryResult result = await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetSummaryAsync(startDate, endDate, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ShouldPassDatesToService()
+	{
+		// Arrange
+		DateOnly startDate = new(2025, 1, 1);
+		DateOnly endDate = new(2025, 6, 30);
+
+		DashboardSummaryResult expected = new(0, 0, 0, new NameCountResult(null, 0), new NameCountResult(null, 0));
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSummaryAsync(startDate, endDate, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetDashboardSummaryQueryHandler handler = new(mockService.Object);
+		GetDashboardSummaryQuery query = new(startDate, endDate);
+
+		// Act
+		await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		mockService.Verify(s => s.GetSummaryAsync(startDate, endDate, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetDashboardSummaryQueryTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetDashboardSummaryQueryTests.cs
@@ -1,0 +1,13 @@
+using Application.Queries.Aggregates.Dashboard;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetDashboardSummaryQueryTests : IQueryTests
+{
+	[Fact]
+	public void Query_CanBeCreated()
+	{
+		GetDashboardSummaryQuery query = new(DateOnly.FromDateTime(DateTime.Today.AddDays(-30)), DateOnly.FromDateTime(DateTime.Today));
+		Assert.NotNull(query);
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByAccountQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByAccountQueryHandlerTests.cs
@@ -1,0 +1,64 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using Application.Queries.Aggregates.Dashboard;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetSpendingByAccountQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ShouldReturnSpendingByAccount()
+	{
+		// Arrange
+		DateOnly startDate = DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly endDate = DateOnly.FromDateTime(DateTime.Today);
+
+		Guid visaId = Guid.NewGuid();
+		Guid amexId = Guid.NewGuid();
+
+		SpendingByAccountResult expected = new(
+		[
+			new SpendingAccountItemResult(visaId, "Visa", 600.00m, 60.00m),
+			new SpendingAccountItemResult(amexId, "Amex", 400.00m, 40.00m)
+		]);
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSpendingByAccountAsync(startDate, endDate, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetSpendingByAccountQueryHandler handler = new(mockService.Object);
+		GetSpendingByAccountQuery query = new(startDate, endDate);
+
+		// Act
+		SpendingByAccountResult result = await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetSpendingByAccountAsync(startDate, endDate, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ShouldPassDatesToService()
+	{
+		// Arrange
+		DateOnly startDate = new(2025, 3, 1);
+		DateOnly endDate = new(2025, 3, 31);
+
+		SpendingByAccountResult expected = new([]);
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSpendingByAccountAsync(startDate, endDate, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetSpendingByAccountQueryHandler handler = new(mockService.Object);
+		GetSpendingByAccountQuery query = new(startDate, endDate);
+
+		// Act
+		await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		mockService.Verify(s => s.GetSpendingByAccountAsync(startDate, endDate, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByAccountQueryTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByAccountQueryTests.cs
@@ -1,0 +1,13 @@
+using Application.Queries.Aggregates.Dashboard;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetSpendingByAccountQueryTests : IQueryTests
+{
+	[Fact]
+	public void Query_CanBeCreated()
+	{
+		GetSpendingByAccountQuery query = new(DateOnly.FromDateTime(DateTime.Today.AddDays(-30)), DateOnly.FromDateTime(DateTime.Today));
+		Assert.NotNull(query);
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByCategoryQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByCategoryQueryHandlerTests.cs
@@ -1,0 +1,64 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using Application.Queries.Aggregates.Dashboard;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetSpendingByCategoryQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ShouldReturnSpendingByCategory()
+	{
+		// Arrange
+		DateOnly startDate = DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly endDate = DateOnly.FromDateTime(DateTime.Today);
+		int limit = 10;
+
+		SpendingByCategoryResult expected = new(
+		[
+			new SpendingCategoryItemResult("Groceries", 500.00m, 50.00m),
+			new SpendingCategoryItemResult("Electronics", 300.00m, 30.00m),
+			new SpendingCategoryItemResult("Dining", 200.00m, 20.00m)
+		]);
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSpendingByCategoryAsync(startDate, endDate, limit, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetSpendingByCategoryQueryHandler handler = new(mockService.Object);
+		GetSpendingByCategoryQuery query = new(startDate, endDate, limit);
+
+		// Act
+		SpendingByCategoryResult result = await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetSpendingByCategoryAsync(startDate, endDate, limit, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ShouldPassLimitToService()
+	{
+		// Arrange
+		DateOnly startDate = new(2025, 1, 1);
+		DateOnly endDate = new(2025, 12, 31);
+		int limit = 5;
+
+		SpendingByCategoryResult expected = new([]);
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSpendingByCategoryAsync(startDate, endDate, limit, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetSpendingByCategoryQueryHandler handler = new(mockService.Object);
+		GetSpendingByCategoryQuery query = new(startDate, endDate, limit);
+
+		// Act
+		await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		mockService.Verify(s => s.GetSpendingByCategoryAsync(startDate, endDate, limit, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByCategoryQueryTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByCategoryQueryTests.cs
@@ -1,0 +1,13 @@
+using Application.Queries.Aggregates.Dashboard;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetSpendingByCategoryQueryTests : IQueryTests
+{
+	[Fact]
+	public void Query_CanBeCreated()
+	{
+		GetSpendingByCategoryQuery query = new(DateOnly.FromDateTime(DateTime.Today.AddDays(-30)), DateOnly.FromDateTime(DateTime.Today), 10);
+		Assert.NotNull(query);
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingOverTimeQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingOverTimeQueryHandlerTests.cs
@@ -1,0 +1,65 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using Application.Queries.Aggregates.Dashboard;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetSpendingOverTimeQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ShouldReturnSpendingOverTime()
+	{
+		// Arrange
+		DateOnly startDate = DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly endDate = DateOnly.FromDateTime(DateTime.Today);
+		string granularity = "monthly";
+
+		SpendingOverTimeResult expected = new(
+		[
+			new SpendingBucketResult("2025-01", 100.00m),
+			new SpendingBucketResult("2025-02", 200.00m)
+		]);
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSpendingOverTimeAsync(startDate, endDate, granularity, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetSpendingOverTimeQueryHandler handler = new(mockService.Object);
+		GetSpendingOverTimeQuery query = new(startDate, endDate, granularity);
+
+		// Act
+		SpendingOverTimeResult result = await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetSpendingOverTimeAsync(startDate, endDate, granularity, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Theory]
+	[InlineData("daily")]
+	[InlineData("weekly")]
+	[InlineData("monthly")]
+	public async Task Handle_ShouldPassGranularityToService(string granularity)
+	{
+		// Arrange
+		DateOnly startDate = new(2025, 1, 1);
+		DateOnly endDate = new(2025, 12, 31);
+
+		SpendingOverTimeResult expected = new([]);
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSpendingOverTimeAsync(startDate, endDate, granularity, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetSpendingOverTimeQueryHandler handler = new(mockService.Object);
+		GetSpendingOverTimeQuery query = new(startDate, endDate, granularity);
+
+		// Act
+		await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		mockService.Verify(s => s.GetSpendingOverTimeAsync(startDate, endDate, granularity, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingOverTimeQueryTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingOverTimeQueryTests.cs
@@ -1,0 +1,13 @@
+using Application.Queries.Aggregates.Dashboard;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetSpendingOverTimeQueryTests : IQueryTests
+{
+	[Fact]
+	public void Query_CanBeCreated()
+	{
+		GetSpendingOverTimeQuery query = new(DateOnly.FromDateTime(DateTime.Today.AddDays(-30)), DateOnly.FromDateTime(DateTime.Today), "monthly");
+		Assert.NotNull(query);
+	}
+}


### PR DESCRIPTION
## Summary

- Installs Recharts and creates reusable chart component wrappers (ChartCard, AreaTimeChart, DonutChart, BarChart)
- Scaffolds Dashboard page with responsive grid layout (1→2→3 cols) and date range selector (7d/30d/90d/YTD/All/Custom)
- Implements 5 dashboard widgets: Summary Statistics cards, Spending Over Time area chart with granularity toggle, Spending by Category donut chart with "Other" grouping, Spending by Account horizontal bar chart, and Recent Receipts list
- Creates `useDashboard` hooks for all 4 dashboard API endpoints (`/api/dashboard/summary`, `/spending-over-time`, `/spending-by-category`, `/spending-by-account`)
- Replaces placeholder Home page with full Dashboard at `/` route, updates nav labels
- Includes backend aggregation API endpoints (MGG-292, previously merged)

## Test plan

- [x] All 949 client tests pass (30 new dashboard tests)
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] ESLint passes (0 new errors)
- [x] .NET solution builds
- [ ] CI pipeline passes
- [ ] Visual QA: dashboard loads at `/`, all widgets render, date range changes refresh data, responsive layout works, dark mode charts display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)