### PR TITLE
fix(infrastructure): handle Task.Delay cancellation in cleanup service and stabilize tests (MGG-282)

### DIFF
--- a/src/Infrastructure/Services/AuthAuditCleanupService.cs
+++ b/src/Infrastructure/Services/AuthAuditCleanupService.cs
@@ -33,7 +33,14 @@ public class AuthAuditCleanupService(
 				logger.LogError(ex, "Error during auth audit cleanup");
 			}
 
-			await Task.Delay(Interval, stoppingToken);
+			try
+			{
+				await Task.Delay(Interval, stoppingToken);
+			}
+			catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+			{
+				break;
+			}
 		}
 	}
 }

--- a/tests/Infrastructure.Tests/Services/AuthAuditCleanupServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/AuthAuditCleanupServiceTests.cs
@@ -38,21 +38,22 @@ public class AuthAuditCleanupServiceTests
 	public async Task ExecuteAsync_CallsCleanupOnService()
 	{
 		// Arrange
-		TaskCompletionSource invoked = new();
+		TaskCompletionSource executed = new();
 		_auditServiceMock
 			.Setup(s => s.CleanupOldEntriesAsync(180, It.IsAny<CancellationToken>()))
 			.Returns<int, CancellationToken>((_, _) =>
 			{
-				invoked.TrySetResult();
+				executed.TrySetResult();
 				return Task.FromResult(5);
 			});
 
 		AuthAuditCleanupService service = new(_scopeFactoryMock.Object, _loggerMock.Object);
 		using CancellationTokenSource cts = new();
 
-		// Act
+		// Act — StartAsync dispatches ExecuteAsync to the thread pool via Task.Run,
+		// so we must wait for the TCS before cancelling to avoid a race.
 		await service.StartAsync(cts.Token);
-		await invoked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+		await executed.Task.WaitAsync(TimeSpan.FromSeconds(5));
 		cts.Cancel();
 		await service.StopAsync(CancellationToken.None);
 
@@ -66,12 +67,12 @@ public class AuthAuditCleanupServiceTests
 	public async Task ExecuteAsync_LogsCleanupStatistics()
 	{
 		// Arrange
-		TaskCompletionSource invoked = new();
+		TaskCompletionSource executed = new();
 		_auditServiceMock
 			.Setup(s => s.CleanupOldEntriesAsync(180, It.IsAny<CancellationToken>()))
 			.Returns<int, CancellationToken>((_, _) =>
 			{
-				invoked.TrySetResult();
+				executed.TrySetResult();
 				return Task.FromResult(42);
 			});
 
@@ -80,7 +81,7 @@ public class AuthAuditCleanupServiceTests
 
 		// Act
 		await service.StartAsync(cts.Token);
-		await invoked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+		await executed.Task.WaitAsync(TimeSpan.FromSeconds(5));
 		cts.Cancel();
 		await service.StopAsync(CancellationToken.None);
 
@@ -99,12 +100,12 @@ public class AuthAuditCleanupServiceTests
 	public async Task ExecuteAsync_ContinuesOnException()
 	{
 		// Arrange
-		TaskCompletionSource invoked = new();
+		TaskCompletionSource executed = new();
 		_auditServiceMock
 			.Setup(s => s.CleanupOldEntriesAsync(180, It.IsAny<CancellationToken>()))
 			.Returns<int, CancellationToken>((_, _) =>
 			{
-				invoked.TrySetResult();
+				executed.TrySetResult();
 				return Task.FromException<int>(new InvalidOperationException("Database error"));
 			});
 
@@ -113,7 +114,7 @@ public class AuthAuditCleanupServiceTests
 
 		// Act — should not throw
 		await service.StartAsync(cts.Token);
-		await invoked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+		await executed.Task.WaitAsync(TimeSpan.FromSeconds(5));
 		cts.Cancel();
 		Func<Task> act = async () => await service.StopAsync(CancellationToken.None);
 


### PR DESCRIPTION
## Summary
- **Production fix**: Wrapped `Task.Delay` in `AuthAuditCleanupService.ExecuteAsync` with its own try-catch for `OperationCanceledException`. Previously the delay was outside the try-catch, so cancellation during the 1-day interval threw an unhandled exception from `ExecuteAsync`.
- **Test fix**: Renamed TCS variable from `invoked` to `executed` for clarity and added a comment explaining WHY the `TaskCompletionSource` synchronization is necessary — in .NET 10, `BackgroundService.StartAsync` dispatches `ExecuteAsync` via `Task.Run`, so the background loop runs on a thread pool thread and tests must synchronize before cancelling to avoid a race.

## Root cause
In .NET 10, `BackgroundService.StartAsync` changed from calling `ExecuteAsync` directly to wrapping it in `Task.Run(() => ExecuteAsync(...))`. This means `ExecuteAsync` runs asynchronously on the thread pool rather than synchronously during `StartAsync`. Tests that immediately cancel after `StartAsync` race against the thread pool: if cancellation fires before `ExecuteAsync` enters its `while` loop, `stoppingToken.IsCancellationRequested` is already true and the loop body never runs.

The `TaskCompletionSource` + `WaitAsync(5s)` pattern ensures the test waits for the mock to be invoked on the thread pool thread before cancelling.

## Test plan
- [x] All 3 `AuthAuditCleanupServiceTests` pass locally
- [x] Ran 5 consecutive iterations with 0 failures
- [x] Full pre-commit hook pipeline passes (788 tests)
- [ ] CI passes on this PR

Closes MGG-282

🤖 Generated with [Claude Code](https://claude.com/claude-code)