### PR TITLE
feat(client): replace Select dropdowns with Combobox for type-ahead filtering

### DIFF
--- a/src/client/src/components/AdjustmentForm.tsx
+++ b/src/client/src/components/AdjustmentForm.tsx
@@ -6,13 +6,7 @@ import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { CurrencyInput } from "@/components/ui/currency-input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Combobox } from "@/components/ui/combobox";
 import {
   Form,
   FormControl,
@@ -94,18 +88,13 @@ export function AdjustmentForm({
             <FormItem>
               <FormLabel>Type</FormLabel>
               <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select adjustment type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {ADJUSTMENT_TYPES.map((t) => (
-                      <SelectItem key={t.value} value={t.value}>
-                        {t.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <Combobox
+                  options={[...ADJUSTMENT_TYPES]}
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  placeholder="Select adjustment type..."
+                  searchPlaceholder="Search types..."
+                />
               </FormControl>
               <FormMessage />
               {serverErrors?.type && (

--- a/src/client/src/components/FilterPanel.tsx
+++ b/src/client/src/components/FilterPanel.tsx
@@ -4,13 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Combobox } from "@/components/ui/combobox";
 import {
   Collapsible,
   CollapsibleContent,
@@ -149,37 +143,34 @@ export function FilterPanel({
             <div key={field.key} className="min-w-[180px] space-y-1.5">
               <Label className="text-xs">{field.label}</Label>
               {field.type === "select" && (
-                <Select
+                <Combobox
+                  options={[
+                    { value: "all", label: "All" },
+                    ...field.options.map((opt) => ({
+                      value: opt,
+                      label: opt,
+                    })),
+                  ]}
                   value={(values[field.key] as string) ?? "all"}
                   onValueChange={(v) => updateField(field.key, v)}
-                >
-                  <SelectTrigger className="h-8 text-xs">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    {field.options.map((opt) => (
-                      <SelectItem key={opt} value={opt}>
-                        {opt}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  placeholder="All"
+                  searchPlaceholder="Search..."
+                  className="h-8 text-xs"
+                />
               )}
               {field.type === "boolean" && (
-                <Select
+                <Combobox
+                  options={[
+                    { value: "all", label: "All" },
+                    { value: "true", label: "Yes" },
+                    { value: "false", label: "No" },
+                  ]}
                   value={(values[field.key] as string) ?? "all"}
                   onValueChange={(v) => updateField(field.key, v)}
-                >
-                  <SelectTrigger className="h-8 text-xs">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    <SelectItem value="true">Yes</SelectItem>
-                    <SelectItem value="false">No</SelectItem>
-                  </SelectContent>
-                </Select>
+                  placeholder="All"
+                  searchPlaceholder="Search..."
+                  className="h-8 text-xs"
+                />
               )}
               {field.type === "dateRange" && (
                 <div className="flex gap-2">

--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -10,13 +10,6 @@ import { CurrencyInput } from "@/components/ui/currency-input";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Form,
   FormControl,
   FormField,
@@ -201,20 +194,18 @@ export function ItemTemplateForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Default Pricing Mode (optional)</FormLabel>
-                <Select
-                  value={field.value ?? ""}
-                  onValueChange={field.onChange}
-                >
-                  <FormControl>
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select pricing mode..." />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="quantity">Quantity</SelectItem>
-                    <SelectItem value="flat">Flat</SelectItem>
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <Combobox
+                    options={[
+                      { value: "quantity", label: "Quantity" },
+                      { value: "flat", label: "Flat" },
+                    ]}
+                    value={field.value ?? ""}
+                    onValueChange={field.onChange}
+                    placeholder="Select pricing mode..."
+                    searchPlaceholder="Search modes..."
+                  />
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -29,13 +29,6 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Form,
   FormControl,
   FormField,
@@ -375,15 +368,16 @@ export function ReceiptItemForm({
             <FormItem>
               <FormLabel>Pricing Mode</FormLabel>
               <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select pricing mode" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="quantity">Qty x Unit Price</SelectItem>
-                    <SelectItem value="flat">Flat Price</SelectItem>
-                  </SelectContent>
-                </Select>
+                <Combobox
+                  options={[
+                    { value: "quantity", label: "Qty x Unit Price" },
+                    { value: "flat", label: "Flat Price" },
+                  ]}
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  placeholder="Select pricing mode..."
+                  searchPlaceholder="Search modes..."
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -48,13 +48,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Combobox } from "@/components/ui/combobox";
 import {
   Form,
   FormControl,
@@ -66,7 +60,10 @@ import {
 import { Label } from "@/components/ui/label";
 import { Pencil } from "lucide-react";
 
-const AVAILABLE_ROLES = ["Admin", "User"];
+const ROLE_OPTIONS = [
+  { value: "Admin", label: "Admin" },
+  { value: "User", label: "User" },
+];
 
 const createUserSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
@@ -430,23 +427,15 @@ function AdminUsers() {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Role</FormLabel>
-                    <Select
-                      onValueChange={field.onChange}
-                      defaultValue={field.value}
-                    >
-                      <FormControl>
-                        <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Select a role" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {AVAILABLE_ROLES.map((role) => (
-                          <SelectItem key={role} value={role}>
-                            {role}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <Combobox
+                        options={ROLE_OPTIONS}
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        placeholder="Select a role..."
+                        searchPlaceholder="Search roles..."
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -528,23 +517,15 @@ function AdminUsers() {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Role</FormLabel>
-                    <Select
-                      onValueChange={field.onChange}
-                      value={field.value}
-                    >
-                      <FormControl>
-                        <SelectTrigger className="w-full">
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {AVAILABLE_ROLES.map((role) => (
-                          <SelectItem key={role} value={role}>
-                            {role}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <Combobox
+                        options={ROLE_OPTIONS}
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        placeholder="Select a role..."
+                        searchPlaceholder="Search roles..."
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/src/client/src/pages/AuditLog.tsx
+++ b/src/client/src/pages/AuditLog.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { format } from "date-fns";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useRecentAuditLogs } from "@/hooks/useAudit";
@@ -21,13 +21,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Combobox } from "@/components/ui/combobox";
 import { cn } from "@/lib/utils";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 
@@ -196,6 +190,25 @@ function AuditLog() {
     [pagination],
   );
 
+  const entityTypeOptions = useMemo(
+    () => [
+      { value: "all", label: "All Types" },
+      ...ENTITY_TYPES.map((t) => ({ value: t, label: ENTITY_TYPE_LABELS[t] })),
+    ],
+    [],
+  );
+
+  const actionOptions = useMemo(
+    () => [
+      { value: "all", label: "All Actions" },
+      ...ACTION_TYPES.map((a) => ({
+        value: ACTION_FILTER_VALUES[a] ?? a,
+        label: a,
+      })),
+    ],
+    [],
+  );
+
   const { data, isLoading } = useRecentAuditLogs({
     offset: pagination.offset,
     limit: pagination.limit,
@@ -236,32 +249,22 @@ function AuditLog() {
           }}
           className="max-w-xs"
         />
-        <Select value={entityTypeFilter} onValueChange={handleEntityTypeChange}>
-          <SelectTrigger className="w-[160px]">
-            <SelectValue placeholder="Entity Type" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Types</SelectItem>
-            {ENTITY_TYPES.map((t) => (
-              <SelectItem key={t} value={t}>
-                {ENTITY_TYPE_LABELS[t]}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Select value={actionFilter} onValueChange={handleActionChange}>
-          <SelectTrigger className="w-[140px]">
-            <SelectValue placeholder="Action" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Actions</SelectItem>
-            {ACTION_TYPES.map((a) => (
-              <SelectItem key={a} value={ACTION_FILTER_VALUES[a] ?? a}>
-                {a}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Combobox
+          options={entityTypeOptions}
+          value={entityTypeFilter}
+          onValueChange={handleEntityTypeChange}
+          placeholder="Entity Type"
+          searchPlaceholder="Search types..."
+          className="w-[160px]"
+        />
+        <Combobox
+          options={actionOptions}
+          value={actionFilter}
+          onValueChange={handleActionChange}
+          placeholder="Action"
+          searchPlaceholder="Search actions..."
+          className="w-[140px]"
+        />
         <DateRangePicker
           from={dateFrom}
           to={dateTo}

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -19,13 +19,6 @@ import { Combobox } from "@/components/ui/combobox";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import { Badge } from "@/components/ui/badge";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Form,
   FormControl,
   FormField,
@@ -391,23 +384,21 @@ export function Step3Items({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Pricing Mode</FormLabel>
-                  <Select
-                    onValueChange={(v) => {
-                      field.onChange(v);
-                      if (v === "flat") form.setValue("quantity", 1);
-                    }}
-                    value={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="quantity">Quantity</SelectItem>
-                      <SelectItem value="flat">Flat</SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <FormControl>
+                    <Combobox
+                      options={[
+                        { value: "quantity", label: "Quantity" },
+                        { value: "flat", label: "Flat" },
+                      ]}
+                      value={field.value}
+                      onValueChange={(v) => {
+                        field.onChange(v);
+                        if (v === "flat") form.setValue("quantity", 1);
+                      }}
+                      placeholder="Select pricing mode..."
+                      searchPlaceholder="Search modes..."
+                    />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION
## Summary
- Replace all `<Select>` dropdown components with the existing `<Combobox>` component across 7 files to add type-ahead search/filtering to every dropdown in the app
- Converted: adjustment type, pricing mode, role selectors, audit log entity type/action filters, and generic FilterPanel select/boolean fields
- Pagination page-size selector intentionally kept as `<Select>` since type-ahead adds no value to infrastructure UI

Resolves MGG-320

## Test plan
- All 84 existing tests pass (AdjustmentForm, FilterPanel, AdminUsers, AuditLog, ReceiptItemForm, ItemTemplateForm, Step3Items, Combobox)
- Open any form with a dropdown (e.g., create adjustment, create receipt item, audit log filters) and verify:
  - Clicking the dropdown opens a popover with a search input
  - Typing narrows the option list to matching entries
  - Selecting an option closes the popover and updates the form value
  - Side effects are preserved (e.g., selecting "flat" pricing mode sets quantity to 1)