### PR TITLE
fix(client): replace date range button row with responsive dropdown (MGG-333)

### DIFF
--- a/src/client/src/components/dashboard/DateRangeSelector.test.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.test.tsx
@@ -72,7 +72,7 @@ describe("DateRangeSelector", () => {
     );
   });
 
-  it("renders a dropdown selector for narrow viewports", () => {
+  it("renders a dropdown selector", () => {
     const onChange = vi.fn();
     renderWithProviders(
       <DateRangeSelector value={defaultRange} onChange={onChange} />,

--- a/src/client/src/components/dashboard/DateRangeSelector.test.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.test.tsx
@@ -71,4 +71,12 @@ describe("DateRangeSelector", () => {
       }),
     );
   });
+
+  it("renders a dropdown selector for narrow viewports", () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <DateRangeSelector value={defaultRange} onChange={onChange} />,
+    );
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
 });

--- a/src/client/src/components/dashboard/DateRangeSelector.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.tsx
@@ -7,6 +7,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Calendar } from "@/components/ui/calendar";
 import type { DateRange } from "@/hooks/useDashboard";
 import type { DateRange as DayPickerDateRange } from "react-day-picker";
@@ -109,18 +116,52 @@ export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
     return "Select range";
   }, [activePreset, value.startDate, value.endDate]);
 
+  const handleSelectChange = useCallback(
+    (val: string) => {
+      if (val === "custom") {
+        setActivePreset("custom");
+        setCalendarOpen(true);
+      } else {
+        handlePreset(val as PresetKey);
+      }
+    },
+    [handlePreset],
+  );
+
   return (
-    <div className="flex items-center gap-2 flex-wrap">
-      {(Object.keys(presets) as PresetKey[]).map((key) => (
-        <Button
-          key={key}
-          variant={activePreset === key ? "default" : "outline"}
-          size="sm"
-          onClick={() => handlePreset(key)}
-        >
-          {presets[key].label}
-        </Button>
-      ))}
+    <div className="flex items-center gap-2">
+      {/* Dropdown for narrow screens */}
+      <div className="sm:hidden">
+        <Select value={activePreset} onValueChange={handleSelectChange}>
+          <SelectTrigger size="sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {(Object.keys(presets) as PresetKey[]).map((key) => (
+              <SelectItem key={key} value={key}>
+                {presets[key].label}
+              </SelectItem>
+            ))}
+            <SelectItem value="custom">Custom</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Button row for wider screens */}
+      <div className="hidden sm:flex items-center gap-2">
+        {(Object.keys(presets) as PresetKey[]).map((key) => (
+          <Button
+            key={key}
+            variant={activePreset === key ? "default" : "outline"}
+            size="sm"
+            onClick={() => handlePreset(key)}
+          >
+            {presets[key].label}
+          </Button>
+        ))}
+      </div>
+
+      {/* Calendar popover — always visible */}
       <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
         <PopoverTrigger asChild>
           <Button
@@ -129,7 +170,9 @@ export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
             className="gap-1.5"
           >
             <CalendarIcon className="h-3.5 w-3.5" />
-            {activePreset === "custom" ? displayLabel : "Custom"}
+            <span className="hidden sm:inline">
+              {activePreset === "custom" ? displayLabel : "Custom"}
+            </span>
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="end">

--- a/src/client/src/components/dashboard/DateRangeSelector.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.tsx
@@ -119,7 +119,6 @@ export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
   const handleSelectChange = useCallback(
     (val: string) => {
       if (val === "custom") {
-        setActivePreset("custom");
         setCalendarOpen(true);
       } else {
         handlePreset(val as PresetKey);
@@ -168,6 +167,7 @@ export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
             variant={activePreset === "custom" ? "default" : "outline"}
             size="sm"
             className="gap-1.5"
+            aria-label={activePreset === "custom" ? displayLabel : "Custom"}
           >
             <CalendarIcon className="h-3.5 w-3.5" />
             <span className="hidden sm:inline">


### PR DESCRIPTION
## Summary
- At narrow viewports the dashboard date-range preset buttons (7d/30d/90d/YTD/All Time) wrapped onto multiple rows due to `flex-wrap`
- Replaced the button row with a `Select` dropdown below the `sm` breakpoint while keeping the button row for wider screens
- The calendar popover trigger is always visible (icon-only on mobile, full label on desktop)

Resolves MGG-333

## Test plan
- Resize browser below 640px — verify preset buttons are hidden and a Select dropdown appears
- Select a preset from the dropdown — verify the date range updates
- Select "Custom" from the dropdown — verify the calendar popover opens
- Resize above 640px — verify the button row reappears and the dropdown is hidden
- Click preset buttons at wide viewport — verify they still work
- Run `npx vitest run src/components/dashboard/DateRangeSelector.test.tsx` — all 5 tests pass