### PR TITLE
docs: document frontend testing conventions and mock fidelity rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,20 @@ All functions, objects, and arrays returned from custom hooks (`use*`) **must** 
 
 **Why:** Consumers may place hook return values in `useEffect`/`useMemo`/`useCallback` dependency arrays. Unstable references cause infinite render loops that are invisible in static review and pass individual test files but hang the full test suite.
 
+## Testing
+
+Full details in **[docs/testing.md](docs/testing.md)** — covers both .NET and React testing, coverage thresholds, and CI reporting.
+
+### Frontend Mock Fidelity
+
+**All API hook mocks must use the real response shape.** List endpoints return `{ data: T[], total, offset, limit }` — never mock them as bare arrays. Incorrect mock shapes hide integration bugs that only surface at runtime.
+
+- **Hook-level tests** (`useX.test.ts`): mock `client.GET`/`POST`/`PUT`/`DELETE` with the full API response envelope
+- **Component-level tests** (`Page.test.tsx`): mock hook modules with `mockQueryResult()`/`mockMutationResult()` from `@/test/mock-hooks.ts`
+- **Never cast** mock return values with `as ReturnType<typeof useHook>` — use the helper functions instead
+
+See [docs/testing.md](docs/testing.md#mock-fidelity-rules) for correct vs incorrect examples and the full test utilities reference.
+
 ## Agent Workflow Rules
 
 ### Tests and Code Review

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -123,6 +123,186 @@ Configured in `src/client/vite.config.ts` under `test.coverage.exclude`:
 - **No snapshot tests** (brittle, low coverage signal)
 - Test files: `*.test.ts` / `*.test.tsx` colocated with source
 
+### Mock Fidelity Rules
+
+Mock data must match the real API response shape. When tests use simplified or incorrect mock shapes, they pass in isolation but hide integration bugs that surface at runtime.
+
+**Core principle:** If the real API returns `{ data: T[], total, offset, limit }`, the mock must return that same envelope. Never mock a paginated endpoint as a bare array.
+
+#### Paginated Response Shape
+
+All list endpoints return a paginated envelope:
+
+```typescript
+// Real API response shape (from OpenAPI-generated types)
+{
+  data: T[],       // the array of items
+  total: number,   // total count across all pages
+  offset: number,  // current page offset
+  limit: number,   // page size
+}
+```
+
+Hooks like `useAccounts()` unwrap this: they return `{ ...query, data: query.data?.data, total: query.data?.total ?? 0 }`. But the **mock at the API client level** must still use the full envelope.
+
+#### Correct vs Incorrect Mocks (Case Study)
+
+A real bug occurred when hook-level tests mocked `client.GET` with a bare array instead of the paginated envelope. The hook's `query.data?.data` destructuring returned `undefined` at runtime because the mock shape didn't match reality.
+
+```typescript
+// WRONG: bare array -- hook's .data?.data unwrap returns undefined
+(client.GET as Mock).mockResolvedValue({
+  data: [{ id: "1", name: "Checking" }],
+  error: undefined,
+});
+
+// CORRECT: paginated envelope matching real API shape
+(client.GET as Mock).mockResolvedValue({
+  data: { data: [{ id: "1", name: "Checking" }], total: 1, offset: 0, limit: 50 },
+  error: undefined,
+});
+```
+
+The same principle applies to single-entity endpoints (no envelope) and mutation responses. Match the real shape.
+
+#### mockQueryResult and mockMutationResult
+
+When testing **components** that consume hooks (not testing hooks themselves), use the helpers in `src/client/src/test/mock-hooks.ts`:
+
+- `mockQueryResult(overrides)` -- creates a full `UseQueryResult` with all TanStack Query fields (`isSuccess`, `isPending`, `isFetching`, etc.). Pass overrides for the fields your test cares about.
+- `mockMutationResult(overrides)` -- creates a full `UseMutationResult` with `mutate`, `mutateAsync`, `isPending`, etc.
+
+**Why these exist:** Casting mocks with `as ReturnType<typeof useHook>` fails `tsc -b` because it misses required properties. These helpers provide type-safe defaults.
+
+```typescript
+// Component-level test: mock the hook return value
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
+
+vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+  data: [{ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }],
+  total: 1,
+  isLoading: false,
+}));
+
+vi.mocked(useCreateAccount).mockReturnValue(mockMutationResult({
+  mutate: mockMutate,
+  isPending: false,
+}));
+```
+
+**When NOT to use them:** Hook-level tests (files like `useAccounts.test.ts`) that call `renderHook()` and test the hook directly. Those tests mock `client.GET`/`POST`/`PUT`/`DELETE` at the API client level and let the real hook execute.
+
+#### mockApiSuccess and mockApiError
+
+For hook-level tests that mock `client.GET`/`POST`/etc., use the helpers in `src/client/src/test/mock-api-client.ts`:
+
+```typescript
+import mockClient, { mockApiSuccess, mockApiError, resetMockClient } from "@/test/mock-api-client";
+
+// Shorthand for { data: <value>, error: undefined }
+mockClient.GET.mockResolvedValue(mockApiSuccess({ data: accounts, total: 1, offset: 0, limit: 50 }));
+
+// Shorthand for { data: undefined, error: <value> }
+mockClient.GET.mockResolvedValue(mockApiError({ message: "Not found" }));
+```
+
+### Test Layers
+
+Frontend tests fall into two layers with different mocking strategies:
+
+#### Hook-Level Tests (`useX.test.ts`)
+
+Test the hook in isolation. Mock at the **API client boundary**.
+
+- Mock `@/lib/api-client` with `vi.mock()` so `client.GET`/`POST`/etc. are `vi.fn()`
+- Mock `sonner` for toast assertions
+- Use `renderHook()` with a `QueryClientProvider` wrapper
+- Assert on the hook's return values (`data`, `isSuccess`, `isError`)
+- Assert on the API client calls (`client.GET` called with correct path and params)
+
+```typescript
+vi.mock("@/lib/api-client", () => ({
+  default: { GET: vi.fn(), POST: vi.fn(), PUT: vi.fn(), DELETE: vi.fn() },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// Then in the test:
+(client.GET as Mock).mockResolvedValue({
+  data: { data: accounts, total: 1, offset: 0, limit: 50 },
+  error: undefined,
+});
+
+const { result } = renderHook(() => useAccounts(), { wrapper: createWrapper() });
+await waitFor(() => expect(result.current.isSuccess).toBe(true));
+```
+
+#### Component-Level Tests (`Page.test.tsx`)
+
+Test the rendered UI. Mock at the **hook boundary**.
+
+- Mock the entire hook module with `vi.mock("@/hooks/useX", ...)`
+- Use `mockQueryResult()`/`mockMutationResult()` for hook return values
+- Use `renderWithProviders()` or `renderWithQueryClient()` from `@/test/test-utils`
+- Assert on rendered DOM elements (`screen.getByRole`, `screen.getByText`)
+- Assert on user interactions (`userEvent.click`, `userEvent.type`)
+
+```typescript
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+  useCreateAccount: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useUpdateAccount: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+// Override for specific test:
+vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+  data: items,
+  total: items.length,
+  isLoading: false,
+}));
+```
+
+#### Integration Tests (MSW)
+
+Test hooks against a mock HTTP server for higher-fidelity validation.
+
+- Use MSW (Mock Service Worker) with `setupServer()` from `msw/node`
+- Setup file: `src/client/src/test/setup.integration.ts` starts and resets the server
+- Test files: `*.integration.test.ts` (colocated with hook tests)
+- Response bodies must match the real API response shape exactly
+
+```typescript
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+
+server.use(
+  http.get("*/api/accounts", () => {
+    return HttpResponse.json({
+      data: [
+        { id: "11111111-1111-1111-1111-111111111111", accountCode: "1000", name: "Cash", isActive: true },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    });
+  }),
+);
+```
+
+### Test Utilities Reference
+
+| File | Purpose |
+|------|---------|
+| `src/client/src/test/test-utils.tsx` | `renderWithProviders()`, `renderWithQueryClient()`, `createWrapper()`, `createQueryWrapper()`, `createQueryClient()` |
+| `src/client/src/test/mock-hooks.ts` | `mockQueryResult()`, `mockMutationResult()` for component-level tests |
+| `src/client/src/test/mock-api-client.ts` | `mockApiSuccess()`, `mockApiError()`, `resetMockClient()` for hook-level tests |
+| `src/client/src/test/setup.ts` | Global setup: imports `@testing-library/jest-dom`, polyfills `localStorage` |
+| `src/client/src/test/setup.integration.ts` | Integration test setup: starts MSW server, resets handlers between tests |
+| `src/client/src/test/setup-combobox-polyfills.ts` | Polyfills `ResizeObserver` and `scrollIntoView` for radix-ui/cmdk components |
+| `src/client/src/test/msw/server.ts` | MSW server instance (`setupServer()`) |
+
 ## CI Coverage Reporting
 
 Both stacks report coverage on every PR via GitHub Actions (`.github/workflows/github-ci.yml`):

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -194,17 +194,22 @@ vi.mocked(useCreateAccount).mockReturnValue(mockMutationResult({
 
 #### mockApiSuccess and mockApiError
 
-For hook-level tests that mock `client.GET`/`POST`/etc., use the helpers in `src/client/src/test/mock-api-client.ts`:
+For hook-level tests that mock `client.GET`/`POST`/etc., optional helpers in `src/client/src/test/mock-api-client.ts` provide shorthand for success/error response shapes. To use them, you must wire the mock client into the module system with `vi.mock`:
 
 ```typescript
 import mockClient, { mockApiSuccess, mockApiError, resetMockClient } from "@/test/mock-api-client";
 
-// Shorthand for { data: <value>, error: undefined }
-mockClient.GET.mockResolvedValue(mockApiSuccess({ data: accounts, total: 1, offset: 0, limit: 50 }));
+// REQUIRED: wire mockClient as the module that hooks import
+vi.mock("@/lib/api-client", () => ({ default: mockClient }));
 
-// Shorthand for { data: undefined, error: <value> }
+beforeEach(() => resetMockClient());
+
+// Then in tests:
+mockClient.GET.mockResolvedValue(mockApiSuccess({ data: accounts, total: 1, offset: 0, limit: 50 }));
 mockClient.GET.mockResolvedValue(mockApiError({ message: "Not found" }));
 ```
+
+**Note:** Most existing hook tests use an inline `vi.mock` pattern instead (see the Hook-Level Tests section below). Either approach works — the key requirement is that `vi.mock("@/lib/api-client", ...)` is called so the mock is actually wired into the module system.
 
 ### Test Layers
 


### PR DESCRIPTION
## Summary
- Added comprehensive frontend testing conventions to `docs/testing.md` covering mock fidelity rules, paginated response mock shapes, correct vs incorrect mock patterns (with case study), test layers (hook-level, component-level, MSW integration), and a test utilities reference table
- Added a "Testing" section to `AGENTS.md` with the frontend mock fidelity rule and a link to the detailed docs

Resolves RECEIPTS-298

## Test plan
- Review `docs/testing.md` for accuracy against existing test files in `src/client/src/test/` and `src/client/src/hooks/*.test.ts`
- Verify code examples match the actual patterns in `useAccounts.test.ts`, `Accounts.test.tsx`, and `useAccounts.integration.test.tsx`
- Confirm `AGENTS.md` section links correctly to `docs/testing.md#mock-fidelity-rules`