### PR TITLE
feat(client): add shared mock factories for API response shapes

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -246,7 +246,8 @@ const list2 = mockAccountListResponse([
 ]);
 
 // Override pagination metadata
-const page2 = mockAccountListResponse(items, { offset: 50, total: 200 });
+const customItems = [mockAccountResponse({ name: "Business" })];
+const page2 = mockAccountListResponse(customItems, { offset: 50, total: 200 });
 ```
 
 **Generic paginated helper** for custom types:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -211,6 +211,57 @@ mockClient.GET.mockResolvedValue(mockApiError({ message: "Not found" }));
 
 **Note:** Most existing hook tests use an inline `vi.mock` pattern instead (see the Hook-Level Tests section below). Either approach works — the key requirement is that `vi.mock("@/lib/api-client", ...)` is called so the mock is actually wired into the module system.
 
+#### Mock Factories (mock-api.ts)
+
+Reusable factory functions in `src/client/src/test/mock-api.ts` produce correctly-shaped API response objects matching the OpenAPI-generated DTOs. They make the correct mock shape the easy path and prevent shape mismatches that cause silent test failures.
+
+**Item factories** create a single response object with sensible defaults. Pass a `Partial<T>` to override any field:
+
+```typescript
+import { mockAccountResponse, mockReceiptResponse, mockTransactionResponse } from "@/test/mock-api";
+
+// Minimal: all required fields filled with defaults
+const account = mockAccountResponse();
+
+// Override specific fields for your test scenario
+const checking = mockAccountResponse({ name: "Checking", accountCode: "ACC-001" });
+const receipt = mockReceiptResponse({ location: "Walmart", taxAmount: 5.25 });
+const txn = mockTransactionResponse({ amount: 42.00, date: "2025-03-01" });
+```
+
+Available item factories: `mockAccountResponse`, `mockCategoryResponse`, `mockSubcategoryResponse`, `mockReceiptResponse`, `mockReceiptItemResponse`, `mockTransactionResponse`, `mockAdjustmentResponse`, `mockItemTemplateResponse`.
+
+**List factories** wrap items in the paginated envelope (`{ data, total, offset, limit }`):
+
+```typescript
+import { mockAccountListResponse, mockAccountResponse } from "@/test/mock-api";
+
+// Default: one item with default values
+const list = mockAccountListResponse();
+
+// Custom items
+const list2 = mockAccountListResponse([
+  mockAccountResponse({ name: "Checking" }),
+  mockAccountResponse({ name: "Savings", isActive: false }),
+]);
+
+// Override pagination metadata
+const page2 = mockAccountListResponse(items, { offset: 50, total: 200 });
+```
+
+**Generic paginated helper** for custom types:
+
+```typescript
+import { mockPaginatedResponse } from "@/test/mock-api";
+
+const response = mockPaginatedResponse([{ custom: "data" }], { total: 100 });
+// → { data: [{ custom: "data" }], total: 100, offset: 0, limit: 50 }
+```
+
+**ID generation**: Each factory call generates a unique deterministic ID. Call `resetMockIds()` in `beforeEach` if your tests depend on specific ID values.
+
+**When to use**: In component-level tests alongside `mockQueryResult`/`mockMutationResult`, and in hook-level tests with `mockApiSuccess` to build realistic response payloads.
+
 ### Test Layers
 
 Frontend tests fall into two layers with different mocking strategies:
@@ -302,6 +353,7 @@ server.use(
 |------|---------|
 | `src/client/src/test/test-utils.tsx` | `renderWithProviders()`, `renderWithQueryClient()`, `createWrapper()`, `createQueryWrapper()`, `createQueryClient()` |
 | `src/client/src/test/mock-hooks.ts` | `mockQueryResult()`, `mockMutationResult()` for component-level tests |
+| `src/client/src/test/mock-api.ts` | `mockAccountResponse()`, `mockReceiptResponse()`, etc. -- type-safe factories for API response shapes |
 | `src/client/src/test/mock-api-client.ts` | `mockApiSuccess()`, `mockApiError()`, `resetMockClient()` for hook-level tests |
 | `src/client/src/test/setup.ts` | Global setup: imports `@testing-library/jest-dom`, polyfills `localStorage` |
 | `src/client/src/test/setup.integration.ts` | Integration test setup: starts MSW server, resets handlers between tests |

--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
+import { mockAccountResponse } from "@/test/mock-api";
 import Accounts from "./Accounts";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -118,8 +119,8 @@ describe("Accounts", () => {
 
   it("renders table with accounts when data exists", async () => {
     const items = [
-      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
-      { id: "2", accountCode: "ACC-002", name: "Savings", isActive: true },
+      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking" }),
+      mockAccountResponse({ id: "2", accountCode: "ACC-002", name: "Savings" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -159,7 +160,7 @@ describe("Accounts", () => {
   it("opens edit dialog when Edit button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
+      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -202,7 +203,7 @@ describe("Accounts", () => {
   it("closes edit dialog when dismissed", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
+      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -281,7 +282,7 @@ describe("Accounts", () => {
     }));
 
     const items = [
-      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
+      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -321,7 +322,7 @@ describe("Accounts", () => {
   it("renders NoResults when search returns no matches", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: [{ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }],
+      data: [mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking" })],
       isLoading: false,
     }));
 
@@ -340,10 +341,9 @@ describe("Accounts", () => {
   });
 
   it("defaults to showing only active accounts", async () => {
-
     const items = [
-      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
-      { id: "2", accountCode: "ACC-002", name: "Savings", isActive: false },
+      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }),
+      mockAccountResponse({ id: "2", accountCode: "ACC-002", name: "Savings", isActive: false }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -390,11 +390,10 @@ describe("Accounts", () => {
   });
 
   it("shows inactive accounts when Inactive tab is selected", async () => {
-
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "1", accountCode: "ACC-001", name: "Checking", isActive: true },
-      { id: "2", accountCode: "ACC-002", name: "Savings", isActive: false },
+      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }),
+      mockAccountResponse({ id: "2", accountCode: "ACC-002", name: "Savings", isActive: false }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -2,6 +2,7 @@ import "@/test/setup-combobox-polyfills";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
+import { mockReceiptResponse } from "@/test/mock-api";
 import Receipts from "./Receipts";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -124,8 +125,8 @@ describe("Receipts", () => {
 
   it("renders table with receipts when data exists", async () => {
     const items = [
-      { id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
-      { id: "2", location: "Target", date: "2024-01-20", taxAmount: 3.50 },
+      mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }),
+      mockReceiptResponse({ id: "2", location: "Target", date: "2024-01-20", taxAmount: 3.50 }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -164,7 +165,7 @@ describe("Receipts", () => {
   it("closes edit dialog when dismissed", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
+      mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -213,7 +214,7 @@ describe("Receipts", () => {
   it("opens edit dialog when Edit button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
+      mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -244,7 +245,7 @@ describe("Receipts", () => {
   it("toggles checkbox selection and shows delete button", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
+      mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -282,7 +283,7 @@ describe("Receipts", () => {
     }));
 
     const items = [
-      { id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
+      mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -356,7 +357,7 @@ describe("Receipts", () => {
   it("renders NoResults when search returns no matches", async () => {
     const { useReceipts } = await import("@/hooks/useReceipts");
     vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
-      data: [{ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }],
+      data: [mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 })],
       isLoading: false,
     }));
 
@@ -384,7 +385,7 @@ describe("Receipts", () => {
     }));
 
     const items = [
-      { id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
+      mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -424,8 +425,8 @@ describe("Receipts", () => {
   it("toggles select all checkbox", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 },
-      { id: "2", location: "Chipotle", date: "2024-01-20", taxAmount: 1.50 },
+      mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }),
+      mockReceiptResponse({ id: "2", location: "Chipotle", date: "2024-01-20", taxAmount: 1.50 }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");

--- a/src/client/src/pages/Transactions.test.tsx
+++ b/src/client/src/pages/Transactions.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
+import { mockTransactionResponse } from "@/test/mock-api";
 import Transactions from "./Transactions";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -147,8 +148,8 @@ describe("Transactions", () => {
 
   it("renders table with transactions when data exists", async () => {
     const items = [
-      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
-      { id: "t2", receiptId: "r2", accountId: "a2", amount: 100.00, date: "2024-01-20" },
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+      mockTransactionResponse({ id: "t2", receiptId: "r2", accountId: "a2", amount: 100.00, date: "2024-01-20" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -181,8 +182,8 @@ describe("Transactions", () => {
 
   it("renders receipt location and receipt date columns", async () => {
     const items = [
-      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
-      { id: "t2", receiptId: "r2", accountId: "a2", amount: 100.00, date: "2024-01-20" },
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+      mockTransactionResponse({ id: "t2", receiptId: "r2", accountId: "a2", amount: 100.00, date: "2024-01-20" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -229,7 +230,7 @@ describe("Transactions", () => {
   it("closes edit dialog when dismissed", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -278,7 +279,7 @@ describe("Transactions", () => {
   it("renders NoResults when search returns no matches", async () => {
     const { useTransactions } = await import("@/hooks/useTransactions");
     vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
-      data: [{ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }],
+      data: [mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" })],
       isLoading: false,
     }));
 
@@ -299,7 +300,7 @@ describe("Transactions", () => {
   it("opens edit dialog when Edit button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -334,7 +335,7 @@ describe("Transactions", () => {
   it("toggles checkbox selection and shows delete button", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -372,7 +373,7 @@ describe("Transactions", () => {
     }));
 
     const items = [
-      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
@@ -412,8 +413,8 @@ describe("Transactions", () => {
   it("toggles select all checkbox", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [
-      { id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" },
-      { id: "t2", receiptId: "r2", accountId: "a2", amount: 100.00, date: "2024-01-20" },
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+      mockTransactionResponse({ id: "t2", receiptId: "r2", accountId: "a2", amount: 100.00, date: "2024-01-20" }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");

--- a/src/client/src/test/mock-api.ts
+++ b/src/client/src/test/mock-api.ts
@@ -119,9 +119,9 @@ export function mockSubcategoryResponse(
   overrides?: Partial<SubcategoryResponse>,
 ): SubcategoryResponse {
   return {
-    id: nextId(),
+    id: overrides?.id ?? nextId(),
     name: "Test Subcategory",
-    categoryId: nextId(),
+    categoryId: overrides?.categoryId ?? nextId(),
     description: null,
     ...overrides,
   };
@@ -145,8 +145,8 @@ export function mockReceiptItemResponse(
   overrides?: Partial<ReceiptItemResponse>,
 ): ReceiptItemResponse {
   return {
-    id: nextId(),
-    receiptId: nextId(),
+    id: overrides?.id ?? nextId(),
+    receiptId: overrides?.receiptId ?? nextId(),
     receiptItemCode: null,
     description: "Test Item",
     quantity: 1,
@@ -163,9 +163,9 @@ export function mockTransactionResponse(
   overrides?: Partial<TransactionResponse>,
 ): TransactionResponse {
   return {
-    id: nextId(),
-    receiptId: nextId(),
-    accountId: nextId(),
+    id: overrides?.id ?? nextId(),
+    receiptId: overrides?.receiptId ?? nextId(),
+    accountId: overrides?.accountId ?? nextId(),
     amount: 25.0,
     date: "2025-01-15",
     ...overrides,
@@ -177,8 +177,8 @@ export function mockAdjustmentResponse(
   overrides?: Partial<AdjustmentResponse>,
 ): AdjustmentResponse {
   return {
-    id: nextId(),
-    receiptId: nextId(),
+    id: overrides?.id ?? nextId(),
+    receiptId: overrides?.receiptId ?? nextId(),
     type: "tip",
     amount: 5.0,
     description: null,

--- a/src/client/src/test/mock-api.ts
+++ b/src/client/src/test/mock-api.ts
@@ -1,0 +1,276 @@
+/**
+ * Shared mock factories for API response shapes.
+ *
+ * These factories produce correctly-shaped objects matching the OpenAPI-generated
+ * DTOs, making it easy to write tests with the right shapes and hard to write
+ * them with wrong shapes.
+ *
+ * Usage:
+ *   import { mockAccountResponse, mockAccountListResponse } from "@/test/mock-api";
+ *
+ *   const account = mockAccountResponse({ name: "My Account" });
+ *   const list = mockAccountListResponse([account]);
+ */
+import type { components } from "@/generated/api";
+
+// ---------------------------------------------------------------------------
+// Type aliases for readability
+// ---------------------------------------------------------------------------
+type AccountResponse = components["schemas"]["AccountResponse"];
+type CategoryResponse = components["schemas"]["CategoryResponse"];
+type SubcategoryResponse = components["schemas"]["SubcategoryResponse"];
+type ReceiptResponse = components["schemas"]["ReceiptResponse"];
+type ReceiptItemResponse = components["schemas"]["ReceiptItemResponse"];
+type TransactionResponse = components["schemas"]["TransactionResponse"];
+type AdjustmentResponse = components["schemas"]["AdjustmentResponse"];
+type ItemTemplateResponse = components["schemas"]["ItemTemplateResponse"];
+
+type AccountListResponse = components["schemas"]["AccountListResponse"];
+type CategoryListResponse = components["schemas"]["CategoryListResponse"];
+type SubcategoryListResponse = components["schemas"]["SubcategoryListResponse"];
+type ReceiptListResponse = components["schemas"]["ReceiptListResponse"];
+type ReceiptItemListResponse = components["schemas"]["ReceiptItemListResponse"];
+type TransactionListResponse = components["schemas"]["TransactionListResponse"];
+type AdjustmentListResponse = components["schemas"]["AdjustmentListResponse"];
+type ItemTemplateListResponse =
+  components["schemas"]["ItemTemplateListResponse"];
+
+// ---------------------------------------------------------------------------
+// Internal counter for deterministic IDs in tests
+// ---------------------------------------------------------------------------
+let counter = 0;
+
+function nextId(): string {
+  counter += 1;
+  const hex = counter.toString(16).padStart(12, "0");
+  return `00000000-0000-4000-a000-${hex}`;
+}
+
+/**
+ * Reset the internal ID counter. Call in `beforeEach` if tests depend on
+ * deterministic IDs.
+ */
+export function resetMockIds(): void {
+  counter = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Generic paginated response factory
+// ---------------------------------------------------------------------------
+
+interface PaginatedEnvelope<T> {
+  data: T[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+/**
+ * Wraps an array of items in the standard paginated response envelope
+ * (`{ data, total, offset, limit }`).
+ *
+ * By default, `total` equals the length of `items`, `offset` is 0, and
+ * `limit` is 50. Use `overrides` to customise any field.
+ */
+export function mockPaginatedResponse<T>(
+  items: T[],
+  overrides?: Partial<PaginatedEnvelope<T>>,
+): PaginatedEnvelope<T> {
+  return {
+    data: items,
+    total: items.length,
+    offset: 0,
+    limit: 50,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-entity item factories
+// ---------------------------------------------------------------------------
+
+/** Creates a single `AccountResponse` with sensible defaults. */
+export function mockAccountResponse(
+  overrides?: Partial<AccountResponse>,
+): AccountResponse {
+  return {
+    id: nextId(),
+    accountCode: "ACC-001",
+    name: "Test Account",
+    isActive: true,
+    ...overrides,
+  };
+}
+
+/** Creates a single `CategoryResponse` with sensible defaults. */
+export function mockCategoryResponse(
+  overrides?: Partial<CategoryResponse>,
+): CategoryResponse {
+  return {
+    id: nextId(),
+    name: "Test Category",
+    description: null,
+    ...overrides,
+  };
+}
+
+/** Creates a single `SubcategoryResponse` with sensible defaults. */
+export function mockSubcategoryResponse(
+  overrides?: Partial<SubcategoryResponse>,
+): SubcategoryResponse {
+  return {
+    id: nextId(),
+    name: "Test Subcategory",
+    categoryId: nextId(),
+    description: null,
+    ...overrides,
+  };
+}
+
+/** Creates a single `ReceiptResponse` with sensible defaults. */
+export function mockReceiptResponse(
+  overrides?: Partial<ReceiptResponse>,
+): ReceiptResponse {
+  return {
+    id: nextId(),
+    location: "Test Store",
+    date: "2025-01-15",
+    taxAmount: 5.0,
+    ...overrides,
+  };
+}
+
+/** Creates a single `ReceiptItemResponse` with sensible defaults. */
+export function mockReceiptItemResponse(
+  overrides?: Partial<ReceiptItemResponse>,
+): ReceiptItemResponse {
+  return {
+    id: nextId(),
+    receiptId: nextId(),
+    receiptItemCode: null,
+    description: "Test Item",
+    quantity: 1,
+    unitPrice: 9.99,
+    category: "General",
+    subcategory: null,
+    pricingMode: "quantity",
+    ...overrides,
+  };
+}
+
+/** Creates a single `TransactionResponse` with sensible defaults. */
+export function mockTransactionResponse(
+  overrides?: Partial<TransactionResponse>,
+): TransactionResponse {
+  return {
+    id: nextId(),
+    receiptId: nextId(),
+    accountId: nextId(),
+    amount: 25.0,
+    date: "2025-01-15",
+    ...overrides,
+  };
+}
+
+/** Creates a single `AdjustmentResponse` with sensible defaults. */
+export function mockAdjustmentResponse(
+  overrides?: Partial<AdjustmentResponse>,
+): AdjustmentResponse {
+  return {
+    id: nextId(),
+    receiptId: nextId(),
+    type: "tip",
+    amount: 5.0,
+    description: null,
+    ...overrides,
+  };
+}
+
+/** Creates a single `ItemTemplateResponse` with sensible defaults. */
+export function mockItemTemplateResponse(
+  overrides?: Partial<ItemTemplateResponse>,
+): ItemTemplateResponse {
+  return {
+    id: nextId(),
+    name: "Test Template",
+    description: null,
+    defaultCategory: null,
+    defaultSubcategory: null,
+    defaultUnitPrice: null,
+    defaultUnitPriceCurrency: null,
+    defaultPricingMode: null,
+    defaultItemCode: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-entity list response factories
+// ---------------------------------------------------------------------------
+
+/** Creates an `AccountListResponse` in the paginated envelope. */
+export function mockAccountListResponse(
+  items?: AccountResponse[],
+  overrides?: Partial<PaginatedEnvelope<AccountResponse>>,
+): AccountListResponse {
+  return mockPaginatedResponse(items ?? [mockAccountResponse()], overrides);
+}
+
+/** Creates a `CategoryListResponse` in the paginated envelope. */
+export function mockCategoryListResponse(
+  items?: CategoryResponse[],
+  overrides?: Partial<PaginatedEnvelope<CategoryResponse>>,
+): CategoryListResponse {
+  return mockPaginatedResponse(items ?? [mockCategoryResponse()], overrides);
+}
+
+/** Creates a `SubcategoryListResponse` in the paginated envelope. */
+export function mockSubcategoryListResponse(
+  items?: SubcategoryResponse[],
+  overrides?: Partial<PaginatedEnvelope<SubcategoryResponse>>,
+): SubcategoryListResponse {
+  return mockPaginatedResponse(items ?? [mockSubcategoryResponse()], overrides);
+}
+
+/** Creates a `ReceiptListResponse` in the paginated envelope. */
+export function mockReceiptListResponse(
+  items?: ReceiptResponse[],
+  overrides?: Partial<PaginatedEnvelope<ReceiptResponse>>,
+): ReceiptListResponse {
+  return mockPaginatedResponse(items ?? [mockReceiptResponse()], overrides);
+}
+
+/** Creates a `ReceiptItemListResponse` in the paginated envelope. */
+export function mockReceiptItemListResponse(
+  items?: ReceiptItemResponse[],
+  overrides?: Partial<PaginatedEnvelope<ReceiptItemResponse>>,
+): ReceiptItemListResponse {
+  return mockPaginatedResponse(items ?? [mockReceiptItemResponse()], overrides);
+}
+
+/** Creates a `TransactionListResponse` in the paginated envelope. */
+export function mockTransactionListResponse(
+  items?: TransactionResponse[],
+  overrides?: Partial<PaginatedEnvelope<TransactionResponse>>,
+): TransactionListResponse {
+  return mockPaginatedResponse(items ?? [mockTransactionResponse()], overrides);
+}
+
+/** Creates an `AdjustmentListResponse` in the paginated envelope. */
+export function mockAdjustmentListResponse(
+  items?: AdjustmentResponse[],
+  overrides?: Partial<PaginatedEnvelope<AdjustmentResponse>>,
+): AdjustmentListResponse {
+  return mockPaginatedResponse(items ?? [mockAdjustmentResponse()], overrides);
+}
+
+/** Creates an `ItemTemplateListResponse` in the paginated envelope. */
+export function mockItemTemplateListResponse(
+  items?: ItemTemplateResponse[],
+  overrides?: Partial<PaginatedEnvelope<ItemTemplateResponse>>,
+): ItemTemplateListResponse {
+  return mockPaginatedResponse(
+    items ?? [mockItemTemplateResponse()],
+    overrides,
+  );
+}


### PR DESCRIPTION
## Summary
- Add reusable factory functions in `src/client/src/test/mock-api.ts` that produce correctly-shaped API response objects matching the OpenAPI-generated DTOs (item factories for 8 entity types + list factories with paginated envelope + generic `mockPaginatedResponse` helper)
- Migrate `Accounts.test.tsx`, `Receipts.test.tsx`, and `Transactions.test.tsx` to use the new factories as proof of concept, replacing inline object literals with type-safe factory calls
- Document usage in `docs/testing.md` including item factories, list factories, generic helper, and ID management

Resolves RECEIPTS-296

## Test plan
- All 1117 frontend tests pass (`npx vitest run`)
- TypeScript type-checking passes (`npx tsc --noEmit`)
- Pre-commit hooks pass (formatting, types, linting)
- Migrated tests produce identical behavior -- factory defaults fill in all required fields, and overrides preserve test-specific values