### PR TITLE
fix(client): use placeholder for zero-value currency fields (MGG-322)

### DIFF
--- a/src/client/src/components/ui/currency-input.test.tsx
+++ b/src/client/src/components/ui/currency-input.test.tsx
@@ -128,4 +128,43 @@ describe("CurrencyInput", () => {
 
     expect(screen.getByText("EUR")).toBeInTheDocument();
   });
+
+  it("keeps text empty (not '0.00') when focusing a zero-value field", async () => {
+    const user = userEvent.setup();
+
+    render(<ControlledCurrencyInput initialValue={0} />);
+
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+
+    expect(input).toHaveValue("");
+  });
+
+  it("returns to empty with placeholder after focusing and blurring a zero-value field without typing", async () => {
+    const user = userEvent.setup();
+
+    render(<ControlledCurrencyInput initialValue={0} />);
+
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    await user.tab();
+
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("placeholder", "0.00");
+  });
+
+  it("applies normal formatting when typing a value into a zero-value field and blurring", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ControlledCurrencyInput initialValue={0} onChange={onChange} />);
+
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    await user.type(input, "42.5");
+    await user.tab();
+
+    expect(onChange).toHaveBeenCalledWith(42.5);
+    expect(input).toHaveValue("42.50");
+  });
 });

--- a/src/client/src/components/ui/currency-input.test.tsx
+++ b/src/client/src/components/ui/currency-input.test.tsx
@@ -44,6 +44,14 @@ describe("CurrencyInput", () => {
     expect(screen.getByText("$")).toBeInTheDocument();
   });
 
+  it("shows placeholder instead of 0.00 when value is zero", () => {
+    render(<CurrencyInput {...defaultProps} value={0} />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("placeholder", "0.00");
+  });
+
   it("formats value on blur to two decimal places", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();

--- a/src/client/src/components/ui/currency-input.tsx
+++ b/src/client/src/components/ui/currency-input.tsx
@@ -18,12 +18,14 @@ export function CurrencyInput({
   className,
   ...props
 }: CurrencyInputProps) {
-  const [text, setText] = useState(() => formatDecimal(value));
+  const [text, setText] = useState(() =>
+    value === 0 ? "" : formatDecimal(value),
+  );
   const inputRef = useRef<HTMLInputElement>(null);
   const [focused, setFocused] = useState(false);
 
-  // When not focused, derive display value from the prop directly
-  const displayValue = focused ? text : formatDecimal(value);
+  // When not focused, show empty string for zero so placeholder is visible
+  const displayValue = focused ? text : value === 0 ? "" : formatDecimal(value);
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const raw = parseCurrencyInput(e.target.value);
@@ -40,15 +42,19 @@ export function CurrencyInput({
 
   function handleFocus() {
     setFocused(true);
-    setText(formatDecimal(value));
-    setTimeout(() => inputRef.current?.select(), 0);
+    if (value === 0) {
+      setText("");
+    } else {
+      setText(formatDecimal(value));
+      setTimeout(() => inputRef.current?.select(), 0);
+    }
   }
 
   function handleBlur() {
     setFocused(false);
     const num = parseFloat(text);
     const final = isNaN(num) ? 0 : num;
-    setText(formatDecimal(final));
+    setText(final === 0 ? "" : formatDecimal(final));
     onChange(final);
     onBlur?.();
   }
@@ -75,6 +81,7 @@ export function CurrencyInput({
         type="text"
         inputMode="decimal"
         value={displayValue}
+        placeholder="0.00"
         onChange={handleChange}
         onFocus={handleFocus}
         onBlur={handleBlur}

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -32,7 +32,7 @@ import type { WizardTransaction } from "./wizardReducer";
 
 const txnSchema = z.object({
   accountId: z.string().min(1, "Account is required"),
-  amount: z.number().refine((v) => v !== 0, "Amount must be non-zero"),
+  amount: z.number().refine((v) => v !== 0, "Amount is required"),
   date: z.string().min(1, "Date is required"),
 });
 


### PR DESCRIPTION
## Summary
- When value is 0, currency fields now show an empty input with `placeholder="0.00"` instead of prefilled "0.00" text
- Users can click and type immediately without needing to select-all first
- On focus, zero-value fields start empty; on blur, they return to empty so the placeholder remains visible

## Test plan
- [x] Unit tests pass (7/7 including new placeholder test)
- [ ] Manual: currency fields show gray "0.00" placeholder when empty
- [ ] Manual: clicking a zero-value field lets you type immediately

Closes MGG-322

🤖 Generated with [Claude Code](https://claude.com/claude-code)