### PR TITLE
test(client): add integration tests for Trips page (RECEIPTS-290)

### DIFF
--- a/src/client/src/pages/Trips.integration.test.tsx
+++ b/src/client/src/pages/Trips.integration.test.tsx
@@ -1,0 +1,79 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse, delay } from "msw";
+import { server } from "@/test/msw/server";
+import { renderWithQueryClient } from "@/test/test-utils";
+import Trips from "./Trips";
+
+describe("Trips page integration", () => {
+  it("renders receipt table with data from MSW handler", async () => {
+    renderWithQueryClient(<Trips />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Grocery Store")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Hardware Store")).toBeInTheDocument();
+    expect(screen.getByText("Restaurant")).toBeInTheDocument();
+
+    expect(screen.getByRole("columnheader", { name: "Location" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Date" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Tax Amount" })).toBeInTheDocument();
+  });
+
+  it("selecting a receipt loads trip data", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Trips />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Grocery Store")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Grocery Store"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Milk")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Bread")).toBeInTheDocument();
+    expect(screen.getAllByText("$17.73").length).toBeGreaterThan(0);
+    expect(screen.getByText("Cash")).toBeInTheDocument();
+  });
+
+  it('shows "No trip found" when API returns 404', async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Trips />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Restaurant")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Restaurant"));
+
+    await waitFor(() => {
+      expect(screen.getByText("No trip found for this receipt.")).toBeInTheDocument();
+    });
+  });
+
+  it("handles loading states correctly", async () => {
+    server.use(
+      http.get("*/api/receipts", async () => {
+        await delay(200);
+        return HttpResponse.json({
+          data: [{ id: "aaaa1111-1111-1111-1111-111111111111", location: "Delayed Store", date: "2025-01-15", taxAmount: 1.0 }],
+          total: 1,
+          offset: 0,
+          limit: 50,
+        });
+      }),
+    );
+
+    renderWithQueryClient(<Trips />);
+
+    expect(document.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Delayed Store")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/client/src/test/msw/fixtures/index.ts
+++ b/src/client/src/test/msw/fixtures/index.ts
@@ -4,3 +4,4 @@ export { receipts } from "./receipts";
 export { receiptItems } from "./receipt-items";
 export { transactions } from "./transactions";
 export { tripResponse } from "./trips";
+export { enumMetadata } from "./metadata";

--- a/src/client/src/test/msw/fixtures/metadata.ts
+++ b/src/client/src/test/msw/fixtures/metadata.ts
@@ -1,0 +1,17 @@
+import type { components } from "@/generated/api";
+
+type EnumMetadataResponse = components["schemas"]["EnumMetadataResponse"];
+
+export const enumMetadata: EnumMetadataResponse = {
+  adjustmentTypes: [
+    { value: "discount", label: "Discount" },
+    { value: "surcharge", label: "Surcharge" },
+  ],
+  authEventTypes: [{ value: "login", label: "Login" }],
+  pricingModes: [
+    { value: "quantity", label: "Quantity" },
+    { value: "flat", label: "Flat" },
+  ],
+  auditActions: [{ value: "created", label: "Created" }],
+  entityTypes: [{ value: "receipt", label: "Receipt" }],
+};

--- a/src/client/src/test/msw/handlers/index.ts
+++ b/src/client/src/test/msw/handlers/index.ts
@@ -4,6 +4,7 @@ import { receiptHandlers } from "./receipts";
 import { receiptItemHandlers } from "./receipt-items";
 import { transactionHandlers } from "./transactions";
 import { tripHandlers } from "./trips";
+import { metadataHandlers } from "./metadata";
 
 export const handlers = [
   ...authHandlers,
@@ -12,4 +13,5 @@ export const handlers = [
   ...receiptItemHandlers,
   ...transactionHandlers,
   ...tripHandlers,
+  ...metadataHandlers,
 ];

--- a/src/client/src/test/msw/handlers/metadata.ts
+++ b/src/client/src/test/msw/handlers/metadata.ts
@@ -1,0 +1,8 @@
+import { http, HttpResponse } from "msw";
+import { enumMetadata } from "../fixtures";
+
+export const metadataHandlers = [
+  http.get("*/api/metadata/enums", () => {
+    return HttpResponse.json(enumMetadata);
+  }),
+];


### PR DESCRIPTION
## Summary
- Add proof-of-concept integration tests for the Trips page validating the full chain: component → hooks → React Query → openapi-fetch → MSW handler → rendered UI
- Add metadata handler/fixture (`GET /api/metadata/enums`) required by `useEnumMetadata()` hook
- 4 test cases: table rendering, trip data loading on selection, 404 handling, and loading skeleton states

Resolves RECEIPTS-290

## Test plan
- `cd src/client && npx vitest run --config vitest.integration.config.ts src/pages/Trips.integration.test.tsx` — all 4 tests pass
- `npx tsc -b --noEmit` — no type errors
- `npx eslint src/client/src/test/msw/ src/client/src/pages/Trips.integration.test.tsx` — no lint errors
- Pre-commit hooks pass