### PR TITLE
test(client): add MSW handlers and fixtures for core API endpoints

### DIFF
--- a/src/client/src/test/msw/fixtures/accounts.ts
+++ b/src/client/src/test/msw/fixtures/accounts.ts
@@ -1,0 +1,24 @@
+import type { components } from "@/generated/api";
+
+type AccountResponse = components["schemas"]["AccountResponse"];
+
+export const accounts: AccountResponse[] = [
+  {
+    id: "11111111-1111-1111-1111-111111111111",
+    accountCode: "1000",
+    name: "Cash",
+    isActive: true,
+  },
+  {
+    id: "22222222-2222-2222-2222-222222222222",
+    accountCode: "2000",
+    name: "Credit Card",
+    isActive: true,
+  },
+  {
+    id: "33333333-3333-3333-3333-333333333333",
+    accountCode: "3000",
+    name: "Savings",
+    isActive: false,
+  },
+];

--- a/src/client/src/test/msw/fixtures/auth.ts
+++ b/src/client/src/test/msw/fixtures/auth.ts
@@ -1,0 +1,18 @@
+import type { components } from "@/generated/api";
+
+type TokenResponse = components["schemas"]["TokenResponse"];
+type LoginRequest = components["schemas"]["LoginRequest"];
+
+export const loginRequest: LoginRequest = {
+  email: "test@example.com",
+  password: "Password123!",
+};
+
+export const tokenResponse: TokenResponse = {
+  accessToken: "fake-access-token-for-testing",
+  refreshToken: "fake-refresh-token-for-testing",
+  expiresIn: 3600,
+  mustResetPassword: false,
+  tokenType: "Bearer",
+  scope: "",
+};

--- a/src/client/src/test/msw/fixtures/index.ts
+++ b/src/client/src/test/msw/fixtures/index.ts
@@ -1,0 +1,6 @@
+export { loginRequest, tokenResponse } from "./auth";
+export { accounts } from "./accounts";
+export { receipts } from "./receipts";
+export { receiptItems } from "./receipt-items";
+export { transactions } from "./transactions";
+export { tripResponse } from "./trips";

--- a/src/client/src/test/msw/fixtures/receipt-items.ts
+++ b/src/client/src/test/msw/fixtures/receipt-items.ts
@@ -1,0 +1,39 @@
+import type { components } from "@/generated/api";
+
+type ReceiptItemResponse = components["schemas"]["ReceiptItemResponse"];
+
+export const receiptItems: ReceiptItemResponse[] = [
+  {
+    id: "bbbb1111-1111-1111-1111-111111111111",
+    receiptId: "aaaa1111-1111-1111-1111-111111111111",
+    receiptItemCode: "SKU-001",
+    description: "Milk",
+    quantity: 2,
+    unitPrice: 3.99,
+    category: "Groceries",
+    subcategory: "Dairy",
+    pricingMode: "quantity",
+  },
+  {
+    id: "bbbb2222-2222-2222-2222-222222222222",
+    receiptId: "aaaa1111-1111-1111-1111-111111111111",
+    receiptItemCode: null,
+    description: "Bread",
+    quantity: 1,
+    unitPrice: 4.5,
+    category: "Groceries",
+    subcategory: "Bakery",
+    pricingMode: "flat",
+  },
+  {
+    id: "bbbb3333-3333-3333-3333-333333333333",
+    receiptId: "aaaa2222-2222-2222-2222-222222222222",
+    receiptItemCode: "HW-100",
+    description: "Screwdriver Set",
+    quantity: 1,
+    unitPrice: 24.99,
+    category: "Tools",
+    subcategory: null,
+    pricingMode: "flat",
+  },
+];

--- a/src/client/src/test/msw/fixtures/receipts.ts
+++ b/src/client/src/test/msw/fixtures/receipts.ts
@@ -1,0 +1,24 @@
+import type { components } from "@/generated/api";
+
+type ReceiptResponse = components["schemas"]["ReceiptResponse"];
+
+export const receipts: ReceiptResponse[] = [
+  {
+    id: "aaaa1111-1111-1111-1111-111111111111",
+    location: "Grocery Store",
+    date: "2025-01-15",
+    taxAmount: 5.25,
+  },
+  {
+    id: "aaaa2222-2222-2222-2222-222222222222",
+    location: "Hardware Store",
+    date: "2025-01-20",
+    taxAmount: 3.5,
+  },
+  {
+    id: "aaaa3333-3333-3333-3333-333333333333",
+    location: "Restaurant",
+    date: "2025-02-01",
+    taxAmount: 2.75,
+  },
+];

