### PR TITLE
test(api): improve API test coverage (RECEIPTS-162)

### DIFF
--- a/tests/Presentation.API.Tests/Authentication/ApiKeyAuthenticationHandlerTests.cs
+++ b/tests/Presentation.API.Tests/Authentication/ApiKeyAuthenticationHandlerTests.cs
@@ -1,0 +1,242 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using API.Authentication;
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Presentation.API.Tests.Authentication;
+
+public class ApiKeyAuthenticationHandlerTests
+{
+	private readonly Mock<IApiKeyService> _apiKeyServiceMock;
+	private readonly Mock<IAuthAuditService> _authAuditServiceMock;
+	private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+	private readonly ApiKeyAuthenticationOptions _options;
+
+	public ApiKeyAuthenticationHandlerTests()
+	{
+		_apiKeyServiceMock = new Mock<IApiKeyService>();
+		_authAuditServiceMock = new Mock<IAuthAuditService>();
+		_userManagerMock = new Mock<UserManager<ApplicationUser>>(
+			Mock.Of<IUserStore<ApplicationUser>>(),
+			null!, null!, null!, null!, null!, null!, null!, null!);
+		_options = new ApiKeyAuthenticationOptions();
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_ReturnsNoResult_WhenNoHeader()
+	{
+		// Arrange
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(new DefaultHttpContext());
+
+		// Act
+		AuthenticateResult result = await handler.AuthenticateAsync();
+
+		// Assert
+		result.None.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_ReturnsNoResult_WhenEmptyHeader()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Request.Headers["X-API-Key"] = "";
+
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
+
+		// Act
+		AuthenticateResult result = await handler.AuthenticateAsync();
+
+		// Assert
+		result.None.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_ReturnsFail_WhenInvalidKey()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.Request.Headers["X-API-Key"] = "invalid-key";
+
+		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("invalid-key", It.IsAny<CancellationToken>()))
+			.ReturnsAsync((string?)null);
+
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
+
+		// Act
+		AuthenticateResult result = await handler.AuthenticateAsync();
+
+		// Assert
+		result.Succeeded.Should().BeFalse();
+		result.Failure!.Message.Should().Be("Invalid API key.");
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_ReturnsSuccess_WithClaimsForValidKey()
+	{
+		// Arrange
+		string userId = Guid.NewGuid().ToString();
+		ApplicationUser user = new() { Id = userId, Email = "test@example.com" };
+
+		DefaultHttpContext context = new();
+		context.Request.Headers["X-API-Key"] = "valid-key";
+
+		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(userId);
+		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
+			.ReturnsAsync(user);
+		_userManagerMock.Setup(u => u.GetRolesAsync(user))
+			.ReturnsAsync(new List<string> { "Admin" });
+
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
+
+		// Act
+		AuthenticateResult result = await handler.AuthenticateAsync();
+
+		// Assert
+		result.Succeeded.Should().BeTrue();
+		ClaimsPrincipal principal = result.Principal!;
+		principal.FindFirst(ClaimTypes.NameIdentifier)!.Value.Should().Be(userId);
+		principal.FindFirst(ClaimTypes.Email)!.Value.Should().Be("test@example.com");
+		principal.FindFirst(ClaimTypes.Role)!.Value.Should().Be("Admin");
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_OmitsEmailClaim_WhenUserHasNullEmail()
+	{
+		// Arrange
+		string userId = Guid.NewGuid().ToString();
+		ApplicationUser user = new() { Id = userId, Email = null };
+
+		DefaultHttpContext context = new();
+		context.Request.Headers["X-API-Key"] = "valid-key";
+
+		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(userId);
+		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
+			.ReturnsAsync(user);
+		_userManagerMock.Setup(u => u.GetRolesAsync(user))
+			.ReturnsAsync(new List<string>());
+
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
+
+		// Act
+		AuthenticateResult result = await handler.AuthenticateAsync();
+
+		// Assert
+		result.Succeeded.Should().BeTrue();
+		result.Principal!.FindFirst(ClaimTypes.Email).Should().BeNull();
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_OnlyHasNameIdentifier_WhenUserNotFound()
+	{
+		// Arrange
+		string userId = Guid.NewGuid().ToString();
+
+		DefaultHttpContext context = new();
+		context.Request.Headers["X-API-Key"] = "valid-key";
+
+		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(userId);
+		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
+			.ReturnsAsync((ApplicationUser?)null);
+
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
+
+		// Act
+		AuthenticateResult result = await handler.AuthenticateAsync();
+
+		// Assert
+		result.Succeeded.Should().BeTrue();
+		ClaimsPrincipal principal = result.Principal!;
+		principal.FindFirst(ClaimTypes.NameIdentifier)!.Value.Should().Be(userId);
+		principal.FindFirst(ClaimTypes.Email).Should().BeNull();
+		principal.FindFirst(ClaimTypes.Role).Should().BeNull();
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_CallsAuditLog_WhenValidKey()
+	{
+		// Arrange
+		string userId = Guid.NewGuid().ToString();
+
+		DefaultHttpContext context = new();
+		context.Request.Headers["X-API-Key"] = "valid-key";
+
+		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(userId);
+		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
+			.ReturnsAsync((ApplicationUser?)null);
+
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
+
+		// Act
+		await handler.AuthenticateAsync();
+
+		// Assert
+		_authAuditServiceMock.Verify(a => a.LogAsync(
+			It.Is<AuthAuditEntryDto>(e =>
+				e.UserId == userId
+				&& e.EventType == "ApiKeyUsed"
+				&& e.Success),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_StillReturnsSuccess_WhenAuditLogThrows()
+	{
+		// Arrange
+		string userId = Guid.NewGuid().ToString();
+
+		DefaultHttpContext context = new();
+		context.Request.Headers["X-API-Key"] = "valid-key";
+
+		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(userId);
+		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
+			.ReturnsAsync((ApplicationUser?)null);
+		_authAuditServiceMock.Setup(a => a.LogAsync(It.IsAny<AuthAuditEntryDto>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("DB connection failed"));
+
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
+
+		// Act
+		AuthenticateResult result = await handler.AuthenticateAsync();
+
+		// Assert
+		result.Succeeded.Should().BeTrue();
+	}
+
+	private async Task<ApiKeyAuthenticationHandler> CreateHandlerAsync(HttpContext context)
+	{
+		Mock<IOptionsMonitor<ApiKeyAuthenticationOptions>> optionsMonitorMock = new();
+		optionsMonitorMock.Setup(o => o.Get(ApiKeyAuthenticationDefaults.AuthenticationScheme))
+			.Returns(_options);
+
+		ApiKeyAuthenticationHandler handler = new(
+			optionsMonitorMock.Object,
+			NullLoggerFactory.Instance,
+			UrlEncoder.Default,
+			_apiKeyServiceMock.Object,
+			_authAuditServiceMock.Object,
+			_userManagerMock.Object);
+
+		AuthenticationScheme scheme = new(
+			ApiKeyAuthenticationDefaults.AuthenticationScheme,
+			null,
+			typeof(ApiKeyAuthenticationHandler));
+
+		await handler.InitializeAsync(scheme, context);
+		return handler;
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/DashboardControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/DashboardControllerTests.cs
@@ -60,6 +60,9 @@ public class DashboardControllerTests
 	public async Task GetDashboardSummary_UsesDefaultDates_WhenNullDatesProvided()
 	{
 		// Arrange
+		DateOnly today = DateOnly.FromDateTime(DateTime.Today);
+		DateOnly expectedStart = today.AddDays(-30);
+
 		DashboardSummaryResult summaryResult = new(
 			TotalReceipts: 0,
 			TotalSpent: 0m,
@@ -80,8 +83,8 @@ public class DashboardControllerTests
 		Assert.IsType<Ok<DashboardSummaryResponse>>(result.Result);
 		_mediatorMock.Verify(m => m.Send(
 			It.Is<GetDashboardSummaryQuery>(q =>
-				q.StartDate == DateOnly.FromDateTime(DateTime.Today.AddDays(-30))
-				&& q.EndDate == DateOnly.FromDateTime(DateTime.Today)),
+				q.StartDate == expectedStart
+				&& q.EndDate == today),
 			It.IsAny<CancellationToken>()), Times.Once);
 	}
 
@@ -470,6 +473,9 @@ public class DashboardControllerTests
 	public async Task GetSpendingByAccount_UsesDefaultDates_WhenNullDatesProvided()
 	{
 		// Arrange
+		DateOnly today = DateOnly.FromDateTime(DateTime.Today);
+		DateOnly expectedStart = today.AddDays(-30);
+
 		SpendingByAccountResult accountResult = new([]);
 
 		_mediatorMock.Setup(m => m.Send(
@@ -485,8 +491,8 @@ public class DashboardControllerTests
 		Assert.IsType<Ok<SpendingByAccountResponse>>(result.Result);
 		_mediatorMock.Verify(m => m.Send(
 			It.Is<GetSpendingByAccountQuery>(q =>
-				q.StartDate == DateOnly.FromDateTime(DateTime.Today.AddDays(-30))
-				&& q.EndDate == DateOnly.FromDateTime(DateTime.Today)),
+				q.StartDate == expectedStart
+				&& q.EndDate == today),
 			It.IsAny<CancellationToken>()), Times.Once);
 	}
 

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/DashboardControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/DashboardControllerTests.cs
@@ -1,0 +1,513 @@
+using API.Controllers.Aggregates;
+using API.Generated.Dtos;
+using Application.Models.Dashboard;
+using Application.Queries.Aggregates.Dashboard;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+
+namespace Presentation.API.Tests.Controllers.Aggregates;
+
+public class DashboardControllerTests
+{
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly DashboardController _controller;
+
+	public DashboardControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_controller = new DashboardController(_mediatorMock.Object);
+	}
+
+	#region GetDashboardSummary
+
+	[Fact]
+	public async Task GetDashboardSummary_ReturnsOkResult_WithValidDates()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+		DashboardSummaryResult summaryResult = new(
+			TotalReceipts: 5,
+			TotalSpent: 150.50m,
+			AverageTripAmount: 30.10m,
+			MostUsedAccount: new NameCountResult("Checking", 3),
+			MostUsedCategory: new NameCountResult("Groceries", 4));
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDashboardSummaryQuery>(q => q.StartDate == start && q.EndDate == end),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(summaryResult);
+
+		// Act
+		Results<Ok<DashboardSummaryResponse>, BadRequest<string>> result =
+			await _controller.GetDashboardSummary(start, end, CancellationToken.None);
+
+		// Assert
+		Ok<DashboardSummaryResponse> okResult = Assert.IsType<Ok<DashboardSummaryResponse>>(result.Result);
+		DashboardSummaryResponse response = okResult.Value!;
+		response.TotalReceipts.Should().Be(5);
+		response.TotalSpent.Should().Be(150.50);
+		response.AverageTripAmount.Should().Be(30.10);
+		response.MostUsedAccount.Name.Should().Be("Checking");
+		response.MostUsedAccount.Count.Should().Be(3);
+		response.MostUsedCategory.Name.Should().Be("Groceries");
+		response.MostUsedCategory.Count.Should().Be(4);
+	}
+
+	[Fact]
+	public async Task GetDashboardSummary_UsesDefaultDates_WhenNullDatesProvided()
+	{
+		// Arrange
+		DashboardSummaryResult summaryResult = new(
+			TotalReceipts: 0,
+			TotalSpent: 0m,
+			AverageTripAmount: 0m,
+			MostUsedAccount: new NameCountResult(null, 0),
+			MostUsedCategory: new NameCountResult(null, 0));
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetDashboardSummaryQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(summaryResult);
+
+		// Act
+		Results<Ok<DashboardSummaryResponse>, BadRequest<string>> result =
+			await _controller.GetDashboardSummary(null, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<DashboardSummaryResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetDashboardSummaryQuery>(q =>
+				q.StartDate == DateOnly.FromDateTime(DateTime.Today.AddDays(-30))
+				&& q.EndDate == DateOnly.FromDateTime(DateTime.Today)),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetDashboardSummary_ReturnsBadRequest_WhenStartDateAfterEndDate()
+	{
+		// Arrange
+		DateOnly start = new(2024, 2, 1);
+		DateOnly end = new(2024, 1, 1);
+
+		// Act
+		Results<Ok<DashboardSummaryResponse>, BadRequest<string>> result =
+			await _controller.GetDashboardSummary(start, end, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("startDate must be before or equal to endDate");
+	}
+
+	[Fact]
+	public async Task GetDashboardSummary_ReturnsOk_WhenStartDateEqualsEndDate()
+	{
+		// Arrange
+		DateOnly date = new(2024, 1, 15);
+		DashboardSummaryResult summaryResult = new(
+			TotalReceipts: 1,
+			TotalSpent: 25m,
+			AverageTripAmount: 25m,
+			MostUsedAccount: new NameCountResult("Savings", 1),
+			MostUsedCategory: new NameCountResult("Food", 1));
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDashboardSummaryQuery>(q => q.StartDate == date && q.EndDate == date),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(summaryResult);
+
+		// Act
+		Results<Ok<DashboardSummaryResponse>, BadRequest<string>> result =
+			await _controller.GetDashboardSummary(date, date, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<DashboardSummaryResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetDashboardSummary_ThrowsException_WhenMediatorFails()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetDashboardSummaryQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		// Act
+		Func<Task> act = () => _controller.GetDashboardSummary(start, end, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	#endregion
+
+	#region GetSpendingOverTime
+
+	[Fact]
+	public async Task GetSpendingOverTime_ReturnsOkResult_WithValidParameters()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 3, 31);
+		SpendingOverTimeResult overTimeResult = new(
+		[
+			new SpendingBucketResult("2024-01", 100m),
+			new SpendingBucketResult("2024-02", 200m),
+			new SpendingBucketResult("2024-03", 150m),
+		]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingOverTimeQuery>(q =>
+				q.StartDate == start && q.EndDate == end && q.Granularity == "monthly"),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(overTimeResult);
+
+		// Act
+		Results<Ok<SpendingOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingOverTime(start, end, "monthly", CancellationToken.None);
+
+		// Assert
+		Ok<SpendingOverTimeResponse> okResult = Assert.IsType<Ok<SpendingOverTimeResponse>>(result.Result);
+		SpendingOverTimeResponse response = okResult.Value!;
+		response.Buckets.Should().HaveCount(3);
+		response.Buckets.First().Period.Should().Be("2024-01");
+		response.Buckets.First().Amount.Should().Be(100);
+	}
+
+	[Fact]
+	public async Task GetSpendingOverTime_UsesDefaultGranularity_WhenNullGranularity()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+		SpendingOverTimeResult overTimeResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingOverTimeQuery>(q => q.Granularity == "monthly"),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(overTimeResult);
+
+		// Act
+		Results<Ok<SpendingOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingOverTime(start, end, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingOverTimeResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetSpendingOverTimeQuery>(q => q.Granularity == "monthly"),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetSpendingOverTime_ReturnsBadRequest_WhenInvalidDates()
+	{
+		// Arrange
+		DateOnly start = new(2024, 2, 1);
+		DateOnly end = new(2024, 1, 1);
+
+		// Act
+		Results<Ok<SpendingOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingOverTime(start, end, "monthly", CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("startDate must be before or equal to endDate");
+	}
+
+	[Fact]
+	public async Task GetSpendingOverTime_ReturnsBadRequest_WhenInvalidGranularity()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+
+		// Act
+		Results<Ok<SpendingOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingOverTime(start, end, "yearly", CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid granularity");
+	}
+
+	[Theory]
+	[InlineData("daily")]
+	[InlineData("weekly")]
+	[InlineData("monthly")]
+	public async Task GetSpendingOverTime_AcceptsValidGranularities(string granularity)
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+		SpendingOverTimeResult overTimeResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingOverTimeQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(overTimeResult);
+
+		// Act
+		Results<Ok<SpendingOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingOverTime(start, end, granularity, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingOverTimeResponse>>(result.Result);
+	}
+
+	[Theory]
+	[InlineData("Daily")]
+	[InlineData("WEEKLY")]
+	[InlineData("Monthly")]
+	public async Task GetSpendingOverTime_AcceptsCaseInsensitiveGranularity(string granularity)
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+		SpendingOverTimeResult overTimeResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingOverTimeQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(overTimeResult);
+
+		// Act
+		Results<Ok<SpendingOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingOverTime(start, end, granularity, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingOverTimeResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetSpendingOverTime_ThrowsException_WhenMediatorFails()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingOverTimeQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		// Act
+		Func<Task> act = () => _controller.GetSpendingOverTime(start, end, "monthly", CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	#endregion
+
+	#region GetSpendingByCategory
+
+	[Fact]
+	public async Task GetSpendingByCategory_ReturnsOkResult_WithValidParameters()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+		SpendingByCategoryResult categoryResult = new(
+		[
+			new SpendingCategoryItemResult("Groceries", 100m, 50m),
+			new SpendingCategoryItemResult("Gas", 100m, 50m),
+		]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByCategoryQuery>(q =>
+				q.StartDate == start && q.EndDate == end && q.Limit == 10),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(categoryResult);
+
+		// Act
+		Results<Ok<SpendingByCategoryResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByCategory(start, end, 10, CancellationToken.None);
+
+		// Assert
+		Ok<SpendingByCategoryResponse> okResult = Assert.IsType<Ok<SpendingByCategoryResponse>>(result.Result);
+		SpendingByCategoryResponse response = okResult.Value!;
+		response.Items.Should().HaveCount(2);
+		response.Items.First().CategoryName.Should().Be("Groceries");
+		response.Items.First().Amount.Should().Be(100);
+		response.Items.First().Percentage.Should().Be(50);
+	}
+
+	[Fact]
+	public async Task GetSpendingByCategory_ReturnsBadRequest_WhenInvalidDates()
+	{
+		// Arrange
+		DateOnly start = new(2024, 2, 1);
+		DateOnly end = new(2024, 1, 1);
+
+		// Act
+		Results<Ok<SpendingByCategoryResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByCategory(start, end, 10, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("startDate must be before or equal to endDate");
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	[InlineData(101)]
+	public async Task GetSpendingByCategory_ReturnsBadRequest_WhenLimitOutOfRange(int limit)
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+
+		// Act
+		Results<Ok<SpendingByCategoryResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByCategory(start, end, limit, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("limit must be between 1 and 100");
+	}
+
+	[Theory]
+	[InlineData(1)]
+	[InlineData(100)]
+	public async Task GetSpendingByCategory_AcceptsBoundaryLimits(int limit)
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+		SpendingByCategoryResult categoryResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByCategoryQuery>(q => q.Limit == limit),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(categoryResult);
+
+		// Act
+		Results<Ok<SpendingByCategoryResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByCategory(start, end, limit, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingByCategoryResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetSpendingByCategory_ThrowsException_WhenMediatorFails()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingByCategoryQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		// Act
+		Func<Task> act = () => _controller.GetSpendingByCategory(start, end, 10, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	#endregion
+
+	#region GetSpendingByAccount
+
+	[Fact]
+	public async Task GetSpendingByAccount_ReturnsOkResult_WithValidDates()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+		Guid accountId = Guid.NewGuid();
+		SpendingByAccountResult accountResult = new(
+		[
+			new SpendingAccountItemResult(accountId, "Checking", 200m, 100m),
+		]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByAccountQuery>(q => q.StartDate == start && q.EndDate == end),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(accountResult);
+
+		// Act
+		Results<Ok<SpendingByAccountResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByAccount(start, end, CancellationToken.None);
+
+		// Assert
+		Ok<SpendingByAccountResponse> okResult = Assert.IsType<Ok<SpendingByAccountResponse>>(result.Result);
+		SpendingByAccountResponse response = okResult.Value!;
+		response.Items.Should().HaveCount(1);
+		response.Items.First().AccountId.Should().Be(accountId);
+		response.Items.First().AccountName.Should().Be("Checking");
+		response.Items.First().Amount.Should().Be(200);
+		response.Items.First().Percentage.Should().Be(100);
+	}
+
+	[Fact]
+	public async Task GetSpendingByAccount_ReturnsBadRequest_WhenInvalidDates()
+	{
+		// Arrange
+		DateOnly start = new(2024, 2, 1);
+		DateOnly end = new(2024, 1, 1);
+
+		// Act
+		Results<Ok<SpendingByAccountResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByAccount(start, end, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("startDate must be before or equal to endDate");
+	}
+
+	[Fact]
+	public async Task GetSpendingByAccount_UsesDefaultDates_WhenNullDatesProvided()
+	{
+		// Arrange
+		SpendingByAccountResult accountResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingByAccountQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(accountResult);
+
+		// Act
+		Results<Ok<SpendingByAccountResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByAccount(null, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingByAccountResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetSpendingByAccountQuery>(q =>
+				q.StartDate == DateOnly.FromDateTime(DateTime.Today.AddDays(-30))
+				&& q.EndDate == DateOnly.FromDateTime(DateTime.Today)),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetSpendingByAccount_ThrowsException_WhenMediatorFails()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingByAccountQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		// Act
+		Func<Task> act = () => _controller.GetSpendingByAccount(start, end, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	#endregion
+}

--- a/tests/Presentation.API.Tests/Middleware/MustResetPasswordMiddlewareTests.cs
+++ b/tests/Presentation.API.Tests/Middleware/MustResetPasswordMiddlewareTests.cs
@@ -1,0 +1,155 @@
+using System.Security.Claims;
+using System.Text.Json;
+using API.Middleware;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Presentation.API.Tests.Middleware;
+
+public class MustResetPasswordMiddlewareTests
+{
+	[Fact]
+	public async Task InvokeAsync_PassesThrough_WhenUnauthenticated()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		bool nextCalled = false;
+
+		MustResetPasswordMiddleware middleware = new(_ =>
+		{
+			nextCalled = true;
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		nextCalled.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task InvokeAsync_PassesThrough_WhenAuthenticatedWithoutMustResetClaim()
+	{
+		// Arrange
+		DefaultHttpContext context = new();
+		context.User = new ClaimsPrincipal(new ClaimsIdentity(
+		[
+			new Claim(ClaimTypes.NameIdentifier, "user-1"),
+		], "TestScheme"));
+		bool nextCalled = false;
+
+		MustResetPasswordMiddleware middleware = new(_ =>
+		{
+			nextCalled = true;
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		nextCalled.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task InvokeAsync_PassesThrough_WhenMustResetAndPathIsChangePassword()
+	{
+		// Arrange
+		DefaultHttpContext context = CreateMustResetContext("/api/auth/change-password");
+		bool nextCalled = false;
+
+		MustResetPasswordMiddleware middleware = new(_ =>
+		{
+			nextCalled = true;
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		nextCalled.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task InvokeAsync_PassesThrough_WhenMustResetAndPathIsLogout()
+	{
+		// Arrange
+		DefaultHttpContext context = CreateMustResetContext("/api/auth/logout");
+		bool nextCalled = false;
+
+		MustResetPasswordMiddleware middleware = new(_ =>
+		{
+			nextCalled = true;
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		nextCalled.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task InvokeAsync_Returns403WithProblemDetails_WhenMustResetAndPathIsOther()
+	{
+		// Arrange
+		DefaultHttpContext context = CreateMustResetContext("/api/receipts");
+		context.Response.Body = new MemoryStream();
+
+		MustResetPasswordMiddleware middleware = new(_ => Task.CompletedTask);
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+		context.Response.ContentType.Should().Contain("application/problem+json");
+
+		context.Response.Body.Position = 0;
+		ProblemDetails? problemDetails = await JsonSerializer.DeserializeAsync<ProblemDetails>(
+			context.Response.Body,
+			new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+		problemDetails.Should().NotBeNull();
+		problemDetails!.Status.Should().Be(403);
+		problemDetails.Title.Should().Be("Forbidden");
+		problemDetails.Detail.Should().Be("Password change required");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_DoesNotCallNext_WhenMustResetAndPathIsBlocked()
+	{
+		// Arrange
+		DefaultHttpContext context = CreateMustResetContext("/api/dashboard/summary");
+		context.Response.Body = new MemoryStream();
+		bool nextCalled = false;
+
+		MustResetPasswordMiddleware middleware = new(_ =>
+		{
+			nextCalled = true;
+			return Task.CompletedTask;
+		});
+
+		// Act
+		await middleware.InvokeAsync(context);
+
+		// Assert
+		nextCalled.Should().BeFalse();
+	}
+
+	private static DefaultHttpContext CreateMustResetContext(string path)
+	{
+		DefaultHttpContext context = new();
+		context.User = new ClaimsPrincipal(new ClaimsIdentity(
+		[
+			new Claim(ClaimTypes.NameIdentifier, "user-1"),
+			new Claim("must_reset_password", "true"),
+		], "TestScheme"));
+		context.Request.Path = path;
+		return context;
+	}
+}


### PR DESCRIPTION
## Summary
- Add `DashboardControllerTests` (23 tests) covering all 4 dashboard endpoints: summary, spending-over-time, spending-by-category, spending-by-account with date validation, default parameters, boundary limits, granularity validation, and mediator exception propagation
- Add `MustResetPasswordMiddlewareTests` (6 tests) covering unauthenticated passthrough, missing claim passthrough, allowed paths (change-password, logout), 403 ProblemDetails blocking, and next delegate suppression
- Add `ApiKeyAuthenticationHandlerTests` (8 tests) covering missing/empty header NoResult, invalid key Fail, valid key Success with claims (NameIdentifier, Email, Role), null email omission, user-not-found fallback, audit logging verification, and audit failure resilience

## Test plan
- [x] All 42 new tests pass
- [x] All 626 existing + new tests in Presentation.API.Tests pass
- [x] Pre-commit hooks pass (build, format, lint, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)