### PR TITLE
fix(infrastructure): add rollback and retry recovery to database seeder (MGG-342)

### DIFF
--- a/src/Infrastructure/Services/DatabaseSeederService.cs
+++ b/src/Infrastructure/Services/DatabaseSeederService.cs
@@ -86,8 +86,17 @@ public static class DatabaseSeederService
 		}
 		catch when (userCreatedHere)
 		{
-			// Delete orphaned user so the next retry can succeed
-			await userManager.DeleteAsync(adminUser);
+			// Delete orphaned user so the next retry can succeed.
+			// Swallow delete failures to preserve the original exception.
+			try
+			{
+				await userManager.DeleteAsync(adminUser);
+			}
+			catch
+			{
+				// Intentionally swallowed — the original role-assignment exception is more important.
+			}
+
 			throw;
 		}
 	}

--- a/src/Infrastructure/Services/DatabaseSeederService.cs
+++ b/src/Infrastructure/Services/DatabaseSeederService.cs
@@ -36,38 +36,59 @@ public static class DatabaseSeederService
 			return;
 		}
 
-		IList<ApplicationUser> existingAdmins = await userManager.GetUsersInRoleAsync(AppRoles.Admin);
-		if (existingAdmins.Count > 0)
+		// Look up by email (not role membership) to detect orphaned users from partial failures
+		ApplicationUser? adminUser = await userManager.FindByEmailAsync(adminEmail);
+		bool userCreatedHere = false;
+
+		if (adminUser == null)
 		{
-			return;
+			adminUser = new()
+			{
+				UserName = adminEmail,
+				Email = adminEmail,
+				FirstName = configuration[ConfigurationVariables.AdminSeedFirstName],
+				LastName = configuration[ConfigurationVariables.AdminSeedLastName],
+				MustResetPassword = true,
+				CreatedAt = DateTimeOffset.UtcNow,
+			};
+
+			IdentityResult result = await userManager.CreateAsync(adminUser, adminPassword);
+			if (!result.Succeeded)
+			{
+				throw new InvalidOperationException(
+					$"Failed to create admin user: {string.Join(", ", result.Errors.Select(e => e.Description))}");
+			}
+
+			userCreatedHere = true;
 		}
 
-		ApplicationUser adminUser = new()
+		try
 		{
-			UserName = adminEmail,
-			Email = adminEmail,
-			FirstName = configuration[ConfigurationVariables.AdminSeedFirstName],
-			LastName = configuration[ConfigurationVariables.AdminSeedLastName],
-			MustResetPassword = true,
-			CreatedAt = DateTimeOffset.UtcNow,
-		};
-
-		IdentityResult result = await userManager.CreateAsync(adminUser, adminPassword);
-		if (result.Succeeded)
-		{
-			IdentityResult addAdmin = await userManager.AddToRoleAsync(adminUser, AppRoles.Admin);
-			if (!addAdmin.Succeeded)
+			if (!await userManager.IsInRoleAsync(adminUser, AppRoles.Admin))
 			{
-				throw new InvalidOperationException(
-					$"Failed to assign Admin role: {string.Join(", ", addAdmin.Errors.Select(e => e.Description))}");
+				IdentityResult addAdmin = await userManager.AddToRoleAsync(adminUser, AppRoles.Admin);
+				if (!addAdmin.Succeeded)
+				{
+					throw new InvalidOperationException(
+						$"Failed to assign Admin role: {string.Join(", ", addAdmin.Errors.Select(e => e.Description))}");
+				}
 			}
 
-			IdentityResult addUser = await userManager.AddToRoleAsync(adminUser, AppRoles.User);
-			if (!addUser.Succeeded)
+			if (!await userManager.IsInRoleAsync(adminUser, AppRoles.User))
 			{
-				throw new InvalidOperationException(
-					$"Failed to assign User role: {string.Join(", ", addUser.Errors.Select(e => e.Description))}");
+				IdentityResult addUser = await userManager.AddToRoleAsync(adminUser, AppRoles.User);
+				if (!addUser.Succeeded)
+				{
+					throw new InvalidOperationException(
+						$"Failed to assign User role: {string.Join(", ", addUser.Errors.Select(e => e.Description))}");
+				}
 			}
+		}
+		catch when (userCreatedHere)
+		{
+			// Delete orphaned user so the next retry can succeed
+			await userManager.DeleteAsync(adminUser);
+			throw;
 		}
 	}
 }

--- a/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
@@ -155,6 +155,8 @@ public class DatabaseSeederServiceTests
 			.ReturnsAsync(IdentityResult.Success);
 		_mockUserManager.Setup(u => u.IsInRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin))
 			.ReturnsAsync(false);
