### PR TITLE
feat(infrastructure): add __SeedHistory table for precise seeder tracking (RECEIPTS-348)

### DIFF
--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -46,6 +46,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 	public virtual DbSet<ItemEmbeddingEntity> ItemEmbeddings { get; set; } = null!;
 	public virtual DbSet<AuditLogEntity> AuditLogs { get; set; } = null!;
 	public virtual DbSet<AuthAuditLogEntity> AuthAuditLogs { get; set; } = null!;
+	public virtual DbSet<SeedHistoryEntry> SeedHistory { get; set; } = null!;
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
@@ -159,7 +160,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
 	private List<AuditEntry> CollectAuditEntries()
 	{
-		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity)];
+		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity), typeof(SeedHistoryEntry)];
 		List<AuditEntry> auditEntries = [];
 		DateTimeOffset now = DateTimeOffset.UtcNow;
 

--- a/src/Infrastructure/Configurations/SeedHistoryEntryConfiguration.cs
+++ b/src/Infrastructure/Configurations/SeedHistoryEntryConfiguration.cs
@@ -1,0 +1,18 @@
+using Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Configurations;
+
+public class SeedHistoryEntryConfiguration : IEntityTypeConfiguration<SeedHistoryEntry>
+{
+	public void Configure(EntityTypeBuilder<SeedHistoryEntry> builder)
+	{
+		builder.ToTable("__SeedHistory");
+		builder.HasKey(e => e.SeedId);
+
+		builder.Property(e => e.SeedId)
+			.HasMaxLength(150)
+			.IsRequired();
+	}
+}

--- a/src/Infrastructure/Entities/SeedHistoryEntry.cs
+++ b/src/Infrastructure/Entities/SeedHistoryEntry.cs
@@ -1,0 +1,7 @@
+namespace Infrastructure.Entities;
+
+public class SeedHistoryEntry
+{
+	public string SeedId { get; set; } = string.Empty;
+	public DateTimeOffset AppliedAt { get; set; }
+}

--- a/src/Infrastructure/Migrations/20260312184034_AddSeedHistoryTable.Designer.cs
+++ b/src/Infrastructure/Migrations/20260312184034_AddSeedHistoryTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260312184034_AddSeedHistoryTable")]
+    partial class AddSeedHistoryTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260312184034_AddSeedHistoryTable.cs
+++ b/src/Infrastructure/Migrations/20260312184034_AddSeedHistoryTable.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddSeedHistoryTable : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.CreateTable(
+			name: "__SeedHistory",
+			columns: table => new
+			{
+				SeedId = table.Column<string>(type: "text", maxLength: 150, nullable: false),
+				AppliedAt = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false)
+			},
+			constraints: table =>
+			{
+				table.PrimaryKey("PK___SeedHistory", x => x.SeedId);
+			});
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropTable(
+			name: "__SeedHistory");
+	}
+}

--- a/src/Infrastructure/Services/DatabaseSeederService.cs
+++ b/src/Infrastructure/Services/DatabaseSeederService.cs
@@ -1,16 +1,29 @@
 using Common;
 using Infrastructure.Entities;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.Services;
 
 public static class DatabaseSeederService
 {
+	private const string RolesAndAdminSeedId = "RolesAndAdmin_v1";
+
 	public static async Task SeedRolesAndAdminAsync(IServiceProvider services)
 	{
 		using IServiceScope scope = services.CreateScope();
+		ApplicationDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+		ILogger logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(DatabaseSeederService));
+
+		if (await dbContext.SeedHistory.AnyAsync(s => s.SeedId == RolesAndAdminSeedId))
+		{
+			logger.LogInformation("Seed operation '{SeedId}' already applied — skipping.", RolesAndAdminSeedId);
+			return;
+		}
+
 		RoleManager<IdentityRole> roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
 		UserManager<ApplicationUser> userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
 		IConfiguration configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
@@ -99,5 +112,14 @@ public static class DatabaseSeederService
 
 			throw;
 		}
+
+		dbContext.SeedHistory.Add(new SeedHistoryEntry
+		{
+			SeedId = RolesAndAdminSeedId,
+			AppliedAt = DateTimeOffset.UtcNow,
+		});
+		await dbContext.SaveChangesAsync();
+
+		logger.LogInformation("Seed operation '{SeedId}' completed and recorded.", RolesAndAdminSeedId);
 	}
 }

