### PR TITLE
fix(api): validate X-SignalR-Connection-Id header against server-side tracker

### DIFF
--- a/src/Presentation/API/Hubs/EntityHub.cs
+++ b/src/Presentation/API/Hubs/EntityHub.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+using API.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
@@ -5,6 +7,21 @@ using Microsoft.AspNetCore.SignalR;
 namespace API.Hubs;
 
 [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
-public class EntityHub : Hub<IEntityHubClient>
+public class EntityHub(ISignalRConnectionTracker connectionTracker) : Hub<IEntityHubClient>
 {
+	public override Task OnConnectedAsync()
+	{
+		var userId = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+		if (userId is not null)
+		{
+			connectionTracker.TrackConnection(Context.ConnectionId, userId);
+		}
+		return base.OnConnectedAsync();
+	}
+
+	public override Task OnDisconnectedAsync(Exception? exception)
+	{
+		connectionTracker.RemoveConnection(Context.ConnectionId);
+		return base.OnDisconnectedAsync(exception);
+	}
 }

--- a/src/Presentation/API/Services/EntityChangeNotifier.cs
+++ b/src/Presentation/API/Services/EntityChangeNotifier.cs
@@ -10,20 +10,22 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 {
 	private readonly IHubContext<EntityHub, IEntityHubClient> _hubContext;
 	private readonly IHttpContextAccessor _httpContextAccessor;
+	private readonly ISignalRConnectionTracker _connectionTracker;
 	private readonly ConcurrentDictionary<(string EntityType, string ChangeType, string? UserId, string? AuthMethod, string? ConnectionId), NotificationBucket> _pending = new();
 	private readonly Timer _flushTimer;
 	private readonly TimeSpan _flushInterval;
 	private int _disposed;
 
-	public EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor)
-		: this(hubContext, httpContextAccessor, TimeSpan.FromSeconds(1))
+	public EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor, ISignalRConnectionTracker connectionTracker)
+		: this(hubContext, httpContextAccessor, connectionTracker, TimeSpan.FromSeconds(1))
 	{
 	}
 
-	internal EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor, TimeSpan flushInterval)
+	internal EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor, ISignalRConnectionTracker connectionTracker, TimeSpan flushInterval)
 	{
 		_hubContext = hubContext;
 		_httpContextAccessor = httpContextAccessor;
+		_connectionTracker = connectionTracker;
 		_flushInterval = flushInterval;
 		_flushTimer = new Timer(_ => _ = FlushAsync(), null, _flushInterval, _flushInterval);
 	}
@@ -90,9 +92,13 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 			: authType is not null
 				? "jwt"
 				: null;
-		// connectionId is client-supplied and untrusted; spoofing suppresses a toast
-		// but does not affect data integrity or query invalidation.
 		var connectionId = httpContext.Request.Headers["X-SignalR-Connection-Id"].FirstOrDefault();
+
+		// Validate that the claimed connection ID actually belongs to this user.
+		if (connectionId is not null && (userId is null || !_connectionTracker.IsConnectionOwnedBy(connectionId, userId)))
+		{
+			connectionId = null;
+		}
 
 		return new NotificationOrigin(userId, authMethod, connectionId);
 	}

--- a/src/Presentation/API/Services/ISignalRConnectionTracker.cs
+++ b/src/Presentation/API/Services/ISignalRConnectionTracker.cs
@@ -1,0 +1,8 @@
+namespace API.Services;
+
+public interface ISignalRConnectionTracker
+{
+	void TrackConnection(string connectionId, string userId);
+	void RemoveConnection(string connectionId);
+	bool IsConnectionOwnedBy(string connectionId, string userId);
+}

--- a/src/Presentation/API/Services/ProgramService.cs
+++ b/src/Presentation/API/Services/ProgramService.cs
@@ -30,6 +30,7 @@ public static class ProgramService
 		services.AddSingleton<IAuthorizationMiddlewareResultHandler, AuthorizationLoggingHandler>();
 
 		services.AddSignalR();
+		services.AddSingleton<ISignalRConnectionTracker, SignalRConnectionTracker>();
 		services.AddSingleton<IEntityChangeNotifier, EntityChangeNotifier>();
 
 		return services;

