### PR TITLE
chore(ci): trigger CI on PRs to develop branch (MGG-344)

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: ["main"]
+    branches: ["main", "develop"]
 
 env:
   DOTNET_VERSION: "10.0.x"


### PR DESCRIPTION
## Summary
- Add `develop` to the `pull_request.branches` filter in `github-ci.yml` so CI runs on PRs targeting both `main` and `develop`

## Test plan
- [x] Verify this PR itself triggers CI (targets `develop`)

Fixes MGG-344

🤖 Generated with [Claude Code](https://claude.com/claude-code)