### PR TITLE
fix(client): crash on category select — paginated response treated as array (MGG-338)

### DIFF
--- a/src/client/src/components/ItemTemplateForm.test.tsx
+++ b/src/client/src/components/ItemTemplateForm.test.tsx
@@ -24,19 +24,23 @@ vi.mock("@/hooks/useEnumMetadata", () => ({
 
 vi.mock("@/hooks/useCategories", () => ({
   useCategories: vi.fn(() => ({
-    data: [
-      { id: "cat-1", name: "Groceries" },
-      { id: "cat-2", name: "Electronics" },
-    ],
+    data: {
+      data: [
+        { id: "cat-1", name: "Groceries" },
+        { id: "cat-2", name: "Electronics" },
+      ],
+    },
   })),
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
   useSubcategoriesByCategoryId: vi.fn(() => ({
-    data: [
-      { id: "sub-1", name: "Dairy" },
-      { id: "sub-2", name: "Bakery" },
-    ],
+    data: {
+      data: [
+        { id: "sub-1", name: "Dairy" },
+        { id: "sub-2", name: "Bakery" },
+      ],
+    },
   })),
 }));
 

--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -53,7 +53,7 @@ export function ItemTemplateForm({
 
   const { data: categories } = useCategories();
   const categoryOptions =
-    (categories as { id: string; name: string }[] | undefined)?.map((c) => ({
+    (categories?.data as { id: string; name: string }[] | undefined)?.map((c) => ({
       value: c.name,
       label: c.name,
     })) ?? [];
@@ -77,7 +77,7 @@ export function ItemTemplateForm({
   const watchedCategory = form.watch("defaultCategory");
 
   const selectedCategoryId =
-    (categories as { id: string; name: string }[] | undefined)?.find(
+    (categories?.data as { id: string; name: string }[] | undefined)?.find(
       (c) => c.name === watchedCategory,
     )?.id ?? null;
 
@@ -85,7 +85,7 @@ export function ItemTemplateForm({
     useSubcategoriesByCategoryId(selectedCategoryId);
 
   const subcategoryOptions =
-    (subcategoriesData as { id: string; name: string }[] | undefined)?.map(
+    (subcategoriesData?.data as { id: string; name: string }[] | undefined)?.map(
       (s) => ({
         value: s.name,
         label: s.name,

--- a/src/client/src/components/ReceiptItemForm.test.tsx
+++ b/src/client/src/components/ReceiptItemForm.test.tsx
@@ -25,28 +25,34 @@ vi.mock("@/hooks/useEnumMetadata", () => ({
 
 vi.mock("@/hooks/useReceipts", () => ({
   useReceipts: vi.fn(() => ({
-    data: [
-      { id: "r-1", location: "Walmart", date: "2024-01-15" },
-    ],
+    data: {
+      data: [
+        { id: "r-1", location: "Walmart", date: "2024-01-15" },
+      ],
+    },
     isLoading: false,
   })),
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
   useCategories: vi.fn(() => ({
-    data: [
-      { id: "cat-1", name: "Groceries" },
-      { id: "cat-2", name: "Electronics" },
-    ],
+    data: {
+      data: [
+        { id: "cat-1", name: "Groceries" },
+        { id: "cat-2", name: "Electronics" },
+      ],
+    },
   })),
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
   useSubcategoriesByCategoryId: vi.fn(() => ({
-    data: [
-      { id: "sub-1", name: "Dairy" },
-      { id: "sub-2", name: "Bakery" },
-    ],
+    data: {
+      data: [
+        { id: "sub-1", name: "Dairy" },
+        { id: "sub-2", name: "Bakery" },
+      ],
+    },
   })),
   useCreateSubcategory: vi.fn(() => ({
     mutateAsync: vi.fn(),
@@ -55,16 +61,18 @@ vi.mock("@/hooks/useSubcategories", () => ({
 
 vi.mock("@/hooks/useItemTemplates", () => ({
   useItemTemplates: vi.fn(() => ({
-    data: [
-      {
-        id: "tmpl-1",
-        name: "Milk",
-        defaultCategory: "Groceries",
-        defaultSubcategory: "Dairy",
-        defaultUnitPrice: 3.99,
-        defaultItemCode: "MLK-001",
-      },
-    ],
+    data: {
+      data: [
+        {
+          id: "tmpl-1",
+          name: "Milk",
+          defaultCategory: "Groceries",
+          defaultSubcategory: "Dairy",
+          defaultUnitPrice: 3.99,
+          defaultItemCode: "MLK-001",
+        },
+      ],
+    },
   })),
 }));
 

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -101,14 +101,14 @@ export function ReceiptItemForm({
   const categories = categoriesResponse?.data as { id: string; name: string }[] | undefined;
   const { data: itemTemplatesData } = useItemTemplates();
   const templates = useMemo(
-    () => (itemTemplatesData as ItemTemplate[] | undefined) ?? [],
+    () => (itemTemplatesData?.data as ItemTemplate[] | undefined) ?? [],
     [itemTemplatesData],
   );
 
   const receiptOptions = useMemo(
     () =>
       (
-        (receipts as
+        (receipts?.data as
           | {
               id: string;
               location: string;
@@ -161,7 +161,7 @@ export function ReceiptItemForm({
   const subcategoryOptions = useMemo(
     () =>
       (
-        (subcategoriesData as { id: string; name: string }[] | undefined) ?? []
+        (subcategoriesData?.data as { id: string; name: string }[] | undefined) ?? []
       ).map((s) => ({
         value: s.name,
         label: s.name,

--- a/src/client/src/components/SubcategoryForm.test.tsx
+++ b/src/client/src/components/SubcategoryForm.test.tsx
@@ -9,10 +9,12 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
 
 vi.mock("@/hooks/useCategories", () => ({
   useCategories: vi.fn(() => ({
-    data: [
-      { id: "cat-1", name: "Groceries" },
-      { id: "cat-2", name: "Utilities" },
-    ],
+    data: {
+      data: [
+        { id: "cat-1", name: "Groceries" },
+        { id: "cat-2", name: "Utilities" },
+      ],
+    },
   })),
 }));
 

--- a/src/client/src/components/SubcategoryForm.tsx
+++ b/src/client/src/components/SubcategoryForm.tsx
@@ -49,7 +49,7 @@ export function SubcategoryForm({
   const { data: categories } = useCategories();
 
   const categoryOptions = (
-    categories as { id: string; name: string }[] | undefined
+    categories?.data as { id: string; name: string }[] | undefined
   )?.map((c) => ({
     value: c.id,
     label: c.name,

--- a/src/client/src/components/ui/combobox.tsx
+++ b/src/client/src/components/ui/combobox.tsx
@@ -89,6 +89,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
         <PopoverContent
           className="w-[--radix-popover-trigger-width] p-0"
           align="start"
+          aria-describedby={undefined}
         >
           <Command>
             <CommandInput

--- a/src/client/src/pages/ItemTemplates.test.tsx
+++ b/src/client/src/pages/ItemTemplates.test.tsx
@@ -80,11 +80,11 @@ vi.mock("@/hooks/useListKeyboardNav", () => ({
 
 // Mocks needed by ItemTemplateForm (rendered inside dialogs)
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({ data: [], isLoading: false })),
+  useCategories: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategoriesByCategoryId: vi.fn(() => ({ data: [], isLoading: false })),
+  useSubcategoriesByCategoryId: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
 }));
 
 vi.mock("@/hooks/usePagination", () => ({

--- a/src/client/src/pages/ReceiptItems.test.tsx
+++ b/src/client/src/pages/ReceiptItems.test.tsx
@@ -81,21 +81,21 @@ vi.mock("@/hooks/useListKeyboardNav", () => ({
 
 // Mocks needed by ReceiptItemForm (rendered inside dialogs)
 vi.mock("@/hooks/useReceipts", () => ({
-  useReceipts: vi.fn(() => ({ data: [], isLoading: false })),
+  useReceipts: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({ data: [], isLoading: false })),
+  useCategories: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategories: vi.fn(() => ({ data: [], isLoading: false })),
-  useSubcategoriesByCategoryId: vi.fn(() => ({ data: [], isLoading: false })),
+  useSubcategories: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
+  useSubcategoriesByCategoryId: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
   useCreateSubcategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/hooks/useItemTemplates", () => ({
-  useItemTemplates: vi.fn(() => ({ data: [], isLoading: false })),
+  useItemTemplates: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
 }));
 
 vi.mock("@/hooks/usePagination", () => ({

--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@/hooks/useSubcategories", () => ({
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({ data: [], isLoading: false })),
+  useCategories: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useFuzzySearch", () => ({
@@ -122,12 +122,9 @@ async function setupWithData(items = ITEMS, categories = CATEGORIES) {
   );
 
   const { useCategories } = await import("@/hooks/useCategories");
-  // Use Object.assign to create an array with a .data property so both
-  // the page (accesses .data) and SubcategoryForm (iterates directly) work.
-  const catData = Object.assign([...categories], { data: categories });
   vi.mocked(useCategories).mockReturnValue(
     mockQueryResult({
-      data: catData,
+      data: { data: categories },
       isLoading: false,
     }),
   );

--- a/src/client/src/pages/wizard/Step3Items.test.tsx
+++ b/src/client/src/pages/wizard/Step3Items.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@/hooks/useCategories", () => ({
 vi.mock("@/hooks/useSubcategories", () => ({
   useSubcategoriesByCategoryId: vi.fn(() =>
     mockQueryResult({
-      data: [],
+      data: { data: [] },
       isLoading: false,
       isSuccess: true,
     }),

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -129,7 +129,7 @@ export function Step3Items({
   const subcategoryOptions = useMemo(
     () =>
       (
-        (subcategories as { id: string; name: string }[] | undefined) ?? []
+        (subcategories?.data as { id: string; name: string }[] | undefined) ?? []
       ).map((s) => ({ value: s.name, label: s.name })),
     [subcategories],
   );


### PR DESCRIPTION
## Summary
- Fix `TypeError: .map is not a function` crash when selecting a category in `ReceiptItemForm` and related forms
- List hooks (`useCategories`, `useSubcategories`, `useReceipts`, `useItemTemplates`) return paginated response objects `{ data, total, offset, limit }`, but several components cast the response directly as an array
- Add `.data` accessor in `ReceiptItemForm`, `ItemTemplateForm`, `SubcategoryForm`, and `Step3Items` to match the pattern already used in `GlobalSearchDialog`, `TransactionForm`, `Subcategories`, etc.
- Suppress Radix UI `aria-describedby` warning in `Combobox` by passing `aria-describedby={undefined}` to `PopoverContent`

## Test plan
- [x] All 788 .NET backend tests pass
- [x] Pre-commit hooks pass (TypeScript type check, ESLint)
- [x] No new lint warnings introduced
- [ ] Manual: select a category in ReceiptItemForm — no crash
- [ ] Manual: create/edit item template — category and subcategory dropdowns populate
- [ ] Manual: create subcategory — category dropdown populates
- [ ] Manual: wizard Step 3 — subcategory dropdown populates after selecting category

Fixes MGG-338

🤖 Generated with [Claude Code](https://claude.com/claude-code)