### PR TITLE
fix(infrastructure): check AddToRoleAsync return values in database seeder (MGG-281)

### DIFF
--- a/src/Infrastructure/Services/DatabaseSeederService.cs
+++ b/src/Infrastructure/Services/DatabaseSeederService.cs
@@ -50,8 +50,19 @@ public static class DatabaseSeederService
 		IdentityResult result = await userManager.CreateAsync(adminUser, adminPassword);
 		if (result.Succeeded)
 		{
-			await userManager.AddToRoleAsync(adminUser, AppRoles.Admin);
-			await userManager.AddToRoleAsync(adminUser, AppRoles.User);
+			IdentityResult addAdmin = await userManager.AddToRoleAsync(adminUser, AppRoles.Admin);
+			if (!addAdmin.Succeeded)
+			{
+				throw new InvalidOperationException(
+					$"Failed to assign Admin role: {string.Join(", ", addAdmin.Errors.Select(e => e.Description))}");
+			}
+
+			IdentityResult addUser = await userManager.AddToRoleAsync(adminUser, AppRoles.User);
+			if (!addUser.Succeeded)
+			{
+				throw new InvalidOperationException(
+					$"Failed to assign User role: {string.Join(", ", addUser.Errors.Select(e => e.Description))}");
+			}
 		}
 	}
 }

--- a/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
@@ -1,0 +1,122 @@
+using Common;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Infrastructure.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Infrastructure.Tests.Services;
+
+public class DatabaseSeederServiceTests
+{
+	private readonly Mock<RoleManager<IdentityRole>> _mockRoleManager;
+	private readonly Mock<UserManager<ApplicationUser>> _mockUserManager;
+	private readonly IConfiguration _configuration;
+	private readonly IServiceProvider _serviceProvider;
+
+	public DatabaseSeederServiceTests()
+	{
+		Mock<IRoleStore<IdentityRole>> roleStore = new();
+		_mockRoleManager = new Mock<RoleManager<IdentityRole>>(
+			roleStore.Object, null!, null!, null!, null!);
+
+		Mock<IUserStore<ApplicationUser>> userStore = new();
+		_mockUserManager = new Mock<UserManager<ApplicationUser>>(
+			userStore.Object, null!, null!, null!, null!, null!, null!, null!, null!);
+
+		_configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[ConfigurationVariables.AdminSeedEmail] = "admin@test.com",
+				[ConfigurationVariables.AdminSeedPassword] = "Password123!",
+				[ConfigurationVariables.AdminSeedFirstName] = "Admin",
+				[ConfigurationVariables.AdminSeedLastName] = "User",
+			})
+			.Build();
+
+		ServiceCollection services = new();
+		services.AddSingleton(_mockRoleManager.Object);
+		services.AddSingleton(_mockUserManager.Object);
+		services.AddSingleton(_configuration);
+		_serviceProvider = services.BuildServiceProvider();
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenAddToAdminRoleFails_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(true);
+
+		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
+			.ReturnsAsync(new List<ApplicationUser>());
+
+		_mockUserManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Success);
+
+		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "RoleFail", Description = "Admin role assignment failed" }));
+
+		// Act
+		Func<Task> act = () => DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*Admin role*Admin role assignment failed*");
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenAddToUserRoleFails_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(true);
+
+		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
+			.ReturnsAsync(new List<ApplicationUser>());
+
+		_mockUserManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Success);
+
+		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin))
+			.ReturnsAsync(IdentityResult.Success);
+
+		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.User))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "RoleFail", Description = "User role assignment failed" }));
+
+		// Act
+		Func<Task> act = () => DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*User role*User role assignment failed*");
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenBothRoleAssignmentsSucceed_DoesNotThrow()
+	{
+		// Arrange
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(true);
+
+		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
+			.ReturnsAsync(new List<ApplicationUser>());
+
+		_mockUserManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Success);
+
+		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Success);
+
+		// Act
+		Func<Task> act = () => DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+
+		_mockUserManager.Verify(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin), Times.Once);
+		_mockUserManager.Verify(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.User), Times.Once);
+	}
+}


### PR DESCRIPTION
## Summary
- **Bug:** `AddToRoleAsync` return values were discarded in `DatabaseSeederService.SeedRolesAndAdminAsync`, so a partial role-assignment failure (e.g. Admin role assigned but User role fails) left the admin permanently missing a role with no recovery path — on subsequent startups the user already exists and seeding is skipped.
- **Fix:** Both `AddToRoleAsync` calls now check their `IdentityResult` and throw `InvalidOperationException` with the error details on failure.
- **Tests:** Added `DatabaseSeederServiceTests` covering Admin role failure, User role failure, and success scenarios.

Closes MGG-281

## Test plan
- [x] Unit tests for Admin role assignment failure → throws with correct message
- [x] Unit tests for User role assignment failure → throws with correct message
- [x] Unit tests for successful role assignment → no exception, both roles verified
- [x] All 791 existing tests pass
- [x] Pre-commit hooks pass (build, format, lint, drift check, tsc, eslint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)