--- a/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
@@ -3,18 +3,21 @@ using FluentAssertions;
 using Infrastructure.Entities;
 using Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Infrastructure.Tests.Services;
 
-public class DatabaseSeederServiceTests
+public class DatabaseSeederServiceTests : IDisposable
 {
 	private readonly Mock<RoleManager<IdentityRole>> _mockRoleManager;
 	private readonly Mock<UserManager<ApplicationUser>> _mockUserManager;
 	private readonly IConfiguration _configuration;
-	private readonly IServiceProvider _serviceProvider;
+	private readonly ServiceProvider _serviceProvider;
+	private readonly ApplicationDbContext _dbContext;
 
 	public DatabaseSeederServiceTests()
 	{
@@ -40,7 +43,28 @@ public class DatabaseSeederServiceTests
 		services.AddSingleton(_mockRoleManager.Object);
 		services.AddSingleton(_mockUserManager.Object);
 		services.AddSingleton(_configuration);
+		services.AddSingleton<ILoggerFactory>(new LoggerFactory());
+
+		DbContextOptions<ApplicationDbContext> dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		_dbContext = new ApplicationDbContext(dbOptions);
+		services.AddScoped(_ => new ApplicationDbContext(dbOptions));
+
 		_serviceProvider = services.BuildServiceProvider();
+	}
+
+	public void Dispose()
+	{
+		_dbContext.Dispose();
+		_serviceProvider.Dispose();
+		GC.SuppressFinalize(this);
+	}
+
+	private void SetupRolesExist()
+	{
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(true);
 	}
 
 	private void SetupFullySeedableUser()
@@ -53,6 +77,62 @@ public class DatabaseSeederServiceTests
 			.ReturnsAsync(false);
 		_mockUserManager.Setup(u => u.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
 			.ReturnsAsync(IdentityResult.Success);
+	}
+
+	private async Task MarkSeedAsApplied()
+	{
+		_dbContext.SeedHistory.Add(new SeedHistoryEntry
+		{
+			SeedId = "RolesAndAdmin_v1",
+			AppliedAt = DateTimeOffset.UtcNow,
+		});
+		await _dbContext.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenAlreadySeeded_SkipsEntireOperation()
+	{
+		// Arrange
+		await MarkSeedAsApplied();
+
+		// Act
+		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert — nothing was touched
+		_mockRoleManager.Verify(r => r.RoleExistsAsync(It.IsAny<string>()), Times.Never);
+		_mockRoleManager.Verify(r => r.CreateAsync(It.IsAny<IdentityRole>()), Times.Never);
+		_mockUserManager.Verify(u => u.FindByEmailAsync(It.IsAny<string>()), Times.Never);
+		_mockUserManager.Verify(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenSuccessful_RecordsSeedHistory()
+	{
+		// Arrange
+		SetupRolesExist();
+		SetupFullySeedableUser();
+
+		// Act
+		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert
+		bool recorded = await _dbContext.SeedHistory.AnyAsync(s => s.SeedId == "RolesAndAdmin_v1");
+		recorded.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenSuccessful_SecondCallSkips()
+	{
+		// Arrange
+		SetupRolesExist();
+		SetupFullySeedableUser();
+
+		// Act — run twice
+		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+		await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider);
+
+		// Assert — user creation happened only once
+		_mockUserManager.Verify(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Once);
 	}
 
 	[Fact]
@@ -72,6 +152,23 @@ public class DatabaseSeederServiceTests
 		// Assert
 		await act.Should().ThrowAsync<InvalidOperationException>()
 			.WithMessage("*Failed to create role*Role already exists.*");
+	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenRoleCreationFails_DoesNotRecordSeedHistory()
+	{
+		// Arrange
+		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
+			.ReturnsAsync(false);
+		_mockRoleManager.Setup(r => r.CreateAsync(It.IsAny<IdentityRole>()))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "Fail", Description = "Fail" }));
+
+		// Act
+		try { await DatabaseSeederService.SeedRolesAndAdminAsync(_serviceProvider); } catch { }
+
+		// Assert
+		bool recorded = await _dbContext.SeedHistory.AnyAsync(s => s.SeedId == "RolesAndAdmin_v1");
+		recorded.Should().BeFalse();
 	}
 
 	[Fact]
@@ -104,8 +201,7 @@ public class DatabaseSeederServiceTests
 	public async Task SeedRolesAndAdminAsync_SkipsExistingRoles()
 	{
 		// Arrange
-		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
-			.ReturnsAsync(true);
+		SetupRolesExist();
 
 		ApplicationUser existingUser = new() { Email = "admin@test.com" };
 		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
@@ -124,8 +220,7 @@ public class DatabaseSeederServiceTests
 	public async Task SeedRolesAndAdminAsync_WhenUserCreationFails_ThrowsInvalidOperationException()
 	{
 		// Arrange
-		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
-			.ReturnsAsync(true);
+		SetupRolesExist();
 
 		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
 			.ReturnsAsync((ApplicationUser?)null);
@@ -146,8 +241,7 @@ public class DatabaseSeederServiceTests
 	public async Task SeedRolesAndAdminAsync_WhenAddToAdminRoleFails_ThrowsAndDeletesUser()
 	{
 		// Arrange
-		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
-			.ReturnsAsync(true);
+		SetupRolesExist();
 
 		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
 			.ReturnsAsync((ApplicationUser?)null);
@@ -175,8 +269,7 @@ public class DatabaseSeederServiceTests
 	public async Task SeedRolesAndAdminAsync_WhenAddToUserRoleFails_ThrowsAndDeletesUser()
 	{
 		// Arrange
-		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
-			.ReturnsAsync(true);
+		SetupRolesExist();
 
 		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
 			.ReturnsAsync((ApplicationUser?)null);
@@ -206,9 +299,7 @@ public class DatabaseSeederServiceTests
 	public async Task SeedRolesAndAdminAsync_WhenBothRoleAssignmentsSucceed_DoesNotThrow()
 	{
 		// Arrange
-		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
-			.ReturnsAsync(true);
-
+		SetupRolesExist();
 		SetupFullySeedableUser();
 
 		// Act
@@ -225,8 +316,7 @@ public class DatabaseSeederServiceTests
 	public async Task SeedRolesAndAdminAsync_WhenExistingUserHasAllRoles_SkipsRoleAssignment()
 	{
 		// Arrange
-		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
-			.ReturnsAsync(true);
+		SetupRolesExist();
 
 		ApplicationUser existingUser = new() { Email = "admin@test.com" };
 		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
@@ -246,8 +336,7 @@ public class DatabaseSeederServiceTests
 	public async Task SeedRolesAndAdminAsync_WhenExistingUserLacksRoles_AssignsRolesWithoutCreating()
 	{
 		// Arrange — simulates orphaned user from a previous partial failure
-		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
-			.ReturnsAsync(true);
+		SetupRolesExist();
 
 		ApplicationUser orphanedUser = new() { Email = "admin@test.com" };
 		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))
@@ -270,8 +359,7 @@ public class DatabaseSeederServiceTests
 	public async Task SeedRolesAndAdminAsync_WhenRoleAssignmentFailsForOrphanedUser_DoesNotDeleteUser()
 	{
 		// Arrange — orphaned user from a previous run; role assignment fails again
-		_mockRoleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>()))
-			.ReturnsAsync(true);
+		SetupRolesExist();
 
 		ApplicationUser orphanedUser = new() { Email = "admin@test.com" };
 		_mockUserManager.Setup(u => u.FindByEmailAsync("admin@test.com"))


### PR DESCRIPTION
## Summary

- Adds a `__SeedHistory` table (analogous to EF Core's `__EFMigrationsHistory`) that records completed seed operations by ID
- Refactors `DatabaseSeederService` to check this table before running, instead of inferring state from role membership or email lookups
- Only writes the seed record after the full operation succeeds — partial failures leave no record, so the next run retries correctly
- Supersedes the heuristic approach proposed in RECEIPTS-347

## Changes

- **New entity**: `SeedHistoryEntry` (`SeedId` string PK + `AppliedAt` timestamp)
- **New configuration**: `SeedHistoryEntryConfiguration` maps to `__SeedHistory` table
- **Migration**: `AddSeedHistoryTable` creates the table
- **DbContext**: Added `SeedHistory` DbSet, excluded from audit logging
- **Seeder**: Checks `__SeedHistory` for `RolesAndAdmin_v1` before running; records on success
- **Tests**: 14 tests (4 new for seed history behavior, 10 existing updated for new DI setup)

## Test plan

- [x] All 1,140 .NET tests pass (14 DatabaseSeederService tests including 4 new ones)
- [ ] Verify migration applies cleanly against a real PostgreSQL instance
- [ ] Run `DbSeeder` twice — second run should log "already applied" and skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)