### PR TITLE
fix(infrastructure): handle Task.Delay cancellation in EmbeddingGenerationService (MGG-343)

### DIFF
--- a/src/Infrastructure/Services/EmbeddingGenerationService.cs
+++ b/src/Infrastructure/Services/EmbeddingGenerationService.cs
@@ -18,7 +18,14 @@ public class EmbeddingGenerationService(
 
 	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 	{
-		await Task.Delay(InitialDelay, stoppingToken);
+		try
+		{
+			await Task.Delay(InitialDelay, stoppingToken);
+		}
+		catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+		{
+			return;
+		}
 
 		while (!stoppingToken.IsCancellationRequested)
 		{
@@ -39,7 +46,14 @@ public class EmbeddingGenerationService(
 				logger.LogError(ex, "Error during embedding generation cycle");
 			}
 
-			await Task.Delay(Interval, stoppingToken);
+			try
+			{
+				await Task.Delay(Interval, stoppingToken);
+			}
+			catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+			{
+				break;
+			}
 		}
 	}
 

--- a/tests/Infrastructure.Tests/Services/EmbeddingGenerationServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/EmbeddingGenerationServiceTests.cs
@@ -376,6 +376,49 @@ public class EmbeddingGenerationServiceTests
 			Times.AtLeastOnce());
 	}
 
+	[Fact]
+	public async Task ExecuteAsync_CancellationDuringInitialDelay_DoesNotThrow()
+	{
+		// Arrange — cancel immediately so the 10-second initial delay is interrupted
+		EmbeddingGenerationService service = new(_scopeFactoryMock.Object, _loggerMock.Object);
+		using CancellationTokenSource cts = new();
+
+		// Act — start and cancel right away; the service should be sitting in the initial delay
+		await service.StartAsync(cts.Token);
+		cts.Cancel();
+		Func<Task> act = async () => await service.StopAsync(CancellationToken.None);
+
+		// Assert — the OperationCanceledException from Task.Delay should be caught internally
+		await act.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public async Task ExecuteAsync_CancellationDuringLoopDelay_DoesNotThrow()
+	{
+		// Arrange — let ProcessPendingEmbeddingsAsync run once (short-circuit via IsConfigured=false),
+		// then cancel during the 30-second loop delay.
+		TaskCompletionSource processed = new();
+		_embeddingServiceMock
+			.Setup(e => e.IsConfigured)
+			.Returns(() =>
+			{
+				processed.TrySetResult();
+				return false;
+			});
+
+		EmbeddingGenerationService service = new(_scopeFactoryMock.Object, _loggerMock.Object);
+		using CancellationTokenSource cts = new();
+
+		// Act — wait for the first processing cycle to complete, then cancel
+		await service.StartAsync(cts.Token);
+		await processed.Task.WaitAsync(TimeSpan.FromSeconds(15));
+		cts.Cancel();
+		Func<Task> act = async () => await service.StopAsync(CancellationToken.None);
+
+		// Assert — the OperationCanceledException from the loop Task.Delay should be caught internally
+		await act.Should().NotThrowAsync();
+	}
+
 	private static float[] CreateFakeEmbedding()
 	{
 		float[] embedding = new float[OnnxEmbeddingService.EmbeddingDimension];


### PR DESCRIPTION
## Summary
- Wrap both `Task.Delay` calls in `EmbeddingGenerationService.ExecuteAsync` with try-catch for `OperationCanceledException` filtered by `stoppingToken.IsCancellationRequested`, matching the pattern applied to `AuthAuditCleanupService` in PR #175
- Initial delay (line 21): unprotected `await Task.Delay(InitialDelay, stoppingToken)` → wrapped with try-catch, returns on cancellation
- Loop delay (line 42): `await Task.Delay(Interval, stoppingToken)` outside try-catch → wrapped with try-catch, breaks on cancellation
- Add unit tests for cancellation during both initial and loop delays

## Test plan
- [x] `ExecuteAsync_CancellationDuringInitialDelay_DoesNotThrow` — cancels during 10s initial delay, verifies graceful return
- [x] `ExecuteAsync_CancellationDuringLoopDelay_DoesNotThrow` — cancels during 30s loop delay, verifies graceful break
- [x] All 796 existing + new tests pass
- [x] Pre-commit hooks pass (Spectral, dotnet format, build, drift check, unit tests, tsc, eslint)

Closes MGG-343

🤖 Generated with [Claude Code](https://claude.com/claude-code)