### PR TITLE
chore(client): upgrade eslint-plugin-react-hook-stability to 0.2.0 (MGG-331)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Receipts",
+  "name": "batch-mgg-331",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "batch-mgg-331",
+  "name": "Receipts",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/client/eslint.config.js
+++ b/src/client/eslint.config.js
@@ -29,6 +29,7 @@ export default defineConfig([
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
+      "react-hook-stability/require-stable-hook-returns": "error",
     },
   },
   {

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -34,7 +34,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
-        "@mggarofalo/eslint-plugin-react-hook-stability": "^0.1.4",
+        "@mggarofalo/eslint-plugin-react-hook-stability": "^0.2.0",
         "@tailwindcss/vite": "^4.2.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1845,9 +1845,9 @@
       }
     },
     "node_modules/@mggarofalo/eslint-plugin-react-hook-stability": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@mggarofalo/eslint-plugin-react-hook-stability/-/eslint-plugin-react-hook-stability-0.1.4.tgz",
-      "integrity": "sha512-vJQG33I632nS0HsEgpKVqYlXgneHa1jMg2vwu9vjEaxWsr2W32jlgf+fYxM3ecm+87RfoFZrzlqQII7muHRCKw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mggarofalo/eslint-plugin-react-hook-stability/-/eslint-plugin-react-hook-stability-0.2.0.tgz",
+      "integrity": "sha512-f1qvt0wuM4Ps01+jw9ugFqyE7PLcACMZbCIzx1RRfsVJcWNsJJiL4F2iyhKRe/gDdkQJLTga0Ui2ILGDgnt3yQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@mggarofalo/eslint-plugin-react-hook-stability": "^0.1.4",
+    "@mggarofalo/eslint-plugin-react-hook-stability": "^0.2.0",
     "@tailwindcss/vite": "^4.2.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/src/client/src/components/ui/form-field-context.ts
+++ b/src/client/src/components/ui/form-field-context.ts
@@ -30,7 +30,10 @@ export const useFormField = () => {
   const itemContext = React.useContext(FormItemContext)
   const { getFieldState } = useFormContext()
   const formState = useFormState({ name: fieldContext.name })
-  const fieldState = getFieldState(fieldContext.name, formState)
+  const { invalid, isDirty, isTouched, isValidating, error } = getFieldState(
+    fieldContext.name,
+    formState,
+  )
 
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>")
@@ -45,8 +48,12 @@ export const useFormField = () => {
       formItemId: `${id}-form-item`,
       formDescriptionId: `${id}-form-item-description`,
       formMessageId: `${id}-form-item-message`,
-      ...fieldState,
+      invalid,
+      isDirty,
+      isTouched,
+      isValidating,
+      error,
     }),
-    [id, fieldContext.name, fieldState],
+    [id, fieldContext.name, invalid, isDirty, isTouched, isValidating, error],
   )
 }

--- a/src/client/src/components/ui/form-field-context.ts
+++ b/src/client/src/components/ui/form-field-context.ts
@@ -38,12 +38,15 @@ export const useFormField = () => {
 
   const { id } = itemContext
 
-  return {
-    id,
-    name: fieldContext.name,
-    formItemId: `${id}-form-item`,
-    formDescriptionId: `${id}-form-item-description`,
-    formMessageId: `${id}-form-item-message`,
-    ...fieldState,
-  }
+  return React.useMemo(
+    () => ({
+      id,
+      name: fieldContext.name,
+      formItemId: `${id}-form-item`,
+      formDescriptionId: `${id}-form-item-description`,
+      formMessageId: `${id}-form-item-message`,
+      ...fieldState,
+    }),
+    [id, fieldContext.name, fieldState],
+  )
 }

--- a/src/client/src/hooks/useListKeyboardNav.ts
+++ b/src/client/src/hooks/useListKeyboardNav.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useMemo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 export interface UseListKeyboardNavOptions<T> {
@@ -136,13 +136,18 @@ export function useListKeyboardNav<T>({
     [selected, items.length, onSelectAll, onDeselectAll],
   );
 
-  return {
-    focusedIndex,
-    setFocusedIndex,
-    tableRef,
-    focusedId:
-      focusedIndex >= 0 && focusedIndex < items.length
-        ? getId(items[focusedIndex])
-        : null,
-  };
+  const focusedId =
+    focusedIndex >= 0 && focusedIndex < items.length
+      ? getId(items[focusedIndex])
+      : null;
+
+  return useMemo(
+    () => ({
+      focusedIndex,
+      setFocusedIndex,
+      tableRef,
+      focusedId,
+    }),
+    [focusedIndex, setFocusedIndex, tableRef, focusedId],
+  );
 }

--- a/src/client/src/hooks/useSignalR.ts
+++ b/src/client/src/hooks/useSignalR.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import * as signalR from "@microsoft/signalr";
 import { useQueryClient } from "@tanstack/react-query";
 import { getAccessToken, parseJwtPayload } from "@/lib/auth";
@@ -170,5 +170,5 @@ export function useSignalR(enabled: boolean) {
     };
   }, [enabled, queryClient]);
 
-  return { connectionState };
+  return useMemo(() => ({ connectionState }), [connectionState]);
 }


### PR DESCRIPTION
## Summary
- Upgrade `@mggarofalo/eslint-plugin-react-hook-stability` from `^0.1.4` to `^0.2.0`, adding detection for bare array returns and unstable wrapper objects
- Promote `react-hook-stability/require-stable-hook-returns` rule from `warn` to `error` so violations block commits
- Fix 3 newly detected unstable wrapper object returns (`useFormField`, `useListKeyboardNav`, `useSignalR`) by wrapping in `useMemo`

Resolves MGG-331

## Test plan
- ESLint passes with zero errors (5 pre-existing warnings from other rules remain)
- Synthetic violation test: created a hook with bare `return []`, confirmed lint catches it as an error, then reverted
- All 1117 client tests pass
- All 925 .NET tests pass
- Pre-commit hooks pass (build, lint, formatting, type-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)