### PR TITLE
fix(client): replace crypto.randomUUID with fallback for non-secure contexts (MGG-323)

### DIFF
--- a/src/client/src/lib/id.test.ts
+++ b/src/client/src/lib/id.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { generateId } from "./id";
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("generateId", () => {
+  it("returns a valid UUID v4 string", () => {
+    const id = generateId();
+    expect(id).toMatch(UUID_V4_REGEX);
+  });
+
+  it("generates unique IDs on each call", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateId()));
+    expect(ids.size).toBe(100);
+  });
+
+  it("produces a valid UUID v4 via the fallback path", () => {
+    const original = crypto.randomUUID;
+    try {
+      // Force the fallback by removing randomUUID
+      Object.defineProperty(crypto, "randomUUID", {
+        value: undefined,
+        configurable: true,
+      });
+      const id = generateId();
+      expect(id).toMatch(UUID_V4_REGEX);
+    } finally {
+      Object.defineProperty(crypto, "randomUUID", {
+        value: original,
+        configurable: true,
+      });
+    }
+  });
+
+  it("generates unique IDs via the fallback path", () => {
+    const original = crypto.randomUUID;
+    try {
+      Object.defineProperty(crypto, "randomUUID", {
+        value: undefined,
+        configurable: true,
+      });
+      const ids = new Set(Array.from({ length: 100 }, () => generateId()));
+      expect(ids.size).toBe(100);
+    } finally {
+      Object.defineProperty(crypto, "randomUUID", {
+        value: original,
+        configurable: true,
+      });
+    }
+  });
+});

--- a/src/client/src/lib/id.ts
+++ b/src/client/src/lib/id.ts
@@ -1,0 +1,19 @@
+/**
+ * Generate a UUID v4 string. Uses crypto.randomUUID() when available
+ * (secure contexts), otherwise falls back to crypto.getRandomValues()
+ * which works in all contexts.
+ */
+export function generateId(): string {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  // Fallback: RFC 4122 v4 UUID via getRandomValues
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 1
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
+    "",
+  );
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/src/client/src/pages/ReceiptItems.tsx
+++ b/src/client/src/pages/ReceiptItems.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
   useReceiptItems,
@@ -241,7 +242,7 @@ function ReceiptItems() {
         savedFilters={savedFilters}
         onSaveFilter={(name) =>
           saveFilter({
-            id: crypto.randomUUID(),
+            id: generateId(),
             name,
             entityType: "receiptItems",
             values: filterValues,

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
   useReceipts,
@@ -199,7 +200,7 @@ function Receipts() {
         savedFilters={savedFilters}
         onSaveFilter={(name) =>
           saveFilter({
-            id: crypto.randomUUID(),
+            id: generateId(),
             name,
             entityType: "receipts",
             values: filterValues,

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useState, useMemo, useEffect } from "react";
+import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
   useSubcategories,
@@ -298,7 +299,7 @@ function Subcategories() {
         savedFilters={savedFilters}
         onSaveFilter={(name) =>
           saveFilter({
-            id: crypto.randomUUID(),
+            id: generateId(),
             name,
             entityType: "subcategories",
             values: filterValues,

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
   useTransactions,
@@ -239,7 +240,7 @@ function Transactions() {
         savedFilters={savedFilters}
         onSaveFilter={(name) =>
           saveFilter({
-            id: crypto.randomUUID(),
+            id: generateId(),
             name,
             entityType: "transactions",
             values: filterValues,

--- a/src/client/src/pages/Trips.tsx
+++ b/src/client/src/pages/Trips.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { generateId } from "@/lib/id";
 import { useTripByReceiptId } from "@/hooks/useTrips";
 import { useReceipts } from "@/hooks/useReceipts";
 import { usePageTitle } from "@/hooks/usePageTitle";
@@ -151,7 +152,7 @@ function Trips() {
           savedFilters={savedFilters}
           onSaveFilter={(name) =>
             saveFilter({
-              id: crypto.randomUUID(),
+              id: generateId(),
               name,
               entityType: "trips",
               values: filterValues,

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
+import { generateId } from "@/lib/id";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -92,7 +93,7 @@ export function Step2Transactions({
   const handleAdd = useCallback(
     (values: TxnFormValues) => {
       const newTxn: WizardTransaction = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         ...values,
       };
       setTransactions((prev) => [...prev, newTxn]);

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useRef } from "react";
+import { generateId } from "@/lib/id";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -219,7 +220,7 @@ export function Step3Items({
   const handleAdd = useCallback(
     (values: ItemFormValues) => {
       const newItem: WizardReceiptItem = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         receiptItemCode: values.receiptItemCode ?? "",
         description: values.description,
         pricingMode: values.pricingMode,


### PR DESCRIPTION
## Summary
- Add `generateId()` utility in `src/client/src/lib/id.ts` that uses `crypto.randomUUID()` when available (secure contexts) and falls back to `crypto.getRandomValues()` for plain HTTP
- Replace all 7 direct `crypto.randomUUID()` calls across pages with the new utility
- Fixes `Uncaught TypeError: crypto.randomUUID is not a function` when accessing the app over non-HTTPS

## Test plan
- [ ] Verify adding transactions, receipt items, subcategories, receipts, and trips works over plain HTTP
- [ ] Verify the same flows still work over HTTPS/localhost
- [ ] Confirm generated IDs are valid UUID v4 format

🤖 Generated with [Claude Code](https://claude.com/claude-code)