### PR TITLE
fix(infrastructure): check IdentityResult from role creation in database seeder (MGG-280)

### DIFF
--- a/src/Infrastructure/Services/DatabaseSeederService.cs
+++ b/src/Infrastructure/Services/DatabaseSeederService.cs
@@ -19,7 +19,12 @@ public static class DatabaseSeederService
 		{
 			if (!await roleManager.RoleExistsAsync(role))
 			{
-				await roleManager.CreateAsync(new IdentityRole(role));
+				IdentityResult roleResult = await roleManager.CreateAsync(new IdentityRole(role));
+				if (!roleResult.Succeeded)
+				{
+					throw new InvalidOperationException(
+						$"Failed to create role '{role}': {string.Join(", ", roleResult.Errors.Select(e => e.Description))}");
+				}
 			}
 		}
 

--- a/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
@@ -44,6 +44,65 @@ public class DatabaseSeederServiceTests
 	}
 
 	[Fact]
+	public async Task SeedRolesAndAdminAsync_ThrowsWhenRoleCreationFails()
+	{
+		// Arrange
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(false);
+
+		IdentityError error = new() { Code = "DuplicateRoleName", Description = "Role already exists." };
+		_mockRoleManager.Setup(r => r.CreateAsync(It.IsAny<IdentityRole>()))
+			.ReturnsAsync(IdentityResult.Failed(error));
+
+		// Act
+		Func<Task> act = () => DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*Failed to create role*Role already exists.*");
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_CreatesAllRolesWhenNoneExist()
+	{
+		// Arrange
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(false);
+		_mockRoleManager.Setup(r => r.CreateAsync(It.IsAny<IdentityRole>()))
+			.ReturnsAsync(IdentityResult.Success);
+
+		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
+			.ReturnsAsync(new List<ApplicationUser> { new() });
+
+		// Act
+		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		foreach (string role in AppRoles.All)
+		{
+			_mockRoleManager.Verify(r => r.CreateAsync(
+				It.Is<IdentityRole>(ir => ir.Name == role)), Times.Once);
+		}
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_SkipsExistingRoles()
+	{
+		// Arrange
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(true);
+
+		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
+			.ReturnsAsync(new List<ApplicationUser> { new() });
+
+		// Act
+		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		_mockRoleManager.Verify(r => r.CreateAsync(It.IsAny<IdentityRole>()), Times.Never);
+	}
+
+	[Fact]
 	public async Task SeedRolesAndAdminAsync_WhenAddToAdminRoleFails_ThrowsInvalidOperationException()
 	{
 		// Arrange


### PR DESCRIPTION
## Summary
- Check the `IdentityResult` returned by `roleManager.CreateAsync` in `DatabaseSeederService.SeedRolesAndAdminAsync` and throw `InvalidOperationException` if role creation fails
- Previously the result was silently discarded, allowing the seeder to continue without required roles
- Adds unit tests for the seeder: failure throws, all roles created, existing roles skipped

## Test plan
- [x] New unit tests verify `InvalidOperationException` is thrown with error details when role creation fails
- [x] New unit tests verify all roles are created when none exist
- [x] New unit tests verify existing roles are skipped
- [x] All pre-commit hooks pass (format, build, lint, unit tests)

Fixes MGG-280

🤖 Generated with [Claude Code](https://claude.com/claude-code)