### PR TITLE
refactor(infrastructure): optimize DB queries for performance (MGG-304)

### DIFF
--- a/src/Infrastructure/Repositories/AccountRepository.cs
+++ b/src/Infrastructure/Repositories/AccountRepository.cs
@@ -4,7 +4,6 @@ using Infrastructure.Entities.Core;
 using Infrastructure.Extensions;
 using Infrastructure.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Repositories;
 
@@ -81,17 +80,9 @@ public class AccountRepository(IDbContextFactory<ApplicationDbContext> contextFa
 	public async Task<List<AccountEntity>> CreateAsync(List<AccountEntity> entities, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		List<AccountEntity> createdEntities = [];
-
-		foreach (AccountEntity entity in entities)
-		{
-			EntityEntry<AccountEntity> entityEntry = await context.Accounts.AddAsync(entity, cancellationToken);
-			createdEntities.Add(entityEntry.Entity);
-		}
-
+		context.Accounts.AddRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
-
-		return createdEntities;
+		return entities;
 	}
 
 	public async Task UpdateAsync(List<AccountEntity> entities, CancellationToken cancellationToken)

--- a/src/Infrastructure/Repositories/AdjustmentRepository.cs
+++ b/src/Infrastructure/Repositories/AdjustmentRepository.cs
@@ -4,7 +4,6 @@ using Infrastructure.Entities.Core;
 using Infrastructure.Extensions;
 using Infrastructure.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Repositories;
 
@@ -108,17 +107,9 @@ public class AdjustmentRepository(IDbContextFactory<ApplicationDbContext> contex
 	public async Task<List<AdjustmentEntity>> CreateAsync(List<AdjustmentEntity> entities, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		List<AdjustmentEntity> createdEntities = [];
-
-		foreach (AdjustmentEntity entity in entities)
-		{
-			EntityEntry<AdjustmentEntity> entityEntry = await context.Adjustments.AddAsync(entity, cancellationToken);
-			createdEntities.Add(entityEntry.Entity);
-		}
-
+		context.Adjustments.AddRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
-
-		return createdEntities;
+		return entities;
 	}
 
 	public async Task UpdateAsync(List<AdjustmentEntity> entities, CancellationToken cancellationToken)

--- a/src/Infrastructure/Repositories/CategoryRepository.cs
+++ b/src/Infrastructure/Repositories/CategoryRepository.cs
@@ -4,7 +4,6 @@ using Infrastructure.Entities.Core;
 using Infrastructure.Extensions;
 using Infrastructure.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Repositories;
 
@@ -55,17 +54,9 @@ public class CategoryRepository(IDbContextFactory<ApplicationDbContext> contextF
 	public async Task<List<CategoryEntity>> CreateAsync(List<CategoryEntity> entities, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		List<CategoryEntity> createdEntities = [];
-
-		foreach (CategoryEntity entity in entities)
-		{
-			EntityEntry<CategoryEntity> entityEntry = await context.Categories.AddAsync(entity, cancellationToken);
-			createdEntities.Add(entityEntry.Entity);
-		}
-
+		context.Categories.AddRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
-
-		return createdEntities;
+		return entities;
 	}
 
 	public async Task UpdateAsync(List<CategoryEntity> entities, CancellationToken cancellationToken)

--- a/src/Infrastructure/Repositories/ItemTemplateRepository.cs
+++ b/src/Infrastructure/Repositories/ItemTemplateRepository.cs
@@ -4,7 +4,6 @@ using Infrastructure.Entities.Core;
 using Infrastructure.Extensions;
 using Infrastructure.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Repositories;
 
@@ -55,17 +54,9 @@ public class ItemTemplateRepository(IDbContextFactory<ApplicationDbContext> cont
 	public async Task<List<ItemTemplateEntity>> CreateAsync(List<ItemTemplateEntity> entities, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		List<ItemTemplateEntity> createdEntities = [];
-
-		foreach (ItemTemplateEntity entity in entities)
-		{
-			EntityEntry<ItemTemplateEntity> entityEntry = await context.ItemTemplates.AddAsync(entity, cancellationToken);
-			createdEntities.Add(entityEntry.Entity);
-		}
-
+		context.ItemTemplates.AddRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
-
-		return createdEntities;
+		return entities;
 	}
 
 	public async Task UpdateAsync(List<ItemTemplateEntity> entities, CancellationToken cancellationToken)

--- a/src/Infrastructure/Repositories/ReceiptItemRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptItemRepository.cs
@@ -4,7 +4,6 @@ using Infrastructure.Entities.Core;
 using Infrastructure.Extensions;
 using Infrastructure.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Repositories;
 
@@ -128,17 +127,9 @@ public class ReceiptItemRepository(IDbContextFactory<ApplicationDbContext> conte
 	public async Task<List<ReceiptItemEntity>> CreateAsync(List<ReceiptItemEntity> entities, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		List<ReceiptItemEntity> createdEntities = [];
-
-		foreach (ReceiptItemEntity entity in entities)
-		{
-			EntityEntry<ReceiptItemEntity> entityEntry = await context.ReceiptItems.AddAsync(entity, cancellationToken);
-			createdEntities.Add(entityEntry.Entity);
-		}
-
+		context.ReceiptItems.AddRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
-
-		return createdEntities;
+		return entities;
 	}
 
 	public async Task UpdateAsync(List<ReceiptItemEntity> entities, CancellationToken cancellationToken)

--- a/src/Infrastructure/Repositories/ReceiptRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptRepository.cs
@@ -4,7 +4,6 @@ using Infrastructure.Entities.Core;
 using Infrastructure.Extensions;
 using Infrastructure.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Repositories;
 
@@ -74,17 +73,9 @@ public class ReceiptRepository(IDbContextFactory<ApplicationDbContext> contextFa
 	public async Task<List<ReceiptEntity>> CreateAsync(List<ReceiptEntity> entities, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		List<ReceiptEntity> createdEntities = [];
-
-		foreach (ReceiptEntity entity in entities)
-		{
-			EntityEntry<ReceiptEntity> entityEntry = await context.Receipts.AddAsync(entity, cancellationToken);
-			createdEntities.Add(entityEntry.Entity);
-		}
-
+		context.Receipts.AddRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
-
-		return createdEntities;
+		return entities;
 	}
 
 	public async Task UpdateAsync(List<ReceiptEntity> entities, CancellationToken cancellationToken)

--- a/src/Infrastructure/Repositories/SubcategoryRepository.cs
+++ b/src/Infrastructure/Repositories/SubcategoryRepository.cs
@@ -4,7 +4,6 @@ using Infrastructure.Entities.Core;
 using Infrastructure.Extensions;
 using Infrastructure.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Repositories;
 
@@ -75,17 +74,9 @@ public class SubcategoryRepository(IDbContextFactory<ApplicationDbContext> conte
 	public async Task<List<SubcategoryEntity>> CreateAsync(List<SubcategoryEntity> entities, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		List<SubcategoryEntity> createdEntities = [];
-
-		foreach (SubcategoryEntity entity in entities)
-		{
-			EntityEntry<SubcategoryEntity> entityEntry = await context.Subcategories.AddAsync(entity, cancellationToken);
-			createdEntities.Add(entityEntry.Entity);
-		}
-
+		context.Subcategories.AddRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
-
-		return createdEntities;
+		return entities;
 	}
 
 	public async Task UpdateAsync(List<SubcategoryEntity> entities, CancellationToken cancellationToken)

--- a/src/Infrastructure/Repositories/TransactionRepository.cs
+++ b/src/Infrastructure/Repositories/TransactionRepository.cs
@@ -4,7 +4,6 @@ using Infrastructure.Entities.Core;
 using Infrastructure.Extensions;
 using Infrastructure.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Repositories;
 
@@ -119,17 +118,9 @@ public class TransactionRepository(IDbContextFactory<ApplicationDbContext> conte
 	public async Task<List<TransactionEntity>> CreateAsync(List<TransactionEntity> entities, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		List<TransactionEntity> createdEntities = [];
-
-		foreach (TransactionEntity entity in entities)
-		{
-			EntityEntry<TransactionEntity> entityEntry = await context.Transactions.AddAsync(entity, cancellationToken);
-			createdEntities.Add(entityEntry.Entity);
-		}
-
+		context.Transactions.AddRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
-
-		return createdEntities;
+		return entities;
 	}
 
 	public async Task UpdateAsync(List<TransactionEntity> entities, CancellationToken cancellationToken)

--- a/src/Infrastructure/Services/DashboardService.cs
+++ b/src/Infrastructure/Services/DashboardService.cs
@@ -35,8 +35,11 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 
 		// Most-used account = account with the most transactions in range
 		// Single query: EF Core translates Account!.Name to a SQL JOIN, eliminating a second round-trip.
+		// IgnoreQueryFilters: include soft-deleted accounts so all transactions are counted.
 		var mostUsedAccountData = await context.Transactions
+			.IgnoreQueryFilters()
 			.AsNoTracking()
+			.Where(t => t.DeletedAt == null)
 			.Where(t => receiptIds.Contains(t.ReceiptId))
 			.GroupBy(t => t.Account!.Name)
 			.Select(g => new { AccountName = g.Key, Count = g.Count() })

--- a/src/Infrastructure/Services/DashboardService.cs
+++ b/src/Infrastructure/Services/DashboardService.cs
@@ -34,28 +34,18 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 		decimal averageTripAmount = totalReceipts > 0 ? Math.Round(totalSpent / totalReceipts, 2) : 0;
 
 		// Most-used account = account with the most transactions in range
+		// Single query: EF Core translates Account!.Name to a SQL JOIN, eliminating a second round-trip.
 		var mostUsedAccountData = await context.Transactions
 			.AsNoTracking()
 			.Where(t => receiptIds.Contains(t.ReceiptId))
-			.GroupBy(t => t.AccountId)
-			.Select(g => new { AccountId = g.Key, Count = g.Count() })
+			.GroupBy(t => t.Account!.Name)
+			.Select(g => new { AccountName = g.Key, Count = g.Count() })
 			.OrderByDescending(g => g.Count)
 			.FirstOrDefaultAsync(cancellationToken);
 
-		NameCountResult mostUsedAccount;
-		if (mostUsedAccountData != null)
-		{
-			string? accountName = await context.Accounts
-				.AsNoTracking()
-				.Where(a => a.Id == mostUsedAccountData.AccountId)
-				.Select(a => a.Name)
-				.FirstOrDefaultAsync(cancellationToken);
-			mostUsedAccount = new NameCountResult(accountName, mostUsedAccountData.Count);
-		}
-		else
-		{
-			mostUsedAccount = new NameCountResult(null, 0);
-		}
+		NameCountResult mostUsedAccount = mostUsedAccountData != null
+			? new NameCountResult(mostUsedAccountData.AccountName, mostUsedAccountData.Count)
+			: new NameCountResult(null, 0);
 
 		// Most-used category = category with the most receipt items in range
 		var mostUsedCategoryData = await context.ReceiptItems
@@ -141,19 +131,20 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 			.Where(r => r.Date >= startDate && r.Date <= endDate)
 			.Select(r => r.Id);
 
-		var allCategorySpending = context.ReceiptItems
+		// Single query: materialize all categories (bounded by distinct category count, typically < 50),
+		// then compute total in memory to avoid enumerating the IQueryable twice.
+		var allCategories = await context.ReceiptItems
 			.AsNoTracking()
 			.Where(ri => receiptIds.Contains(ri.ReceiptId))
 			.GroupBy(ri => ri.Category)
 			.Select(g => new { Category = g.Key, Amount = g.Sum(ri => ri.TotalAmount) })
-			.OrderByDescending(g => g.Amount);
-
-		// Compute total from ALL categories before applying the limit
-		decimal total = await allCategorySpending.SumAsync(g => g.Amount, cancellationToken);
-
-		var categorySpending = await allCategorySpending
-			.Take(limit)
+			.OrderByDescending(g => g.Amount)
 			.ToListAsync(cancellationToken);
+
+		decimal total = allCategories.Sum(c => c.Amount);
+
+		var categorySpending = allCategories
+			.Take(limit);
 
 		List<SpendingCategoryItemResult> items = categorySpending
 			.Select(c => new SpendingCategoryItemResult(


### PR DESCRIPTION
## Summary

- **GetSummaryAsync N+1 fix**: Replaced two-query pattern (group by AccountId + separate name lookup) with a single query using the `Account` navigation property — EF Core translates `t.Account!.Name` to a SQL JOIN
- **GetSpendingByCategoryAsync double enumeration fix**: Materialized grouped results once instead of calling `SumAsync` then `Take().ToListAsync()` on the same IQueryable (two separate DB round-trips)
- **All 8 repository `CreateAsync()` methods**: Replaced `AddAsync` loop with synchronous `AddRange` — `AddAsync` is only needed for server-side value generators (e.g., HiLo sequences), this project uses client-generated Guid IDs

## Test plan

- [x] `dotnet build Receipts.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Receipts.slnx` — all 1,180 tests pass
- [x] Pre-commit hooks pass (quick mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)