--- a/src/Presentation/API/Services/SignalRConnectionTracker.cs
+++ b/src/Presentation/API/Services/SignalRConnectionTracker.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+
+namespace API.Services;
+
+public sealed class SignalRConnectionTracker : ISignalRConnectionTracker
+{
+	private readonly ConcurrentDictionary<string, string> _connectionToUser = new();
+
+	public void TrackConnection(string connectionId, string userId)
+	{
+		_connectionToUser[connectionId] = userId;
+	}
+
+	public void RemoveConnection(string connectionId)
+	{
+		_connectionToUser.TryRemove(connectionId, out _);
+	}
+
+	public bool IsConnectionOwnedBy(string connectionId, string userId)
+	{
+		return _connectionToUser.TryGetValue(connectionId, out string? owner) && owner == userId;
+	}
+}

--- a/tests/Presentation.API.Tests/Hubs/EntityHubTests.cs
+++ b/tests/Presentation.API.Tests/Hubs/EntityHubTests.cs
@@ -1,4 +1,7 @@
+using System.Security.Claims;
 using API.Hubs;
+using API.Services;
+using FluentAssertions;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
 
@@ -8,6 +11,8 @@ public class EntityHubTests
 {
 	private readonly Mock<IHubCallerClients<IEntityHubClient>> _mockClients;
 	private readonly Mock<IEntityHubClient> _mockClientProxy;
+	private readonly Mock<ISignalRConnectionTracker> _mockTracker;
+	private readonly Mock<HubCallerContext> _mockContext;
 	private readonly EntityHub _hub;
 
 	public EntityHubTests()
@@ -15,25 +20,63 @@ public class EntityHubTests
 		_mockClients = new Mock<IHubCallerClients<IEntityHubClient>>();
 		_mockClientProxy = new Mock<IEntityHubClient>();
 		_mockClients.Setup(clients => clients.All).Returns(_mockClientProxy.Object);
+		_mockTracker = new Mock<ISignalRConnectionTracker>();
 
-		_hub = new EntityHub
+		_mockContext = new Mock<HubCallerContext>();
+		_mockContext.Setup(c => c.ConnectionId).Returns("conn-123");
+
+		_hub = new EntityHub(_mockTracker.Object)
 		{
 			Clients = _mockClients.Object,
-			Context = new Mock<HubCallerContext>().Object
+			Context = _mockContext.Object,
 		};
 	}
 
 	[Fact]
-	public async Task OnConnectedAsync_CompletesSuccessfully()
+	public async Task OnConnectedAsync_TracksConnectionForAuthenticatedUser()
 	{
-		// Act & Assert - should not throw
+		// Arrange
+		var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, "user-42") };
+		var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Bearer"));
+		_mockContext.Setup(c => c.User).Returns(principal);
+
+		// Act
 		await _hub.OnConnectedAsync();
+
+		// Assert
+		_mockTracker.Verify(t => t.TrackConnection("conn-123", "user-42"), Times.Once);
 	}
 
 	[Fact]
