### PR TITLE
test(client): install MSW and configure integration test project (MGG-252)

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -52,6 +52,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^28.1.0",
+        "msw": "^2.12.10",
         "openapi-typescript": "^7.13.0",
         "prettier": "^3.8.1",
         "shadcn": "^3.8.5",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
@@ -62,6 +63,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^28.1.0",
+    "msw": "^2.12.10",
     "openapi-typescript": "^7.13.0",
     "prettier": "^3.8.1",
     "shadcn": "^3.8.5",

--- a/src/client/src/hooks/useAccounts.integration.test.tsx
+++ b/src/client/src/hooks/useAccounts.integration.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import { useAccounts } from "./useAccounts";
+import { createQueryWrapper } from "@/test/test-utils";
+
+describe("useAccounts (integration)", () => {
+  it("returns account list from API", async () => {
+    server.use(
+      http.get("*/api/accounts", () => {
+        return HttpResponse.json({
+          data: [
+            { id: "11111111-1111-1111-1111-111111111111", accountCode: "1000", name: "Cash", isActive: true },
+            { id: "22222222-2222-2222-2222-222222222222", accountCode: "2000", name: "Credit Card", isActive: true },
+          ],
+          total: 2,
+          offset: 0,
+          limit: 50,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useAccounts(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.total).toBe(2);
+  });
+
+  it("surfaces API errors", async () => {
+    server.use(
+      http.get("*/api/accounts", () => {
+        return HttpResponse.json({ message: "Internal Server Error" }, { status: 500 });
+      }),
+    );
+
+    const { result } = renderHook(() => useAccounts(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/client/src/hooks/useAccounts.ts
+++ b/src/client/src/hooks/useAccounts.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -15,7 +16,7 @@ export function useAccounts(offset = 0, limit = 50, sortBy?: string | null, sort
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useAccount(id: string | null) {

--- a/src/client/src/hooks/useAdjustments.ts
+++ b/src/client/src/hooks/useAdjustments.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -13,7 +14,7 @@ export function useAdjustments(offset = 0, limit = 50, sortBy?: string | null, s
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useAdjustment(id: string | null) {
@@ -42,7 +43,7 @@ export function useAdjustmentsByReceiptId(receiptId: string | null, offset = 0, 
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useCreateAdjustment() {
@@ -159,7 +160,7 @@ export function useDeletedAdjustments(offset = 0, limit = 50, sortBy?: string | 
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useRestoreAdjustment() {

--- a/src/client/src/hooks/useAudit.ts
+++ b/src/client/src/hooks/useAudit.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 
@@ -29,7 +30,7 @@ export function useEntityAuditHistory(
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export interface AuditLogFilters {
@@ -94,5 +95,5 @@ export function useRecentAuditLogs(filters: AuditLogFilters = {}) {
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }

--- a/src/client/src/hooks/useAuthAudit.ts
+++ b/src/client/src/hooks/useAuthAudit.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 
@@ -24,7 +25,7 @@ export function useMyAuthAuditLog(
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useRecentAuthAuditLogs(
@@ -50,7 +51,7 @@ export function useRecentAuthAuditLogs(
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useFailedAuthAttempts(
@@ -76,5 +77,5 @@ export function useFailedAuthAttempts(
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }

--- a/src/client/src/hooks/useCategories.ts
+++ b/src/client/src/hooks/useCategories.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -13,7 +14,7 @@ export function useCategories(offset = 0, limit = 50, sortBy?: string | null, so
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useCategory(id: string | null) {

--- a/src/client/src/hooks/useItemTemplates.ts
+++ b/src/client/src/hooks/useItemTemplates.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -13,7 +14,7 @@ export function useItemTemplates(offset = 0, limit = 50, sortBy?: string | null,
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useItemTemplate(id: string | null) {
@@ -137,7 +138,7 @@ export function useDeletedItemTemplates(offset = 0, limit = 50, sortBy?: string 
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useRestoreItemTemplate() {

--- a/src/client/src/hooks/useReceiptItems.ts
+++ b/src/client/src/hooks/useReceiptItems.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -13,7 +14,7 @@ export function useReceiptItems(offset = 0, limit = 50, sortBy?: string | null, 
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useReceiptItem(id: string | null) {
@@ -42,7 +43,7 @@ export function useReceiptItemsByReceiptId(receiptId: string | null, offset = 0,
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useCreateReceiptItem() {
@@ -195,7 +196,7 @@ export function useDeletedReceiptItems(offset = 0, limit = 50, sortBy?: string |
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useRestoreReceiptItem() {

--- a/src/client/src/hooks/useReceipts.ts
+++ b/src/client/src/hooks/useReceipts.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -13,7 +14,7 @@ export function useReceipts(offset = 0, limit = 50, sortBy?: string | null, sort
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useReceipt(id: string | null) {
@@ -125,7 +126,7 @@ export function useDeletedReceipts(offset = 0, limit = 50, sortBy?: string | nul
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useRestoreReceipt() {

--- a/src/client/src/hooks/useSubcategories.ts
+++ b/src/client/src/hooks/useSubcategories.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -13,7 +14,7 @@ export function useSubcategories(offset = 0, limit = 50, sortBy?: string | null,
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useSubcategory(id: string | null) {
@@ -42,7 +43,7 @@ export function useSubcategoriesByCategoryId(categoryId: string | null, offset =
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useCreateSubcategory() {

--- a/src/client/src/hooks/useTransactions.ts
+++ b/src/client/src/hooks/useTransactions.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -13,7 +14,7 @@ export function useTransactions(offset = 0, limit = 50, sortBy?: string | null, 
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useTransaction(id: string | null) {
@@ -42,7 +43,7 @@ export function useTransactionsByReceiptId(receiptId: string | null, offset = 0,
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useCreateTransaction() {
@@ -170,7 +171,7 @@ export function useDeletedTransactions(offset = 0, limit = 50, sortBy?: string |
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useRestoreTransaction() {

--- a/src/client/src/hooks/useUsers.ts
+++ b/src/client/src/hooks/useUsers.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   useQuery,
   useMutation,
@@ -17,7 +18,7 @@ export function useUsers(offset = 0, limit = 50, sortBy?: string | null, sortDir
       return data;
     },
   });
-  return { ...query, data: query.data?.data, total: query.data?.total ?? 0 };
+  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
 export function useUser(userId: string | null) {

--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -8,7 +8,7 @@ vi.mock("@/hooks/usePageTitle", () => ({
 }));
 
 vi.mock("@/hooks/useAccounts", () => ({
-  useAccounts: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useAccounts: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useCreateAccount: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateAccount: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
@@ -91,7 +91,8 @@ describe("Accounts", () => {
   it("renders empty state when no accounts exist", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 
@@ -133,7 +134,8 @@ describe("Accounts", () => {
 
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -172,7 +174,8 @@ describe("Accounts", () => {
 
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -355,7 +358,8 @@ describe("Accounts", () => {
 
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -374,7 +378,8 @@ describe("Accounts", () => {
 
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 
@@ -404,7 +409,8 @@ describe("Accounts", () => {
 
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/Categories.test.tsx
+++ b/src/client/src/pages/Categories.test.tsx
@@ -8,7 +8,7 @@ vi.mock("@/hooks/usePageTitle", () => ({
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useCategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useCreateCategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateCategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
@@ -95,7 +95,8 @@ describe("Categories", () => {
   it("renders empty state when no categories exist", async () => {
     const { useCategories } = await import("@/hooks/useCategories");
     vi.mocked(useCategories).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 
@@ -137,7 +138,8 @@ describe("Categories", () => {
 
     const { useCategories } = await import("@/hooks/useCategories");
     vi.mocked(useCategories).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -176,7 +178,8 @@ describe("Categories", () => {
 
     const { useCategories } = await import("@/hooks/useCategories");
     vi.mocked(useCategories).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -9,7 +9,7 @@ vi.mock("@/hooks/usePageTitle", () => ({
 }));
 
 vi.mock("@/hooks/useReceipts", () => ({
-  useReceipts: vi.fn(() => ({ data: { data: [], total: 0, offset: 0, limit: 50 }, isLoading: false })),
+  useReceipts: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useCreateReceipt: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateReceipt: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useDeleteReceipts: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -97,7 +97,8 @@ describe("Receipts", () => {
   it("renders empty state when no receipts exist", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: [], total: 0, offset: 0, limit: 50 },
+      data: [],
+      total: 0,
       isLoading: false,
     }));
 
@@ -139,7 +140,8 @@ describe("Receipts", () => {
 
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -226,7 +228,8 @@ describe("Receipts", () => {
 
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -256,7 +259,8 @@ describe("Receipts", () => {
 
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -395,7 +399,8 @@ describe("Receipts", () => {
 
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 
@@ -435,7 +440,8 @@ describe("Receipts", () => {
 
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: { data: items, total: items.length, offset: 0, limit: 50 },
+      data: items,
+      total: items.length,
       isLoading: false,
     }));
 

--- a/src/client/src/pages/SecurityLog.test.tsx
+++ b/src/client/src/pages/SecurityLog.test.tsx
@@ -15,15 +15,18 @@ vi.mock("@/hooks/usePermission", () => ({
 
 vi.mock("@/hooks/useAuthAudit", () => ({
   useMyAuthAuditLog: vi.fn(() => ({
-    data: { data: [], total: 0, offset: 0, limit: 50 },
+    data: [],
+    total: 0,
     isLoading: false,
   })),
   useRecentAuthAuditLogs: vi.fn(() => ({
-    data: { data: [], total: 0, offset: 0, limit: 50 },
+    data: [],
+    total: 0,
     isLoading: false,
   })),
   useFailedAuthAttempts: vi.fn(() => ({
-    data: { data: [], total: 0, offset: 0, limit: 50 },
+    data: [],
+    total: 0,
     isLoading: false,
   })),
 }));

--- a/src/client/src/test/msw/server.ts
+++ b/src/client/src/test/msw/server.ts
@@ -1,0 +1,3 @@
+import { setupServer } from "msw/node";
+
+export const server = setupServer();

--- a/src/client/src/test/setup.integration.ts
+++ b/src/client/src/test/setup.integration.ts
@@ -1,0 +1,28 @@
+/// <reference types="vitest/globals" />
+import "@testing-library/jest-dom/vitest";
+import { server } from "./msw/server";
+
+// Polyfill localStorage for jsdom environments where it's not properly initialized
+if (typeof globalThis.localStorage === "undefined" || typeof globalThis.localStorage.setItem !== "function") {
+  const store: Record<string, string> = {};
+  globalThis.localStorage = {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  } as Storage;
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     pool: "threads",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
+    exclude: ["src/**/*.integration.test.{ts,tsx}"],
     coverage: {
       provider: "v8",
       reporter: ["text", "cobertura", "html"],

--- a/src/client/vitest.integration.config.ts
+++ b/src/client/vitest.integration.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.integration.ts"],
+    include: ["src/**/*.integration.test.{ts,tsx}"],
+    env: {
+      VITE_API_URL: "http://localhost",
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Install MSW and create a dedicated Vitest integration test config (`vitest.integration.config.ts`) so integration tests (real hooks + real API client + MSW-intercepted fetch) run independently from unit tests
- Add smoke test for `useAccounts` with happy path (200) and error path (500) exercising the full hook → openapi-fetch → MSW chain
- Wrap all 23 paginated hook returns in `useMemo` to fix pre-existing `react-hook-stability/require-stable-hook-returns` lint errors

## Key design decisions
- `onUnhandledRequest: "error"` — unhandled fetch calls fail loudly
- `VITE_API_URL: "http://localhost"` in integration config — Node's native fetch can't resolve relative URLs without a browser origin
- No coverage thresholds for integration tests — coverage tracked via unit tests only

## Test plan
- [x] `npm test` — 130 files, 1117 unit tests pass, no integration files picked up
- [x] `npm run test:integration` — 1 file, 2 tests pass
- [x] `npx tsc -b --noEmit` — clean
- [x] `npx eslint src/client/src` — 0 errors (5 pre-existing warnings)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)