### PR TITLE
fix(ci): trigger Docker publish only on release tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,6 @@ name: Docker Publish
 
 on:
   push:
-    branches: ["main"]
     tags: ["v*.*.*"]
 
 env:
@@ -114,7 +113,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
## Summary
- Remove `branches: ["main"]` trigger from `docker-publish.yml` so images are only built on `v*.*.*` tag pushes (created by release-please)
- Fix `latest` tag logic: replace `enable={{is_default_branch}}` (always false for tag refs) with unconditional apply

## Test plan
- [ ] CI passes on this PR
- [ ] Next release-please tag triggers Docker publish as expected
- [ ] Merging a normal PR to main no longer triggers Docker publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)