### PR TITLE
test(client): add typeahead filtering tests for Combobox and category selector (MGG-339)

### DIFF
--- a/src/client/src/components/ItemTemplateForm.test.tsx
+++ b/src/client/src/components/ItemTemplateForm.test.tsx
@@ -1,6 +1,21 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { ItemTemplateForm } from "./ItemTemplateForm";
+
+// Polyfill ResizeObserver and scrollIntoView for radix-ui / cmdk in jsdom
+beforeAll(() => {
+  if (typeof window.ResizeObserver === "undefined") {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
+});
 
 vi.mock("@/hooks/useFormShortcuts", () => ({
   useFormShortcuts: vi.fn(),
@@ -139,5 +154,40 @@ describe("ItemTemplateForm", () => {
     expect(screen.getByText("Default Unit Price (optional)")).toBeInTheDocument();
     expect(screen.getByText("Default Pricing Mode (optional)")).toBeInTheDocument();
     expect(screen.getByText("Default Item Code (optional)")).toBeInTheDocument();
+  });
+
+  it("filters category options via typeahead and selects a filtered result", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<ItemTemplateForm {...defaultProps} onSubmit={onSubmit} />);
+
+    // Open the category combobox
+    const categoryCombobox = screen.getByRole("combobox", { name: /^default category/i });
+    await user.click(categoryCombobox);
+
+    // Both categories should be visible
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+      expect(screen.getByText("Electronics")).toBeInTheDocument();
+    });
+
+    // Type to filter — only "Electronics" should match
+    await user.type(
+      screen.getByPlaceholderText("Search categories..."),
+      "elec",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Electronics")).toBeInTheDocument();
+      expect(screen.queryByText("Groceries")).not.toBeInTheDocument();
+    });
+
+    // Select the filtered result
+    await user.click(screen.getByText("Electronics"));
+
+    // Verify the combobox now shows the selected value
+    await waitFor(() => {
+      expect(categoryCombobox).toHaveTextContent("Electronics");
+    });
   });
 });

--- a/src/client/src/components/ui/combobox.test.tsx
+++ b/src/client/src/components/ui/combobox.test.tsx
@@ -92,4 +92,103 @@ describe("Combobox", () => {
 
     expect(screen.getByRole("combobox")).toHaveTextContent("custom-value");
   });
+
+  it("filters options when typing in the search input", async () => {
+    const user = userEvent.setup();
+    render(<Combobox {...defaultProps} />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Apple")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("Search fruit..."), "app");
+
+    await waitFor(() => {
+      expect(screen.getByText("Apple")).toBeInTheDocument();
+      expect(screen.queryByText("Banana")).not.toBeInTheDocument();
+      expect(screen.queryByText("Cherry")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows empty message when no options match the search", async () => {
+    const user = userEvent.setup();
+    render(
+      <Combobox {...defaultProps} emptyMessage="Nothing found." />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Apple")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("Search fruit..."), "xyz");
+
+    await waitFor(() => {
+      expect(screen.getByText("Nothing found.")).toBeInTheDocument();
+    });
+  });
+
+  it("clears search and shows all options after selecting a filtered item", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Combobox {...defaultProps} onValueChange={onValueChange} />);
+
+    // Open and type to filter
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => {
+      expect(screen.getByText("Apple")).toBeInTheDocument();
+    });
+    await user.type(screen.getByPlaceholderText("Search fruit..."), "ban");
+
+    await waitFor(() => {
+      expect(screen.getByText("Banana")).toBeInTheDocument();
+      expect(screen.queryByText("Apple")).not.toBeInTheDocument();
+    });
+
+    // Select the filtered item
+    await user.click(screen.getByText("Banana"));
+    expect(onValueChange).toHaveBeenCalledWith("banana");
+
+    // Reopen — all options should be visible (search was cleared)
+    await user.click(screen.getByRole("combobox"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Apple")).toBeInTheDocument();
+      expect(screen.getByText("Banana")).toBeInTheDocument();
+      expect(screen.getByText("Cherry")).toBeInTheDocument();
+    });
+  });
+
+  it("filters by sublabel when present", async () => {
+    const optionsWithSublabels: ComboboxOption[] = [
+      { value: "milk", label: "Milk", sublabel: "Dairy" },
+      { value: "bread", label: "Bread", sublabel: "Bakery" },
+      { value: "apple", label: "Apple", sublabel: "Produce" },
+    ];
+    const user = userEvent.setup();
+    render(
+      <Combobox
+        {...defaultProps}
+        options={optionsWithSublabels}
+        searchPlaceholder="Search items..."
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => {
+      expect(screen.getByText("Milk")).toBeInTheDocument();
+    });
+
+    // Type the sublabel text — should match the item with that sublabel
+    await user.type(screen.getByPlaceholderText("Search items..."), "dairy");
+
+    await waitFor(() => {
+      expect(screen.getByText("Milk")).toBeInTheDocument();
+      expect(screen.queryByText("Bread")).not.toBeInTheDocument();
+      expect(screen.queryByText("Apple")).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds 4 typeahead filtering tests to `combobox.test.tsx`: filter by label, empty message on no match, search cleared on selection, filter by sublabel
- Adds 1 integration-level typeahead test to `ItemTemplateForm.test.tsx`: opens category Combobox, types to filter, selects filtered result — validates the full pipeline after MGG-338 crash fix
- Adds jsdom polyfills (ResizeObserver, scrollIntoView) to ItemTemplateForm test file for cmdk/radix compatibility

## Test plan
- [x] `npx vitest run src/components/ui/combobox.test.tsx` — 10 tests pass (4 new)
- [x] `npx vitest run src/components/ItemTemplateForm.test.tsx` — 8 tests pass (1 new)
- [x] Pre-commit hooks pass (Spectral, dotnet format, build, drift check, unit tests, tsc, eslint)

Closes MGG-339

🤖 Generated with [Claude Code](https://claude.com/claude-code)