### PR TITLE
fix(hooks): auto-run worktree-setup when prerequisites missing

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,7 +18,10 @@ next_step() {
 }
 
 next_step "Checking prerequisites..."
-bash scripts/worktree-setup.sh --check
+if ! bash scripts/worktree-setup.sh --check 2>/dev/null; then
+  echo "  -> Auto-fixing: running worktree-setup.sh..."
+  bash scripts/worktree-setup.sh
+fi
 
 if [ "${PRECOMMIT_QUICK:-}" != "1" ]; then
   next_step "Linting OpenAPI spec..."


### PR DESCRIPTION
## Summary
- Pre-commit hook now auto-runs `worktree-setup.sh` when `--check` fails, instead of failing with an error message
- Eliminates the recurring issue of agents failing their first commit in fresh worktrees or bypassing hooks with `--no-verify`

## Test plan
- [x] Verified live — first commit in this worktree triggered auto-fix, installed all deps, then passed all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)