### PR TITLE
fix(infra): ensure generated admin password meets Identity requirements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
         for secret in pg_password jwt_key admin_password; do
           if [ ! -f "/secrets/$${secret}" ]; then
             tr -dc 'A-Za-z0-9+/' < /dev/urandom | head -c 48 > "/secrets/$${secret}"
+            if [ "$${secret}" = "admin_password" ]; then
+              printf '!A1' >> "/secrets/$${secret}"
+            fi
             chmod 644 "/secrets/$${secret}"
             echo "Generated /secrets/$${secret}"
           else


### PR DESCRIPTION
## Summary
- Append `!A1` to the generated `admin_password` in the init container so it always satisfies ASP.NET Identity's default policy (uppercase, digit, non-alphanumeric)
- Without this, the random charset `A-Za-z0-9+/` could produce passwords lacking a special character, causing silent user creation failure in the seeder

## Test plan
- [x] `docker compose down -v && docker compose up -d` from clean state
- [x] Verify generated password ends with `!A1`
- [x] Verify `POST /api/auth/login` returns a valid JWT with the generated credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)