--- a/src/client/src/test/msw/fixtures/transactions.ts
+++ b/src/client/src/test/msw/fixtures/transactions.ts
@@ -7,7 +7,7 @@ export const transactions: TransactionResponse[] = [
     id: "cccc1111-1111-1111-1111-111111111111",
     receiptId: "aaaa1111-1111-1111-1111-111111111111",
     accountId: "11111111-1111-1111-1111-111111111111",
-    amount: 12.48,
+    amount: 17.73,
     date: "2025-01-15",
   },
   {

--- a/src/client/src/test/msw/fixtures/transactions.ts
+++ b/src/client/src/test/msw/fixtures/transactions.ts
@@ -1,0 +1,27 @@
+import type { components } from "@/generated/api";
+
+type TransactionResponse = components["schemas"]["TransactionResponse"];
+
+export const transactions: TransactionResponse[] = [
+  {
+    id: "cccc1111-1111-1111-1111-111111111111",
+    receiptId: "aaaa1111-1111-1111-1111-111111111111",
+    accountId: "11111111-1111-1111-1111-111111111111",
+    amount: 12.48,
+    date: "2025-01-15",
+  },
+  {
+    id: "cccc2222-2222-2222-2222-222222222222",
+    receiptId: "aaaa2222-2222-2222-2222-222222222222",
+    accountId: "22222222-2222-2222-2222-222222222222",
+    amount: 28.49,
+    date: "2025-01-20",
+  },
+  {
+    id: "cccc3333-3333-3333-3333-333333333333",
+    receiptId: "aaaa3333-3333-3333-3333-333333333333",
+    accountId: "11111111-1111-1111-1111-111111111111",
+    amount: 15.0,
+    date: "2025-02-01",
+  },
+];

--- a/src/client/src/test/msw/fixtures/trips.ts
+++ b/src/client/src/test/msw/fixtures/trips.ts
@@ -1,0 +1,28 @@
+import type { components } from "@/generated/api";
+import { receipts } from "./receipts";
+import { receiptItems } from "./receipt-items";
+import { transactions } from "./transactions";
+import { accounts } from "./accounts";
+
+type TripResponse = components["schemas"]["TripResponse"];
+
+const receipt = receipts[0];
+const items = receiptItems.filter((i) => i.receiptId === receipt.id);
+const txns = transactions.filter((t) => t.receiptId === receipt.id);
+
+export const tripResponse: TripResponse = {
+  receipt: {
+    receipt,
+    items,
+    adjustments: [],
+    subtotal: items.reduce((sum, i) => sum + i.quantity * i.unitPrice, 0),
+    adjustmentTotal: 0,
+    expectedTotal: items.reduce((sum, i) => sum + i.quantity * i.unitPrice, 0) + receipt.taxAmount,
+    warnings: [],
+  },
+  transactions: txns.map((t) => ({
+    transaction: t,
+    account: accounts.find((a) => a.id === t.accountId)!,
+  })),
+  warnings: [],
+};

--- a/src/client/src/test/msw/handlers/accounts.ts
+++ b/src/client/src/test/msw/handlers/accounts.ts
@@ -29,11 +29,11 @@ export const accountHandlers = [
     });
   }),
 
