### PR TITLE
feat(client): persist locations and show them in a dropdown (MGG-319)

### DIFF
--- a/src/client/src/components/ReceiptForm.test.tsx
+++ b/src/client/src/components/ReceiptForm.test.tsx
@@ -2,6 +2,21 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ReceiptForm } from "./ReceiptForm";
 
+// Polyfill ResizeObserver and scrollIntoView for radix-ui / cmdk in jsdom
+beforeAll(() => {
+  if (typeof window.ResizeObserver === "undefined") {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
+});
+
 vi.mock("@/hooks/useFormShortcuts", () => ({
   useFormShortcuts: vi.fn(),
 }));
@@ -15,14 +30,22 @@ describe("ReceiptForm", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it("renders in create mode with empty fields and correct submit button text", () => {
     render(<ReceiptForm {...defaultProps} />);
 
-    expect(screen.getByLabelText("Location")).toHaveValue("");
-    expect(screen.getByRole("button", { name: /create receipt/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    // Combobox renders as a button with role="combobox"; empty value shows placeholder
+    expect(screen.getByRole("combobox")).toHaveTextContent(
+      "Select or type a location...",
+    );
+    expect(
+      screen.getByRole("button", { name: /create receipt/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /cancel/i }),
+    ).toBeInTheDocument();
   });
 
   it("renders in edit mode with pre-populated fields and correct submit button text", () => {
@@ -38,17 +61,28 @@ describe("ReceiptForm", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Location")).toHaveValue("Walmart");
-    expect(screen.getByRole("button", { name: /update receipt/i })).toBeInTheDocument();
+    // Combobox shows raw value text when it doesn't match a saved option
+    expect(screen.getByRole("combobox")).toHaveTextContent("Walmart");
+    expect(
+      screen.getByRole("button", { name: /update receipt/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onSubmit with correct data when form is valid", async () => {
     const user = userEvent.setup();
     render(<ReceiptForm {...defaultProps} />);
 
-    await user.type(screen.getByLabelText("Location"), "Target");
+    // Open the combobox and type a custom value
+    await user.click(screen.getByRole("combobox"));
+    const searchInput = screen.getByPlaceholderText("Search locations...");
+    await user.type(searchInput, "Target");
+    // Click the "Use ..." button to select the custom value
+    await user.click(screen.getByText(/Use "Target"/));
+
     await user.type(screen.getByLabelText("Date"), "2024-03-01");
-    await user.click(screen.getByRole("button", { name: /create receipt/i }));
+    await user.click(
+      screen.getByRole("button", { name: /create receipt/i }),
+    );
 
     await waitFor(() => {
       expect(defaultProps.onSubmit).toHaveBeenCalledWith(
@@ -57,7 +91,6 @@ describe("ReceiptForm", () => {
           date: "2024-03-01",
           taxAmount: 0,
         }),
-        expect.anything(),
       );
     });
   });
@@ -66,7 +99,9 @@ describe("ReceiptForm", () => {
     const user = userEvent.setup();
     render(<ReceiptForm {...defaultProps} />);
 
-    await user.click(screen.getByRole("button", { name: /create receipt/i }));
+    await user.click(
+      screen.getByRole("button", { name: /create receipt/i }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Location is required")).toBeInTheDocument();
@@ -101,5 +136,30 @@ describe("ReceiptForm", () => {
     render(<ReceiptForm {...defaultProps} />);
 
     expect(screen.getByLabelText("Date")).toBeInTheDocument();
+  });
+
+  it("persists location to history on submit", async () => {
+    const user = userEvent.setup();
+    render(<ReceiptForm {...defaultProps} />);
+
+    // Open combobox and type custom value
+    await user.click(screen.getByRole("combobox"));
+    const searchInput = screen.getByPlaceholderText("Search locations...");
+    await user.type(searchInput, "Costco");
+    await user.click(screen.getByText(/Use "Costco"/));
+
+    await user.type(screen.getByLabelText("Date"), "2024-06-01");
+    await user.click(
+      screen.getByRole("button", { name: /create receipt/i }),
+    );
+
+    await waitFor(() => {
+      expect(defaultProps.onSubmit).toHaveBeenCalled();
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("receipts:location-history") ?? "[]",
+    ) as string[];
+    expect(stored).toContain("Costco");
   });
 });

--- a/src/client/src/components/ReceiptForm.test.tsx
+++ b/src/client/src/components/ReceiptForm.test.tsx
@@ -1,21 +1,7 @@
+import "@/test/setup-combobox-polyfills";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ReceiptForm } from "./ReceiptForm";
-
-// Polyfill ResizeObserver and scrollIntoView for radix-ui / cmdk in jsdom
-beforeAll(() => {
-  if (typeof window.ResizeObserver === "undefined") {
-    window.ResizeObserver = class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as unknown as typeof ResizeObserver;
-  }
-
-  if (!Element.prototype.scrollIntoView) {
-    Element.prototype.scrollIntoView = vi.fn();
-  }
-});
 
 vi.mock("@/hooks/useFormShortcuts", () => ({
   useFormShortcuts: vi.fn(),
@@ -136,6 +122,58 @@ describe("ReceiptForm", () => {
     render(<ReceiptForm {...defaultProps} />);
 
     expect(screen.getByLabelText("Date")).toBeInTheDocument();
+  });
+
+  it("associates Location label with the combobox trigger via id", () => {
+    render(<ReceiptForm {...defaultProps} />);
+
+    const combobox = screen.getByRole("combobox");
+    const label = screen.getByText("Location");
+
+    // FormControl's Slot passes id to the Combobox trigger button;
+    // FormLabel sets htmlFor to the same id, creating the association.
+    expect(combobox).toHaveAttribute("id");
+    expect(label).toHaveAttribute("for", combobox.getAttribute("id"));
+  });
+
+  it("shows saved locations in the dropdown and allows selection", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      "receipts:location-history",
+      JSON.stringify(["Walmart", "Target", "Costco"]),
+    );
+
+    render(<ReceiptForm {...defaultProps} />);
+
+    // Open the combobox
+    await user.click(screen.getByRole("combobox"));
+
+    // Verify saved locations appear as options
+    expect(screen.getByText("Walmart")).toBeInTheDocument();
+    expect(screen.getByText("Target")).toBeInTheDocument();
+    expect(screen.getByText("Costco")).toBeInTheDocument();
+
+    // Select an existing location
+    await user.click(screen.getByText("Target"));
+
+    // Combobox should show the selected value
+    expect(screen.getByRole("combobox")).toHaveTextContent("Target");
+
+    // Fill remaining fields and submit
+    await user.type(screen.getByLabelText("Date"), "2024-05-10");
+    await user.click(
+      screen.getByRole("button", { name: /create receipt/i }),
+    );
+
+    await waitFor(() => {
+      expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          location: "Target",
+          date: "2024-05-10",
+          taxAmount: 0,
+        }),
+      );
+    });
   });
 
   it("persists location to history on submit", async () => {

--- a/src/client/src/components/ReceiptForm.tsx
+++ b/src/client/src/components/ReceiptForm.tsx
@@ -19,7 +19,10 @@ import {
 } from "@/components/ui/form";
 
 const receiptSchema = z.object({
-  location: z.string().min(1, "Location is required"),
+  location: z
+    .string()
+    .min(1, "Location is required")
+    .max(200, "Location must be 200 characters or fewer"),
   date: z.string().min(1, "Date is required"),
   taxAmount: z.number().min(0, "Tax amount must be non-negative"),
 });
@@ -56,6 +59,10 @@ export function ReceiptForm({
   });
 
   const handleSubmit = (values: ReceiptFormValues) => {
+    // Persist location before calling onSubmit intentionally: the location string
+    // is valid user input regardless of whether the server mutation succeeds.
+    // The user typed a real location name; saving it for future autocomplete
+    // suggestions is correct even if the receipt save ultimately fails.
     addLocation(values.location);
     onSubmit(values);
   };

--- a/src/client/src/components/ReceiptForm.tsx
+++ b/src/client/src/components/ReceiptForm.tsx
@@ -3,8 +3,10 @@ import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
+import { useLocationHistory } from "@/hooks/useLocationHistory";
 import { Button } from "@/components/ui/button";
 import { SubmitButton } from "@/components/ui/submit-button";
+import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import {
@@ -41,6 +43,7 @@ export function ReceiptForm({
 }: ReceiptFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
   useFormShortcuts({ formRef });
+  const { options: locationOptions, add: addLocation } = useLocationHistory();
 
   const form = useForm<ReceiptFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -52,9 +55,14 @@ export function ReceiptForm({
     },
   });
 
+  const handleSubmit = (values: ReceiptFormValues) => {
+    addLocation(values.location);
+    onSubmit(values);
+  };
+
   return (
     <Form {...form}>
-      <form ref={formRef} onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+      <form ref={formRef} onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
         <FormField
           control={form.control}
           name="location"
@@ -62,7 +70,16 @@ export function ReceiptForm({
             <FormItem>
               <FormLabel>Location</FormLabel>
               <FormControl>
-                <Input aria-required="true" {...field} />
+                <Combobox
+                  options={locationOptions}
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  placeholder="Select or type a location..."
+                  searchPlaceholder="Search locations..."
+                  emptyMessage="No saved locations."
+                  allowCustom
+                  aria-required="true"
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/client/src/hooks/useLocationHistory.test.ts
+++ b/src/client/src/hooks/useLocationHistory.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, act } from "@testing-library/react";
+import { useLocationHistory } from "./useLocationHistory";
+
+describe("useLocationHistory", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts with empty locations and options", () => {
+    const { result } = renderHook(() => useLocationHistory());
+    expect(result.current.locations).toEqual([]);
+    expect(result.current.options).toEqual([]);
+  });
+
+  it("adds a location and updates state", () => {
+    const { result } = renderHook(() => useLocationHistory());
+
+    act(() => {
+      result.current.add("Walmart");
+    });
+
+    expect(result.current.locations).toEqual(["Walmart"]);
+  });
+
+  it("returns ComboboxOption objects in options", () => {
+    const { result } = renderHook(() => useLocationHistory());
+
+    act(() => {
+      result.current.add("Target");
+    });
+
+    expect(result.current.options).toEqual([
+      { value: "Target", label: "Target" },
+    ]);
+  });
+
+  it("clears all locations", () => {
+    const { result } = renderHook(() => useLocationHistory());
+
+    act(() => {
+      result.current.add("Walmart");
+      result.current.add("Target");
+    });
+    expect(result.current.locations).toHaveLength(2);
+
+    act(() => {
+      result.current.clear();
+    });
+    expect(result.current.locations).toEqual([]);
+    expect(result.current.options).toEqual([]);
+  });
+
+  it("deduplicates locations (case-insensitive)", () => {
+    const { result } = renderHook(() => useLocationHistory());
+
+    act(() => {
+      result.current.add("Walmart");
+      result.current.add("Target");
+      result.current.add("walmart");
+    });
+
+    expect(result.current.locations).toEqual(["walmart", "Target"]);
+  });
+});

--- a/src/client/src/hooks/useLocationHistory.ts
+++ b/src/client/src/hooks/useLocationHistory.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback, useMemo } from "react";
+import {
+  getLocationHistory,
+  addLocation,
+  clearLocationHistory,
+} from "@/lib/location-history";
+import type { ComboboxOption } from "@/components/ui/combobox";
+
+export function useLocationHistory() {
+  const [locations, setLocations] = useState<string[]>(getLocationHistory);
+
+  const add = useCallback((location: string) => {
+    addLocation(location);
+    setLocations(getLocationHistory());
+  }, []);
+
+  const clear = useCallback(() => {
+    clearLocationHistory();
+    setLocations([]);
+  }, []);
+
+  const options: ComboboxOption[] = useMemo(
+    () => locations.map((loc) => ({ value: loc, label: loc })),
+    [locations],
+  );
+
+  return useMemo(
+    () => ({ locations, options, add, clear }),
+    [locations, options, add, clear],
+  );
+}

--- a/src/client/src/lib/location-history.test.ts
+++ b/src/client/src/lib/location-history.test.ts
@@ -62,6 +62,35 @@ describe("location-history", () => {
       expect(history).toHaveLength(50);
       expect(history[0]).toBe("Store 59");
     });
+
+    it("does not crash when localStorage.setItem throws (quota exceeded)", () => {
+      const original = localStorage.setItem.bind(localStorage);
+      localStorage.setItem = () => {
+        throw new DOMException("QuotaExceededError", "QuotaExceededError");
+      };
+
+      expect(() => addLocation("Walmart")).not.toThrow();
+
+      localStorage.setItem = original;
+    });
+  });
+
+  describe("getLocationHistory runtime validation", () => {
+    it("filters out non-string entries from localStorage", () => {
+      localStorage.setItem(
+        "receipts:location-history",
+        JSON.stringify(["Walmart", 42, null, "Target", { name: "bad" }]),
+      );
+      expect(getLocationHistory()).toEqual(["Walmart", "Target"]);
+    });
+
+    it("returns empty array when localStorage contains a non-array JSON value", () => {
+      localStorage.setItem(
+        "receipts:location-history",
+        JSON.stringify({ not: "an array" }),
+      );
+      expect(getLocationHistory()).toEqual([]);
+    });
   });
 
   describe("clearLocationHistory", () => {

--- a/src/client/src/lib/location-history.test.ts
+++ b/src/client/src/lib/location-history.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getLocationHistory,
+  addLocation,
+  clearLocationHistory,
+} from "./location-history";
+
+describe("location-history", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("getLocationHistory", () => {
+    it("returns empty array when no history exists", () => {
+      expect(getLocationHistory()).toEqual([]);
+    });
+
+    it("returns stored locations", () => {
+      localStorage.setItem(
+        "receipts:location-history",
+        JSON.stringify(["Walmart", "Target"]),
+      );
+      expect(getLocationHistory()).toEqual(["Walmart", "Target"]);
+    });
+
+    it("returns empty array on malformed JSON", () => {
+      localStorage.setItem("receipts:location-history", "not-json");
+      expect(getLocationHistory()).toEqual([]);
+    });
+  });
+
+  describe("addLocation", () => {
+    it("adds a location to the front", () => {
+      addLocation("Walmart");
+      addLocation("Target");
+      expect(getLocationHistory()).toEqual(["Target", "Walmart"]);
+    });
+
+    it("moves duplicate to the front (case-insensitive)", () => {
+      addLocation("Walmart");
+      addLocation("Target");
+      addLocation("walmart");
+      expect(getLocationHistory()).toEqual(["walmart", "Target"]);
+    });
+
+    it("trims whitespace", () => {
+      addLocation("  Costco  ");
+      expect(getLocationHistory()).toEqual(["Costco"]);
+    });
+
+    it("ignores empty strings", () => {
+      addLocation("");
+      addLocation("   ");
+      expect(getLocationHistory()).toEqual([]);
+    });
+
+    it("limits to 50 entries", () => {
+      for (let i = 0; i < 60; i++) {
+        addLocation(`Store ${i}`);
+      }
+      const history = getLocationHistory();
+      expect(history).toHaveLength(50);
+      expect(history[0]).toBe("Store 59");
+    });
+  });
+
+  describe("clearLocationHistory", () => {
+    it("removes all locations", () => {
+      addLocation("Walmart");
+      addLocation("Target");
+      clearLocationHistory();
+      expect(getLocationHistory()).toEqual([]);
+    });
+  });
+});

--- a/src/client/src/lib/location-history.ts
+++ b/src/client/src/lib/location-history.ts
@@ -7,7 +7,11 @@ const MAX_LOCATIONS = 50;
 export function getLocationHistory(): string[] {
   try {
     const raw = localStorage.getItem(LOCATION_HISTORY_KEY);
-    return raw ? (JSON.parse(raw) as string[]) : [];
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((x): x is string => typeof x === "string")
+      : [];
   } catch {
     return [];
   }

--- a/src/client/src/lib/location-history.ts
+++ b/src/client/src/lib/location-history.ts
@@ -1,0 +1,44 @@
+const LOCATION_HISTORY_KEY = "receipts:location-history";
+const MAX_LOCATIONS = 50;
+
+/**
+ * Retrieve saved locations from localStorage, sorted by most-recently-used.
+ */
+export function getLocationHistory(): string[] {
+  try {
+    const raw = localStorage.getItem(LOCATION_HISTORY_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Add a location to the front of the history list.
+ * Deduplication is case-insensitive: if "Walmart" exists and "walmart" is added,
+ * the old entry is removed and the new casing is placed at the front.
+ */
+export function addLocation(location: string): void {
+  const trimmed = location.trim();
+  if (!trimmed) return;
+
+  const history = getLocationHistory().filter(
+    (h) => h.toLowerCase() !== trimmed.toLowerCase(),
+  );
+  history.unshift(trimmed);
+  if (history.length > MAX_LOCATIONS) {
+    history.length = MAX_LOCATIONS;
+  }
+  try {
+    localStorage.setItem(LOCATION_HISTORY_KEY, JSON.stringify(history));
+  } catch {
+    // Ignore storage errors (full, disabled, etc.)
+  }
+}
+
+/**
+ * Remove all saved locations.
+ */
+export function clearLocationHistory(): void {
+  localStorage.removeItem(LOCATION_HISTORY_KEY);
+}

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -3,6 +3,21 @@ import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import Receipts from "./Receipts";
 
+// Polyfill ResizeObserver and scrollIntoView for radix-ui / cmdk in jsdom
+beforeAll(() => {
+  if (typeof window.ResizeObserver === "undefined") {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
+});
+
 vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
 }));
@@ -304,9 +319,13 @@ describe("Receipts", () => {
     renderWithProviders(<Receipts />);
     await user.click(screen.getByRole("button", { name: /edit/i }));
 
-    const locationInput = screen.getByLabelText(/location/i);
-    await user.clear(locationInput);
-    await user.type(locationInput, "Target");
+    // Location is now a Combobox — open it, type a new value, and select it
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const searchInput = screen.getByPlaceholderText("Search locations...");
+    await user.type(searchInput, "Target");
+    await user.click(screen.getByText(/Use "Target"/));
+
     await user.click(screen.getByRole("button", { name: /update receipt/i }));
 
     await vi.waitFor(() => {
@@ -326,7 +345,13 @@ describe("Receipts", () => {
     renderWithProviders(<Receipts />);
     await user.click(screen.getByRole("button", { name: /quick add/i }));
 
-    await user.type(screen.getByLabelText(/location/i), "Walmart");
+    // Location is now a Combobox — open it, type a custom value, and select it
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const searchInput = screen.getByPlaceholderText("Search locations...");
+    await user.type(searchInput, "Walmart");
+    await user.click(screen.getByText(/Use "Walmart"/));
+
     await user.type(screen.getByLabelText(/date/i), "2024-01-15");
     await user.type(screen.getByLabelText(/tax amount/i), "5.25");
     await user.click(screen.getByRole("button", { name: /create receipt/i }));

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -1,22 +1,8 @@
+import "@/test/setup-combobox-polyfills";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import Receipts from "./Receipts";
-
-// Polyfill ResizeObserver and scrollIntoView for radix-ui / cmdk in jsdom
-beforeAll(() => {
-  if (typeof window.ResizeObserver === "undefined") {
-    window.ResizeObserver = class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as unknown as typeof ResizeObserver;
-  }
-
-  if (!Element.prototype.scrollIntoView) {
-    Element.prototype.scrollIntoView = vi.fn();
-  }
-});
 
 vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),

--- a/src/client/src/pages/wizard/Step1TripDetails.test.tsx
+++ b/src/client/src/pages/wizard/Step1TripDetails.test.tsx
@@ -2,15 +2,34 @@ import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { Step1TripDetails } from "./Step1TripDetails";
 
+// Polyfill ResizeObserver and scrollIntoView for radix-ui / cmdk in jsdom
+beforeAll(() => {
+  if (typeof window.ResizeObserver === "undefined") {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
+});
+
 describe("Step1TripDetails", () => {
   const defaultProps = {
     data: { location: "", date: "", taxAmount: 0 },
     onNext: vi.fn(),
   };
 
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("renders the form fields", () => {
     renderWithProviders(<Step1TripDetails {...defaultProps} />);
-    expect(screen.getByLabelText(/location/i)).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
     expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/tax amount/i)).toBeInTheDocument();
   });
@@ -18,7 +37,8 @@ describe("Step1TripDetails", () => {
   it("renders with pre-filled data", () => {
     const data = { location: "Costco", date: "2024-03-15", taxAmount: 7.5 };
     renderWithProviders(<Step1TripDetails {...defaultProps} data={data} />);
-    expect(screen.getByLabelText(/location/i)).toHaveValue("Costco");
+    // Combobox shows raw value as text content when no matching option exists
+    expect(screen.getByRole("combobox")).toHaveTextContent("Costco");
     expect(screen.getByLabelText(/date/i)).toHaveValue("2024-03-15");
   });
 

--- a/src/client/src/pages/wizard/Step1TripDetails.test.tsx
+++ b/src/client/src/pages/wizard/Step1TripDetails.test.tsx
@@ -1,21 +1,7 @@
+import "@/test/setup-combobox-polyfills";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { Step1TripDetails } from "./Step1TripDetails";
-
-// Polyfill ResizeObserver and scrollIntoView for radix-ui / cmdk in jsdom
-beforeAll(() => {
-  if (typeof window.ResizeObserver === "undefined") {
-    window.ResizeObserver = class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as unknown as typeof ResizeObserver;
-  }
-
-  if (!Element.prototype.scrollIntoView) {
-    Element.prototype.scrollIntoView = vi.fn();
-  }
-});
 
 describe("Step1TripDetails", () => {
   const defaultProps = {

--- a/src/client/src/pages/wizard/Step1TripDetails.tsx
+++ b/src/client/src/pages/wizard/Step1TripDetails.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -34,7 +35,13 @@ interface Step1Props {
 }
 
 export function Step1TripDetails({ data, onNext }: Step1Props) {
+  const locationRef = useRef<HTMLButtonElement>(null);
   const { options: locationOptions, add: addLocation } = useLocationHistory();
+
+  // Auto-focus the location combobox when the wizard step mounts
+  useEffect(() => {
+    locationRef.current?.focus();
+  }, []);
 
   const form = useForm<TripFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -47,6 +54,10 @@ export function Step1TripDetails({ data, onNext }: Step1Props) {
   });
 
   const handleSubmit = (values: TripFormValues) => {
+    // Persist location before calling onNext intentionally: the location string
+    // is valid user input regardless of whether the server mutation succeeds.
+    // The user typed a real location name; saving it for future autocomplete
+    // suggestions is correct even if the receipt save ultimately fails.
     addLocation(values.location);
     onNext(values);
   };
@@ -70,6 +81,7 @@ export function Step1TripDetails({ data, onNext }: Step1Props) {
                   <FormLabel>Location</FormLabel>
                   <FormControl>
                     <Combobox
+                      ref={locationRef}
                       options={locationOptions}
                       value={field.value}
                       onValueChange={field.onChange}

--- a/src/client/src/pages/wizard/Step1TripDetails.tsx
+++ b/src/client/src/pages/wizard/Step1TripDetails.tsx
@@ -1,9 +1,10 @@
-import { useRef, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useLocationHistory } from "@/hooks/useLocationHistory";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import {
@@ -33,7 +34,7 @@ interface Step1Props {
 }
 
 export function Step1TripDetails({ data, onNext }: Step1Props) {
-  const locationRef = useRef<HTMLInputElement>(null);
+  const { options: locationOptions, add: addLocation } = useLocationHistory();
 
   const form = useForm<TripFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -45,11 +46,8 @@ export function Step1TripDetails({ data, onNext }: Step1Props) {
     },
   });
 
-  useEffect(() => {
-    locationRef.current?.focus();
-  }, []);
-
   const handleSubmit = (values: TripFormValues) => {
+    addLocation(values.location);
     onNext(values);
   };
 
@@ -71,16 +69,15 @@ export function Step1TripDetails({ data, onNext }: Step1Props) {
                 <FormItem>
                   <FormLabel>Location</FormLabel>
                   <FormControl>
-                    <Input
-                      aria-required="true"
+                    <Combobox
+                      options={locationOptions}
+                      value={field.value}
+                      onValueChange={field.onChange}
                       placeholder="e.g. Walmart, Target, Costco"
-                      {...field}
-                      ref={(el) => {
-                        field.ref(el);
-                        (
-                          locationRef as React.MutableRefObject<HTMLInputElement | null>
-                        ).current = el;
-                      }}
+                      searchPlaceholder="Search locations..."
+                      emptyMessage="No saved locations."
+                      allowCustom
+                      aria-required="true"
                     />
                   </FormControl>
                   <FormMessage />

--- a/src/client/src/test/setup-combobox-polyfills.ts
+++ b/src/client/src/test/setup-combobox-polyfills.ts
@@ -1,0 +1,21 @@
+/**
+ * Polyfills for ResizeObserver and scrollIntoView required by radix-ui / cmdk
+ * in jsdom test environments. Import this file in any test that renders a
+ * Combobox (or any radix Popover / Command-based component).
+ *
+ * Usage: import "@/test/setup-combobox-polyfills";
+ */
+
+beforeAll(() => {
+  if (typeof window.ResizeObserver === "undefined") {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
+});


### PR DESCRIPTION
## Summary
- Add localStorage-backed location history that persists previously entered receipt locations
- Replace the plain text input for location with a searchable Combobox dropdown in both the receipt wizard (Step 1 Trip Details) and the Quick Add / Edit receipt dialog
- Users can select from saved locations or type a custom location (allowCustom mode)
- Location history is case-insensitive deduplicated and capped at 50 entries

## Implementation
- `src/client/src/lib/location-history.ts` -- localStorage persistence layer (get/add/clear)
- `src/client/src/hooks/useLocationHistory.ts` -- React hook returning ComboboxOption[] and add/clear callbacks
- `ReceiptForm.tsx` and `Step1TripDetails.tsx` -- swap Input for Combobox with allowCustom
- Updated all affected tests to use Combobox interaction patterns (role=combobox, search input, Use button)

## Test plan
- [x] 9 unit tests for location-history.ts (persistence, dedup, cap, clear, edge cases)
- [x] 5 unit tests for useLocationHistory hook (state sync, options format, clear)
- [x] 9 tests for ReceiptForm (including new persistence test)
- [x] 5 tests for Step1TripDetails (Combobox rendering and pre-fill)
- [x] 17 tests for Receipts page (Combobox interaction in create/edit flows)
- [x] Full client test suite: 125 files, 1036 tests passing
- [x] TypeScript compiles cleanly
- [x] ESLint passes (no new warnings)

Generated with [Claude Code](https://claude.com/claude-code)