+		_mockUserManager.Setup(u => u.IsInRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.User))
+			.ReturnsAsync(false);
 		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin))
 			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "RoleFail", Description = "Admin role assignment failed" }));
 		_mockUserManager.Setup(u => u.DeleteAsync(It.IsAny<ApplicationUser>()))

--- a/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
@@ -43,6 +43,18 @@ public class DatabaseSeederServiceTests
 		_serviceProvider = services.BuildServiceProvider();
 	}
 
+	private void SetupFullySeedableUser()
+	{
+		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
+			.ReturnsAsync((ApplicationUser?)null);
+		_mockUserManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Success);
+		_mockUserManager.Setup(u => u.IsInRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(false);
+		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Success);
+	}
+
 	[Fact]
 	public async Task SeedRolesAndAdminAsync_ThrowsWhenRoleCreationFails()
 	{
@@ -71,8 +83,11 @@ public class DatabaseSeederServiceTests
 		_mockRoleManager.Setup(r => r.CreateAsync(It.IsAny<IdentityRole>()))
 			.ReturnsAsync(IdentityResult.Success);
 
-		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
-			.ReturnsAsync(new List<ApplicationUser> { new() });
+		ApplicationUser existingUser = new() { Email = "admin@test.com" };
+		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
+			.ReturnsAsync(existingUser);
+		_mockUserManager.Setup(u => u.IsInRoleAsync(existingUser, It.IsAny<string>()))
+			.ReturnsAsync(true);
 
 		// Act
 		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
@@ -92,8 +107,11 @@ public class DatabaseSeederServiceTests
 		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
 			.ReturnsAsync(true);
 
-		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
-			.ReturnsAsync(new List<ApplicationUser> { new() });
+		ApplicationUser existingUser = new() { Email = "admin@test.com" };
+		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
+			.ReturnsAsync(existingUser);
+		_mockUserManager.Setup(u => u.IsInRoleAsync(existingUser, It.IsAny<string>()))
+			.ReturnsAsync(true);
 
 		// Act
 		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
@@ -103,20 +121,44 @@ public class DatabaseSeederServiceTests
 	}
 
 	[Fact]
-	public async Task SeedRolesAndAdminAsync_WhenAddToAdminRoleFails_ThrowsInvalidOperationException()
+	public async Task SeedRolesAndAdminAsync_WhenUserCreationFails_ThrowsInvalidOperationException()
 	{
 		// Arrange
 		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
 			.ReturnsAsync(true);
 
-		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
-			.ReturnsAsync(new List<ApplicationUser>());
+		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
+			.ReturnsAsync((ApplicationUser?)null);
 
+		IdentityError error = new() { Code = "DuplicateEmail", Description = "Email already taken" };
+		_mockUserManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Failed(error));
+
+		// Act
+		Func<Task> act = () => DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*Failed to create admin user*Email already taken*");
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenAddToAdminRoleFails_ThrowsAndDeletesUser()
+	{
+		// Arrange
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(true);
+
+		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
+			.ReturnsAsync((ApplicationUser?)null);
 		_mockUserManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
 			.ReturnsAsync(IdentityResult.Success);
-
+		_mockUserManager.Setup(u => u.IsInRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin))
+			.ReturnsAsync(false);
 		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin))
 			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "RoleFail", Description = "Admin role assignment failed" }));
+		_mockUserManager.Setup(u => u.DeleteAsync(It.IsAny<ApplicationUser>()))
+			.ReturnsAsync(IdentityResult.Success);
 
 		// Act
 		Func<Task> act = () => DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
@@ -124,26 +166,30 @@ public class DatabaseSeederServiceTests
 		// Assert
 		await act.Should().ThrowAsync<InvalidOperationException>()
 			.WithMessage("*Admin role*Admin role assignment failed*");
+		_mockUserManager.Verify(u => u.DeleteAsync(It.IsAny<ApplicationUser>()), Times.Once);
 	}
 
 	[Fact]
-	public async Task SeedRolesAndAdminAsync_WhenAddToUserRoleFails_ThrowsInvalidOperationException()
+	public async Task SeedRolesAndAdminAsync_WhenAddToUserRoleFails_ThrowsAndDeletesUser()
 	{
 		// Arrange
 		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
 			.ReturnsAsync(true);
 
-		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
-			.ReturnsAsync(new List<ApplicationUser>());
-
+		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
+			.ReturnsAsync((ApplicationUser?)null);
 		_mockUserManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
 			.ReturnsAsync(IdentityResult.Success);
-
+		_mockUserManager.Setup(u => u.IsInRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin))
+			.ReturnsAsync(false);
+		_mockUserManager.Setup(u => u.IsInRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.User))
+			.ReturnsAsync(false);
 		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin))
 			.ReturnsAsync(IdentityResult.Success);