-  http.put("*/api/accounts/:id", () => {
+  http.put("*/api/accounts/batch", () => {
     return new HttpResponse(null, { status: 204 });
   }),
 
-  http.put("*/api/accounts/batch", () => {
+  http.put("*/api/accounts/:id", () => {
     return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/src/client/src/test/msw/handlers/accounts.ts
+++ b/src/client/src/test/msw/handlers/accounts.ts
@@ -1,0 +1,39 @@
+import { http, HttpResponse } from "msw";
+import { accounts } from "../fixtures";
+
+export const accountHandlers = [
+  http.get("*/api/accounts", ({ request }) => {
+    const url = new URL(request.url);
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Number(url.searchParams.get("limit") ?? 50);
+    const page = accounts.slice(offset, offset + limit);
+    return HttpResponse.json({
+      data: page,
+      total: accounts.length,
+      offset,
+      limit,
+    });
+  }),
+
+  http.get("*/api/accounts/:id", ({ params }) => {
+    const account = accounts.find((a) => a.id === params.id);
+    if (!account) return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+    return HttpResponse.json(account);
+  }),
+
+  http.post("*/api/accounts", async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({
+      id: "00000000-0000-0000-0000-000000000001",
+      ...body,
+    });
+  }),
+
+  http.put("*/api/accounts/:id", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.put("*/api/accounts/batch", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/src/client/src/test/msw/handlers/auth.ts
+++ b/src/client/src/test/msw/handlers/auth.ts
@@ -1,0 +1,20 @@
+import { http, HttpResponse } from "msw";
+import { tokenResponse } from "../fixtures";
+
+export const authHandlers = [
+  http.post("*/api/auth/login", () => {
+    return HttpResponse.json(tokenResponse);
+  }),
+
+  http.post("*/api/auth/refresh", () => {
+    return HttpResponse.json({
+      ...tokenResponse,
+      accessToken: "refreshed-access-token-for-testing",
+      refreshToken: "refreshed-refresh-token-for-testing",
+    });
+  }),
+
+  http.post("*/api/auth/logout", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/src/client/src/test/msw/handlers/index.ts
+++ b/src/client/src/test/msw/handlers/index.ts
@@ -1,0 +1,15 @@
+import { authHandlers } from "./auth";
+import { accountHandlers } from "./accounts";
+import { receiptHandlers } from "./receipts";
+import { receiptItemHandlers } from "./receipt-items";
+import { transactionHandlers } from "./transactions";
+import { tripHandlers } from "./trips";
+
+export const handlers = [
+  ...authHandlers,
+  ...accountHandlers,
+  ...receiptHandlers,
+  ...receiptItemHandlers,
+  ...transactionHandlers,
+  ...tripHandlers,
+];

--- a/src/client/src/test/msw/handlers/receipt-items.ts
+++ b/src/client/src/test/msw/handlers/receipt-items.ts
@@ -1,0 +1,62 @@
+import { http, HttpResponse } from "msw";
+import { receiptItems } from "../fixtures";
+
+export const receiptItemHandlers = [
+  http.get("*/api/receipt-items", ({ request }) => {
+    const url = new URL(request.url);
+    const receiptId = url.searchParams.get("receiptId");
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Number(url.searchParams.get("limit") ?? 50);
+    const filtered = receiptId ? receiptItems.filter((i) => i.receiptId === receiptId) : receiptItems;
+    const page = filtered.slice(offset, offset + limit);
+    return HttpResponse.json({
+      data: page,
+      total: filtered.length,
+      offset,
+      limit,
+    });
+  }),
+
+  http.get("*/api/receipt-items/deleted", ({ request }) => {
+    const url = new URL(request.url);
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Number(url.searchParams.get("limit") ?? 50);
+    return HttpResponse.json({
+      data: [],
+      total: 0,
+      offset,
+      limit,
+    });
+  }),
+
+  http.get("*/api/receipt-items/:id", ({ params }) => {
+    const item = receiptItems.find((i) => i.id === params.id);
+    if (!item) return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+    return HttpResponse.json(item);
+  }),
+
+  http.post("*/api/receipts/:receiptId/receipt-items", async ({ request, params }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({
+      id: "00000000-0000-0000-0000-000000000003",
+      receiptId: params.receiptId,
+      ...body,
+    });
+  }),
+
+  http.put("*/api/receipt-items/:id", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.put("*/api/receipt-items/batch", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.delete("*/api/receipt-items", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.post("*/api/receipt-items/:id/restore", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/src/client/src/test/msw/handlers/receipt-items.ts
+++ b/src/client/src/test/msw/handlers/receipt-items.ts
@@ -44,11 +44,11 @@ export const receiptItemHandlers = [
     });
   }),
 
-  http.put("*/api/receipt-items/:id", () => {
+  http.put("*/api/receipt-items/batch", () => {
     return new HttpResponse(null, { status: 204 });
   }),
 
-  http.put("*/api/receipt-items/batch", () => {
+  http.put("*/api/receipt-items/:id", () => {
     return new HttpResponse(null, { status: 204 });
   }),
 

--- a/src/client/src/test/msw/handlers/receipts.ts
+++ b/src/client/src/test/msw/handlers/receipts.ts
@@ -1,0 +1,55 @@
+import { http, HttpResponse } from "msw";
+import { receipts } from "../fixtures";
+
+export const receiptHandlers = [
+  http.get("*/api/receipts", ({ request }) => {
+    const url = new URL(request.url);
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Number(url.searchParams.get("limit") ?? 50);
+    const page = receipts.slice(offset, offset + limit);
+    return HttpResponse.json({
+      data: page,
+      total: receipts.length,
+      offset,
+      limit,
+    });
+  }),
+
+  http.get("*/api/receipts/deleted", ({ request }) => {
+    const url = new URL(request.url);
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Number(url.searchParams.get("limit") ?? 50);
+    return HttpResponse.json({
+      data: [],
+      total: 0,
+      offset,
+      limit,
+    });
+  }),
+
+  http.get("*/api/receipts/:id", ({ params }) => {
+    const receipt = receipts.find((r) => r.id === params.id);
+    if (!receipt) return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+    return HttpResponse.json(receipt);
+  }),
+
+  http.post("*/api/receipts", async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({
+      id: "00000000-0000-0000-0000-000000000002",
+      ...body,
+    });
+  }),
+
+  http.put("*/api/receipts/:id", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.delete("*/api/receipts", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.post("*/api/receipts/:id/restore", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/src/client/src/test/msw/handlers/transactions.ts
+++ b/src/client/src/test/msw/handlers/transactions.ts
@@ -1,0 +1,62 @@
+import { http, HttpResponse } from "msw";
+import { transactions } from "../fixtures";
+
+export const transactionHandlers = [
+  http.get("*/api/transactions", ({ request }) => {
+    const url = new URL(request.url);
+    const receiptId = url.searchParams.get("receiptId");
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Number(url.searchParams.get("limit") ?? 50);
+    const filtered = receiptId ? transactions.filter((t) => t.receiptId === receiptId) : transactions;
+    const page = filtered.slice(offset, offset + limit);
+    return HttpResponse.json({
+      data: page,
+      total: filtered.length,
+      offset,
+      limit,
+    });
+  }),
+
+  http.get("*/api/transactions/deleted", ({ request }) => {
+    const url = new URL(request.url);
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Number(url.searchParams.get("limit") ?? 50);
+    return HttpResponse.json({
+      data: [],
+      total: 0,
+      offset,
+      limit,
+    });
+  }),
+
+  http.get("*/api/transactions/:id", ({ params }) => {
+    const txn = transactions.find((t) => t.id === params.id);
+    if (!txn) return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+    return HttpResponse.json(txn);
+  }),
+
+  http.post("*/api/receipts/:receiptId/transactions", async ({ request, params }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({
+      id: "00000000-0000-0000-0000-000000000004",
+      receiptId: params.receiptId,
+      ...body,
+    });
+  }),
+
+  http.put("*/api/transactions/:id", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.put("*/api/transactions/batch", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.delete("*/api/transactions", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.post("*/api/transactions/:id/restore", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/src/client/src/test/msw/handlers/transactions.ts
+++ b/src/client/src/test/msw/handlers/transactions.ts
@@ -44,11 +44,11 @@ export const transactionHandlers = [
     });
   }),
 
-  http.put("*/api/transactions/:id", () => {
+  http.put("*/api/transactions/batch", () => {
     return new HttpResponse(null, { status: 204 });
   }),
 
-  http.put("*/api/transactions/batch", () => {
+  http.put("*/api/transactions/:id", () => {
     return new HttpResponse(null, { status: 204 });
   }),
 

--- a/src/client/src/test/msw/handlers/trips.ts
+++ b/src/client/src/test/msw/handlers/trips.ts
@@ -1,0 +1,16 @@
+import { http, HttpResponse } from "msw";
+import { tripResponse } from "../fixtures";
+
+export const tripHandlers = [
+  http.get("*/api/trips", ({ request }) => {
+    const url = new URL(request.url);
+    const receiptId = url.searchParams.get("receiptId");
+    if (!receiptId) {
+      return HttpResponse.json({ message: "receiptId is required" }, { status: 400 });
+    }
+    if (receiptId === tripResponse.receipt.receipt.id) {
+      return HttpResponse.json(tripResponse);
+    }
+    return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+  }),
+];

--- a/src/client/src/test/msw/server.ts
+++ b/src/client/src/test/msw/server.ts
@@ -1,3 +1,4 @@
 import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
 
-export const server = setupServer();
+export const server = setupServer(...handlers);


### PR DESCRIPTION
## Summary

- Add typed MSW fixture data (accounts, receipts, receipt-items, transactions, trips, auth) using `components["schemas"]` from generated types for compile-time safety
- Add MSW HTTP handlers for all core API endpoints (CRUD, pagination, filtering, soft-delete/restore, auth)
- Wire default handlers into `setupServer()` so future integration tests get baseline responses without per-test handler setup

Resolves RECEIPTS-293

## Test plan

- [x] `npx tsc -b --noEmit` in `src/client/` — all fixtures type-check against generated types
- [x] Existing integration test (`useAccounts.integration.test.tsx`) still passes — `server.use()` overrides work correctly
- [x] `npx eslint src/client/src/test/msw/` — no lint errors
- [x] All pre-commit hooks pass (build, unit tests, format, tsc, eslint, drift check)