### PR TITLE
fix(client): add Enter key submission and focus-after-add in wizard Step 2 (MGG-335)

### DIFF
--- a/src/client/src/pages/wizard/Step2Transactions.test.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.test.tsx
@@ -106,6 +106,9 @@ describe("Step2Transactions", () => {
     // Verify a new transaction row appears with the account name and formatted amount
     expect(await screen.findByText("Checking")).toBeInTheDocument();
     expect(await screen.findByText("$42.50")).toBeInTheDocument();
+
+    // Verify the amount field was reset (not retaining stale value)
+    expect(amountInput).toHaveValue("");
   });
 
   it("focuses the account combobox after adding a transaction", async () => {

--- a/src/client/src/pages/wizard/Step2Transactions.test.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.test.tsx
@@ -1,7 +1,12 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult } from "@/test/mock-hooks";
+import "@/test/setup-combobox-polyfills";
 import { Step2Transactions } from "./Step2Transactions";
+
+vi.mock("@/hooks/useFormShortcuts", () => ({
+  useFormShortcuts: vi.fn(),
+}));
 
 vi.mock("@/hooks/useAccounts", () => ({
   useAccounts: vi.fn(() =>
@@ -78,5 +83,54 @@ describe("Step2Transactions", () => {
     ];
     renderWithProviders(<Step2Transactions {...defaultProps} data={data} />);
     expect(screen.getByText("$25.50")).toBeInTheDocument();
+  });
+
+  it("submits the form when Enter is pressed in the amount field", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithProviders(<Step2Transactions {...defaultProps} />);
+
+    // Select account via combobox
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const checkingOption = await screen.findByText("Checking");
+    await user.click(checkingOption);
+
+    // Type amount
+    const amountInput = screen.getByLabelText(/amount/i);
+    await user.click(amountInput);
+    await user.type(amountInput, "42.50");
+
+    // Press Enter in the amount field to submit
+    await user.keyboard("{Enter}");
+
+    // Verify a new transaction row appears with the account name and formatted amount
+    expect(await screen.findByText("Checking")).toBeInTheDocument();
+    expect(await screen.findByText("$42.50")).toBeInTheDocument();
+  });
+
+  it("focuses the account combobox after adding a transaction", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithProviders(<Step2Transactions {...defaultProps} />);
+
+    // Select account via combobox
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const checkingOption = await screen.findByText("Checking");
+    await user.click(checkingOption);
+
+    // Type amount
+    const amountInput = screen.getByLabelText(/amount/i);
+    await user.click(amountInput);
+    await user.type(amountInput, "10");
+
+    // Press Enter to submit
+    await user.keyboard("{Enter}");
+
+    // Wait for the transaction to appear (useEffect fires after re-render)
+    expect(await screen.findByText("$10.00")).toBeInTheDocument();
+
+    // The useEffect should have focused the combobox trigger
+    const comboboxAfter = screen.getByRole("combobox");
+    expect(document.activeElement).toBe(comboboxAfter);
   });
 });

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -1,8 +1,9 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { generateId } from "@/lib/id";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useAccounts } from "@/hooks/useAccounts";
 import { accountToOption } from "@/lib/combobox-options";
 import { formatCurrency } from "@/lib/format";
@@ -55,7 +56,10 @@ export function Step2Transactions({
   onBack,
 }: Step2Props) {
   const [transactions, setTransactions] = useState<WizardTransaction[]>(data);
+  const formRef = useRef<HTMLFormElement>(null);
+  const accountRef = useRef<HTMLButtonElement>(null);
   const { data: accounts } = useAccounts();
+  useFormShortcuts({ formRef });
 
   const accountOptions = useMemo(
     () =>
@@ -102,6 +106,16 @@ export function Step2Transactions({
     [form, receiptDate],
   );
 
+  // Focus the account field after adding a transaction for rapid entry
+  const transactionCount = transactions.length;
+  const prevCountRef = useRef(transactionCount);
+  useEffect(() => {
+    if (transactionCount > prevCountRef.current) {
+      accountRef.current?.focus();
+    }
+    prevCountRef.current = transactionCount;
+  }, [transactionCount]);
+
   const handleRemove = useCallback((id: string) => {
     setTransactions((prev) => prev.filter((t) => t.id !== id));
   }, []);
@@ -130,6 +144,7 @@ export function Step2Transactions({
       <CardContent className="space-y-6">
         <Form {...form}>
           <form
+            ref={formRef}
             onSubmit={form.handleSubmit(handleAdd)}
             className="grid grid-cols-1 gap-4 sm:grid-cols-3 sm:items-end"
           >
@@ -141,6 +156,7 @@ export function Step2Transactions({
                   <FormLabel>Account</FormLabel>
                   <FormControl>
                     <Combobox
+                      ref={accountRef}
                       options={accountOptions}
                       value={field.value}
                       onValueChange={field.onChange}

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -101,6 +101,9 @@ export function Step2Transactions({
         ...values,
       };
       setTransactions((prev) => [...prev, newTxn]);
+      // Blur before reset so CurrencyInput's handleBlur writes its stale
+      // internal text state first, then form.reset() overwrites it.
+      (document.activeElement as HTMLElement)?.blur?.();
       form.reset({ accountId: "", amount: 0, date: receiptDate });
     },
     [form, receiptDate],


### PR DESCRIPTION
## Summary
- Wire up `useFormShortcuts` for Ctrl/Cmd+Enter form submission in the receipt wizard Step 2 (Transactions), consistent with the standalone `TransactionForm`
- Focus the Account combobox after a successful transaction add via `useEffect` for rapid keyboard-driven entry of multiple transactions
- Add tests for Enter key submission and focus-after-add behavior

## Test plan
- [x] Enter key in Amount field submits the transaction form (verified by test)
- [x] After adding a transaction, focus returns to the Account combobox (verified by test)
- [x] Ctrl/Cmd+Enter submits from any field via `useFormShortcuts`
- [x] All 10 tests pass (8 existing + 2 new)
- [x] ESLint, TypeScript, and full pre-commit hooks pass

Closes MGG-335

🤖 Generated with [Claude Code](https://claude.com/claude-code)