### PR TITLE
feat(client): replace native date inputs with DateInput component (MGG-324)

### DIFF
--- a/src/client/src/components/FilterPanel.test.tsx
+++ b/src/client/src/components/FilterPanel.test.tsx
@@ -203,6 +203,7 @@ describe("FilterPanel", () => {
     await user.click(screen.getByRole("button", { name: /filters/i }));
     const fromInput = screen.getByPlaceholderText("From");
     await user.type(fromInput, "2024-01-15");
+    await user.tab(); // Commit on blur
     expect(onChange).toHaveBeenCalled();
   });
 

--- a/src/client/src/components/FilterPanel.tsx
+++ b/src/client/src/components/FilterPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ChevronDown, ChevronRight, Filter, Save, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { DateInput } from "@/components/ui/date-input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Combobox } from "@/components/ui/combobox";
@@ -174,33 +175,31 @@ export function FilterPanel({
               )}
               {field.type === "dateRange" && (
                 <div className="flex gap-2">
-                  <Input
-                    type="date"
+                  <DateInput
                     className="h-8 text-xs"
                     placeholder="From"
                     value={
                       (values[field.key] as { from?: string } | undefined)
                         ?.from ?? ""
                     }
-                    onChange={(e) =>
+                    onChange={(v) =>
                       updateField(field.key, {
                         ...(values[field.key] as object),
-                        from: e.target.value || undefined,
+                        from: v || undefined,
                       })
                     }
                   />
-                  <Input
-                    type="date"
+                  <DateInput
                     className="h-8 text-xs"
                     placeholder="To"
                     value={
                       (values[field.key] as { to?: string } | undefined)?.to ??
                       ""
                     }
-                    onChange={(e) =>
+                    onChange={(v) =>
                       updateField(field.key, {
                         ...(values[field.key] as object),
-                        to: e.target.value || undefined,
+                        to: v || undefined,
                       })
                     }
                   />

--- a/src/client/src/components/ReceiptForm.tsx
+++ b/src/client/src/components/ReceiptForm.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
+import { DateInput } from "@/components/ui/date-input";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import {
   Form,
@@ -100,7 +101,7 @@ export function ReceiptForm({
             <FormItem>
               <FormLabel>Date</FormLabel>
               <FormControl>
-                <Input type="date" aria-required="true" {...field} />
+                <DateInput aria-required="true" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/client/src/components/ReceiptForm.tsx
+++ b/src/client/src/components/ReceiptForm.tsx
@@ -7,7 +7,6 @@ import { useLocationHistory } from "@/hooks/useLocationHistory";
 import { Button } from "@/components/ui/button";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { Combobox } from "@/components/ui/combobox";
-import { Input } from "@/components/ui/input";
 import { DateInput } from "@/components/ui/date-input";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import {

--- a/src/client/src/components/TransactionForm.tsx
+++ b/src/client/src/components/TransactionForm.tsx
@@ -7,7 +7,7 @@ import { useReceipts } from "@/hooks/useReceipts";
 import { useAccounts } from "@/hooks/useAccounts";
 import { receiptToOption, accountToOption } from "@/lib/combobox-options";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { DateInput } from "@/components/ui/date-input";
 import { Combobox } from "@/components/ui/combobox";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import {
@@ -52,13 +52,21 @@ export function TransactionForm({
 
   const receiptOptions = useMemo(
     () =>
-      ((receipts?.data as { id: string; location: string; date: string }[] | undefined) ?? []).map(receiptToOption),
+      (
+        (receipts?.data as
+          | { id: string; location: string; date: string }[]
+          | undefined) ?? []
+      ).map(receiptToOption),
     [receipts],
   );
 
   const accountOptions = useMemo(
     () =>
-      ((accounts?.data as { id: string; name: string; accountCode: string }[] | undefined) ?? []).map(accountToOption),
+      (
+        (accounts?.data as
+          | { id: string; name: string; accountCode: string }[]
+          | undefined) ?? []
+      ).map(accountToOption),
     [accounts],
   );
 
@@ -76,7 +84,11 @@ export function TransactionForm({
 
   return (
     <Form {...form}>
-      <form ref={formRef} onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+      <form
+        ref={formRef}
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4"
+      >
         <FormField
           control={form.control}
           name="receiptId"
@@ -146,7 +158,7 @@ export function TransactionForm({
             <FormItem>
               <FormLabel>Date</FormLabel>
               <FormControl>
-                <Input type="date" aria-required="true" {...field} />
+                <DateInput aria-required="true" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/client/src/components/ui/date-input.test.tsx
+++ b/src/client/src/components/ui/date-input.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useState } from "react";
+import { createRef, useState } from "react";
 import { DateInput } from "./date-input";
 
 // Controlled wrapper that re-renders with updated value when onChange fires
@@ -59,7 +59,7 @@ describe("DateInput", () => {
     ).toBeInTheDocument();
   });
 
-  it("calls onChange with wire format when user types a valid MM/DD/YYYY date", async () => {
+  it("calls onChange with wire format when user types a valid MM/DD/YYYY date and blurs", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
 
@@ -68,13 +68,12 @@ describe("DateInput", () => {
     const input = screen.getByPlaceholderText("MM/DD/YYYY");
     await user.click(input);
     await user.type(input, "03/15/2024");
+    await user.tab();
 
-    // onChange should have been called with the wire format at some point
-    const calls = onChange.mock.calls.map((c) => c[0]);
-    expect(calls).toContain("2024-03-15");
+    expect(onChange).toHaveBeenCalledWith("2024-03-15");
   });
 
-  it("calls onChange with wire format when user types YYYY-MM-DD", async () => {
+  it("calls onChange with wire format when user types YYYY-MM-DD and blurs", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
 
@@ -83,9 +82,9 @@ describe("DateInput", () => {
     const input = screen.getByPlaceholderText("MM/DD/YYYY");
     await user.click(input);
     await user.type(input, "2024-01-20");
+    await user.tab();
 
-    const calls = onChange.mock.calls.map((c) => c[0]);
-    expect(calls).toContain("2024-01-20");
+    expect(onChange).toHaveBeenCalledWith("2024-01-20");
   });
 
   it("formats the display value on blur after valid input", async () => {
@@ -165,5 +164,203 @@ describe("DateInput", () => {
     await user.tab();
 
     expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  // --- New tests for PR review fixes ---
+
+  it("does not eagerly fire onChange while typing (no intermediate dates)", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<DateInput {...defaultProps} onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "03/1");
+
+    // onChange should not be called while still typing partial text
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("opens calendar and selects a date", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ControlledDateInput
+        initialValue="2024-03-15"
+        onChange={onChange}
+      />,
+    );
+
+    const calendarButton = screen.getByRole("button", { name: /pick a date/i });
+    await user.click(calendarButton);
+
+    // Calendar should be open — select March 20th, 2024 by its full aria-label
+    const dayButton = await screen.findByRole("button", {
+      name: /Wednesday, March 20th, 2024/,
+    });
+    await user.click(dayButton);
+
+    expect(onChange).toHaveBeenCalledWith("2024-03-20");
+  });
+
+  it("rejects date beyond max prop and shows error state", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ControlledDateInput
+        initialValue=""
+        onChange={onChange}
+        max="2024-01-15"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "02/01/2024");
+    await user.tab();
+
+    // Date is after max, so onChange should NOT have been called with the date
+    expect(onChange).not.toHaveBeenCalledWith("2024-02-01");
+    // Input should show invalid state
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("accepts date at or before max prop", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ControlledDateInput
+        initialValue=""
+        onChange={onChange}
+        max="2024-06-15"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "06/15/2024");
+    await user.tab();
+
+    expect(onChange).toHaveBeenCalledWith("2024-06-15");
+    expect(input).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("rejects date before min prop and shows error state", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ControlledDateInput
+        initialValue=""
+        onChange={onChange}
+        min="2024-06-01"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "01/15/2024");
+    await user.tab();
+
+    // Date is before min, so onChange should NOT have been called with the date
+    expect(onChange).not.toHaveBeenCalledWith("2024-01-15");
+    // Input should show invalid state
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("shows error state for unparseable input on blur", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<DateInput {...defaultProps} onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "not-a-date");
+    await user.tab();
+
+    // onChange should not have been called with a date value
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    );
+    // Input should be marked invalid
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("clears error state when valid date is committed", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ControlledDateInput initialValue="" onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+
+    // First type garbage
+    await user.click(input);
+    await user.type(input, "garbage");
+    await user.tab();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+
+    // Now type a valid date
+    await user.click(input);
+    await user.clear(input);
+    await user.type(input, "03/15/2024");
+    await user.tab();
+    expect(input).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("forwards ref to the input element", () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<DateInput {...defaultProps} ref={ref} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    expect(ref.current).toBe(screen.getByPlaceholderText("MM/DD/YYYY"));
+  });
+
+  it("uses inputMode='text' not 'numeric'", () => {
+    render(<DateInput {...defaultProps} />);
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    expect(input).toHaveAttribute("inputMode", "text");
+  });
+
+  it("calendar trigger button has aria-expanded", () => {
+    render(<DateInput {...defaultProps} />);
+    const button = screen.getByRole("button", { name: /pick a date/i });
+    expect(button).toHaveAttribute("aria-expanded");
+  });
+
+  it("calendar trigger button has adequate touch target size (size-11)", () => {
+    render(<DateInput {...defaultProps} />);
+    const button = screen.getByRole("button", { name: /pick a date/i });
+    // size-11 = 44px (2.75rem), check the class is present
+    expect(button.className).toContain("size-11");
+  });
+
+  it("rejects ambiguous partial matches via round-trip check", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<DateInput {...defaultProps} onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "03/1");
+    fireEvent.blur(input);
+
+    // Should not have committed a date — partial input fails round-trip
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    );
+  });
+
+  it("commits valid date on Enter key", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ControlledDateInput initialValue="" onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "03/15/2024");
+    await user.keyboard("{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith("2024-03-15");
   });
 });

--- a/src/client/src/components/ui/date-input.test.tsx
+++ b/src/client/src/components/ui/date-input.test.tsx
@@ -363,4 +363,68 @@ describe("DateInput", () => {
 
     expect(onChange).toHaveBeenCalledWith("2024-03-15");
   });
+
+  it("reformats display value after Enter key commit", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ControlledDateInput initialValue="" onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "2024-06-01");
+    await user.keyboard("{Enter}");
+
+    // After Enter, blur is triggered so display should show MM/DD/YYYY format
+    expect(input).toHaveValue("06/01/2024");
+  });
+
+  it("does not fire redundant onChange when commitText value matches current value", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ControlledDateInput initialValue="2024-03-15" onChange={onChange} />,
+    );
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    // Focus then blur without changing the value
+    await user.click(input);
+    await user.tab();
+
+    // onChange should NOT have been called since value didn't change
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not fire redundant onChange on calendar pick followed by blur", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ControlledDateInput
+        initialValue="2024-03-15"
+        onChange={onChange}
+      />,
+    );
+
+    const calendarButton = screen.getByRole("button", { name: /pick a date/i });
+    await user.click(calendarButton);
+
+    // Select March 20th, 2024
+    const dayButton = await screen.findByRole("button", {
+      name: /Wednesday, March 20th, 2024/,
+    });
+    await user.click(dayButton);
+
+    // onChange fired once for the calendar pick
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("2024-03-20");
+
+    // Now focus and blur the input — should NOT fire onChange again
+    onChange.mockClear();
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.tab();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/src/client/src/components/ui/date-input.test.tsx
+++ b/src/client/src/components/ui/date-input.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { DateInput } from "./date-input";
+
+// Controlled wrapper that re-renders with updated value when onChange fires
+function ControlledDateInput({
+  initialValue = "",
+  onChange: externalOnChange,
+  ...rest
+}: {
+  initialValue?: string;
+  onChange?: (value: string) => void;
+} & Omit<React.ComponentProps<typeof DateInput>, "value" | "onChange">) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <DateInput
+      value={value}
+      onChange={(v) => {
+        setValue(v);
+        externalOnChange?.(v);
+      }}
+      {...rest}
+    />
+  );
+}
+
+describe("DateInput", () => {
+  const defaultProps = {
+    value: "",
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders with placeholder when value is empty", () => {
+    render(<DateInput {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("");
+  });
+
+  it("renders with formatted display value when given a wire-format date", () => {
+    render(<DateInput {...defaultProps} value="2024-03-15" />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    expect(input).toHaveValue("03/15/2024");
+  });
+
+  it("renders the calendar button", () => {
+    render(<DateInput {...defaultProps} />);
+
+    expect(
+      screen.getByRole("button", { name: "Pick a date" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange with wire format when user types a valid MM/DD/YYYY date", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ControlledDateInput initialValue="" onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "03/15/2024");
+
+    // onChange should have been called with the wire format at some point
+    const calls = onChange.mock.calls.map((c) => c[0]);
+    expect(calls).toContain("2024-03-15");
+  });
+
+  it("calls onChange with wire format when user types YYYY-MM-DD", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ControlledDateInput initialValue="" onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "2024-01-20");
+
+    const calls = onChange.mock.calls.map((c) => c[0]);
+    expect(calls).toContain("2024-01-20");
+  });
+
+  it("formats the display value on blur after valid input", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ControlledDateInput initialValue="" onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.type(input, "2024-06-01");
+    await user.tab();
+
+    // After blur, the display should show MM/DD/YYYY format
+    expect(input).toHaveValue("06/01/2024");
+  });
+
+  it("clears the value when user clears the input and blurs", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ControlledDateInput initialValue="2024-03-15" onChange={onChange} />,
+    );
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.clear(input);
+    await user.tab();
+
+    expect(onChange).toHaveBeenCalledWith("");
+    expect(input).toHaveValue("");
+  });
+
+  it("disables both input and calendar button when disabled", () => {
+    render(<DateInput {...defaultProps} disabled />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    expect(input).toBeDisabled();
+
+    const calendarButton = screen.getByRole("button", { name: "Pick a date" });
+    expect(calendarButton).toBeDisabled();
+  });
+
+  it("passes aria-required through to the input", () => {
+    render(<DateInput {...defaultProps} aria-required="true" />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    expect(input).toHaveAttribute("aria-required", "true");
+  });
+
+  it("updates display when controlled value changes externally", () => {
+    const { rerender } = render(
+      <DateInput value="2024-01-01" onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByPlaceholderText("MM/DD/YYYY")).toHaveValue("01/01/2024");
+
+    rerender(<DateInput value="2024-12-25" onChange={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText("MM/DD/YYYY")).toHaveValue("12/25/2024");
+  });
+
+  it("supports custom placeholder via props", () => {
+    render(<DateInput {...defaultProps} placeholder="Select date" />);
+
+    expect(screen.getByPlaceholderText("Select date")).toBeInTheDocument();
+  });
+
+  it("calls onBlur when the input loses focus", async () => {
+    const onBlur = vi.fn();
+    const user = userEvent.setup();
+
+    render(<DateInput {...defaultProps} onBlur={onBlur} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(input);
+    await user.tab();
+
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/client/src/components/ui/date-input.tsx
+++ b/src/client/src/components/ui/date-input.tsx
@@ -1,5 +1,11 @@
-import { useState, useRef, useCallback, type ComponentProps } from "react";
-import { format, parse, isValid } from "date-fns";
+import {
+  useState,
+  useRef,
+  useCallback,
+  type ComponentProps,
+  type Ref,
+} from "react";
+import { format, parse, isValid, isAfter, isBefore } from "date-fns";
 import { CalendarIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -35,7 +41,7 @@ function tryParseDate(text: string): Date | null {
   if (!trimmed) return null;
   for (const fmt of PARSE_FORMATS) {
     const d = parse(trimmed, fmt, new Date());
-    if (isValid(d)) return d;
+    if (isValid(d) && format(d, fmt) === trimmed) return d;
   }
   return null;
 }
@@ -47,10 +53,22 @@ function wireToDisplay(wire: string): string {
   return d ? format(d, DISPLAY_FORMAT) : wire;
 }
 
-interface DateInputProps extends Omit<
-  ComponentProps<"input">,
-  "type" | "value" | "onChange" | "onBlur"
-> {
+/**
+ * Assigns a value to a React ref, handling both callback refs and ref objects.
+ */
+function assignRef<T>(ref: Ref<T> | undefined, value: T | null): void {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref && typeof ref === "object" && "current" in ref) {
+    (ref as React.MutableRefObject<T | null>).current = value;
+  }
+}
+
+interface DateInputProps
+  extends Omit<
+    ComponentProps<"input">,
+    "type" | "value" | "onChange" | "onBlur"
+  > {
   /** Date value in YYYY-MM-DD wire format. */
   value: string;
   /** Called with YYYY-MM-DD wire format string. */
@@ -58,6 +76,10 @@ interface DateInputProps extends Omit<
   onBlur?: () => void;
   /** Maximum selectable date in YYYY-MM-DD format. */
   max?: string;
+  /** Minimum selectable date in YYYY-MM-DD format. */
+  min?: string;
+  /** React 19 ref-as-prop */
+  ref?: Ref<HTMLInputElement>;
 }
 
 export function DateInput({
@@ -65,13 +87,16 @@ export function DateInput({
   onChange,
   onBlur,
   max,
+  min,
+  ref,
   className,
   disabled,
   ...props
 }: DateInputProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const internalRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);
   const [focused, setFocused] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
   // Local text tracks what the user is typing while focused
   const [localText, setLocalText] = useState("");
 
@@ -79,17 +104,53 @@ export function DateInput({
   // When focused, show the user's in-progress typed text.
   const displayValue = focused ? localText : wireToDisplay(value);
 
+  // Parse min/max to Date for calendar and validation
+  const maxDate = max ? (tryParseDate(max) ?? undefined) : undefined;
+  const minDate = min ? (tryParseDate(min) ?? undefined) : undefined;
+
+  // Build calendar disabled matcher combining min and max
+  const calendarDisabled = (() => {
+    const matchers: Array<{ before: Date } | { after: Date }> = [];
+    if (minDate) matchers.push({ before: minDate });
+    if (maxDate) matchers.push({ after: maxDate });
+    return matchers.length > 0 ? matchers : undefined;
+  })();
+
+  // Callback ref that assigns to both internal and forwarded ref
+  const mergedRef = useCallback(
+    (el: HTMLInputElement | null) => {
+      (internalRef as React.MutableRefObject<HTMLInputElement | null>).current =
+        el;
+      assignRef(ref, el);
+    },
+    [ref],
+  );
+
   const commitText = useCallback(
     (raw: string) => {
       const d = tryParseDate(raw);
       if (d) {
+        // Enforce max bound
+        if (maxDate && isAfter(d, maxDate)) {
+          setIsInvalid(true);
+          return;
+        }
+        // Enforce min bound
+        if (minDate && isBefore(d, minDate)) {
+          setIsInvalid(true);
+          return;
+        }
+        setIsInvalid(false);
         onChange(format(d, WIRE_FORMAT));
       } else if (!raw.trim()) {
+        setIsInvalid(false);
         onChange("");
+      } else {
+        // Non-empty but unparseable text — mark invalid
+        setIsInvalid(true);
       }
-      // If text is non-empty but unparseable, keep it so the user can fix it
     },
-    [onChange],
+    [onChange, maxDate, minDate],
   );
 
   function handleFocus() {
@@ -100,11 +161,8 @@ export function DateInput({
 
   function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
     setLocalText(e.target.value);
-    // Eagerly commit if the typed text is a valid date
-    const d = tryParseDate(e.target.value);
-    if (d) {
-      onChange(format(d, WIRE_FORMAT));
-    }
+    // Don't eagerly commit — let commitText on blur/Enter handle parsing.
+    // This prevents wrong intermediate dates from firing onChange.
   }
 
   function handleBlur() {
@@ -123,26 +181,24 @@ export function DateInput({
     if (date) {
       const wire = format(date, WIRE_FORMAT);
       onChange(wire);
+      setIsInvalid(false);
       // Also update local text in case input is still focused
       setLocalText(format(date, DISPLAY_FORMAT));
     }
     setOpen(false);
     // Return focus to the text input after picking
-    setTimeout(() => inputRef.current?.focus(), 0);
+    setTimeout(() => internalRef.current?.focus(), 0);
   }
 
   // Convert wire value to Date for the calendar's `selected` prop
   const selectedDate = value ? (tryParseDate(value) ?? undefined) : undefined;
 
-  // Convert max prop to Date for calendar's `disabled` matcher
-  const maxDate = max ? (tryParseDate(max) ?? undefined) : undefined;
-
   return (
     <div className="relative flex items-center">
       <input
-        ref={inputRef}
+        ref={mergedRef}
         type="text"
-        inputMode="numeric"
+        inputMode="text"
         data-slot="input"
         value={displayValue}
         onFocus={handleFocus}
@@ -151,8 +207,9 @@ export function DateInput({
         onKeyDown={handleKeyDown}
         placeholder="MM/DD/YYYY"
         disabled={disabled}
+        aria-invalid={isInvalid || undefined}
         className={cn(
-          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 pr-9 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 pr-11 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
           "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
           className,
@@ -166,8 +223,9 @@ export function DateInput({
             variant="ghost"
             size="icon"
             disabled={disabled}
-            className="absolute right-0 h-9 w-9 rounded-l-none text-muted-foreground hover:text-foreground"
+            className="absolute right-0 size-11 rounded-l-none text-muted-foreground hover:text-foreground"
             aria-label="Pick a date"
+            aria-expanded={open}
           >
             <CalendarIcon className="h-4 w-4" />
           </Button>
@@ -178,7 +236,7 @@ export function DateInput({
             selected={selectedDate}
             onSelect={handleCalendarSelect}
             defaultMonth={selectedDate}
-            disabled={maxDate ? { after: maxDate } : undefined}
+            disabled={calendarDisabled}
           />
         </PopoverContent>
       </Popover>

--- a/src/client/src/components/ui/date-input.tsx
+++ b/src/client/src/components/ui/date-input.tsx
@@ -1,0 +1,187 @@
+import { useState, useRef, useCallback, type ComponentProps } from "react";
+import { format, parse, isValid } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+/**
+ * Supported text input formats for parsing user-typed dates.
+ * Tried in order; first valid parse wins.
+ */
+const PARSE_FORMATS = [
+  "yyyy-MM-dd",
+  "MM/dd/yyyy",
+  "M/d/yyyy",
+  "MM-dd-yyyy",
+  "M-d-yyyy",
+  "MMddyyyy",
+  "yyyyMMdd",
+];
+
+/** Canonical wire format used by the rest of the app. */
+const WIRE_FORMAT = "yyyy-MM-dd";
+
+/** Display format shown to the user in the text input. */
+const DISPLAY_FORMAT = "MM/dd/yyyy";
+
+function tryParseDate(text: string): Date | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  for (const fmt of PARSE_FORMATS) {
+    const d = parse(trimmed, fmt, new Date());
+    if (isValid(d)) return d;
+  }
+  return null;
+}
+
+/** Convert a wire-format value to display text. */
+function wireToDisplay(wire: string): string {
+  if (!wire) return "";
+  const d = tryParseDate(wire);
+  return d ? format(d, DISPLAY_FORMAT) : wire;
+}
+
+interface DateInputProps extends Omit<
+  ComponentProps<"input">,
+  "type" | "value" | "onChange" | "onBlur"
+> {
+  /** Date value in YYYY-MM-DD wire format. */
+  value: string;
+  /** Called with YYYY-MM-DD wire format string. */
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  /** Maximum selectable date in YYYY-MM-DD format. */
+  max?: string;
+}
+
+export function DateInput({
+  value,
+  onChange,
+  onBlur,
+  max,
+  className,
+  disabled,
+  ...props
+}: DateInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [focused, setFocused] = useState(false);
+  // Local text tracks what the user is typing while focused
+  const [localText, setLocalText] = useState("");
+
+  // When not focused, always derive the display from the controlled prop.
+  // When focused, show the user's in-progress typed text.
+  const displayValue = focused ? localText : wireToDisplay(value);
+
+  const commitText = useCallback(
+    (raw: string) => {
+      const d = tryParseDate(raw);
+      if (d) {
+        onChange(format(d, WIRE_FORMAT));
+      } else if (!raw.trim()) {
+        onChange("");
+      }
+      // If text is non-empty but unparseable, keep it so the user can fix it
+    },
+    [onChange],
+  );
+
+  function handleFocus() {
+    setFocused(true);
+    // Initialize local text from the current wire value
+    setLocalText(wireToDisplay(value));
+  }
+
+  function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setLocalText(e.target.value);
+    // Eagerly commit if the typed text is a valid date
+    const d = tryParseDate(e.target.value);
+    if (d) {
+      onChange(format(d, WIRE_FORMAT));
+    }
+  }
+
+  function handleBlur() {
+    commitText(localText);
+    setFocused(false);
+    onBlur?.();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      commitText(localText);
+    }
+  }
+
+  function handleCalendarSelect(date: Date | undefined) {
+    if (date) {
+      const wire = format(date, WIRE_FORMAT);
+      onChange(wire);
+      // Also update local text in case input is still focused
+      setLocalText(format(date, DISPLAY_FORMAT));
+    }
+    setOpen(false);
+    // Return focus to the text input after picking
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  // Convert wire value to Date for the calendar's `selected` prop
+  const selectedDate = value ? (tryParseDate(value) ?? undefined) : undefined;
+
+  // Convert max prop to Date for calendar's `disabled` matcher
+  const maxDate = max ? (tryParseDate(max) ?? undefined) : undefined;
+
+  return (
+    <div className="relative flex items-center">
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode="numeric"
+        data-slot="input"
+        value={displayValue}
+        onFocus={handleFocus}
+        onChange={handleTextChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        placeholder="MM/DD/YYYY"
+        disabled={disabled}
+        className={cn(
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 pr-9 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          className,
+        )}
+        {...props}
+      />
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            disabled={disabled}
+            className="absolute right-0 h-9 w-9 rounded-l-none text-muted-foreground hover:text-foreground"
+            aria-label="Pick a date"
+          >
+            <CalendarIcon className="h-4 w-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="end">
+          <Calendar
+            mode="single"
+            selected={selectedDate}
+            onSelect={handleCalendarSelect}
+            defaultMonth={selectedDate}
+            disabled={maxDate ? { after: maxDate } : undefined}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/client/src/components/ui/date-input.tsx
+++ b/src/client/src/components/ui/date-input.tsx
@@ -2,6 +2,7 @@ import {
   useState,
   useRef,
   useCallback,
+  useMemo,
   type ComponentProps,
   type Ref,
 } from "react";
@@ -105,16 +106,22 @@ export function DateInput({
   const displayValue = focused ? localText : wireToDisplay(value);
 
   // Parse min/max to Date for calendar and validation
-  const maxDate = max ? (tryParseDate(max) ?? undefined) : undefined;
-  const minDate = min ? (tryParseDate(min) ?? undefined) : undefined;
+  const maxDate = useMemo(
+    () => (max ? (tryParseDate(max) ?? undefined) : undefined),
+    [max],
+  );
+  const minDate = useMemo(
+    () => (min ? (tryParseDate(min) ?? undefined) : undefined),
+    [min],
+  );
 
   // Build calendar disabled matcher combining min and max
-  const calendarDisabled = (() => {
+  const calendarDisabled = useMemo(() => {
     const matchers: Array<{ before: Date } | { after: Date }> = [];
     if (minDate) matchers.push({ before: minDate });
     if (maxDate) matchers.push({ after: maxDate });
     return matchers.length > 0 ? matchers : undefined;
-  })();
+  }, [minDate, maxDate]);
 
   // Callback ref that assigns to both internal and forwarded ref
   const mergedRef = useCallback(
@@ -141,16 +148,22 @@ export function DateInput({
           return;
         }
         setIsInvalid(false);
-        onChange(format(d, WIRE_FORMAT));
+        const wire = format(d, WIRE_FORMAT);
+        // Skip redundant onChange when value hasn't changed (e.g., calendar pick → blur)
+        if (wire !== value) {
+          onChange(wire);
+        }
       } else if (!raw.trim()) {
         setIsInvalid(false);
-        onChange("");
+        if (value !== "") {
+          onChange("");
+        }
       } else {
         // Non-empty but unparseable text — mark invalid
         setIsInvalid(true);
       }
     },
-    [onChange, maxDate, minDate],
+    [onChange, maxDate, minDate, value],
   );
 
   function handleFocus() {
@@ -174,6 +187,8 @@ export function DateInput({
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Enter") {
       commitText(localText);
+      // Blur triggers the normal blur flow which reformats the display
+      internalRef.current?.blur();
     }
   }
 
@@ -186,8 +201,6 @@ export function DateInput({
       setLocalText(format(date, DISPLAY_FORMAT));
     }
     setOpen(false);
-    // Return focus to the text input after picking
-    setTimeout(() => internalRef.current?.focus(), 0);
   }
 
   // Convert wire value to Date for the calendar's `selected` prop

--- a/src/client/src/pages/ApiKeys.tsx
+++ b/src/client/src/pages/ApiKeys.tsx
@@ -30,6 +30,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { DateInput } from "@/components/ui/date-input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
@@ -203,54 +204,61 @@ function ApiKeys() {
             </p>
           ) : (
             <div ref={tableRef}>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead>Last Used</TableHead>
-                  <TableHead>Expires</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {apiKeys.map((key, index) => {
-                  const status = getKeyStatus(key);
-                  return (
-                    <TableRow
-                      key={key.id}
-                      className={`cursor-pointer ${focusedId === key.id ? "bg-accent" : ""}`}
-                      onClick={(e) => {
-                        if ((e.target as HTMLElement).closest("button, input, a, [role='button']")) return;
-                        setFocusedIndex(index);
-                      }}
-                    >
-                      <TableCell className="font-medium">{key.name}</TableCell>
-                      <TableCell>{formatDate(key.createdAt)}</TableCell>
-                      <TableCell>{formatDate(key.lastUsedAt)}</TableCell>
-                      <TableCell>{formatDate(key.expiresAt)}</TableCell>
-                      <TableCell>
-                        <Badge variant={statusBadgeVariant(status)}>
-                          {status}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {status === "active" && (
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => setRevokeId(key.id)}
-                          >
-                            Revoke
-                          </Button>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Created</TableHead>
+                    <TableHead>Last Used</TableHead>
+                    <TableHead>Expires</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {apiKeys.map((key, index) => {
+                    const status = getKeyStatus(key);
+                    return (
+                      <TableRow
+                        key={key.id}
+                        className={`cursor-pointer ${focusedId === key.id ? "bg-accent" : ""}`}
+                        onClick={(e) => {
+                          if (
+                            (e.target as HTMLElement).closest(
+                              "button, input, a, [role='button']",
+                            )
+                          )
+                            return;
+                          setFocusedIndex(index);
+                        }}
+                      >
+                        <TableCell className="font-medium">
+                          {key.name}
+                        </TableCell>
+                        <TableCell>{formatDate(key.createdAt)}</TableCell>
+                        <TableCell>{formatDate(key.lastUsedAt)}</TableCell>
+                        <TableCell>{formatDate(key.expiresAt)}</TableCell>
+                        <TableCell>
+                          <Badge variant={statusBadgeVariant(status)}>
+                            {status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {status === "active" && (
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => setRevokeId(key.id)}
+                            >
+                              Revoke
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
             </div>
           )}
         </CardContent>
@@ -293,7 +301,7 @@ function ApiKeys() {
                   <FormItem>
                     <FormLabel>Expiration Date (optional)</FormLabel>
                     <FormControl>
-                      <Input type="date" {...field} />
+                      <DateInput {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -338,7 +338,9 @@ describe("Receipts", () => {
     await user.type(searchInput, "Walmart");
     await user.click(screen.getByText(/Use "Walmart"/));
 
-    await user.type(screen.getByLabelText(/date/i), "2024-01-15");
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.type(dateInput, "01/15/2024");
+    await user.tab(); // Commit on blur
     await user.type(screen.getByLabelText(/tax amount/i), "5.25");
     await user.click(screen.getByRole("button", { name: /create receipt/i }));
 

--- a/src/client/src/pages/wizard/NewReceipt.test.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.test.tsx
@@ -37,7 +37,8 @@ describe("NewReceipt", () => {
   it("renders Step1 (Trip Details) by default", () => {
     renderWithProviders(<NewReceipt />);
     expect(screen.getByLabelText(/location/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
+    expect(screen.getByText(/^date$/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("MM/DD/YYYY")).toBeInTheDocument();
   });
 
   it("renders the cancel button", () => {

--- a/src/client/src/pages/wizard/Step1TripDetails.test.tsx
+++ b/src/client/src/pages/wizard/Step1TripDetails.test.tsx
@@ -16,7 +16,7 @@ describe("Step1TripDetails", () => {
   it("renders the form fields", () => {
     renderWithProviders(<Step1TripDetails {...defaultProps} />);
     expect(screen.getByRole("combobox")).toBeInTheDocument();
-    expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("MM/DD/YYYY")).toBeInTheDocument();
     expect(screen.getByLabelText(/tax amount/i)).toBeInTheDocument();
   });
 
@@ -25,7 +25,7 @@ describe("Step1TripDetails", () => {
     renderWithProviders(<Step1TripDetails {...defaultProps} data={data} />);
     // Combobox shows raw value as text content when no matching option exists
     expect(screen.getByRole("combobox")).toHaveTextContent("Costco");
-    expect(screen.getByLabelText(/date/i)).toHaveValue("2024-03-15");
+    expect(screen.getByPlaceholderText("MM/DD/YYYY")).toHaveValue("03/15/2024");
   });
 
   it("renders the Next button", () => {

--- a/src/client/src/pages/wizard/Step1TripDetails.test.tsx
+++ b/src/client/src/pages/wizard/Step1TripDetails.test.tsx
@@ -16,6 +16,7 @@ describe("Step1TripDetails", () => {
   it("renders the form fields", () => {
     renderWithProviders(<Step1TripDetails {...defaultProps} />);
     expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByText(/^date$/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText("MM/DD/YYYY")).toBeInTheDocument();
     expect(screen.getByLabelText(/tax amount/i)).toBeInTheDocument();
   });

--- a/src/client/src/pages/wizard/Step1TripDetails.tsx
+++ b/src/client/src/pages/wizard/Step1TripDetails.tsx
@@ -6,7 +6,6 @@ import { useLocationHistory } from "@/hooks/useLocationHistory";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Combobox } from "@/components/ui/combobox";
-import { Input } from "@/components/ui/input";
 import { DateInput } from "@/components/ui/date-input";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import {

--- a/src/client/src/pages/wizard/Step1TripDetails.tsx
+++ b/src/client/src/pages/wizard/Step1TripDetails.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
+import { DateInput } from "@/components/ui/date-input";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import {
   Form,
@@ -104,8 +105,7 @@ export function Step1TripDetails({ data, onNext }: Step1Props) {
                 <FormItem>
                   <FormLabel>Date</FormLabel>
                   <FormControl>
-                    <Input
-                      type="date"
+                    <DateInput
                       aria-required="true"
                       max={new Date().toISOString().split("T")[0]}
                       {...field}

--- a/src/client/src/pages/wizard/Step2Transactions.test.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.test.tsx
@@ -35,7 +35,7 @@ describe("Step2Transactions", () => {
   it("renders the form fields", () => {
     renderWithProviders(<Step2Transactions {...defaultProps} />);
     expect(screen.getByLabelText(/amount/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("MM/DD/YYYY")).toBeInTheDocument();
   });
 
   it("renders Back and Next buttons", () => {
@@ -75,9 +75,7 @@ describe("Step2Transactions", () => {
     const data = [
       { id: "1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
     ];
-    renderWithProviders(
-      <Step2Transactions {...defaultProps} data={data} />,
-    );
+    renderWithProviders(<Step2Transactions {...defaultProps} data={data} />);
     expect(screen.getByText("$25.50")).toBeInTheDocument();
   });
 });

--- a/src/client/src/pages/wizard/Step2Transactions.test.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.test.tsx
@@ -35,6 +35,7 @@ describe("Step2Transactions", () => {
   it("renders the form fields", () => {
     renderWithProviders(<Step2Transactions {...defaultProps} />);
     expect(screen.getByLabelText(/amount/i)).toBeInTheDocument();
+    expect(screen.getByText(/^date$/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText("MM/DD/YYYY")).toBeInTheDocument();
   });
 

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -7,7 +7,7 @@ import { accountToOption } from "@/lib/combobox-options";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
+import { DateInput } from "@/components/ui/date-input";
 import { Combobox } from "@/components/ui/combobox";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import { Badge } from "@/components/ui/badge";
@@ -175,7 +175,7 @@ export function Step2Transactions({
                 <FormItem>
                   <FormLabel>Date</FormLabel>
                   <FormControl>
-                    <Input type="date" aria-required="true" {...field} />
+                    <DateInput aria-required="true" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
## Summary
- Created a new `DateInput` component (`src/client/src/components/ui/date-input.tsx`) that replaces Chrome's native `<input type="date">` with a text input + calendar popover hybrid
- The text input accepts multiple date formats (MM/DD/YYYY, YYYY-MM-DD, M/D/YYYY, etc.) and eagerly validates as the user types
- A calendar icon button opens a react-day-picker calendar dropdown for point-and-click date selection
- Replaced all 6 `<Input type="date">` usages across ReceiptForm, TransactionForm, FilterPanel, ApiKeys, Step1TripDetails, and Step2Transactions

## Technical Details
- Uses the existing `react-day-picker` and `date-fns` dependencies (already in package.json)
- Wire format remains `YYYY-MM-DD` for API compatibility; display format is `MM/DD/YYYY`
- Follows the same controlled-component pattern as `CurrencyInput` (focused/unfocused state derivation, no useEffect for state sync)
- Passes ESLint, TypeScript, and all existing + new tests (12 new DateInput tests, 78 total affected tests passing)

## Test plan
- [x] New `date-input.test.tsx` with 12 tests covering rendering, typing, formatting, blur behavior, disabled state, controlled value updates, and accessibility
- [x] All existing tests for modified components pass (ReceiptForm, TransactionForm, FilterPanel, ApiKeys, Step1TripDetails, Step2Transactions)
- [x] TypeScript compilation clean
- [x] ESLint clean (no new errors/warnings)
- [x] Full pre-commit pipeline passed (207 .NET tests + frontend checks)
- [ ] Manual verification: test date typing in various formats
- [ ] Manual verification: test calendar picker dropdown
- [ ] Manual verification: test with keyboard navigation

Closes MGG-324

🤖 Generated with [Claude Code](https://claude.com/claude-code)