### PR TITLE
refactor(client): unwrap paginated response in list hooks (MGG-341)

### DIFF
--- a/src/client/src/components/GlobalSearchDialog.test.tsx
+++ b/src/client/src/components/GlobalSearchDialog.test.tsx
@@ -69,10 +69,11 @@ describe("GlobalSearchDialog", () => {
   it("renders account items when accounts data is available", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: { data: [
+      data: [
         { id: "acc-1", accountCode: "ACC001", name: "Checking" },
         { id: "acc-2", accountCode: "ACC002", name: "Savings" },
-      ], total: 2, offset: 0, limit: 50 },
+      ],
+      total: 2,
     }));
 
     renderWithQueryClient(
@@ -144,14 +145,15 @@ describe("GlobalSearchDialog", () => {
   it("renders receipt items when receiptItems data is available", async () => {
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
     vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
-      data: { data: [
+      data: [
         {
           id: "ri-1",
           receiptItemCode: "RI001",
           description: "Test Item",
           category: "Food",
         },
-      ], total: 1, offset: 0, limit: 50 },
+      ],
+      total: 1,
     }));
 
     renderWithQueryClient(
@@ -166,9 +168,10 @@ describe("GlobalSearchDialog", () => {
   it("renders transaction items when transactions data is available", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: { data: [
+      data: [
         { id: "txn-1", amount: 42.5, date: "2024-01-15" },
-      ], total: 1, offset: 0, limit: 50 },
+      ],
+      total: 1,
     }));
 
     renderWithQueryClient(
@@ -183,10 +186,11 @@ describe("GlobalSearchDialog", () => {
   it("renders receipt items when receipts data is available", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: [
+      data: [
         { id: "r-1", location: "Store A" },
         { id: "r-2", location: "Store B" },
-      ], total: 2, offset: 0, limit: 50 },
+      ],
+      total: 2,
     }));
 
     renderWithQueryClient(
@@ -199,9 +203,10 @@ describe("GlobalSearchDialog", () => {
   it("selecting an account item closes dialog", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: { data: [
+      data: [
         { id: "acc-1", accountCode: "ACC001", name: "Checking" },
-      ], total: 1, offset: 0, limit: 50 },
+      ],
+      total: 1,
     }));
 
     const user = userEvent.setup();
@@ -216,9 +221,10 @@ describe("GlobalSearchDialog", () => {
   it("selecting a receipt item closes dialog", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: [
+      data: [
         { id: "r-1", location: "Downtown" },
-      ], total: 1, offset: 0, limit: 50 },
+      ],
+      total: 1,
     }));
 
     const user = userEvent.setup();
@@ -233,9 +239,10 @@ describe("GlobalSearchDialog", () => {
   it("selecting a transaction item closes dialog", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: { data: [
+      data: [
         { id: "txn-1", amount: 100, date: "2024-06-01" },
-      ], total: 1, offset: 0, limit: 50 },
+      ],
+      total: 1,
     }));
 
     const user = userEvent.setup();

--- a/src/client/src/components/GlobalSearchDialog.tsx
+++ b/src/client/src/components/GlobalSearchDialog.tsx
@@ -24,30 +24,6 @@ import { useReceipts } from "@/hooks/useReceipts";
 import { useReceiptItems } from "@/hooks/useReceiptItems";
 import { useTransactions } from "@/hooks/useTransactions";
 
-interface AccountResponse {
-  id: string;
-  accountCode: string;
-  name: string;
-}
-
-interface ReceiptResponse {
-  id: string;
-  location: string;
-}
-
-interface ReceiptItemResponse {
-  id: string;
-  receiptItemCode: string;
-  description: string;
-  category: string;
-}
-
-interface TransactionResponse {
-  id: string;
-  amount: number;
-  date: string;
-}
-
 interface GlobalSearchDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -67,15 +43,10 @@ export function GlobalSearchDialog({
   onOpenChange,
 }: GlobalSearchDialogProps) {
   const navigate = useNavigate();
-  const { data: accountsResponse } = useAccounts();
-  const { data: receiptsResponse } = useReceipts();
-  const { data: receiptItemsResponse } = useReceiptItems();
-  const { data: transactionsResponse } = useTransactions();
-
-  const accounts = accountsResponse?.data as AccountResponse[] | undefined;
-  const receipts = receiptsResponse?.data as ReceiptResponse[] | undefined;
-  const receiptItems = receiptItemsResponse?.data as ReceiptItemResponse[] | undefined;
-  const transactions = transactionsResponse?.data as TransactionResponse[] | undefined;
+  const { data: accounts } = useAccounts();
+  const { data: receipts } = useReceipts();
+  const { data: receiptItems } = useReceiptItems();
+  const { data: transactions } = useTransactions();
 
   const toggleOpen = useCallback(() => {
     onOpenChange(!open);

--- a/src/client/src/components/ItemTemplateForm.test.tsx
+++ b/src/client/src/components/ItemTemplateForm.test.tsx
@@ -39,23 +39,21 @@ vi.mock("@/hooks/useEnumMetadata", () => ({
 
 vi.mock("@/hooks/useCategories", () => ({
   useCategories: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "cat-1", name: "Groceries" },
-        { id: "cat-2", name: "Electronics" },
-      ],
-    },
+    data: [
+      { id: "cat-1", name: "Groceries" },
+      { id: "cat-2", name: "Electronics" },
+    ],
+    total: 2,
   })),
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
   useSubcategoriesByCategoryId: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "sub-1", name: "Dairy" },
-        { id: "sub-2", name: "Bakery" },
-      ],
-    },
+    data: [
+      { id: "sub-1", name: "Dairy" },
+      { id: "sub-2", name: "Bakery" },
+    ],
+    total: 2,
   })),
 }));
 

