### PR TITLE
feat(client): show version and commit hash in UI (MGG-340)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,6 +60,9 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VITE_APP_VERSION=${{ github.ref_name }}
+            VITE_COMMIT_HASH=${{ github.sha }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=build-${{ matrix.platform_pair }}
           cache-to: type=gha,mode=min,scope=build-${{ matrix.platform_pair }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@
 FROM node:22-alpine AS client-build
 WORKDIR /app/client
 
+ARG VITE_APP_VERSION=dev
+ARG VITE_COMMIT_HASH=local
+ENV VITE_APP_VERSION=${VITE_APP_VERSION}
+ENV VITE_COMMIT_HASH=${VITE_COMMIT_HASH}
+
 # Copy only files needed for npm install first (layer caching)
 COPY src/client/package.json src/client/package-lock.json ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,6 @@
 FROM node:22-alpine AS client-build
 WORKDIR /app/client
 
-ARG VITE_APP_VERSION=dev
-ARG VITE_COMMIT_HASH=local
-ENV VITE_APP_VERSION=${VITE_APP_VERSION}
-ENV VITE_COMMIT_HASH=${VITE_COMMIT_HASH}
-
 # Copy only files needed for npm install first (layer caching)
 COPY src/client/package.json src/client/package-lock.json ./
 
@@ -15,6 +10,12 @@ RUN npm ci
 # Copy OpenAPI spec (needed for type generation) and client source
 COPY openapi/spec.yaml /openapi/spec.yaml
 COPY src/client/ ./
+
+# Inject version info after npm ci so the install layer stays cached
+ARG VITE_APP_VERSION=dev
+ARG VITE_COMMIT_HASH=local
+ENV VITE_APP_VERSION=${VITE_APP_VERSION}
+ENV VITE_COMMIT_HASH=${VITE_COMMIT_HASH}
 
 RUN npm run build
 

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.6",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.6",
+      "version": "0.1.12",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",

--- a/src/client/src/components/Layout.test.tsx
+++ b/src/client/src/components/Layout.test.tsx
@@ -225,4 +225,10 @@ describe("Layout", () => {
       expect(screen.getByText("API Keys")).toBeInTheDocument();
     });
   });
+
+  it("does not show version info when version is dev and hash is local", () => {
+    // Default globals from vite.config.ts define block are "dev" and "local"
+    renderLayout();
+    expect(screen.queryByText(/dev/)).not.toBeInTheDocument();
+  });
 });

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -45,7 +45,7 @@ import { cn } from "@/lib/utils";
 
 const appVersion = __APP_VERSION__;
 const commitHash = __COMMIT_HASH__;
-const showVersion = !(appVersion === "dev" && commitHash === "local");
+const showVersion = appVersion !== "dev" && commitHash !== "local";
 const shortHash = commitHash.slice(0, 7);
 const commitUrl = `https://github.com/mggarofalo/Receipts/commit/${commitHash}`;
 

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -41,6 +42,12 @@ import {
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
 import { cn } from "@/lib/utils";
+
+const appVersion = __APP_VERSION__;
+const commitHash = __COMMIT_HASH__;
+const showVersion = !(appVersion === "dev" && commitHash === "local");
+const shortHash = commitHash.slice(0, 7);
+const commitUrl = `https://github.com/mggarofalo/Receipts/commit/${commitHash}`;
 
 const connectionStateColors: Record<SignalRConnectionState, string> = {
   connected: "bg-green-500",
@@ -318,6 +325,23 @@ export function Layout() {
                   <DropdownMenuItem onClick={handleLogout}>
                     Logout
                   </DropdownMenuItem>
+                  {showVersion && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                        {appVersion} &middot;{" "}
+                        <a
+                          href={commitUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {shortHash}
+                        </a>
+                      </DropdownMenuLabel>
+                    </>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             )}
@@ -414,6 +438,19 @@ export function Layout() {
                   Logout
                 </button>
               </>
+            )}
+            {showVersion && (
+              <p className="px-3 py-2 text-xs text-muted-foreground">
+                {appVersion} &middot;{" "}
+                <a
+                  href={commitUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:underline"
+                >
+                  {shortHash}
+                </a>
+              </p>
             )}
           </div>
         </SheetContent>

--- a/src/client/src/vite-env.d.ts
+++ b/src/client/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;
+declare const __COMMIT_HASH__: string;

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -5,6 +5,10 @@ import path from "path";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.VITE_APP_VERSION || "dev"),
+    __COMMIT_HASH__: JSON.stringify(process.env.VITE_COMMIT_HASH || "local"),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- Inject `__APP_VERSION__` and `__COMMIT_HASH__` at Vite build time via `define` constants
- Display version and linked commit hash in the user dropdown menu (desktop) and mobile navigation drawer
- Hidden in dev mode when both values are `dev`/`local` (no useful info to show)
- Pass version tag and commit SHA as Docker build args in CI so production images reflect the deployed version

## Changes
- `src/client/vite.config.ts` — `define` block for build-time constants
- `src/client/src/vite-env.d.ts` — TypeScript declarations for globals
- `src/client/src/components/Layout.tsx` — Version display in user dropdown and mobile drawer
- `Dockerfile` — `ARG`/`ENV` for `VITE_APP_VERSION` and `VITE_COMMIT_HASH` in client-build stage
- `.github/workflows/docker-publish.yml` — `build-args` passing `github.ref_name` and `github.sha`
- `src/client/src/components/Layout.test.tsx` — Test for version hidden in dev mode

## Test plan
- [x] ESLint passes with no new warnings
- [x] All 16 Layout tests pass (including new version test)
- [x] All 788 .NET tests pass
- [ ] Visually verify version appears in user dropdown when `VITE_APP_VERSION` / `VITE_COMMIT_HASH` env vars are set during build
- [ ] Verify commit hash links to correct GitHub commit URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)