### PR TITLE
fix(client): use batch endpoints for wizard receipt creation (MGG-337)

### DIFF
--- a/src/client/src/hooks/useReceiptItems.ts
+++ b/src/client/src/hooks/useReceiptItems.ts
@@ -78,6 +78,40 @@ export function useCreateReceiptItem() {
   });
 }
 
+export function useCreateReceiptItemsBatch() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      receiptId,
+      body,
+    }: {
+      receiptId: string;
+      body: {
+        receiptItemCode: string;
+        description: string;
+        quantity: number;
+        unitPrice: number;
+        category: string;
+        subcategory: string;
+        pricingMode: "quantity" | "flat";
+      }[];
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/receipts/{receiptId}/receipt-items/batch",
+        { params: { path: { receiptId } }, body },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
+    },
+    onError: () => {
+      toast.error("Failed to create receipt items");
+    },
+  });
+}
+
 export function useUpdateReceiptItem() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/client/src/hooks/useTransactions.ts
+++ b/src/client/src/hooks/useTransactions.ts
@@ -70,6 +70,32 @@ export function useCreateTransaction() {
   });
 }
 
+export function useCreateTransactionsBatch() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      receiptId,
+      body,
+    }: {
+      receiptId: string;
+      body: { amount: number; date: string; accountId: string }[];
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/receipts/{receiptId}/transactions/batch",
+        { params: { path: { receiptId } }, body },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["transactions"] });
+    },
+    onError: () => {
+      toast.error("Failed to create transactions");
+    },
+  });
+}
+
 export function useUpdateTransaction() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/client/src/pages/wizard/NewReceipt.test.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.test.tsx
@@ -12,11 +12,11 @@ vi.mock("@/hooks/useReceipts", () => ({
 }));
 
 vi.mock("@/hooks/useTransactions", () => ({
-  useCreateTransaction: vi.fn(() => mockMutationResult()),
+  useCreateTransactionsBatch: vi.fn(() => mockMutationResult()),
 }));
 
 vi.mock("@/hooks/useReceiptItems", () => ({
-  useCreateReceiptItem: vi.fn(() => mockMutationResult()),
+  useCreateReceiptItemsBatch: vi.fn(() => mockMutationResult()),
 }));
 
 describe("NewReceipt", () => {

--- a/src/client/src/pages/wizard/NewReceipt.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.tsx
@@ -2,8 +2,8 @@ import { useState, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useCreateReceipt } from "@/hooks/useReceipts";
-import { useCreateTransaction } from "@/hooks/useTransactions";
-import { useCreateReceiptItem } from "@/hooks/useReceiptItems";
+import { useCreateTransactionsBatch } from "@/hooks/useTransactions";
+import { useCreateReceiptItemsBatch } from "@/hooks/useReceiptItems";
 import { useWizard } from "./useWizard";
 import { WizardStepper } from "./WizardStepper";
 import { Step1TripDetails } from "./Step1TripDetails";
@@ -43,8 +43,8 @@ export default function NewReceipt() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { mutateAsync: createReceiptAsync } = useCreateReceipt();
-  const { mutateAsync: createTransactionAsync } = useCreateTransaction();
-  const { mutateAsync: createReceiptItemAsync } = useCreateReceiptItem();
+  const { mutateAsync: createTransactionsBatchAsync } = useCreateTransactionsBatch();
+  const { mutateAsync: createReceiptItemsBatchAsync } = useCreateReceiptItemsBatch();
 
   const hasData =
     state.receipt.location !== "" ||
@@ -87,27 +87,27 @@ export default function NewReceipt() {
 
       const receiptId = (receipt as { id: string }).id;
 
-      // 2. Create transactions sequentially
-      for (const txn of state.transactions) {
-        await createTransactionAsync(
+      // 2. Create transactions in batch
+      if (state.transactions.length > 0) {
+        await createTransactionsBatchAsync(
           {
             receiptId,
-            body: {
+            body: state.transactions.map((txn) => ({
               accountId: txn.accountId,
               amount: txn.amount,
               date: txn.date,
-            },
+            })),
           },
           { onSuccess: undefined, onError: undefined },
         );
       }
 
-      // 3. Create receipt items sequentially
-      for (const item of state.items) {
-        await createReceiptItemAsync(
+      // 3. Create receipt items in batch
+      if (state.items.length > 0) {
+        await createReceiptItemsBatchAsync(
           {
             receiptId,
-            body: {
+            body: state.items.map((item) => ({
               receiptItemCode: item.receiptItemCode,
               description: item.description,
               quantity: item.quantity,
@@ -115,7 +115,7 @@ export default function NewReceipt() {
               category: item.category,
               subcategory: item.subcategory,
               pricingMode: item.pricingMode,
-            },
+            })),
           },
           { onSuccess: undefined, onError: undefined },
         );
@@ -134,8 +134,8 @@ export default function NewReceipt() {
   }, [
     state,
     createReceiptAsync,
-    createTransactionAsync,
-    createReceiptItemAsync,
+    createTransactionsBatchAsync,
+    createReceiptItemsBatchAsync,
     reset,
     navigate,
   ]);


### PR DESCRIPTION
## Summary
- Replace sequential per-item API calls in the New Receipt wizard with single batch POST requests to `/transactions/batch` and `/receipt-items/batch`
- Add `useCreateTransactionsBatch` and `useCreateReceiptItemsBatch` hooks that call the existing server-side batch endpoints
- Eliminates N+1 round-trips and prevents partial-creation scenarios when a mid-sequence request fails

## Test plan
- [x] TypeScript type check passes
- [x] ESLint passes with no new warnings
- [x] All 4 NewReceipt.test.tsx tests pass with updated mocks
- [x] All 1108 client tests pass
- [x] All 1138 backend tests pass
- [x] No spec drift detected
- [ ] Manual: create a receipt with multiple transactions and items — verify all created in single round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)