### PR TITLE
fix: align pre-commit tsc check with CI build pipeline (MGG-329)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -46,7 +46,7 @@ if [ "${PRECOMMIT_QUICK:-}" != "1" ]; then
 fi
 
 next_step "Checking TypeScript types..."
-npx tsc --noEmit --project src/client/tsconfig.json
+npx tsc -b src/client/tsconfig.json --noEmit
 
 next_step "Linting React client..."
 npx eslint src/client/src

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Validates the commit message against the Conventional Commits convention using `
 3. `dotnet build -p:TreatWarningsAsErrors=true` — build (also regenerates DTOs and `openapi/generated/API.json`)
 4. `node scripts/check-drift.mjs` — semantic drift detection
 5. `dotnet test --no-build --filter "Category!=Integration"` — run unit tests
-6. `npx tsc --noEmit` — TypeScript type checking
+6. `npx tsc -b --noEmit` — TypeScript type checking
 7. `npx eslint src/client/src` — React client linting
 
 **Quick mode** runs only steps 0, 2, 6, 7 (prerequisites, format, tsc, eslint):


### PR DESCRIPTION
## Summary
- Switched pre-commit hook from `tsc --noEmit` (standalone mode) to `tsc -b --noEmit` (build mode) to match CI semantics
- Updated AGENTS.md pipeline documentation to reflect the new command
- Eliminates the class of CI-only type errors seen in MGG-305, where standalone mode missed errors that build mode caught

## Test plan
- [x] `npx tsc -b src/client/tsconfig.json --noEmit` passes from repo root
- [x] Pre-commit hook runs successfully with the new command
- [ ] CI passes with same `tsc -b` semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)