### PR TITLE
fix(infrastructure): fix seeder admin lookup and set CreatedAt (MGG-316, MGG-325)

### DIFF
--- a/src/Infrastructure/Services/DatabaseSeederService.cs
+++ b/src/Infrastructure/Services/DatabaseSeederService.cs
@@ -31,8 +31,8 @@ public static class DatabaseSeederService
 			return;
 		}
 
-		ApplicationUser? existingAdmin = await userManager.FindByEmailAsync(adminEmail);
-		if (existingAdmin is not null)
+		IList<ApplicationUser> existingAdmins = await userManager.GetUsersInRoleAsync(AppRoles.Admin);
+		if (existingAdmins.Count > 0)
 		{
 			return;
 		}
@@ -44,6 +44,7 @@ public static class DatabaseSeederService
 			FirstName = configuration[ConfigurationVariables.AdminSeedFirstName],
 			LastName = configuration[ConfigurationVariables.AdminSeedLastName],
 			MustResetPassword = true,
+			CreatedAt = DateTimeOffset.UtcNow,
 		};
 
 		IdentityResult result = await userManager.CreateAsync(adminUser, adminPassword);


### PR DESCRIPTION
## Summary
- Change admin seeder to look up existing admins via `GetUsersInRoleAsync(AppRoles.Admin)` instead of `FindByEmailAsync`, preventing duplicate admin creation after email/name changes
- Set `CreatedAt = DateTimeOffset.UtcNow` on the seeded admin user so it shows a real date instead of `DateTime.MinValue`

## Test plan
- [ ] Seed admin, change email/password in app, restart container — verify no duplicate admin is created
- [ ] Verify seeded admin's `CreatedAt` shows current timestamp, not 12/31/0001

🤖 Generated with [Claude Code](https://claude.com/claude-code)