--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -53,7 +53,7 @@ export function ItemTemplateForm({
 
   const { data: categories } = useCategories();
   const categoryOptions =
-    (categories?.data as { id: string; name: string }[] | undefined)?.map((c) => ({
+    (categories as { id: string; name: string }[] | undefined)?.map((c) => ({
       value: c.name,
       label: c.name,
     })) ?? [];
@@ -77,7 +77,7 @@ export function ItemTemplateForm({
   const watchedCategory = form.watch("defaultCategory");
 
   const selectedCategoryId =
-    (categories?.data as { id: string; name: string }[] | undefined)?.find(
+    (categories as { id: string; name: string }[] | undefined)?.find(
       (c) => c.name === watchedCategory,
     )?.id ?? null;
 
@@ -85,7 +85,7 @@ export function ItemTemplateForm({
     useSubcategoriesByCategoryId(selectedCategoryId);
 
   const subcategoryOptions =
-    (subcategoriesData?.data as { id: string; name: string }[] | undefined)?.map(
+    (subcategoriesData as { id: string; name: string }[] | undefined)?.map(
       (s) => ({
         value: s.name,
         label: s.name,

--- a/src/client/src/components/ReceiptItemForm.test.tsx
+++ b/src/client/src/components/ReceiptItemForm.test.tsx
@@ -25,34 +25,31 @@ vi.mock("@/hooks/useEnumMetadata", () => ({
 
 vi.mock("@/hooks/useReceipts", () => ({
   useReceipts: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "r-1", location: "Walmart", date: "2024-01-15" },
-      ],
-    },
+    data: [
+      { id: "r-1", location: "Walmart", date: "2024-01-15" },
+    ],
+    total: 1,
     isLoading: false,
   })),
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
   useCategories: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "cat-1", name: "Groceries" },
-        { id: "cat-2", name: "Electronics" },
-      ],
-    },
+    data: [
+      { id: "cat-1", name: "Groceries" },
+      { id: "cat-2", name: "Electronics" },
+    ],
+    total: 2,
   })),
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
   useSubcategoriesByCategoryId: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "sub-1", name: "Dairy" },
-        { id: "sub-2", name: "Bakery" },
-      ],
-    },
+    data: [
+      { id: "sub-1", name: "Dairy" },
+      { id: "sub-2", name: "Bakery" },
+    ],
+    total: 2,
   })),
   useCreateSubcategory: vi.fn(() => ({
     mutateAsync: vi.fn(),
@@ -61,18 +58,17 @@ vi.mock("@/hooks/useSubcategories", () => ({
 
 vi.mock("@/hooks/useItemTemplates", () => ({
   useItemTemplates: vi.fn(() => ({
-    data: {
-      data: [
-        {
-          id: "tmpl-1",
-          name: "Milk",
-          defaultCategory: "Groceries",
-          defaultSubcategory: "Dairy",
-          defaultUnitPrice: 3.99,
-          defaultItemCode: "MLK-001",
-        },
-      ],
-    },
+    data: [
+      {
+        id: "tmpl-1",
+        name: "Milk",
+        defaultCategory: "Groceries",
+        defaultSubcategory: "Dairy",
+        defaultUnitPrice: 3.99,
+        defaultItemCode: "MLK-001",
+      },
+    ],
+    total: 1,
   })),
 }));
 

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -97,18 +97,17 @@ export function ReceiptItemForm({
     useFieldHistory(itemCodeHistory);
 
   const { data: receipts, isLoading: receiptsLoading } = useReceipts();
-  const { data: categoriesResponse } = useCategories();
-  const categories = categoriesResponse?.data as { id: string; name: string }[] | undefined;
+  const { data: categories } = useCategories();
   const { data: itemTemplatesData } = useItemTemplates();
   const templates = useMemo(
-    () => (itemTemplatesData?.data as ItemTemplate[] | undefined) ?? [],
+    () => (itemTemplatesData as ItemTemplate[] | undefined) ?? [],
     [itemTemplatesData],
   );
 
   const receiptOptions = useMemo(
     () =>
       (
-        (receipts?.data as
+        (receipts as
           | {
               id: string;
               location: string;
@@ -161,7 +160,7 @@ export function ReceiptItemForm({
   const subcategoryOptions = useMemo(
     () =>
       (
-        (subcategoriesData?.data as { id: string; name: string }[] | undefined) ?? []
+        (subcategoriesData as { id: string; name: string }[] | undefined) ?? []
       ).map((s) => ({
         value: s.name,
         label: s.name,

--- a/src/client/src/components/SubcategoryForm.test.tsx
+++ b/src/client/src/components/SubcategoryForm.test.tsx
@@ -9,12 +9,11 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
 
 vi.mock("@/hooks/useCategories", () => ({
   useCategories: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "cat-1", name: "Groceries" },
-        { id: "cat-2", name: "Utilities" },
-      ],
-    },
+    data: [
+      { id: "cat-1", name: "Groceries" },
+      { id: "cat-2", name: "Utilities" },
+    ],
+    total: 2,
   })),
 }));
 

--- a/src/client/src/components/SubcategoryForm.tsx
+++ b/src/client/src/components/SubcategoryForm.tsx
@@ -49,7 +49,7 @@ export function SubcategoryForm({
   const { data: categories } = useCategories();
 
   const categoryOptions = (
-    categories?.data as { id: string; name: string }[] | undefined
+    categories as { id: string; name: string }[] | undefined
   )?.map((c) => ({
     value: c.id,
     label: c.name,

--- a/src/client/src/components/TransactionForm.test.tsx
+++ b/src/client/src/components/TransactionForm.test.tsx
@@ -8,28 +8,20 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
 
 vi.mock("@/hooks/useReceipts", () => ({
   useReceipts: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "r-1", location: "Walmart", date: "2024-01-15" },
-      ],
-      total: 1,
-      offset: 0,
-      limit: 50,
-    },
+    data: [
+      { id: "r-1", location: "Walmart", date: "2024-01-15" },
+    ],
+    total: 1,
     isLoading: false,
   })),
 }));
 
 vi.mock("@/hooks/useAccounts", () => ({
   useAccounts: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "a-1", name: "Checking", accountCode: "CHK-001" },
-      ],
-      total: 1,
-      offset: 0,
-      limit: 50,
-    },
+    data: [
+      { id: "a-1", name: "Checking", accountCode: "CHK-001" },
+    ],
+    total: 1,
     isLoading: false,
   })),
 }));

--- a/src/client/src/components/TransactionForm.tsx
+++ b/src/client/src/components/TransactionForm.tsx
@@ -53,7 +53,7 @@ export function TransactionForm({
   const receiptOptions = useMemo(
     () =>
       (
-        (receipts?.data as
+        (receipts as
           | { id: string; location: string; date: string }[]
           | undefined) ?? []
       ).map(receiptToOption),
@@ -63,7 +63,7 @@ export function TransactionForm({
   const accountOptions = useMemo(
     () =>
       (
-        (accounts?.data as
+        (accounts as
           | { id: string; name: string; accountCode: string }[]
           | undefined) ?? []
       ).map(accountToOption),

--- a/src/client/src/components/dashboard/RecentReceiptsWidget.test.tsx
+++ b/src/client/src/components/dashboard/RecentReceiptsWidget.test.tsx
@@ -12,27 +12,23 @@ const mockUseReceipts = vi.mocked(useReceipts);
 describe("RecentReceiptsWidget", () => {
   it("renders recent receipts", () => {
     mockUseReceipts.mockReturnValue({
-      data: {
-        data: [
-          {
-            id: "1",
-            location: "Grocery Store",
-            date: "2024-01-15",
-            taxAmount: 45.99,
-            description: null,
-          },
-          {
-            id: "2",
-            location: "Gas Station",
-            date: "2024-01-14",
-            taxAmount: 32.5,
-            description: null,
-          },
-        ],
-        total: 2,
-        offset: 0,
-        limit: 5,
-      },
+      data: [
+        {
+          id: "1",
+          location: "Grocery Store",
+          date: "2024-01-15",
+          taxAmount: 45.99,
+          description: null,
+        },
+        {
+          id: "2",
+          location: "Gas Station",
+          date: "2024-01-14",
+          taxAmount: 32.5,
+          description: null,
+        },
+      ],
+      total: 2,
       isLoading: false,
     } as unknown as ReturnType<typeof useReceipts>);
 
@@ -45,7 +41,8 @@ describe("RecentReceiptsWidget", () => {
 
   it("renders View all link", () => {
     mockUseReceipts.mockReturnValue({
-      data: { data: [], total: 0, offset: 0, limit: 5 },
+      data: [],
+      total: 0,
       isLoading: false,
     } as unknown as ReturnType<typeof useReceipts>);
 
@@ -65,7 +62,8 @@ describe("RecentReceiptsWidget", () => {
 
   it("shows empty state when no receipts", () => {
     mockUseReceipts.mockReturnValue({
-      data: { data: [], total: 0, offset: 0, limit: 5 },
+      data: [],
+      total: 0,
       isLoading: false,
     } as unknown as ReturnType<typeof useReceipts>);
 

--- a/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
+++ b/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
@@ -19,7 +19,7 @@ function formatCurrency(value: number | string | undefined): string {
 export function RecentReceiptsWidget({ className }: RecentReceiptsWidgetProps) {
   const { data, isLoading } = useReceipts(0, 5, "date", "desc");
 
-  const receipts = useMemo(() => data?.data ?? [], [data?.data]);
+  const receipts = useMemo(() => data ?? [], [data]);
 
   return (
     <ChartCard

--- a/src/client/src/hooks/useAccounts.test.ts
+++ b/src/client/src/hooks/useAccounts.test.ts
@@ -43,7 +43,7 @@ describe("useAccounts", () => {
     const accounts = [
       { id: "1", accountCode: "ACC1", name: "Checking", isActive: true },
     ];
-    (client.GET as Mock).mockResolvedValue({ data: accounts, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: accounts, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useAccounts(), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useAccounts.ts
+++ b/src/client/src/hooks/useAccounts.ts
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 // Note: Accounts are reference entities and cannot be deleted or restored.
 
 export function useAccounts(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["accounts", "list", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/accounts", {
@@ -15,6 +15,7 @@ export function useAccounts(offset = 0, limit = 50, sortBy?: string | null, sort
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useAccount(id: string | null) {

--- a/src/client/src/hooks/useAdjustments.test.ts
+++ b/src/client/src/hooks/useAdjustments.test.ts
@@ -47,7 +47,7 @@ describe("useAdjustments", () => {
     const adjustments = [
       { id: "1", type: "discount", amount: 5.0, description: "Coupon" },
     ];
-    (client.GET as Mock).mockResolvedValue({ data: adjustments, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: adjustments, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useAdjustments(), {
       wrapper: createWrapper(),
@@ -72,7 +72,7 @@ describe("useAdjustments", () => {
 
   it("by-receipt query returns data when receiptId is provided", async () => {
     const items = [{ id: "1", type: "discount", amount: 5.0 }];
-    (client.GET as Mock).mockResolvedValue({ data: items, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: items, total: 1, offset: 0, limit: 200 }, error: undefined });
 
     const { result } = renderHook(() => useAdjustmentsByReceiptId("r-1"), {
       wrapper: createWrapper(),
@@ -152,7 +152,7 @@ describe("useAdjustments", () => {
 
   it("deleted adjustments query returns data on success", async () => {
     const deleted = [{ id: "3", type: "discount", amount: 1.0 }];
-    (client.GET as Mock).mockResolvedValue({ data: deleted, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: deleted, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useDeletedAdjustments(), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useAdjustments.ts
+++ b/src/client/src/hooks/useAdjustments.ts
@@ -3,7 +3,7 @@ import client from "@/lib/api-client";
 import { toast } from "sonner";
 
 export function useAdjustments(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["adjustments", "list", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/adjustments", {
@@ -13,6 +13,7 @@ export function useAdjustments(offset = 0, limit = 50, sortBy?: string | null, s
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useAdjustment(id: string | null) {
@@ -30,7 +31,7 @@ export function useAdjustment(id: string | null) {
 }
 
 export function useAdjustmentsByReceiptId(receiptId: string | null, offset = 0, limit = 200, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["adjustments", "by-receipt", receiptId, offset, limit, sortBy, sortDirection],
     enabled: !!receiptId,
     queryFn: async () => {
@@ -41,6 +42,7 @@ export function useAdjustmentsByReceiptId(receiptId: string | null, offset = 0, 
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useCreateAdjustment() {
@@ -147,7 +149,7 @@ export function useDeleteAdjustments() {
 }
 
 export function useDeletedAdjustments(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["adjustments", "deleted", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/adjustments/deleted", {
@@ -157,6 +159,7 @@ export function useDeletedAdjustments(offset = 0, limit = 50, sortBy?: string | 
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useRestoreAdjustment() {

--- a/src/client/src/hooks/useAudit.test.ts
+++ b/src/client/src/hooks/useAudit.test.ts
@@ -36,7 +36,7 @@ describe("useEntityAuditHistory", () => {
   it("fetches audit history when both entityType and entityId are provided", async () => {
     const mockHistory = [{ id: "a1", action: "Created" }];
     (client.GET as Mock).mockResolvedValue({
-      data: mockHistory,
+      data: { data: mockHistory, total: 1, offset: 0, limit: 50 },
       error: null,
     });
 
@@ -108,7 +108,8 @@ describe("useRecentAuditLogs", () => {
         },
       },
     });
-    expect(result.current.data).toEqual(mockResponse);
+    expect(result.current.data).toEqual(mockResponse.data);
+    expect(result.current.total).toBe(1);
   });
 
   it("fetches recent audit logs with custom filters", async () => {

--- a/src/client/src/hooks/useAudit.ts
+++ b/src/client/src/hooks/useAudit.ts
@@ -9,7 +9,7 @@ export function useEntityAuditHistory(
   sortBy?: string | null,
   sortDirection?: string | null,
 ) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["audit", "entity", entityType, entityId, offset, limit, sortBy, sortDirection],
     enabled: !!entityType && !!entityId,
     queryFn: async () => {
@@ -29,6 +29,7 @@ export function useEntityAuditHistory(
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export interface AuditLogFilters {
@@ -56,7 +57,7 @@ export function useRecentAuditLogs(filters: AuditLogFilters = {}) {
     dateTo,
   } = filters;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [
       "audit",
       "recent",
@@ -93,4 +94,5 @@ export function useRecentAuditLogs(filters: AuditLogFilters = {}) {
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }

--- a/src/client/src/hooks/useAuthAudit.test.ts
+++ b/src/client/src/hooks/useAuthAudit.test.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
 describe("useMyAuthAuditLog", () => {
   it("fetches my auth audit logs with default params", async () => {
     const mockLogs = [{ id: "log1", event: "Login" }];
-    (client.GET as Mock).mockResolvedValue({ data: mockLogs, error: null });
+    (client.GET as Mock).mockResolvedValue({ data: { data: mockLogs, total: 1, offset: 0, limit: 50 }, error: null });
 
     const { result } = renderHook(() => useMyAuthAuditLog(), {
       wrapper: createWrapper(),
@@ -62,7 +62,7 @@ describe("useMyAuthAuditLog", () => {
 
   it("fetches my auth audit logs with custom offset and limit", async () => {
     const mockLogs = [{ id: "log1" }];
-    (client.GET as Mock).mockResolvedValue({ data: mockLogs, error: null });
+    (client.GET as Mock).mockResolvedValue({ data: { data: mockLogs, total: 1, offset: 10, limit: 25 }, error: null });
 
     const { result } = renderHook(() => useMyAuthAuditLog(10, 25), {
       wrapper: createWrapper(),
@@ -86,7 +86,7 @@ describe("useMyAuthAuditLog", () => {
 describe("useRecentAuthAuditLogs", () => {
   it("fetches recent auth audit logs with default params", async () => {
     const mockLogs = [{ id: "log2", event: "Logout" }];
-    (client.GET as Mock).mockResolvedValue({ data: mockLogs, error: null });
+    (client.GET as Mock).mockResolvedValue({ data: { data: mockLogs, total: 1, offset: 0, limit: 50 }, error: null });
 
     const { result } = renderHook(() => useRecentAuthAuditLogs(), {
       wrapper: createWrapper(),
@@ -108,7 +108,7 @@ describe("useRecentAuthAuditLogs", () => {
   });
 
   it("fetches recent auth audit logs with custom offset and limit", async () => {
-    (client.GET as Mock).mockResolvedValue({ data: [], error: null });
+    (client.GET as Mock).mockResolvedValue({ data: { data: [], total: 0, offset: 5, limit: 20 }, error: null });
 
     const { result } = renderHook(() => useRecentAuthAuditLogs(5, 20), {
       wrapper: createWrapper(),
@@ -133,7 +133,7 @@ describe("useFailedAuthAttempts", () => {
   it("fetches failed auth attempts with default params", async () => {
     const mockAttempts = [{ id: "f1", reason: "InvalidPassword" }];
     (client.GET as Mock).mockResolvedValue({
-      data: mockAttempts,
+      data: { data: mockAttempts, total: 1, offset: 0, limit: 50 },
       error: null,
     });
 
@@ -157,7 +157,7 @@ describe("useFailedAuthAttempts", () => {
   });
 
   it("fetches failed auth attempts with custom offset and limit", async () => {
-    (client.GET as Mock).mockResolvedValue({ data: [], error: null });
+    (client.GET as Mock).mockResolvedValue({ data: { data: [], total: 0, offset: 100, limit: 10 }, error: null });
 
     const { result } = renderHook(() => useFailedAuthAttempts(100, 10), {
       wrapper: createWrapper(),
@@ -178,7 +178,7 @@ describe("useFailedAuthAttempts", () => {
   });
 
   it("fetches failed auth attempts with sort params", async () => {
-    (client.GET as Mock).mockResolvedValue({ data: [], error: null });
+    (client.GET as Mock).mockResolvedValue({ data: { data: [], total: 0, offset: 0, limit: 50 }, error: null });
 
     const { result } = renderHook(
       () => useFailedAuthAttempts(0, 50, "timestamp", "asc"),

--- a/src/client/src/hooks/useAuthAudit.ts
+++ b/src/client/src/hooks/useAuthAudit.ts
@@ -7,7 +7,7 @@ export function useMyAuthAuditLog(
   sortBy?: string | null,
   sortDirection?: string | null,
 ) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["auth-audit", "me", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/auth/audit/me", {
@@ -24,6 +24,7 @@ export function useMyAuthAuditLog(
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useRecentAuthAuditLogs(
@@ -32,7 +33,7 @@ export function useRecentAuthAuditLogs(
   sortBy?: string | null,
   sortDirection?: string | null,
 ) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["auth-audit", "recent", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/auth/audit/recent", {
@@ -49,6 +50,7 @@ export function useRecentAuthAuditLogs(
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useFailedAuthAttempts(
@@ -57,7 +59,7 @@ export function useFailedAuthAttempts(
   sortBy?: string | null,
   sortDirection?: string | null,
 ) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["auth-audit", "failed", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/auth/audit/failed", {
@@ -74,4 +76,5 @@ export function useFailedAuthAttempts(
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }

--- a/src/client/src/hooks/useCategories.test.ts
+++ b/src/client/src/hooks/useCategories.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
 describe("useCategories", () => {
   it("list query returns data on success", async () => {
     const categories = [{ id: "1", name: "Food", description: "Groceries" }];
-    (client.GET as Mock).mockResolvedValue({ data: categories, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: categories, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useCategories(), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useCategories.ts
+++ b/src/client/src/hooks/useCategories.ts
@@ -3,7 +3,7 @@ import client from "@/lib/api-client";
 import { toast } from "sonner";
 
 export function useCategories(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["categories", "list", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/categories", {
@@ -13,6 +13,7 @@ export function useCategories(offset = 0, limit = 50, sortBy?: string | null, so
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useCategory(id: string | null) {

--- a/src/client/src/hooks/useItemTemplates.test.ts
+++ b/src/client/src/hooks/useItemTemplates.test.ts
@@ -55,7 +55,7 @@ describe("useItemTemplates", () => {
         defaultItemCode: "GRO",
       },
     ];
-    (client.GET as Mock).mockResolvedValue({ data: templates, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: templates, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useItemTemplates(), {
       wrapper: createWrapper(),
@@ -158,7 +158,7 @@ describe("useItemTemplates", () => {
 
   it("deleted item templates query returns data on success", async () => {
     const deleted = [{ id: "3", name: "Old Template", description: null }];
-    (client.GET as Mock).mockResolvedValue({ data: deleted, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: deleted, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useDeletedItemTemplates(), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useItemTemplates.ts
+++ b/src/client/src/hooks/useItemTemplates.ts
@@ -3,7 +3,7 @@ import client from "@/lib/api-client";
 import { toast } from "sonner";
 
 export function useItemTemplates(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["itemTemplates", "list", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/item-templates", {
@@ -13,6 +13,7 @@ export function useItemTemplates(offset = 0, limit = 50, sortBy?: string | null,
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useItemTemplate(id: string | null) {
@@ -126,7 +127,7 @@ export function useDeleteItemTemplates() {
 }
 
 export function useDeletedItemTemplates(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["itemTemplates", "deleted", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/item-templates/deleted", {
@@ -136,6 +137,7 @@ export function useDeletedItemTemplates(offset = 0, limit = 50, sortBy?: string 
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useRestoreItemTemplate() {

--- a/src/client/src/hooks/useReceiptItems.test.ts
+++ b/src/client/src/hooks/useReceiptItems.test.ts
@@ -56,7 +56,7 @@ describe("useReceiptItems", () => {
         pricingMode: "quantity",
       },
     ];
-    (client.GET as Mock).mockResolvedValue({ data: items, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: items, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useReceiptItems(), {
       wrapper: createWrapper(),
@@ -81,7 +81,7 @@ describe("useReceiptItems", () => {
 
   it("by-receipt query returns data when receiptId is provided", async () => {
     const items = [{ id: "1", receiptItemCode: "RI-1", description: "Apples" }];
-    (client.GET as Mock).mockResolvedValue({ data: items, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: items, total: 1, offset: 0, limit: 200 }, error: undefined });
 
     const { result } = renderHook(() => useReceiptItemsByReceiptId("r-1"), {
       wrapper: createWrapper(),
@@ -173,7 +173,7 @@ describe("useReceiptItems", () => {
 
   it("deleted receipt items query returns data on success", async () => {
     const deleted = [{ id: "3", receiptItemCode: "DEL", description: "Old item" }];
-    (client.GET as Mock).mockResolvedValue({ data: deleted, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: deleted, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useDeletedReceiptItems(), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useReceiptItems.ts
+++ b/src/client/src/hooks/useReceiptItems.ts
@@ -3,7 +3,7 @@ import client from "@/lib/api-client";
 import { toast } from "sonner";
 
 export function useReceiptItems(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["receipt-items", "list", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/receipt-items", {
@@ -13,6 +13,7 @@ export function useReceiptItems(offset = 0, limit = 50, sortBy?: string | null, 
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useReceiptItem(id: string | null) {
@@ -30,7 +31,7 @@ export function useReceiptItem(id: string | null) {
 }
 
 export function useReceiptItemsByReceiptId(receiptId: string | null, offset = 0, limit = 200, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["receipt-items", "by-receipt", receiptId, offset, limit, sortBy, sortDirection],
     enabled: !!receiptId,
     queryFn: async () => {
@@ -41,6 +42,7 @@ export function useReceiptItemsByReceiptId(receiptId: string | null, offset = 0,
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useCreateReceiptItem() {
@@ -183,7 +185,7 @@ export function useDeleteReceiptItems() {
 }
 
 export function useDeletedReceiptItems(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["receipt-items", "deleted", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/receipt-items/deleted", {
@@ -193,6 +195,7 @@ export function useDeletedReceiptItems(offset = 0, limit = 50, sortBy?: string |
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useRestoreReceiptItem() {

--- a/src/client/src/hooks/useReceipts.test.ts
+++ b/src/client/src/hooks/useReceipts.test.ts
@@ -46,7 +46,7 @@ describe("useReceipts", () => {
     const receipts = [
       { id: "1", location: "Walmart", date: "2025-01-01", taxAmount: 5.0 },
     ];
-    (client.GET as Mock).mockResolvedValue({ data: receipts, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: receipts, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useReceipts(), {
       wrapper: createWrapper(),
@@ -140,7 +140,7 @@ describe("useReceipts", () => {
 
   it("deleted receipts query returns data on success", async () => {
     const deleted = [{ id: "3", location: "Old Store", date: "2024-01-01", taxAmount: 0 }];
-    (client.GET as Mock).mockResolvedValue({ data: deleted, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: deleted, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useDeletedReceipts(), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useReceipts.ts
+++ b/src/client/src/hooks/useReceipts.ts
@@ -3,7 +3,7 @@ import client from "@/lib/api-client";
 import { toast } from "sonner";
 
 export function useReceipts(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["receipts", "list", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/receipts", {
@@ -13,6 +13,7 @@ export function useReceipts(offset = 0, limit = 50, sortBy?: string | null, sort
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useReceipt(id: string | null) {
@@ -114,7 +115,7 @@ export function useDeleteReceipts() {
 }
 
 export function useDeletedReceipts(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["receipts", "deleted", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/receipts/deleted", {
@@ -124,6 +125,7 @@ export function useDeletedReceipts(offset = 0, limit = 50, sortBy?: string | nul
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useRestoreReceipt() {

--- a/src/client/src/hooks/useSubcategories.test.ts
+++ b/src/client/src/hooks/useSubcategories.test.ts
@@ -45,7 +45,7 @@ describe("useSubcategories", () => {
       { id: "1", name: "Produce", categoryId: "cat-1", description: null },
     ];
     (client.GET as Mock).mockResolvedValue({
-      data: subcategories,
+      data: { data: subcategories, total: 1, offset: 0, limit: 50 },
       error: undefined,
     });
 
@@ -87,7 +87,7 @@ describe("useSubcategories", () => {
 
   it("by-category query returns data when categoryId is provided", async () => {
     const items = [{ id: "1", name: "Produce", categoryId: "cat-1" }];
-    (client.GET as Mock).mockResolvedValue({ data: items, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: items, total: 1, offset: 0, limit: 200 }, error: undefined });
 
     const { result } = renderHook(() => useSubcategoriesByCategoryId("cat-1"), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useSubcategories.ts
+++ b/src/client/src/hooks/useSubcategories.ts
@@ -3,7 +3,7 @@ import client from "@/lib/api-client";
 import { toast } from "sonner";
 
 export function useSubcategories(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["subcategories", "list", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/subcategories", {
@@ -13,6 +13,7 @@ export function useSubcategories(offset = 0, limit = 50, sortBy?: string | null,
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useSubcategory(id: string | null) {
@@ -30,7 +31,7 @@ export function useSubcategory(id: string | null) {
 }
 
 export function useSubcategoriesByCategoryId(categoryId: string | null, offset = 0, limit = 200, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["subcategories", "byCategory", categoryId, offset, limit, sortBy, sortDirection],
     enabled: !!categoryId,
     queryFn: async () => {
@@ -41,6 +42,7 @@ export function useSubcategoriesByCategoryId(categoryId: string | null, offset =
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useCreateSubcategory() {

--- a/src/client/src/hooks/useTransactions.test.ts
+++ b/src/client/src/hooks/useTransactions.test.ts
@@ -47,7 +47,7 @@ describe("useTransactions", () => {
     const transactions = [
       { id: "1", amount: 100, date: "2025-01-01" },
     ];
-    (client.GET as Mock).mockResolvedValue({ data: transactions, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: transactions, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useTransactions(), {
       wrapper: createWrapper(),
@@ -72,7 +72,7 @@ describe("useTransactions", () => {
 
   it("by-receipt query returns data when receiptId is provided", async () => {
     const items = [{ id: "1", amount: 50, date: "2025-01-01" }];
-    (client.GET as Mock).mockResolvedValue({ data: items, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: items, total: 1, offset: 0, limit: 200 }, error: undefined });
 
     const { result } = renderHook(() => useTransactionsByReceiptId("r-1"), {
       wrapper: createWrapper(),
@@ -152,7 +152,7 @@ describe("useTransactions", () => {
 
   it("deleted transactions query returns data on success", async () => {
     const deleted = [{ id: "3", amount: 10, date: "2024-01-01" }];
-    (client.GET as Mock).mockResolvedValue({ data: deleted, error: undefined });
+    (client.GET as Mock).mockResolvedValue({ data: { data: deleted, total: 1, offset: 0, limit: 50 }, error: undefined });
 
     const { result } = renderHook(() => useDeletedTransactions(), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useTransactions.ts
+++ b/src/client/src/hooks/useTransactions.ts
@@ -3,7 +3,7 @@ import client from "@/lib/api-client";
 import { toast } from "sonner";
 
 export function useTransactions(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["transactions", "list", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/transactions", {
@@ -13,6 +13,7 @@ export function useTransactions(offset = 0, limit = 50, sortBy?: string | null, 
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useTransaction(id: string | null) {
@@ -30,7 +31,7 @@ export function useTransaction(id: string | null) {
 }
 
 export function useTransactionsByReceiptId(receiptId: string | null, offset = 0, limit = 200, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["transactions", "by-receipt", receiptId, offset, limit, sortBy, sortDirection],
     enabled: !!receiptId,
     queryFn: async () => {
@@ -41,6 +42,7 @@ export function useTransactionsByReceiptId(receiptId: string | null, offset = 0,
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useCreateTransaction() {
@@ -158,7 +160,7 @@ export function useDeleteTransactions() {
 }
 
 export function useDeletedTransactions(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["transactions", "deleted", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/transactions/deleted", {
@@ -168,6 +170,7 @@ export function useDeletedTransactions(offset = 0, limit = 50, sortBy?: string |
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useRestoreTransaction() {

--- a/src/client/src/hooks/useUsers.test.ts
+++ b/src/client/src/hooks/useUsers.test.ts
@@ -43,7 +43,7 @@ beforeEach(() => {
 describe("useUsers", () => {
   it("fetches paginated users with page and pageSize", async () => {
     const mockUsers = [{ id: "1", email: "a@b.com" }];
-    (client.GET as Mock).mockResolvedValue({ data: mockUsers, error: null });
+    (client.GET as Mock).mockResolvedValue({ data: { data: mockUsers, total: 1, offset: 0, limit: 10 }, error: null });
 
     const { result } = renderHook(() => useUsers(0, 10), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useUsers.ts
+++ b/src/client/src/hooks/useUsers.ts
@@ -7,7 +7,7 @@ import client from "@/lib/api-client";
 import { toast } from "sonner";
 
 export function useUsers(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["users", "list", offset, limit, sortBy, sortDirection],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/users", {
@@ -17,6 +17,7 @@ export function useUsers(offset = 0, limit = 50, sortBy?: string | null, sortDir
       return data;
     },
   });
+  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
 }
 
 export function useUser(userId: string | null) {

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -64,7 +64,7 @@ function Accounts() {
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
   const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
-  const { data: accountsResponse, isLoading } = useAccounts(offset, limit, sortBy, sortDirection);
+  const { data: accountsData, total: serverTotal, isLoading } = useAccounts(offset, limit, sortBy, sortDirection);
   const createAccount = useCreateAccount();
   const updateAccount = useUpdateAccount();
   const [createOpen, setCreateOpen] = useState(false);
@@ -86,8 +86,7 @@ function Accounts() {
 
   useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
 
-  const data = (accountsResponse?.data as AccountResponse[] | undefined) ?? [];
-  const serverTotal = accountsResponse?.total ?? 0;
+  const data = (accountsData as AccountResponse[] | undefined) ?? [];
 
   const { search, setSearch, results, totalCount, clearSearch } =
     useFuzzySearch({ data, config: SEARCH_CONFIG });

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -15,7 +15,8 @@ vi.mock("@/hooks/useAuth", () => ({
 
 vi.mock("@/hooks/useUsers", () => ({
   useUsers: vi.fn(() => ({
-    data: { data: [], total: 0, offset: 0, limit: 20 },
+    data: [],
+    total: 0,
     isLoading: false,
   })),
   useCreateUser: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
@@ -74,7 +75,8 @@ describe("AdminUsers", () => {
   it("renders loading skeleton when data is loading", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 20 },
+      data: [],
+      total: 0,
       isLoading: true,
     }));
 
@@ -85,7 +87,8 @@ describe("AdminUsers", () => {
   it("renders empty state when no users exist", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 20 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 
@@ -96,21 +99,19 @@ describe("AdminUsers", () => {
   it("renders user table when users exist", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            email: "test@example.com",
-            firstName: "John",
-            lastName: "Doe",
-            roles: ["Admin"],
-            isDisabled: false,
-            createdAt: "2024-01-01",
-            lastLoginAt: "2024-01-15",
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -133,21 +134,19 @@ describe("AdminUsers", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            email: "test@example.com",
-            firstName: "John",
-            lastName: "Doe",
-            roles: ["Admin"],
-            isDisabled: false,
-            createdAt: "2024-01-01",
-            lastLoginAt: "2024-01-15",
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -163,21 +162,19 @@ describe("AdminUsers", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            email: "test@example.com",
-            firstName: "John",
-            lastName: "Doe",
-            roles: ["Admin"],
-            isDisabled: false,
-            createdAt: "2024-01-01",
-            lastLoginAt: "2024-01-15",
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -195,21 +192,19 @@ describe("AdminUsers", () => {
   it("disables Disable button for the current user", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            email: "admin@example.com",
-            firstName: "Admin",
-            lastName: "User",
-            roles: ["Admin"],
-            isDisabled: false,
-            createdAt: "2024-01-01",
-            lastLoginAt: "2024-01-15",
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "1",
+          email: "admin@example.com",
+          firstName: "Admin",
+          lastName: "User",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -220,21 +215,19 @@ describe("AdminUsers", () => {
   it("disables Disable button for already disabled users", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "2",
-            email: "disabled@example.com",
-            firstName: "Disabled",
-            lastName: "User",
-            roles: ["User"],
-            isDisabled: true,
-            createdAt: "2024-01-01",
-            lastLoginAt: "2024-01-15",
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "2",
+          email: "disabled@example.com",
+          firstName: "Disabled",
+          lastName: "User",
+          roles: ["User"],
+          isDisabled: true,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -246,21 +239,19 @@ describe("AdminUsers", () => {
   it("shows user name formatted from first and last name", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            email: "test@example.com",
-            firstName: "John",
-            lastName: "Doe",
-            roles: ["Admin"],
-            isDisabled: false,
-            createdAt: "2024-01-01",
-            lastLoginAt: "2024-01-15",
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -271,21 +262,19 @@ describe("AdminUsers", () => {
   it("shows dash when user has no first or last name", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            email: "test@example.com",
-            firstName: null,
-            lastName: null,
-            roles: ["User"],
-            isDisabled: false,
-            createdAt: "2024-01-01",
-            lastLoginAt: null,
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: null,
+          lastName: null,
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -310,19 +299,17 @@ describe("AdminUsers", () => {
 
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: Array.from({ length: 20 }, (_, i) => ({
-          id: String(i + 1),
-          email: `user${i + 1}@example.com`,
-          firstName: `User`,
-          lastName: `${i + 1}`,
-          roles: ["User"],
-          isDisabled: false,
-          createdAt: "2024-01-01",
-          lastLoginAt: null,
-        })),
-        total: 25, offset: 0, limit: 20,
-      },
+      data: Array.from({ length: 20 }, (_, i) => ({
+        id: String(i + 1),
+        email: `user${i + 1}@example.com`,
+        firstName: `User`,
+        lastName: `${i + 1}`,
+        roles: ["User"],
+        isDisabled: false,
+        createdAt: "2024-01-01",
+        lastLoginAt: null,
+      })),
+      total: 25,
       isLoading: false,
     }));
 
@@ -353,19 +340,17 @@ describe("AdminUsers", () => {
 
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: Array.from({ length: 20 }, (_, i) => ({
-          id: String(i + 1),
-          email: `user${i + 1}@example.com`,
-          firstName: `User`,
-          lastName: `${i + 1}`,
-          roles: ["User"],
-          isDisabled: false,
-          createdAt: "2024-01-01",
-          lastLoginAt: null,
-        })),
-        total: 25, offset: 0, limit: 20,
-      },
+      data: Array.from({ length: 20 }, (_, i) => ({
+        id: String(i + 1),
+        email: `user${i + 1}@example.com`,
+        firstName: `User`,
+        lastName: `${i + 1}`,
+        roles: ["User"],
+        isDisabled: false,
+        createdAt: "2024-01-01",
+        lastLoginAt: null,
+      })),
+      total: 25,
       isLoading: false,
     }));
 
@@ -380,21 +365,19 @@ describe("AdminUsers", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            email: "test@example.com",
-            firstName: "John",
-            lastName: "Doe",
-            roles: ["Admin"],
-            isDisabled: false,
-            createdAt: "2024-01-01",
-            lastLoginAt: "2024-01-15",
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -412,21 +395,19 @@ describe("AdminUsers", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            email: "test@example.com",
-            firstName: "John",
-            lastName: "Doe",
-            roles: ["Admin"],
-            isDisabled: false,
-            createdAt: "2024-01-01",
-            lastLoginAt: "2024-01-15",
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -449,21 +430,19 @@ describe("AdminUsers", () => {
       isPending: false,
     } as unknown as ReturnType<typeof useDeleteUser>);
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "2",
-            email: "other@example.com",
-            firstName: "Other",
-            lastName: "User",
-            roles: ["User"],
-            isDisabled: false,
-            createdAt: "2024-01-01",
-            lastLoginAt: "2024-01-15",
-          },
-        ],
-        total: 1, offset: 0, limit: 20,
-      },
+      data: [
+        {
+          id: "2",
+          email: "other@example.com",
+          firstName: "Other",
+          lastName: "User",
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -97,7 +97,7 @@ function AdminUsers() {
 
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "email", defaultSortDirection: "asc" });
   const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ defaultPageSize: 20 });
-  const { data: usersResponse, isLoading } = useUsers(offset, limit, sortBy, sortDirection);
+  const { data: usersData, total: serverTotal, isLoading } = useUsers(offset, limit, sortBy, sortDirection);
 
   useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
 
@@ -121,8 +121,7 @@ function AdminUsers() {
     email: string;
   } | null>(null);
 
-  const items = usersResponse?.data ?? [];
-  const serverTotal = usersResponse?.total ?? 0;
+  const items = usersData ?? [];
 
   const listItems = items.map((u) => ({ id: u.id }));
   const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({

--- a/src/client/src/pages/AuditLog.test.tsx
+++ b/src/client/src/pages/AuditLog.test.tsx
@@ -25,7 +25,8 @@ vi.mock("@/hooks/useEnumMetadata", () => ({
 
 vi.mock("@/hooks/useAudit", () => ({
   useRecentAuditLogs: vi.fn(() => ({
-    data: { data: [], total: 0, offset: 0, limit: 50 },
+    data: [],
+    total: 0,
     isLoading: false,
   })),
 }));
@@ -109,24 +110,20 @@ describe("AuditLog", () => {
   it("passes server-returned logs to AuditLogTable", async () => {
     const { useRecentAuditLogs } = await import("@/hooks/useAudit");
     vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            entityType: "Account",
-            entityId: "abc-123",
-            action: "Create",
-            changedAt: "2024-01-15T10:00:00Z",
-            changedByUserId: "user-1",
-            changedByApiKeyId: null,
-            ipAddress: "127.0.0.1",
-            changesJson: "{}",
-          },
-        ],
-        total: 1,
-        offset: 0,
-        limit: 50,
-      },
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "abc-123",
+          action: "Create",
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: "user-1",
+          changedByApiKeyId: null,
+          ipAddress: "127.0.0.1",
+          changesJson: "{}",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -137,24 +134,20 @@ describe("AuditLog", () => {
   it("enables Export CSV button when logs exist", async () => {
     const { useRecentAuditLogs } = await import("@/hooks/useAudit");
     vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            entityType: "Account",
-            entityId: "abc-123",
-            action: "Create",
-            changedAt: "2024-01-15T10:00:00Z",
-            changedByUserId: "user-1",
-            changedByApiKeyId: null,
-            ipAddress: "127.0.0.1",
-            changesJson: "{}",
-          },
-        ],
-        total: 1,
-        offset: 0,
-        limit: 50,
-      },
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "abc-123",
+          action: "Create",
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: "user-1",
+          changedByApiKeyId: null,
+          ipAddress: "127.0.0.1",
+          changesJson: "{}",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -168,24 +161,20 @@ describe("AuditLog", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useRecentAuditLogs } = await import("@/hooks/useAudit");
     vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
-      data: {
-        data: [
-          {
-            id: "1",
-            entityType: "Account",
-            entityId: "abc-123",
-            action: "Create",
-            changedAt: "2024-01-15T10:00:00Z",
-            changedByUserId: "user-1",
-            changedByApiKeyId: null,
-            ipAddress: "127.0.0.1",
-            changesJson: "{}",
-          },
-        ],
-        total: 1,
-        offset: 0,
-        limit: 50,
-      },
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "abc-123",
+          action: "Create",
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: "user-1",
+          changedByApiKeyId: null,
+          ipAddress: "127.0.0.1",
+          changesJson: "{}",
+        },
+      ],
+      total: 1,
       isLoading: false,
     }));
 
@@ -237,7 +226,8 @@ describe("AuditLog", () => {
     const { useRecentAuditLogs } = await import("@/hooks/useAudit");
     const mockFn = vi.mocked(useRecentAuditLogs);
     mockFn.mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/AuditLog.tsx
+++ b/src/client/src/pages/AuditLog.tsx
@@ -205,7 +205,7 @@ function AuditLog() {
     [auditActions],
   );
 
-  const { data, isLoading } = useRecentAuditLogs({
+  const { data, total, isLoading } = useRecentAuditLogs({
     offset: pagination.offset,
     limit: pagination.limit,
     sortBy,
@@ -217,8 +217,7 @@ function AuditLog() {
     dateTo: dateTo ? dateTo.toISOString() : null,
   });
 
-  const logs = (data?.data ?? []) as AuditLogEntry[];
-  const total = data?.total ?? 0;
+  const logs = (data ?? []) as AuditLogEntry[];
 
   return (
     <div className="space-y-4">

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -59,7 +59,7 @@ function Categories() {
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
   const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
-  const { data: categoriesResponse, isLoading } = useCategories(offset, limit, sortBy, sortDirection);
+  const { data: categoriesData, total: serverTotal, isLoading } = useCategories(offset, limit, sortBy, sortDirection);
   const createCategory = useCreateCategory();
   const updateCategory = useUpdateCategory();
   const [createOpen, setCreateOpen] = useState(false);
@@ -79,8 +79,7 @@ function Categories() {
 
   useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
 
-  const data = (categoriesResponse?.data as CategoryResponse[] | undefined) ?? [];
-  const serverTotal = categoriesResponse?.total ?? 0;
+  const data = (categoriesData as CategoryResponse[] | undefined) ?? [];
   useSavedFilters("categories");
 
   const { search, setSearch, results, totalCount, clearSearch } =

--- a/src/client/src/pages/ItemTemplates.test.tsx
+++ b/src/client/src/pages/ItemTemplates.test.tsx
@@ -24,7 +24,7 @@ vi.mock("@/hooks/useEnumMetadata", () => ({
 }));
 
 vi.mock("@/hooks/useItemTemplates", () => ({
-  useItemTemplates: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useItemTemplates: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useCreateItemTemplate: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateItemTemplate: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useDeleteItemTemplates: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -80,11 +80,11 @@ vi.mock("@/hooks/useListKeyboardNav", () => ({
 
 // Mocks needed by ItemTemplateForm (rendered inside dialogs)
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
+  useCategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategoriesByCategoryId: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
+  useSubcategoriesByCategoryId: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/usePagination", () => ({
@@ -121,7 +121,8 @@ describe("ItemTemplates", () => {
   it("renders empty state when no templates exist", async () => {
     const { useItemTemplates } = await import("@/hooks/useItemTemplates");
     vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 
@@ -162,7 +163,8 @@ describe("ItemTemplates", () => {
 
     const { useItemTemplates } = await import("@/hooks/useItemTemplates");
     vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -250,7 +252,8 @@ describe("ItemTemplates", () => {
 
     const { useItemTemplates } = await import("@/hooks/useItemTemplates");
     vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -280,7 +283,8 @@ describe("ItemTemplates", () => {
 
     const { useItemTemplates } = await import("@/hooks/useItemTemplates");
     vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -405,7 +409,8 @@ describe("ItemTemplates", () => {
 
     const { useItemTemplates } = await import("@/hooks/useItemTemplates");
     vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -64,7 +64,7 @@ function ItemTemplates() {
   usePageTitle("Item Templates");
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
   const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
-  const { data: itemTemplatesResponse, isLoading } = useItemTemplates(offset, limit, sortBy, sortDirection);
+  const { data: itemTemplatesData, total: serverTotal, isLoading } = useItemTemplates(offset, limit, sortBy, sortDirection);
   const createItemTemplate = useCreateItemTemplate();
   const updateItemTemplate = useUpdateItemTemplate();
   const deleteItemTemplates = useDeleteItemTemplates();
@@ -88,8 +88,7 @@ function ItemTemplates() {
 
   useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
 
-  const data = (itemTemplatesResponse?.data as ItemTemplateResponse[] | undefined) ?? [];
-  const serverTotal = itemTemplatesResponse?.total ?? 0;
+  const data = (itemTemplatesData as ItemTemplateResponse[] | undefined) ?? [];
   useSavedFilters("itemTemplates");
 
   const { search, setSearch, results, totalCount, clearSearch } =

--- a/src/client/src/pages/ReceiptItems.test.tsx
+++ b/src/client/src/pages/ReceiptItems.test.tsx
@@ -24,8 +24,8 @@ vi.mock("@/hooks/useEnumMetadata", () => ({
 }));
 
 vi.mock("@/hooks/useReceiptItems", () => ({
-  useReceiptItems: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
-  useReceiptItemsByReceiptId: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 200 }, isLoading: false })),
+  useReceiptItems: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+  useReceiptItemsByReceiptId: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useCreateReceiptItem: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateReceiptItem: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useDeleteReceiptItems: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -81,21 +81,21 @@ vi.mock("@/hooks/useListKeyboardNav", () => ({
 
 // Mocks needed by ReceiptItemForm (rendered inside dialogs)
 vi.mock("@/hooks/useReceipts", () => ({
-  useReceipts: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
+  useReceipts: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
+  useCategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategories: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
-  useSubcategoriesByCategoryId: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
+  useSubcategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+  useSubcategoriesByCategoryId: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useCreateSubcategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/hooks/useItemTemplates", () => ({
-  useItemTemplates: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
+  useItemTemplates: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/usePagination", () => ({
@@ -132,7 +132,8 @@ describe("ReceiptItems", () => {
   it("renders empty state when no receipt items exist", async () => {
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
     vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 
@@ -173,7 +174,8 @@ describe("ReceiptItems", () => {
 
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
     vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -321,7 +323,8 @@ describe("ReceiptItems", () => {
 
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
     vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -358,7 +361,8 @@ describe("ReceiptItems", () => {
 
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
     vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -398,7 +402,8 @@ describe("ReceiptItems", () => {
 
     const { useReceiptItems } = await import("@/hooks/useReceiptItems");
     vi.mocked(useReceiptItems).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/ReceiptItems.tsx
+++ b/src/client/src/pages/ReceiptItems.tsx
@@ -86,8 +86,8 @@ function ReceiptItems() {
   const allItemsQuery = useReceiptItems(offset, limit, sortBy, sortDirection);
   const filteredItemsQuery = useReceiptItemsByReceiptId(linkParams.receiptId ?? null, offset, limit, sortBy, sortDirection);
   const activeItemsQuery = linkParams.receiptId ? filteredItemsQuery : allItemsQuery;
-  const { data: itemsResponse, isLoading } = activeItemsQuery;
-  const { data: receiptsResponse } = useReceipts(0, 1000);
+  const { data: itemsData, total: serverTotal, isLoading } = activeItemsQuery;
+  const { data: receiptsData } = useReceipts(0, 1000);
   const createItem = useCreateReceiptItem();
   const updateItem = useUpdateReceiptItem();
   const deleteItems = useDeleteReceiptItems();
@@ -113,10 +113,9 @@ function ReceiptItems() {
   useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
 
   const data = useMemo(
-    () => (itemsResponse?.data as ReceiptItemResponse[] | undefined) ?? [],
-    [itemsResponse?.data],
+    () => (itemsData as ReceiptItemResponse[] | undefined) ?? [],
+    [itemsData],
   );
-  const serverTotal = itemsResponse?.total ?? 0;
 
   const categories = useMemo(
     () => [...new Set(data.map((i) => i.category))].sort(),
@@ -138,10 +137,10 @@ function ReceiptItems() {
 
   const receiptMap = useMemo(() => {
     const map = new Map<string, string>();
-    const list = (receiptsResponse?.data as { id: string; location: string }[] | undefined) ?? [];
+    const list = (receiptsData as { id: string; location: string }[] | undefined) ?? [];
     for (const r of list) map.set(r.id, r.location);
     return map;
-  }, [receiptsResponse?.data]);
+  }, [receiptsData]);
 
   const {
     filters: savedFilters,

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -77,7 +77,7 @@ function Receipts() {
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "date", defaultSortDirection: "desc" });
   const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
-  const { data: receiptsResponse, isLoading } = useReceipts(offset, limit, sortBy, sortDirection);
+  const { data: receiptsData, total: serverTotal, isLoading } = useReceipts(offset, limit, sortBy, sortDirection);
   const createReceipt = useCreateReceipt();
   const updateReceipt = useUpdateReceipt();
   const deleteReceipts = useDeleteReceipts();
@@ -100,8 +100,7 @@ function Receipts() {
 
   useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
 
-  const data = (receiptsResponse?.data as ReceiptResponse[] | undefined) ?? [];
-  const serverTotal = receiptsResponse?.total ?? 0;
+  const data = (receiptsData as ReceiptResponse[] | undefined) ?? [];
 
   const {
     filters: savedFilters,

--- a/src/client/src/pages/RecycleBin.test.tsx
+++ b/src/client/src/pages/RecycleBin.test.tsx
@@ -8,22 +8,22 @@ vi.mock("@/hooks/usePageTitle", () => ({
 }));
 
 vi.mock("@/hooks/useReceipts", () => ({
-  useDeletedReceipts: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useDeletedReceipts: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useRestoreReceipt: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/hooks/useReceiptItems", () => ({
-  useDeletedReceiptItems: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useDeletedReceiptItems: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useRestoreReceiptItem: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/hooks/useTransactions", () => ({
-  useDeletedTransactions: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useDeletedTransactions: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useRestoreTransaction: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/hooks/useItemTemplates", () => ({
-  useDeletedItemTemplates: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useDeletedItemTemplates: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useRestoreItemTemplate: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
@@ -43,7 +43,8 @@ describe("RecycleBin", () => {
   beforeEach(async () => {
     const { useDeletedReceipts, useRestoreReceipt } = await import("@/hooks/useReceipts");
     vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
     vi.mocked(useRestoreReceipt).mockReturnValue(mockMutationResult());
@@ -91,19 +92,15 @@ describe("RecycleBin", () => {
   it("renders deleted items in the table when data exists", async () => {
     const { useDeletedReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
-      data: {
-        data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
-        total: 1, offset: 0, limit: 50,
-      },
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
       isLoading: false,
     }));
 
     const { useDeletedItemTemplates } = await import("@/hooks/useItemTemplates");
     vi.mocked(useDeletedItemTemplates).mockReturnValue(mockQueryResult({
-      data: {
-        data: [{ id: "it1", name: "Deleted Template" }],
-        total: 1, offset: 0, limit: 50,
-      },
+      data: [{ id: "it1", name: "Deleted Template" }],
+      total: 1,
       isLoading: false,
     }));
 
@@ -117,10 +114,8 @@ describe("RecycleBin", () => {
   it("renders entity type tabs when deleted items exist", async () => {
     const { useDeletedReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
-      data: {
-        data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
-        total: 1, offset: 0, limit: 50,
-      },
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/RecycleBin.tsx
+++ b/src/client/src/pages/RecycleBin.tsx
@@ -186,7 +186,7 @@ function RecycleBin() {
   const allItems = useMemo(() => {
     const items: DeletedItem[] = [];
 
-    for (const r of receipts.data?.data ?? []) {
+    for (const r of receipts.data ?? []) {
       items.push({
         entityType: "Receipt",
         entityTypeLabel: "Receipt",
@@ -194,7 +194,7 @@ function RecycleBin() {
         label: `${r.location} - ${r.date}`,
       });
     }
-    for (const ri of receiptItems.data?.data ?? []) {
+    for (const ri of receiptItems.data ?? []) {
       items.push({
         entityType: "ReceiptItem",
         entityTypeLabel: "Receipt Item",
@@ -202,7 +202,7 @@ function RecycleBin() {
         label: `${ri.description} (${ri.receiptItemCode ?? "N/A"})`,
       });
     }
-    for (const t of transactions.data?.data ?? []) {
+    for (const t of transactions.data ?? []) {
       items.push({
         entityType: "Transaction",
         entityTypeLabel: "Transaction",
@@ -210,7 +210,7 @@ function RecycleBin() {
         label: `$${t.amount.toFixed(2)} - ${t.date}`,
       });
     }
-    for (const it of itemTemplates.data?.data ?? []) {
+    for (const it of itemTemplates.data ?? []) {
       items.push({
         entityType: "ItemTemplate",
         entityTypeLabel: "Item Template",

--- a/src/client/src/pages/SecurityLog.tsx
+++ b/src/client/src/pages/SecurityLog.tsx
@@ -34,9 +34,9 @@ function SecurityLog() {
     failedPagination.resetPage();
   }, [sortBy, sortDirection, myPagination.resetPage, recentPagination.resetPage, failedPagination.resetPage]);
 
-  const myTotal = myLogs.data?.total ?? 0;
-  const recentTotal = recentLogs.data?.total ?? 0;
-  const failedTotal = failedLogs.data?.total ?? 0;
+  const myTotal = myLogs.total;
+  const recentTotal = recentLogs.total;
+  const failedTotal = failedLogs.total;
 
   return (
     <div className="space-y-4">
@@ -55,7 +55,7 @@ function SecurityLog() {
 
         <TabsContent value="my-activity" className="space-y-4">
           <AuthAuditTable
-            logs={(myLogs.data?.data ?? []) as AuthAuditLog[]}
+            logs={(myLogs.data ?? []) as AuthAuditLog[]}
             isLoading={myLogs.isLoading}
             sortBy={sortBy}
             sortDirection={sortDirection}
@@ -75,7 +75,7 @@ function SecurityLog() {
         {isAdmin() && (
           <TabsContent value="all-events" className="space-y-4">
             <AuthAuditTable
-              logs={(recentLogs.data?.data ?? []) as AuthAuditLog[]}
+              logs={(recentLogs.data ?? []) as AuthAuditLog[]}
               isLoading={recentLogs.isLoading}
               showUsername
               sortBy={sortBy}
@@ -97,7 +97,7 @@ function SecurityLog() {
         {isAdmin() && (
           <TabsContent value="failed-logins" className="space-y-4">
             <AuthAuditTable
-              logs={(failedLogs.data?.data ?? []) as AuthAuditLog[]}
+              logs={(failedLogs.data ?? []) as AuthAuditLog[]}
               isLoading={failedLogs.isLoading}
               showUsername
               sortBy={sortBy}

--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -9,11 +9,13 @@ vi.mock("@/hooks/usePageTitle", () => ({
 
 vi.mock("@/hooks/useSubcategories", () => ({
   useSubcategories: vi.fn(() => ({
-    data: { data: [], total: 0, offset: 0, limit: 50 },
+    data: [],
+    total: 0,
     isLoading: false,
   })),
   useSubcategoriesByCategoryId: vi.fn(() => ({
-    data: { data: [], total: 0, offset: 0, limit: 200 },
+    data: [],
+    total: 0,
     isLoading: false,
   })),
   useCreateSubcategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -21,7 +23,7 @@ vi.mock("@/hooks/useSubcategories", () => ({
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({ data: { data: [] }, isLoading: false })),
+  useCategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useFuzzySearch", () => ({
@@ -116,7 +118,8 @@ async function setupWithData(items = ITEMS, categories = CATEGORIES) {
   const { useSubcategories } = await import("@/hooks/useSubcategories");
   vi.mocked(useSubcategories).mockReturnValue(
     mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }),
   );
@@ -124,7 +127,8 @@ async function setupWithData(items = ITEMS, categories = CATEGORIES) {
   const { useCategories } = await import("@/hooks/useCategories");
   vi.mocked(useCategories).mockReturnValue(
     mockQueryResult({
-      data: { data: categories },
+      data: categories,
+      total: categories.length,
       isLoading: false,
     }),
   );
@@ -157,7 +161,8 @@ describe("Subcategories", () => {
     const { useSubcategories } = await import("@/hooks/useSubcategories");
     vi.mocked(useSubcategories).mockReturnValue(
       mockQueryResult({
-        data: { data: [], total: 0, offset: 0, limit: 50 },
+        data: [],
+        total: 0,
         isLoading: false,
       }),
     );

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -75,8 +75,8 @@ function Subcategories() {
   const allSubcatQuery = useSubcategories(offset, limit, sortBy, sortDirection);
   const filteredSubcatQuery = useSubcategoriesByCategoryId(linkParams.categoryId ?? null, offset, limit, sortBy, sortDirection);
   const activeSubcatQuery = linkParams.categoryId ? filteredSubcatQuery : allSubcatQuery;
-  const { data: subcategoriesResponse, isLoading: subcategoriesLoading } = activeSubcatQuery;
-  const { data: categoriesResponse, isLoading: categoriesLoading } = useCategories();
+  const { data: subcategoriesData, total: serverTotal, isLoading: subcategoriesLoading } = activeSubcatQuery;
+  const { data: categoriesData, isLoading: categoriesLoading } = useCategories();
   const createSubcategory = useCreateSubcategory();
   const updateSubcategory = useUpdateSubcategory();
   const isLoading = subcategoriesLoading || categoriesLoading;
@@ -103,12 +103,11 @@ function Subcategories() {
 
   useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
 
-  const data = (subcategoriesResponse?.data as SubcategoryResponse[] | undefined) ?? [];
-  const serverTotal = subcategoriesResponse?.total ?? 0;
+  const data = (subcategoriesData as SubcategoryResponse[] | undefined) ?? [];
 
   const categoryList = useMemo(
-    () => (categoriesResponse?.data as CategoryResponse[] | undefined) ?? [],
-    [categoriesResponse?.data],
+    () => (categoriesData as CategoryResponse[] | undefined) ?? [],
+    [categoriesData],
   );
 
   const categoryMap = useMemo(() => {

--- a/src/client/src/pages/Transactions.test.tsx
+++ b/src/client/src/pages/Transactions.test.tsx
@@ -8,8 +8,8 @@ vi.mock("@/hooks/usePageTitle", () => ({
 }));
 
 vi.mock("@/hooks/useTransactions", () => ({
-  useTransactions: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
-  useTransactionsByReceiptId: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 200 }, isLoading: false })),
+  useTransactions: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+  useTransactionsByReceiptId: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useCreateTransaction: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateTransaction: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useDeleteTransactions: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -66,26 +66,22 @@ vi.mock("@/hooks/useListKeyboardNav", () => ({
 // Mocks needed by TransactionForm (rendered inside dialogs) and receipt/account lookups
 vi.mock("@/hooks/useReceipts", () => ({
   useReceipts: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "r1", location: "Whole Foods", date: "2024-01-14" },
-        { id: "r2", location: "Target Store", date: "2024-01-19" },
-      ],
-      total: 2, offset: 0, limit: 1000,
-    },
+    data: [
+      { id: "r1", location: "Whole Foods", date: "2024-01-14" },
+      { id: "r2", location: "Target Store", date: "2024-01-19" },
+    ],
+    total: 2,
     isLoading: false,
   })),
 }));
 
 vi.mock("@/hooks/useAccounts", () => ({
   useAccounts: vi.fn(() => ({
-    data: {
-      data: [
-        { id: "a1", name: "Chase Checking" },
-        { id: "a2", name: "Amex Gold" },
-      ],
-      total: 2, offset: 0, limit: 1000,
-    },
+    data: [
+      { id: "a1", name: "Chase Checking" },
+      { id: "a2", name: "Amex Gold" },
+    ],
+    total: 2,
     isLoading: false,
   })),
 }));
@@ -124,7 +120,8 @@ describe("Transactions", () => {
   it("renders empty state when no transactions exist", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 
@@ -166,7 +163,8 @@ describe("Transactions", () => {
 
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -199,7 +197,8 @@ describe("Transactions", () => {
 
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -350,7 +349,8 @@ describe("Transactions", () => {
 
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -387,7 +387,8 @@ describe("Transactions", () => {
 
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -427,7 +428,8 @@ describe("Transactions", () => {
 
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -96,9 +96,9 @@ function Transactions() {
   const allTxnQuery = useTransactions(offset, limit, sortBy, sortDirection);
   const filteredTxnQuery = useTransactionsByReceiptId(linkParams.receiptId ?? null, offset, limit, sortBy, sortDirection);
   const activeTxnQuery = linkParams.receiptId ? filteredTxnQuery : allTxnQuery;
-  const { data: transactionsResponse, isLoading } = activeTxnQuery;
-  const { data: accountsResponse } = useAccounts(0, 1000);
-  const { data: receiptsResponse } = useReceipts(0, 1000);
+  const { data: transactionsData, total: serverTotal, isLoading } = activeTxnQuery;
+  const { data: accountsData } = useAccounts(0, 1000);
+  const { data: receiptsData } = useReceipts(0, 1000);
   const createTransaction = useCreateTransaction();
   const updateTransaction = useUpdateTransaction();
   const deleteTransactions = useDeleteTransactions();
@@ -120,26 +120,24 @@ function Transactions() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const serverTotal = transactionsResponse?.total ?? 0;
-
   const accountMap = useMemo(() => {
     const map = new Map<string, string>();
-    const list = (accountsResponse?.data as { id: string; name: string }[] | undefined) ?? [];
+    const list = (accountsData as { id: string; name: string }[] | undefined) ?? [];
     for (const a of list) map.set(a.id, a.name);
     return map;
-  }, [accountsResponse?.data]);
+  }, [accountsData]);
 
   const receiptMap = useMemo(() => {
     const map = new Map<string, ReceiptInfo>();
-    const list = (receiptsResponse?.data as { id: string; location: string; date: string }[] | undefined) ?? [];
+    const list = (receiptsData as { id: string; location: string; date: string }[] | undefined) ?? [];
     for (const r of list) map.set(r.id, { location: r.location, date: r.date });
     return map;
-  }, [receiptsResponse?.data]);
+  }, [receiptsData]);
 
   useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
 
   const data: EnrichedTransaction[] = useMemo(() => {
-    const list = (transactionsResponse?.data as TransactionResponse[] | undefined) ?? [];
+    const list = (transactionsData as TransactionResponse[] | undefined) ?? [];
     return list.map((txn) => {
       const receipt = receiptMap.get(txn.receiptId);
       return {
@@ -148,7 +146,7 @@ function Transactions() {
         receiptLocation: receipt?.location,
       };
     });
-  }, [transactionsResponse?.data, accountMap, receiptMap]);
+  }, [transactionsData, accountMap, receiptMap]);
 
   const {
     filters: savedFilters,

--- a/src/client/src/pages/Trips.test.tsx
+++ b/src/client/src/pages/Trips.test.tsx
@@ -32,7 +32,7 @@ vi.mock("@/hooks/useTrips", () => ({
 }));
 
 vi.mock("@/hooks/useReceipts", () => ({
-  useReceipts: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 25 }, isLoading: false })),
+  useReceipts: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useFuzzySearch", () => ({
@@ -117,7 +117,8 @@ describe("Trips", () => {
 
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 10000 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -140,7 +141,8 @@ describe("Trips", () => {
   it("renders empty state when no receipts found", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 25 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 
@@ -163,7 +165,8 @@ describe("Trips", () => {
   it("renders no-results state when search yields nothing but receipts exist", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: [{ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }], total: 1, offset: 0, limit: 10000 },
+      data: [{ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }],
+      total: 1,
       isLoading: false,
     }));
 
@@ -184,7 +187,8 @@ describe("Trips", () => {
   it("shows empty state when searching with zero receipts in database", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 10000 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/Trips.tsx
+++ b/src/client/src/pages/Trips.tsx
@@ -70,16 +70,16 @@ function Trips() {
   const [receiptId, setReceiptId] = useState<string | null>(null);
   const { data: trip, isLoading: tripLoading, isError } = useTripByReceiptId(receiptId);
 
-  const { data: receiptsResponse, isLoading: receiptsLoading } = useReceipts(0, 10000);
+  const { data: receiptsData, isLoading: receiptsLoading } = useReceipts(0, 10000);
 
   const [filterValues, setFilterValues] = useState<FilterValues>({});
 
   const data = useMemo(() => {
-    const list = (receiptsResponse?.data as ReceiptResponse[] | undefined) ?? [];
+    const list = (receiptsData as ReceiptResponse[] | undefined) ?? [];
     return [...list].sort(
       (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
     );
-  }, [receiptsResponse?.data]);
+  }, [receiptsData]);
 
   const {
     filters: savedFilters,

--- a/src/client/src/pages/wizard/Step2Transactions.test.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.test.tsx
@@ -11,12 +11,11 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
 vi.mock("@/hooks/useAccounts", () => ({
   useAccounts: vi.fn(() =>
     mockQueryResult({
-      data: {
-        data: [
-          { id: "acct-1", name: "Checking", accountCode: "CHK" },
-          { id: "acct-2", name: "Credit Card", accountCode: "CC" },
-        ],
-      },
+      data: [
+        { id: "acct-1", name: "Checking", accountCode: "CHK" },
+        { id: "acct-2", name: "Credit Card", accountCode: "CC" },
+      ],
+      total: 2,
       isLoading: false,
       isSuccess: true,
     }),

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -64,7 +64,7 @@ export function Step2Transactions({
   const accountOptions = useMemo(
     () =>
       (
-        (accounts?.data as
+        (accounts as
           | { id: string; name: string; accountCode: string }[]
           | undefined) ?? []
       ).map(accountToOption),

--- a/src/client/src/pages/wizard/Step3Items.test.tsx
+++ b/src/client/src/pages/wizard/Step3Items.test.tsx
@@ -6,12 +6,11 @@ import { Step3Items } from "./Step3Items";
 vi.mock("@/hooks/useCategories", () => ({
   useCategories: vi.fn(() =>
     mockQueryResult({
-      data: {
-        data: [
-          { id: "cat-1", name: "Food" },
-          { id: "cat-2", name: "Transport" },
-        ],
-      },
+      data: [
+        { id: "cat-1", name: "Food" },
+        { id: "cat-2", name: "Transport" },
+      ],
+      total: 2,
       isLoading: false,
       isSuccess: true,
     }),
@@ -21,7 +20,8 @@ vi.mock("@/hooks/useCategories", () => ({
 vi.mock("@/hooks/useSubcategories", () => ({
   useSubcategoriesByCategoryId: vi.fn(() =>
     mockQueryResult({
-      data: { data: [] },
+      data: [],
+      total: 0,
       isLoading: false,
       isSuccess: true,
     }),

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -89,7 +89,7 @@ export function Step3Items({
   const categoryOptions = useMemo(
     () =>
       (
-        (categories?.data as
+        (categories as
           | { id: string; name: string }[]
           | undefined) ?? []
       ).map((c) => ({ value: c.name, label: c.name })),
@@ -132,7 +132,7 @@ export function Step3Items({
   const selectedCategoryObj = useMemo(
     () =>
       (
-        (categories?.data as
+        (categories as
           | { id: string; name: string }[]
           | undefined) ?? []
       ).find((c) => c.name === selectedCategory),
@@ -148,7 +148,7 @@ export function Step3Items({
   const subcategoryOptions = useMemo(
     () =>
       (
-        (subcategories?.data as { id: string; name: string }[] | undefined) ?? []
+        (subcategories as { id: string; name: string }[] | undefined) ?? []
       ).map((s) => ({ value: s.name, label: s.name })),
     [subcategories],
   );

--- a/src/client/src/pages/wizard/Step4Review.test.tsx
+++ b/src/client/src/pages/wizard/Step4Review.test.tsx
@@ -7,12 +7,11 @@ import type { WizardState } from "./wizardReducer";
 vi.mock("@/hooks/useAccounts", () => ({
   useAccounts: vi.fn(() =>
     mockQueryResult({
-      data: {
-        data: [
-          { id: "acct-1", name: "Checking" },
-          { id: "acct-2", name: "Credit Card" },
-        ],
-      },
+      data: [
+        { id: "acct-1", name: "Checking" },
+        { id: "acct-2", name: "Credit Card" },
+      ],
+      total: 2,
       isLoading: false,
       isSuccess: true,
     }),

--- a/src/client/src/pages/wizard/Step4Review.tsx
+++ b/src/client/src/pages/wizard/Step4Review.tsx
@@ -35,7 +35,7 @@ export function Step4Review({
 
   const accountNameMap = useMemo(() => {
     const map = new Map<string, string>();
-    for (const acct of (accounts?.data as { id: string; name: string }[] | undefined) ?? []) {
+    for (const acct of (accounts as { id: string; name: string }[] | undefined) ?? []) {
       map.set(acct.id, acct.name);
     }
     return map;


### PR DESCRIPTION
## Summary
- Refactored all 22 list hooks across 11 hook files to unwrap paginated API responses internally, returning `data: T[]` and `total: number` directly instead of the raw `PaginatedResponse<T>` wrapper
- Updated all consumer components (pages, widgets, wizard steps, forms, search dialog) to remove the redundant `.data` access pattern (`response?.data` → direct array usage)
- Updated all hook and component test files to match the new return shape

## Motivation
List hooks previously returned the raw React Query result wrapping a `{ data: T[], total, offset, limit }` paginated response. This forced every consumer to write `data?.data` to reach the actual array — an awkward, error-prone pattern. Now hooks unwrap internally via:

```typescript
const query = useQuery({...});
return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
```

Consumers simply use `data` as the array directly.

## Test plan
- [x] All 1117 Vitest tests pass across 130 test files
- [x] TypeScript type checking passes with no errors
- [x] ESLint passes (0 errors, 5 pre-existing warnings)
- [x] All .NET backend tests pass (584 tests)
- [x] All infrastructure tests pass (210 tests)

Closes MGG-341

🤖 Generated with [Claude Code](https://claude.com/claude-code)