-	public async Task OnDisconnectedAsync_CompletesSuccessfully()
+	public async Task OnConnectedAsync_DoesNotTrackWhenNoUserId()
 	{
-		// Act & Assert - should not throw
+		// Arrange — no user claims
+		_mockContext.Setup(c => c.User).Returns(new ClaimsPrincipal());
+
+		// Act
+		await _hub.OnConnectedAsync();
+
+		// Assert
+		_mockTracker.Verify(t => t.TrackConnection(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task OnDisconnectedAsync_RemovesConnection()
+	{
+		// Act
 		await _hub.OnDisconnectedAsync(null);
+
+		// Assert
+		_mockTracker.Verify(t => t.RemoveConnection("conn-123"), Times.Once);
+	}
+
+	[Fact]
+	public async Task OnDisconnectedAsync_RemovesConnectionOnError()
+	{
+		// Act
+		await _hub.OnDisconnectedAsync(new InvalidOperationException("test"));
+
+		// Assert
+		_mockTracker.Verify(t => t.RemoveConnection("conn-123"), Times.Once);
 	}
 }

--- a/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
+++ b/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
@@ -14,6 +14,7 @@ public class EntityChangeNotifierTests : IDisposable
 	private readonly Mock<IHubContext<EntityHub, IEntityHubClient>> _hubContextMock;
 	private readonly Mock<IEntityHubClient> _clientMock;
 	private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock;
+	private readonly Mock<ISignalRConnectionTracker> _connectionTrackerMock;
 	private readonly EntityChangeNotifier _notifier;
 
 	public EntityChangeNotifierTests()
@@ -31,8 +32,11 @@ public class EntityChangeNotifierTests : IDisposable
 		_httpContextAccessorMock = new Mock<IHttpContextAccessor>();
 		_httpContextAccessorMock.Setup(a => a.HttpContext).Returns((HttpContext?)null);
 
+		_connectionTrackerMock = new Mock<ISignalRConnectionTracker>();
+		_connectionTrackerMock.Setup(t => t.IsConnectionOwnedBy(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+
 		// Use a very long flush interval so the timer never fires during tests
-		_notifier = new EntityChangeNotifier(_hubContextMock.Object, _httpContextAccessorMock.Object, TimeSpan.FromHours(1));
+		_notifier = new EntityChangeNotifier(_hubContextMock.Object, _httpContextAccessorMock.Object, _connectionTrackerMock.Object, TimeSpan.FromHours(1));
 	}
 
 	public void Dispose()
@@ -223,7 +227,8 @@ public class EntityChangeNotifierTests : IDisposable
 		hubContextMock.Setup(h => h.Clients).Returns(hubClientsMock.Object);
 		Mock<IHttpContextAccessor> httpContextAccessorMock = new();
 		httpContextAccessorMock.Setup(a => a.HttpContext).Returns((HttpContext?)null);
-		var notifier = new EntityChangeNotifier(hubContextMock.Object, httpContextAccessorMock.Object, TimeSpan.FromHours(1));
+		Mock<ISignalRConnectionTracker> trackerMock = new();
+		var notifier = new EntityChangeNotifier(hubContextMock.Object, httpContextAccessorMock.Object, trackerMock.Object, TimeSpan.FromHours(1));
 
 		Guid id = Guid.NewGuid();
 		await notifier.NotifyCreated("receipt", id);
@@ -357,5 +362,47 @@ public class EntityChangeNotifierTests : IDisposable
 				n.UserId == "user-B")),
 			Times.Once);
 		_clientMock.Verify(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()), Times.Exactly(2));
+	}
+
+	[Fact]
+	public async Task NotifyCreated_WithSpoofedConnectionId_SetsConnectionIdToNull()
+	{
+		// Arrange — tracker says this connection does NOT belong to the user
+		var context = CreateJwtHttpContext("user-123", "spoofed-conn");
+		_httpContextAccessorMock.Setup(a => a.HttpContext).Returns(context);
+		_connectionTrackerMock.Setup(t => t.IsConnectionOwnedBy("spoofed-conn", "user-123")).Returns(false);
+
+		// Act
+		await _notifier.NotifyCreated("receipt", Guid.NewGuid());
+		await _notifier.FlushAsync();
+
+		// Assert
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.UserId == "user-123" &&
+				n.AuthMethod == "jwt" &&
+				n.ConnectionId == null)),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task NotifyCreated_UnauthenticatedUserWithConnectionIdHeader_SetsConnectionIdToNull()
+	{
+		// Arrange — HttpContext exists with no user claims but has the connection ID header
+		var context = new DefaultHttpContext();
+		context.Request.Headers["X-SignalR-Connection-Id"] = "conn-abc";
+		_httpContextAccessorMock.Setup(a => a.HttpContext).Returns(context);
+
+		// Act
+		await _notifier.NotifyCreated("receipt", Guid.NewGuid());
+		await _notifier.FlushAsync();
+
+		// Assert
+		_clientMock.Verify(c => c.EntityChanged(
+			It.Is<EntityChangeNotification>(n =>
+				n.UserId == null &&
+				n.AuthMethod == null &&
+				n.ConnectionId == null)),
+			Times.Once);
 	}
 }

