### PR TITLE
fix(client): replace mobile nav drawer with condensed hoverable menus (MGG-334)

### DIFF
--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -330,11 +330,11 @@ export function Layout() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    aria-label={`User menu for ${user.email}`}
+                    aria-label={`User menu for ${user.email || "current user"}`}
                   >
                     <span className="hidden md:inline">{user.email}</span>
                     <span className="md:hidden text-xs font-semibold">
-                      {user.email[0].toUpperCase()}
+                      {user.email ? user.email[0].toUpperCase() : "?"}
                     </span>
                   </Button>
                 </DropdownMenuTrigger>

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -178,7 +178,7 @@ export function Layout() {
     return (
       <NavigationMenuItem key={group.label}>
         <NavigationMenuTrigger
-          className={cn(groupActive && "text-accent-foreground")}
+          className={cn("px-2 md:px-4", groupActive && "text-accent-foreground")}
         >
           {group.label}
         </NavigationMenuTrigger>
@@ -233,8 +233,8 @@ export function Layout() {
       </a>
       <header className="border-b">
         <div className="container mx-auto flex h-14 items-center justify-between px-4">
-          {/* Mobile: hamburger + brand */}
-          <div className="flex items-center gap-2 lg:hidden">
+          {/* Phone: hamburger + brand (below sm only) */}
+          <div className="flex items-center gap-2 sm:hidden">
             <Button
               variant="ghost"
               size="icon"
@@ -249,12 +249,12 @@ export function Layout() {
             </Link>
           </div>
 
-          {/* Desktop: full nav */}
+          {/* Horizontal nav (visible sm+) */}
           <nav
-            className="hidden lg:flex items-center gap-2"
+            className="hidden sm:flex items-center gap-1 md:gap-2"
             aria-label="Main navigation"
           >
-            <Link to="/" className="font-semibold text-lg mr-2">
+            <Link to="/" className="font-semibold text-lg mr-1 md:mr-2">
               Receipts
             </Link>
             <Separator orientation="vertical" className="h-6" />
@@ -266,6 +266,7 @@ export function Layout() {
                       to="/"
                       className={cn(
                         navigationMenuTriggerStyle(),
+                        "px-2 md:px-4",
                         isLinkActive("/") &&
                           "bg-accent/50 text-accent-foreground",
                       )}
@@ -280,12 +281,21 @@ export function Layout() {
             </NavigationMenu>
           </nav>
 
-          {/* Desktop: right-side actions */}
-          <div className="hidden lg:flex items-center gap-3">
+          {/* Right-side actions (sm+: responsive layout) */}
+          <div className="hidden sm:flex items-center gap-1 md:gap-3">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 md:hidden"
+              onClick={() => setSearchOpen(true)}
+              aria-label="Search"
+            >
+              <Search className="h-4 w-4" />
+            </Button>
             <Button
               variant="outline"
               size="sm"
-              className="gap-1.5 text-muted-foreground"
+              className="hidden md:inline-flex gap-1.5 text-muted-foreground"
               onClick={() => setSearchOpen(true)}
             >
               <Search className="h-3.5 w-3.5" />
@@ -298,12 +308,16 @@ export function Layout() {
               className="flex items-center gap-1.5"
               role="status"
               aria-live="polite"
+              title={connectionStateLabels[connectionState]}
             >
               <span
                 className={`h-2 w-2 rounded-full ${connectionStateColors[connectionState]}`}
                 aria-hidden="true"
               />
-              <span className="text-xs text-muted-foreground">
+              <span className="hidden md:inline text-xs text-muted-foreground">
+                {connectionStateLabels[connectionState]}
+              </span>
+              <span className="sr-only md:hidden">
                 {connectionStateLabels[connectionState]}
               </span>
             </div>
@@ -313,8 +327,15 @@ export function Layout() {
             {user && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="sm">
-                    {user.email}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`User menu for ${user.email}`}
+                  >
+                    <span className="hidden md:inline">{user.email}</span>
+                    <span className="md:hidden text-xs font-semibold">
+                      {user.email[0].toUpperCase()}
+                    </span>
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
@@ -347,8 +368,8 @@ export function Layout() {
             )}
           </div>
 
-          {/* Mobile: compact actions */}
-          <div className="flex items-center gap-1 lg:hidden">
+          {/* Phone-only: compact actions */}
+          <div className="flex items-center gap-1 sm:hidden">
             <Button
               variant="ghost"
               size="icon"
@@ -383,7 +404,7 @@ export function Layout() {
         </div>
       </main>
 
-      {/* Mobile navigation drawer */}
+      {/* Phone navigation drawer (below sm only) */}
       <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
         <SheetContent side="left" className="w-72">
           <SheetHeader>


### PR DESCRIPTION
## Summary
- Push the hamburger/sheet drawer breakpoint from `lg` (1024px) down to `sm` (640px) so the horizontal `NavigationMenu` with hover/tap dropdown groups is visible on tablets and small laptops
- At `sm`–`md`: nav triggers use compact padding (`px-2`), search shows icon-only, connection status shows dot-only (with sr-only label for a11y), user button shows initial instead of full email
- At `md`+: full labels, search button with text + kbd shortcut, connection label, and full user email reappear
- The sheet drawer is retained only for very small phone viewports (`< 640px`)

Closes MGG-334

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] `npx eslint src/components/Layout.tsx` passes
- [x] All 16 Layout.test.tsx tests pass
- [x] Full pre-commit hook pipeline passes (791 tests)
- [ ] Manual: resize browser 640–1024px and verify dropdown menus appear inline
- [ ] Manual: resize below 640px and verify hamburger + sheet still works
- [ ] Manual: verify search, theme toggle, connection status, user menu all accessible at every width

🤖 Generated with [Claude Code](https://claude.com/claude-code)