### PR TITLE
fix(client): wrap custom hook returns in useMemo for referential stability (MGG-327)

### DIFF
--- a/src/client/src/hooks/useBreadcrumbs.ts
+++ b/src/client/src/hooks/useBreadcrumbs.ts
@@ -1,4 +1,5 @@
 import { useLocation } from "react-router";
+import { useMemo } from "react";
 
 const routeLabels: Record<string, string> = {
   "/": "Home",
@@ -33,27 +34,31 @@ export interface BreadcrumbSegment {
   path: string;
 }
 
+const EMPTY: BreadcrumbSegment[] = [];
+
 export function useBreadcrumbs(): BreadcrumbSegment[] {
   const { pathname } = useLocation();
 
-  if (pathname === "/") return [];
+  return useMemo(() => {
+    if (pathname === "/") return EMPTY;
 
-  const crumbs: BreadcrumbSegment[] = [{ label: "Home", path: "/" }];
+    const crumbs: BreadcrumbSegment[] = [{ label: "Home", path: "/" }];
 
-  // Handle nested paths like /admin/users
-  const label = routeLabels[pathname];
-  if (label) {
-    crumbs.push({ label, path: pathname });
-  } else {
-    // Build segments for unknown paths
-    const parts = pathname.split("/").filter(Boolean);
-    let accumulated = "";
-    for (const part of parts) {
-      accumulated += `/${part}`;
-      const segLabel = routeLabels[accumulated] ?? toTitleCase(part);
-      crumbs.push({ label: segLabel, path: accumulated });
+    // Handle nested paths like /admin/users
+    const label = routeLabels[pathname];
+    if (label) {
+      crumbs.push({ label, path: pathname });
+    } else {
+      // Build segments for unknown paths
+      const parts = pathname.split("/").filter(Boolean);
+      let accumulated = "";
+      for (const part of parts) {
+        accumulated += `/${part}`;
+        const segLabel = routeLabels[accumulated] ?? toTitleCase(part);
+        crumbs.push({ label: segLabel, path: accumulated });
+      }
     }
-  }
 
-  return crumbs;
+    return crumbs;
+  }, [pathname]);
 }

--- a/src/client/src/hooks/useEntityLinkParams.ts
+++ b/src/client/src/hooks/useEntityLinkParams.ts
@@ -25,5 +25,8 @@ export function useEntityLinkParams<T extends string>(recognizedParams: readonly
 
   const hasActiveFilter = Object.keys(params).length > 0;
 
-  return { params, clearParams, hasActiveFilter };
+  return useMemo(
+    () => ({ params, clearParams, hasActiveFilter }),
+    [params, clearParams, hasActiveFilter],
+  );
 }

--- a/src/client/src/hooks/useFuzzySearch.ts
+++ b/src/client/src/hooks/useFuzzySearch.ts
@@ -58,12 +58,10 @@ export function useFuzzySearch<T>({
     setDebouncedSearch("");
   }, []);
 
-  return {
-    search,
-    setSearch,
-    results,
-    totalCount: data.length,
-    isSearching,
-    clearSearch,
-  };
+  const totalCount = data.length;
+
+  return useMemo(
+    () => ({ search, setSearch, results, totalCount, isSearching, clearSearch }),
+    [search, setSearch, results, totalCount, isSearching, clearSearch],
+  );
 }

--- a/src/client/src/hooks/useGlobalShortcuts.ts
+++ b/src/client/src/hooks/useGlobalShortcuts.ts
@@ -5,12 +5,14 @@ import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
 
 export function useGlobalShortcuts() {
   const ctx = useContext(ShortcutsContext);
+  const helpOpen = ctx?.helpOpen;
+  const setHelpOpen = ctx?.setHelpOpen;
 
   // ? — Toggle help modal (useKeyboardShortcut because react-hotkeys-hook
   // doesn't match the "?" key)
   const toggleHelp = useCallback(
-    () => ctx?.setHelpOpen(!ctx?.helpOpen),
-    [ctx],
+    () => setHelpOpen?.(!helpOpen),
+    [helpOpen, setHelpOpen],
   );
   useKeyboardShortcut({
     key: "?",

--- a/src/client/src/hooks/usePagination.ts
+++ b/src/client/src/hooks/usePagination.ts
@@ -1,4 +1,4 @@
-import { useReducer, useMemo, useCallback } from "react";
+import { useCallback, useMemo, useReducer } from "react";
 import { getPersistedPageSize, persistPageSize } from "@/lib/page-size";
 
 interface UsePaginationOptions<T> {
@@ -68,13 +68,24 @@ export function usePagination<T>({
     dispatch({ type: "SET_PAGE_SIZE", size });
   }, []);
 
-  return {
-    paginatedItems,
-    currentPage: safePage,
-    pageSize: state.pageSize,
-    totalItems,
-    totalPages,
-    setPage,
-    setPageSize,
-  };
+  return useMemo(
+    () => ({
+      paginatedItems,
+      currentPage: safePage,
+      pageSize: state.pageSize,
+      totalItems,
+      totalPages,
+      setPage,
+      setPageSize,
+    }),
+    [
+      paginatedItems,
+      safePage,
+      state.pageSize,
+      totalItems,
+      totalPages,
+      setPage,
+      setPageSize,
+    ],
+  );
 }

--- a/src/client/src/hooks/useSavedFilters.ts
+++ b/src/client/src/hooks/useSavedFilters.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import type { FilterPreset } from "@/lib/search";
 import {
   getSavedFilters,
@@ -27,5 +27,5 @@ export function useSavedFilters(entityType: string) {
     [entityType],
   );
 
-  return { filters, save, remove };
+  return useMemo(() => ({ filters, save, remove }), [filters, save, remove]);
 }

--- a/src/client/src/hooks/useSearchHistory.ts
+++ b/src/client/src/hooks/useSearchHistory.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import {
   getSearchHistory,
   addSearchHistoryEntry,
@@ -18,5 +18,8 @@ export function useSearchHistory() {
     setHistory([]);
   }, []);
 
-  return { history, addEntry, clearAll };
+  return useMemo(
+    () => ({ history, addEntry, clearAll }),
+    [history, addEntry, clearAll],
+  );
 }

--- a/src/client/src/hooks/useServerPagination.ts
+++ b/src/client/src/hooks/useServerPagination.ts
@@ -72,14 +72,25 @@ export function useServerPagination({
     dispatch({ type: "SET_OFFSET", offset: 0 });
   }, []);
 
-  return {
-    offset: state.offset,
-    limit: state.limit,
-    currentPage,
-    pageSize: state.limit,
-    totalPages,
-    setPage,
-    setPageSize,
-    resetPage,
-  };
+  return useMemo(
+    () => ({
+      offset: state.offset,
+      limit: state.limit,
+      currentPage,
+      pageSize: state.limit,
+      totalPages,
+      setPage,
+      setPageSize,
+      resetPage,
+    }),
+    [
+      state.offset,
+      state.limit,
+      currentPage,
+      totalPages,
+      setPage,
+      setPageSize,
+      resetPage,
+    ],
+  );
 }

--- a/src/client/src/hooks/useServerSort.ts
+++ b/src/client/src/hooks/useServerSort.ts
@@ -1,5 +1,5 @@
 import { useSearchParams } from "react-router";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 interface UseServerSortOptions {
   defaultSortBy?: string;
@@ -41,5 +41,8 @@ export function useServerSort({
     [sortBy, sortDirection, setSearchParams],
   );
 
-  return { sortBy, sortDirection, toggleSort };
+  return useMemo(
+    () => ({ sortBy, sortDirection, toggleSort }),
+    [sortBy, sortDirection, toggleSort],
+  );
 }

--- a/src/client/src/hooks/useSubmitTimeout.ts
+++ b/src/client/src/hooks/useSubmitTimeout.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const WARNING_DELAY_MS = 5_000;
 
@@ -31,5 +31,7 @@ export function useSubmitTimeout(isSubmitting: boolean): {
     return () => clearTimeout(timer);
   }, [isSubmitting, submitGeneration]);
 
-  return { isWarning: isSubmitting && warningGeneration === submitGeneration };
+  const isWarning = isSubmitting && warningGeneration === submitGeneration;
+
+  return useMemo(() => ({ isWarning }), [isWarning]);
 }


### PR DESCRIPTION
## Summary

- Wrapped `useBreadcrumbs` array return in `useMemo` keyed on `pathname`, with a module-level `EMPTY` constant for the root-path early return
- Narrowed `useGlobalShortcuts` callback deps from the full context object (`[ctx]`) to individual properties (`[helpOpen, setHelpOpen]`)
- Wrapped return objects in `useMemo` with correct dependency arrays for 8 hooks: `useServerSort`, `useSavedFilters`, `useSearchHistory`, `useEntityLinkParams`, `useFuzzySearch`, `usePagination`, `useServerPagination`, `useSubmitTimeout`

Resolves MGG-327

## Test plan

- [x] All 257 hook tests pass (`npx vitest run src/hooks/`)
- [x] `tsc -b --noEmit` clean
- [x] ESLint clean on all changed files
- [x] Full pre-commit hook passes (8/8 steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)