--- a/tests/Presentation.API.Tests/Services/SignalRConnectionTrackerTests.cs
+++ b/tests/Presentation.API.Tests/Services/SignalRConnectionTrackerTests.cs
@@ -1,0 +1,86 @@
+using API.Services;
+using FluentAssertions;
+
+namespace Presentation.API.Tests.Services;
+
+public class SignalRConnectionTrackerTests
+{
+	private readonly SignalRConnectionTracker _tracker = new();
+
+	[Fact]
+	public void TrackConnection_ThenIsConnectionOwnedBy_ReturnsTrueForCorrectUser()
+	{
+		// Arrange
+		_tracker.TrackConnection("conn-1", "user-A");
+
+		// Act
+		bool result = _tracker.IsConnectionOwnedBy("conn-1", "user-A");
+
+		// Assert
+		result.Should().BeTrue();
+	}
+
+	[Fact]
+	public void IsConnectionOwnedBy_ReturnsFalseForWrongUser()
+	{
+		// Arrange
+		_tracker.TrackConnection("conn-1", "user-A");
+
+		// Act
+		bool result = _tracker.IsConnectionOwnedBy("conn-1", "user-B");
+
+		// Assert
+		result.Should().BeFalse();
+	}
+
+	[Fact]
+	public void IsConnectionOwnedBy_ReturnsFalseForUnknownConnection()
+	{
+		// Act
+		bool result = _tracker.IsConnectionOwnedBy("unknown-conn", "user-A");
+
+		// Assert
+		result.Should().BeFalse();
+	}
+
+	[Fact]
+	public void RemoveConnection_MakesIsConnectionOwnedByReturnFalse()
+	{
+		// Arrange
+		_tracker.TrackConnection("conn-1", "user-A");
+
+		// Act
+		_tracker.RemoveConnection("conn-1");
+
+		// Assert
+		_tracker.IsConnectionOwnedBy("conn-1", "user-A").Should().BeFalse();
+	}
+
+	[Fact]
+	public void MultipleConnections_ForSameUser_AllValidateCorrectly()
+	{
+		// Arrange
+		_tracker.TrackConnection("conn-1", "user-A");
+		_tracker.TrackConnection("conn-2", "user-A");
+		_tracker.TrackConnection("conn-3", "user-A");
+
+		// Act & Assert
+		_tracker.IsConnectionOwnedBy("conn-1", "user-A").Should().BeTrue();
+		_tracker.IsConnectionOwnedBy("conn-2", "user-A").Should().BeTrue();
+		_tracker.IsConnectionOwnedBy("conn-3", "user-A").Should().BeTrue();
+	}
+
+	[Fact]
+	public void TrackConnection_WithExistingConnectionId_OverwritesPreviousUser()
+	{
+		// Arrange
+		_tracker.TrackConnection("conn-1", "user-A");
+
+		// Act
+		_tracker.TrackConnection("conn-1", "user-B");
+
+		// Assert
+		_tracker.IsConnectionOwnedBy("conn-1", "user-B").Should().BeTrue();
+		_tracker.IsConnectionOwnedBy("conn-1", "user-A").Should().BeFalse();
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ISignalRConnectionTracker` / `SignalRConnectionTracker` to map active SignalR connection IDs to authenticated user IDs
- `EntityHub` now tracks connections on connect and removes them on disconnect
- `EntityChangeNotifier.CaptureOrigin()` validates the client-supplied `X-SignalR-Connection-Id` header against the tracker — spoofed or unowned connection IDs are discarded (set to `null`)
- Closes the threat where a malicious client could suppress toast notifications on other users' sessions by spoofing the header

## Test plan
- [x] New `SignalRConnectionTrackerTests` (6 tests): track, remove, ownership validation, overwrite, multi-connection
- [x] New `EntityHubTests` (4 tests): connect tracks, disconnect removes, no-user skips tracking, error disconnect still removes
- [x] New `EntityChangeNotifierTests` (2 tests): spoofed connection ID → null, unauthenticated user with header → null
- [x] All 1160 existing + new unit tests pass
- [x] Pre-commit hooks pass (build, format, lint, drift, tsc, eslint)

Resolves RECEIPTS-270

🤖 Generated with [Claude Code](https://claude.com/claude-code)