-
 		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.User))
 			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "RoleFail", Description = "User role assignment failed" }));
+		_mockUserManager.Setup(u => u.DeleteAsync(It.IsAny<ApplicationUser>()))
+			.ReturnsAsync(IdentityResult.Success);
 
 		// Act
 		Func<Task> act = () => DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
@@ -151,6 +197,7 @@ public class DatabaseSeederServiceTests
 		// Assert
 		await act.Should().ThrowAsync<InvalidOperationException>()
 			.WithMessage("*User role*User role assignment failed*");
+		_mockUserManager.Verify(u => u.DeleteAsync(It.IsAny<ApplicationUser>()), Times.Once);
 	}
 
 	[Fact]
@@ -160,14 +207,7 @@ public class DatabaseSeederServiceTests
 		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
 			.ReturnsAsync(true);
 
-		_mockUserManager.Setup(u => u.GetUsersInRoleAsync(AppRoles.Admin))
-			.ReturnsAsync(new List<ApplicationUser>());
-
-		_mockUserManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
-			.ReturnsAsync(IdentityResult.Success);
-
-		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
-			.ReturnsAsync(IdentityResult.Success);
+		SetupFullySeedableUser();
 
 		// Act
 		Func<Task> act = () => DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
@@ -177,5 +217,74 @@ public class DatabaseSeederServiceTests
 
 		_mockUserManager.Verify(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.Admin), Times.Once);
 		_mockUserManager.Verify(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), AppRoles.User), Times.Once);
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenExistingUserHasAllRoles_SkipsRoleAssignment()
+	{
+		// Arrange
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(true);
+
+		ApplicationUser existingUser = new() { Email = "admin@test.com" };
+		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
+			.ReturnsAsync(existingUser);
+		_mockUserManager.Setup(u => u.IsInRoleAsync(existingUser, It.IsAny<string>()))
+			.ReturnsAsync(true);
+
+		// Act
+		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		_mockUserManager.Verify(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
+		_mockUserManager.Verify(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenExistingUserLacksRoles_AssignsRolesWithoutCreating()
+	{
+		// Arrange — simulates orphaned user from a previous partial failure
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(true);
+
+		ApplicationUser orphanedUser = new() { Email = "admin@test.com" };
+		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
+			.ReturnsAsync(orphanedUser);
+		_mockUserManager.Setup(u => u.IsInRoleAsync(orphanedUser, It.IsAny<string>()))
+			.ReturnsAsync(false);
+		_mockUserManager.Setup(u => u.AddToRoleAsync(orphanedUser, It.IsAny<string>()))
+			.ReturnsAsync(IdentityResult.Success);
+
+		// Act
+		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		_mockUserManager.Verify(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
+		_mockUserManager.Verify(u => u.AddToRoleAsync(orphanedUser, AppRoles.Admin), Times.Once);
+		_mockUserManager.Verify(u => u.AddToRoleAsync(orphanedUser, AppRoles.User), Times.Once);
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenRoleAssignmentFailsForOrphanedUser_DoesNotDeleteUser()
+	{
+		// Arrange — orphaned user from a previous run; role assignment fails again
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(true);
+
+		ApplicationUser orphanedUser = new() { Email = "admin@test.com" };
+		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
+			.ReturnsAsync(orphanedUser);
+		_mockUserManager.Setup(u => u.IsInRoleAsync(orphanedUser, AppRoles.Admin))
+			.ReturnsAsync(false);
+		_mockUserManager.Setup(u => u.AddToRoleAsync(orphanedUser, AppRoles.Admin))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "RoleFail", Description = "Admin role assignment failed" }));
+
+		// Act
+		Func<Task> act = () => DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert — throws but does NOT delete the pre-existing user
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*Admin role*Admin role assignment failed*");
+		_mockUserManager.Verify(u => u.DeleteAsync(It.IsAny<ApplicationUser>()), Times.Never);
 	}
 }


### PR DESCRIPTION
## Summary
- Look up admin user by email instead of role membership to detect orphaned users from previous partial failures
- Delete newly-created users when role assignment fails, enabling clean retries instead of permanent stuck state
- Throw on user creation failure instead of silently returning
- Check `IsInRoleAsync` before `AddToRoleAsync` for idempotent partial-assignment recovery

Resolves MGG-342

## Test plan
- Run `dotnet test --filter "FullyQualifiedName~DatabaseSeederServiceTests"` — all 10 tests pass
- Key scenarios tested: role creation failure throws, user creation failure throws, admin role assignment failure triggers rollback (user deleted), user role assignment failure triggers rollback, orphaned user recovery assigns roles without re-creating, fully seeded user is skipped, orphaned user role failure does NOT delete pre-existing user