### PR TITLE
test(infrastructure): add integration tests with real PostgreSQL via Testcontainers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,7 @@
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.3" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.12.39" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />
   </ItemGroup>

--- a/Receipts.slnx
+++ b/Receipts.slnx
@@ -18,6 +18,7 @@
     <Project Path="tests/Application.Tests/Application.Tests.csproj" />
     <Project Path="tests/Common.Tests/Common.Tests.csproj" />
     <Project Path="tests/Domain.Tests/Domain.Tests.csproj" />
+    <Project Path="tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj" />
     <Project Path="tests/Infrastructure.Tests/Infrastructure.Tests.csproj" />
     <Project Path="tests/Presentation.API.Tests/Presentation.API.Tests.csproj" />
     <Project Path="tests/SampleData/SampleData.csproj" />

--- a/docs/development.md
+++ b/docs/development.md
@@ -109,12 +109,29 @@ dotnet build Receipts.slnx
 # Run unit tests (same as CI)
 dotnet test Receipts.slnx --filter "Category!=Integration"
 
-# Run all tests including integration (requires ONNX model)
+# Run all tests including integration (requires Docker + ONNX model)
 dotnet test Receipts.slnx
+
+# Run integration tests only (requires Docker)
+dotnet test tests/Infrastructure.IntegrationTests --filter "Category=Integration"
 
 # Run tests for a specific project
 dotnet test tests/Application.Tests/Application.Tests.csproj
 ```
+
+### Integration Tests (Testcontainers)
+
+The `Infrastructure.IntegrationTests` project runs EF Core against a real PostgreSQL instance via [Testcontainers](https://dotnet.testcontainers.org/). These tests catch bugs that InMemory unit tests cannot, such as:
+
+- **DateTimeOffset UTC validation** — Npgsql rejects non-UTC offsets for `timestamptz` columns
+- **Column type mapping** — `decimal(18,2)`, `uuid`, `text`, `date`, enum-to-string, pgvector
+- **Soft-delete cascades** — parent deletion cascades `DeletedAt` to owned children via real SQL
+- **Audit logging** — full `SaveChangesAsync` pipeline with real database round-trips
+- **Query filters** — `HasQueryFilter` generates real SQL `WHERE` clauses
+
+**Requirements:** Docker must be running. The tests automatically start and stop a PostgreSQL container — no manual database setup needed.
+
+**CI note:** Integration tests are tagged `[Trait("Category", "Integration")]` and excluded from the CI unit test step (`--filter "Category!=Integration"`). They run locally or in CI environments with Docker available.
 
 ## Git Hooks
 

--- a/tests/Infrastructure.IntegrationTests/AuditLogTests.cs
+++ b/tests/Infrastructure.IntegrationTests/AuditLogTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Infrastructure.Entities.Audit;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests;
+
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class AuditLogTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task Create_Entity_GeneratesAuditLog()
+	{
+		// Arrange
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		AccountEntity account = AccountEntityGenerator.Generate();
+
+		// Act
+		context.Accounts.Add(account);
+		await context.SaveChangesAsync();
+
+		// Assert — an audit log entry should exist for the creation
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		AuditLogEntity? auditLog = await readContext.AuditLogs
+			.OrderByDescending(a => a.ChangedAt)
+			.FirstOrDefaultAsync(a => a.EntityId == account.Id.ToString()
+				&& a.EntityType == "Account");
+
+		auditLog.Should().NotBeNull();
+		auditLog!.Action.Should().Be(AuditAction.Create);
+		auditLog.EntityId.Should().Be(account.Id.ToString());
+
+		List<FieldChange> changes = auditLog.GetChanges();
+		changes.Should().Contain(c => c.FieldName == "Name" && c.NewValue == account.Name);
+		changes.Should().Contain(c => c.FieldName == "AccountCode" && c.NewValue == account.AccountCode);
+	}
+
+	[Fact]
+	public async Task Update_Entity_GeneratesAuditLogWithFieldChanges()
+	{
+		// Arrange
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		AccountEntity account = AccountEntityGenerator.Generate();
+		context.Accounts.Add(account);
+		await context.SaveChangesAsync();
+
+		// Act — update the account name
+		account.Name = "Updated Account Name";
+		await context.SaveChangesAsync();
+
+		// Assert — an Update audit log should exist with the field change
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		AuditLogEntity? auditLog = await readContext.AuditLogs
+			.OrderByDescending(a => a.ChangedAt)
+			.FirstOrDefaultAsync(a => a.EntityId == account.Id.ToString()
+				&& a.EntityType == "Account"
+				&& a.Action == AuditAction.Update);
+
+		auditLog.Should().NotBeNull();
+		List<FieldChange> changes = auditLog!.GetChanges();
+		changes.Should().ContainSingle(c => c.FieldName == "Name")
+			.Which.NewValue.Should().Be("Updated Account Name");
+	}
+
+	[Fact]
+	public async Task SoftDelete_Entity_GeneratesDeleteAuditLog()
+	{
+		// Arrange
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		// Act — soft-delete the receipt
+		context.Receipts.Remove(receipt);
+		await context.SaveChangesAsync();
+
+		// Assert — a Delete audit log should exist
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		AuditLogEntity? auditLog = await readContext.AuditLogs
+			.OrderByDescending(a => a.ChangedAt)
+			.FirstOrDefaultAsync(a => a.EntityId == receipt.Id.ToString()
+				&& a.EntityType == "Receipt"
+				&& a.Action == AuditAction.Delete);
+
+		auditLog.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task AuditLog_Excludes_AuditLogEntities()
+	{
+		// Arrange — the audit system should not audit itself
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		AccountEntity account = AccountEntityGenerator.Generate();
+
+		// Act — create an entity (which triggers audit log creation)
+		context.Accounts.Add(account);
+		await context.SaveChangesAsync();
+
+		// Assert — no audit log should exist for AuditLogEntity type
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		List<AuditLogEntity> selfAuditLogs = await readContext.AuditLogs
+			.Where(a => a.EntityType == "AuditLog" || a.EntityType == "AuditLogEntity")
+			.ToListAsync();
+
+		selfAuditLogs.Should().BeEmpty("the audit system should not audit its own entries");
+	}
+
+	[Fact]
+	public async Task FullLifecycle_CreateUpdateDelete_ProducesThreeAuditEntries()
+	{
+		// Arrange
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+
+		// Act — Create
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		// Act — Update
+		receipt.Location = "Updated Location";
+		await context.SaveChangesAsync();
+
+		// Act — Soft-delete
+		context.Receipts.Remove(receipt);
+		await context.SaveChangesAsync();
+
+		// Assert — three audit entries for this entity
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		List<AuditLogEntity> auditLogs = await readContext.AuditLogs
+			.Where(a => a.EntityId == receipt.Id.ToString() && a.EntityType == "Receipt")
+			.OrderBy(a => a.ChangedAt)
+			.ToListAsync();
+
+		auditLogs.Should().HaveCount(3);
+		auditLogs[0].Action.Should().Be(AuditAction.Create);
+		auditLogs[1].Action.Should().Be(AuditAction.Update);
+		auditLogs[2].Action.Should().Be(AuditAction.Delete);
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
+++ b/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
@@ -1,0 +1,250 @@
+using Common;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Pgvector;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests;
+
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class ColumnTypeMappingTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task AccountEntity_RoundTrips_AllColumnTypes()
+	{
+		// Arrange — uuid, text, boolean
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		AccountEntity account = AccountEntityGenerator.Generate();
+
+		// Act
+		context.Accounts.Add(account);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		AccountEntity? loaded = await readContext.Accounts.FirstOrDefaultAsync(a => a.Id == account.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.Id.Should().Be(account.Id);
+		loaded.AccountCode.Should().Be(account.AccountCode);
+		loaded.Name.Should().Be(account.Name);
+		loaded.IsActive.Should().Be(account.IsActive);
+	}
+
+	[Fact]
+	public async Task ReceiptEntity_RoundTrips_DecimalAndDateOnly()
+	{
+		// Arrange — decimal(18,2), date, uuid, text, enum-to-text
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+
+		// Act
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		ReceiptEntity? loaded = await readContext.Receipts.FirstOrDefaultAsync(r => r.Id == receipt.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.Location.Should().Be(receipt.Location);
+		loaded.Date.Should().Be(receipt.Date);
+		loaded.TaxAmount.Should().Be(receipt.TaxAmount);
+		loaded.TaxAmountCurrency.Should().Be(Currency.USD);
+	}
+
+	[Fact]
+	public async Task TransactionEntity_RoundTrips_WithForeignKeys()
+	{
+		// Arrange — FK to Receipt and Account
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		AccountEntity account = AccountEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		context.Accounts.Add(account);
+		await context.SaveChangesAsync();
+
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+
+		// Act
+		context.Transactions.Add(transaction);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		TransactionEntity? loaded = await readContext.Transactions.FirstOrDefaultAsync(t => t.Id == transaction.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.ReceiptId.Should().Be(receipt.Id);
+		loaded.AccountId.Should().Be(account.Id);
+		loaded.Amount.Should().Be(transaction.Amount);
+		loaded.AmountCurrency.Should().Be(Currency.USD);
+		loaded.Date.Should().Be(transaction.Date);
+	}
+
+	[Fact]
+	public async Task ReceiptItemEntity_RoundTrips_WithEnumToStringConversion()
+	{
+		// Arrange — PricingMode enum stored as text
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id, PricingMode.Flat);
+
+		// Act
+		context.ReceiptItems.Add(item);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		ReceiptItemEntity? loaded = await readContext.ReceiptItems.FirstOrDefaultAsync(i => i.Id == item.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.PricingMode.Should().Be(PricingMode.Flat);
+		loaded.Quantity.Should().Be(item.Quantity);
+		loaded.UnitPrice.Should().Be(item.UnitPrice);
+		loaded.TotalAmount.Should().Be(item.TotalAmount);
+		loaded.Category.Should().Be(item.Category);
+	}
+
+	[Fact]
+	public async Task AdjustmentEntity_RoundTrips_WithEnumToStringConversion()
+	{
+		// Arrange — AdjustmentType enum stored as text
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		AdjustmentEntity adjustment = new()
+		{
+			Id = Guid.NewGuid(),
+			ReceiptId = receipt.Id,
+			Type = AdjustmentType.Coupon,
+			Amount = 3.50m,
+			AmountCurrency = Currency.USD,
+			Description = "Test coupon",
+		};
+
+		// Act
+		context.Adjustments.Add(adjustment);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		AdjustmentEntity? loaded = await readContext.Adjustments.FirstOrDefaultAsync(a => a.Id == adjustment.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.Type.Should().Be(AdjustmentType.Coupon);
+		loaded.Amount.Should().Be(3.50m);
+		loaded.Description.Should().Be("Test coupon");
+	}
+
+	[Fact]
+	public async Task CategoryAndSubcategory_RoundTrip_WithForeignKey()
+	{
+		// Arrange
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		CategoryEntity category = CategoryEntityGenerator.Generate();
+		context.Categories.Add(category);
+		await context.SaveChangesAsync();
+
+		SubcategoryEntity subcategory = new()
+		{
+			Id = Guid.NewGuid(),
+			Name = "Test Sub",
+			CategoryId = category.Id,
+			Description = "Sub description",
+		};
+		context.Subcategories.Add(subcategory);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		SubcategoryEntity? loaded = await readContext.Subcategories
+			.Include(s => s.Category)
+			.FirstOrDefaultAsync(s => s.Id == subcategory.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.CategoryId.Should().Be(category.Id);
+		loaded.Category.Should().NotBeNull();
+		loaded.Category!.Name.Should().Be(category.Name);
+	}
+
+	[Fact]
+	public async Task ItemTemplateEntity_RoundTrips_AllFields()
+	{
+		// Arrange
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ItemTemplateEntity template = new()
+		{
+			Id = Guid.NewGuid(),
+			Name = $"Template_{Guid.NewGuid():N}",
+			DefaultCategory = "Groceries",
+			DefaultSubcategory = "Produce",
+			DefaultUnitPrice = 2.99m,
+			DefaultUnitPriceCurrency = Currency.USD,
+			DefaultPricingMode = "quantity",
+			DefaultItemCode = "PROD001",
+			Description = "Fresh produce template",
+		};
+
+		// Act
+		context.ItemTemplates.Add(template);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		ItemTemplateEntity? loaded = await readContext.ItemTemplates.FirstOrDefaultAsync(t => t.Id == template.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.Name.Should().Be(template.Name);
+		loaded.DefaultCategory.Should().Be("Groceries");
+		loaded.DefaultUnitPrice.Should().Be(2.99m);
+		loaded.DefaultPricingMode.Should().Be("quantity");
+	}
+
+	[Fact]
+	public async Task ItemEmbeddingEntity_RoundTrips_VectorColumn()
+	{
+		// Arrange — pgvector column type
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		float[] values = new float[384];
+		for (int i = 0; i < values.Length; i++)
+		{
+			values[i] = i * 0.001f;
+		}
+
+		ItemEmbeddingEntity embedding = new()
+		{
+			Id = Guid.NewGuid(),
+			EntityType = "ItemTemplate",
+			EntityId = Guid.NewGuid(),
+			EntityText = "Test embedding text",
+			Embedding = new Vector(values),
+			ModelVersion = "all-MiniLM-L6-v2",
+			CreatedAt = DateTimeOffset.UtcNow,
+		};
+
+		// Act
+		context.ItemEmbeddings.Add(embedding);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		ItemEmbeddingEntity? loaded = await readContext.ItemEmbeddings
+			.FirstOrDefaultAsync(e => e.Id == embedding.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.EntityType.Should().Be("ItemTemplate");
+		loaded.Embedding.ToArray().Should().HaveCount(384);
+		loaded.Embedding.ToArray()[0].Should().BeApproximately(0f, 0.001f);
+		loaded.ModelVersion.Should().Be("all-MiniLM-L6-v2");
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/DateTimeOffsetUtcTests.cs
+++ b/tests/Infrastructure.IntegrationTests/DateTimeOffsetUtcTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Infrastructure.Entities;
+using Infrastructure.IntegrationTests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.IntegrationTests;
+
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class DateTimeOffsetUtcTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task NonUtcDateTimeOffset_IsPersisted_AsUtc()
+	{
+		// Arrange — create a user so the ApiKey FK is satisfied
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+
+		ApplicationUser user = new()
+		{
+			Id = Guid.NewGuid().ToString(),
+			UserName = $"test-utc-{Guid.NewGuid():N}",
+			NormalizedUserName = $"TEST-UTC-{Guid.NewGuid():N}",
+			Email = "utctest@example.com",
+			NormalizedEmail = "UTCTEST@EXAMPLE.COM",
+			SecurityStamp = Guid.NewGuid().ToString(),
+			CreatedAt = DateTimeOffset.UtcNow,
+		};
+		context.Users.Add(user);
+		await context.SaveChangesAsync();
+
+		// Create an ApiKey with a deliberately non-UTC DateTimeOffset (EST = -5h)
+		DateTimeOffset easternTime = new(2026, 3, 15, 10, 30, 0, TimeSpan.FromHours(-5));
+		ApiKeyEntity apiKey = new()
+		{
+			Id = Guid.NewGuid(),
+			Name = "UTC-Test-Key",
+			KeyHash = $"hash-{Guid.NewGuid():N}",
+			UserId = user.Id,
+			CreatedAt = easternTime,
+			ExpiresAt = easternTime.AddDays(30),
+		};
+
+		// Act — save to real Postgres (this would throw without the UTC converter)
+		context.ApiKeys.Add(apiKey);
+		await context.SaveChangesAsync();
+
+		// Assert — read it back and verify UTC normalization
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		ApiKeyEntity? loaded = await readContext.ApiKeys.FirstOrDefaultAsync(k => k.Id == apiKey.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.CreatedAt.Offset.Should().Be(TimeSpan.Zero, "Npgsql returns timestamptz as UTC");
+		loaded.CreatedAt.Should().Be(easternTime.ToUniversalTime());
+		loaded.ExpiresAt!.Value.Offset.Should().Be(TimeSpan.Zero);
+		loaded.ExpiresAt.Value.Should().Be(easternTime.AddDays(30).ToUniversalTime());
+	}
+
+	[Fact]
+	public async Task UtcDateTimeOffset_RoundTrips_Correctly()
+	{
+		// Arrange
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+
+		ApplicationUser user = new()
+		{
+			Id = Guid.NewGuid().ToString(),
+			UserName = $"test-roundtrip-{Guid.NewGuid():N}",
+			NormalizedUserName = $"TEST-ROUNDTRIP-{Guid.NewGuid():N}",
+			Email = "roundtrip@example.com",
+			NormalizedEmail = "ROUNDTRIP@EXAMPLE.COM",
+			SecurityStamp = Guid.NewGuid().ToString(),
+			CreatedAt = DateTimeOffset.UtcNow,
+		};
+		context.Users.Add(user);
+		await context.SaveChangesAsync();
+
+		DateTimeOffset utcNow = DateTimeOffset.UtcNow;
+		ApiKeyEntity apiKey = new()
+		{
+			Id = Guid.NewGuid(),
+			Name = "RoundTrip-Key",
+			KeyHash = $"hash-{Guid.NewGuid():N}",
+			UserId = user.Id,
+			CreatedAt = utcNow,
+		};
+
+		// Act
+		context.ApiKeys.Add(apiKey);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		ApiKeyEntity? loaded = await readContext.ApiKeys.FirstOrDefaultAsync(k => k.Id == apiKey.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.CreatedAt.Should().BeCloseTo(utcNow, TimeSpan.FromMilliseconds(1));
+		loaded.CreatedAt.Offset.Should().Be(TimeSpan.Zero);
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/Fixtures/PostgresCollection.cs
+++ b/tests/Infrastructure.IntegrationTests/Fixtures/PostgresCollection.cs
@@ -1,0 +1,7 @@
+namespace Infrastructure.IntegrationTests.Fixtures;
+
+[CollectionDefinition(Name)]
+public class PostgresCollection : ICollectionFixture<PostgresFixture>
+{
+	public const string Name = "Postgres";
+}

--- a/tests/Infrastructure.IntegrationTests/Fixtures/PostgresFixture.cs
+++ b/tests/Infrastructure.IntegrationTests/Fixtures/PostgresFixture.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Infrastructure.IntegrationTests.Fixtures;
+
+public class PostgresFixture : IAsyncLifetime
+{
+	private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+		.Build();
+
+	public string ConnectionString => _container.GetConnectionString();
+
+	public async Task InitializeAsync()
+	{
+		await _container.StartAsync();
+
+		// Run migrations to create the schema
+		using ApplicationDbContext context = CreateDbContext();
+		await context.Database.MigrateAsync();
+	}
+
+	public ApplicationDbContext CreateDbContext()
+	{
+		NpgsqlDataSourceBuilder dataSourceBuilder = new(ConnectionString);
+		dataSourceBuilder.UseVector();
+		NpgsqlDataSource dataSource = dataSourceBuilder.Build();
+
+		DbContextOptionsBuilder<ApplicationDbContext> builder = new();
+		builder.UseNpgsql(dataSource, b => b.UseVector());
+
+		return new ApplicationDbContext(builder.Options);
+	}
+
+	public async Task DisposeAsync()
+	{
+		await _container.DisposeAsync();
+		GC.SuppressFinalize(this);
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/Fixtures/PostgresFixture.cs
+++ b/tests/Infrastructure.IntegrationTests/Fixtures/PostgresFixture.cs
@@ -9,31 +9,43 @@ public class PostgresFixture : IAsyncLifetime
 	private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("pgvector/pgvector:pg17")
 		.Build();
 
+	private NpgsqlDataSource? _dataSource;
+
 	public string ConnectionString => _container.GetConnectionString();
 
 	public async Task InitializeAsync()
 	{
 		await _container.StartAsync();
 
+		NpgsqlDataSourceBuilder dataSourceBuilder = new(ConnectionString);
+		dataSourceBuilder.UseVector();
+		_dataSource = dataSourceBuilder.Build();
+
 		// Run migrations to create the schema
-		using ApplicationDbContext context = CreateDbContext();
+		await using ApplicationDbContext context = CreateDbContext();
 		await context.Database.MigrateAsync();
 	}
 
 	public ApplicationDbContext CreateDbContext()
 	{
-		NpgsqlDataSourceBuilder dataSourceBuilder = new(ConnectionString);
-		dataSourceBuilder.UseVector();
-		NpgsqlDataSource dataSource = dataSourceBuilder.Build();
+		if (_dataSource is null)
+		{
+			throw new InvalidOperationException("Fixture has not been initialized. Call InitializeAsync() first.");
+		}
 
 		DbContextOptionsBuilder<ApplicationDbContext> builder = new();
-		builder.UseNpgsql(dataSource, b => b.UseVector());
+		builder.UseNpgsql(_dataSource, b => b.UseVector());
 
 		return new ApplicationDbContext(builder.Options);
 	}
 
 	public async Task DisposeAsync()
 	{
+		if (_dataSource is not null)
+		{
+			await _dataSource.DisposeAsync();
+		}
+
 		await _container.DisposeAsync();
 		GC.SuppressFinalize(this);
 	}

--- a/tests/Infrastructure.IntegrationTests/GlobalUsings.cs
+++ b/tests/Infrastructure.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj
+++ b/tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Infrastructure\Infrastructure.csproj" />
+    <ProjectReference Include="..\SampleData\SampleData.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Infrastructure.IntegrationTests/SoftDeleteTests.cs
+++ b/tests/Infrastructure.IntegrationTests/SoftDeleteTests.cs
@@ -40,32 +40,43 @@ public class SoftDeleteTests(PostgresFixture fixture)
 	[Fact]
 	public async Task SoftDelete_Receipt_CascadesToTransactions()
 	{
-		// Arrange — receipt with a child transaction
-		await using ApplicationDbContext context = fixture.CreateDbContext();
-		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
-		AccountEntity account = AccountEntityGenerator.Generate();
-		context.Receipts.Add(receipt);
-		context.Accounts.Add(account);
-		await context.SaveChangesAsync();
+		// Arrange — receipt with a child transaction, saved on one context
+		Guid receiptId;
+		Guid transactionId;
+		{
+			await using ApplicationDbContext setupContext = fixture.CreateDbContext();
+			ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+			AccountEntity account = AccountEntityGenerator.Generate();
+			setupContext.Receipts.Add(receipt);
+			setupContext.Accounts.Add(account);
+			await setupContext.SaveChangesAsync();
 
-		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
-		context.Transactions.Add(transaction);
-		await context.SaveChangesAsync();
+			TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+			setupContext.Transactions.Add(transaction);
+			await setupContext.SaveChangesAsync();
 
-		// Act — soft-delete the receipt
-		context.Receipts.Remove(receipt);
-		await context.SaveChangesAsync();
+			receiptId = receipt.Id;
+			transactionId = transaction.Id;
+		}
+
+		// Act — soft-delete the receipt on a fresh context (children not in ChangeTracker)
+		{
+			await using ApplicationDbContext deleteContext = fixture.CreateDbContext();
+			ReceiptEntity receiptToDelete = await deleteContext.Receipts.FirstAsync(r => r.Id == receiptId);
+			deleteContext.Receipts.Remove(receiptToDelete);
+			await deleteContext.SaveChangesAsync();
+		}
 
 		// Assert — transaction should also be soft-deleted (cascade)
 		await using ApplicationDbContext readContext = fixture.CreateDbContext();
 
 		TransactionEntity? hiddenTx = await readContext.Transactions
-			.FirstOrDefaultAsync(t => t.Id == transaction.Id);
+			.FirstOrDefaultAsync(t => t.Id == transactionId);
 		hiddenTx.Should().BeNull("query filter should exclude cascade-soft-deleted transactions");
 
 		TransactionEntity? deletedTx = await readContext.Transactions
 			.IgnoreQueryFilters()
-			.FirstOrDefaultAsync(t => t.Id == transaction.Id);
+			.FirstOrDefaultAsync(t => t.Id == transactionId);
 		deletedTx.Should().NotBeNull();
 		deletedTx!.DeletedAt.Should().NotBeNull();
 	}
@@ -73,30 +84,41 @@ public class SoftDeleteTests(PostgresFixture fixture)
 	[Fact]
 	public async Task SoftDelete_Receipt_CascadesToReceiptItems()
 	{
-		// Arrange — receipt with a child receipt item
-		await using ApplicationDbContext context = fixture.CreateDbContext();
-		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
-		context.Receipts.Add(receipt);
-		await context.SaveChangesAsync();
+		// Arrange — receipt with a child receipt item, saved on one context
+		Guid receiptId;
+		Guid itemId;
+		{
+			await using ApplicationDbContext setupContext = fixture.CreateDbContext();
+			ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+			setupContext.Receipts.Add(receipt);
+			await setupContext.SaveChangesAsync();
 
-		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
-		context.ReceiptItems.Add(item);
-		await context.SaveChangesAsync();
+			ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
+			setupContext.ReceiptItems.Add(item);
+			await setupContext.SaveChangesAsync();
 
-		// Act — soft-delete the receipt
-		context.Receipts.Remove(receipt);
-		await context.SaveChangesAsync();
+			receiptId = receipt.Id;
+			itemId = item.Id;
+		}
+
+		// Act — soft-delete the receipt on a fresh context (children not in ChangeTracker)
+		{
+			await using ApplicationDbContext deleteContext = fixture.CreateDbContext();
+			ReceiptEntity receiptToDelete = await deleteContext.Receipts.FirstAsync(r => r.Id == receiptId);
+			deleteContext.Receipts.Remove(receiptToDelete);
+			await deleteContext.SaveChangesAsync();
+		}
 
 		// Assert — receipt item should be cascade soft-deleted
 		await using ApplicationDbContext readContext = fixture.CreateDbContext();
 
 		ReceiptItemEntity? hiddenItem = await readContext.ReceiptItems
-			.FirstOrDefaultAsync(i => i.Id == item.Id);
+			.FirstOrDefaultAsync(i => i.Id == itemId);
 		hiddenItem.Should().BeNull("query filter should exclude cascade-soft-deleted receipt items");
 
 		ReceiptItemEntity? deletedItem = await readContext.ReceiptItems
 			.IgnoreQueryFilters()
-			.FirstOrDefaultAsync(i => i.Id == item.Id);
+			.FirstOrDefaultAsync(i => i.Id == itemId);
 		deletedItem.Should().NotBeNull();
 		deletedItem!.DeletedAt.Should().NotBeNull();
 	}
@@ -104,31 +126,42 @@ public class SoftDeleteTests(PostgresFixture fixture)
 	[Fact]
 	public async Task SoftDelete_Receipt_CascadesToAdjustments()
 	{
-		// Arrange — receipt with a child adjustment
-		await using ApplicationDbContext context = fixture.CreateDbContext();
-		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
-		context.Receipts.Add(receipt);
-		await context.SaveChangesAsync();
+		// Arrange — receipt with a child adjustment, saved on one context
+		Guid receiptId;
+		Guid adjustmentId;
+		{
+			await using ApplicationDbContext setupContext = fixture.CreateDbContext();
+			ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+			setupContext.Receipts.Add(receipt);
+			await setupContext.SaveChangesAsync();
 
-		AdjustmentEntity adjustment = AdjustmentEntityGenerator.Generate();
-		adjustment.ReceiptId = receipt.Id;
-		context.Adjustments.Add(adjustment);
-		await context.SaveChangesAsync();
+			AdjustmentEntity adjustment = AdjustmentEntityGenerator.Generate();
+			adjustment.ReceiptId = receipt.Id;
+			setupContext.Adjustments.Add(adjustment);
+			await setupContext.SaveChangesAsync();
 
-		// Act — soft-delete the receipt
-		context.Receipts.Remove(receipt);
-		await context.SaveChangesAsync();
+			receiptId = receipt.Id;
+			adjustmentId = adjustment.Id;
+		}
+
+		// Act — soft-delete the receipt on a fresh context (children not in ChangeTracker)
+		{
+			await using ApplicationDbContext deleteContext = fixture.CreateDbContext();
+			ReceiptEntity receiptToDelete = await deleteContext.Receipts.FirstAsync(r => r.Id == receiptId);
+			deleteContext.Receipts.Remove(receiptToDelete);
+			await deleteContext.SaveChangesAsync();
+		}
 
 		// Assert — adjustment should be cascade soft-deleted
 		await using ApplicationDbContext readContext = fixture.CreateDbContext();
 
 		AdjustmentEntity? hiddenAdj = await readContext.Adjustments
-			.FirstOrDefaultAsync(a => a.Id == adjustment.Id);
+			.FirstOrDefaultAsync(a => a.Id == adjustmentId);
 		hiddenAdj.Should().BeNull("query filter should exclude cascade-soft-deleted adjustments");
 
 		AdjustmentEntity? deletedAdj = await readContext.Adjustments
 			.IgnoreQueryFilters()
-			.FirstOrDefaultAsync(a => a.Id == adjustment.Id);
+			.FirstOrDefaultAsync(a => a.Id == adjustmentId);
 		deletedAdj.Should().NotBeNull();
 		deletedAdj!.DeletedAt.Should().NotBeNull();
 	}

--- a/tests/Infrastructure.IntegrationTests/SoftDeleteTests.cs
+++ b/tests/Infrastructure.IntegrationTests/SoftDeleteTests.cs
@@ -1,0 +1,183 @@
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Extensions;
+using Infrastructure.IntegrationTests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests;
+
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class SoftDeleteTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task SoftDelete_Receipt_SetsDeletedAt()
+	{
+		// Arrange
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		// Act — remove triggers soft delete via HandleSoftDelete()
+		context.Receipts.Remove(receipt);
+		await context.SaveChangesAsync();
+
+		// Assert — query filter hides soft-deleted entities
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		ReceiptEntity? hidden = await readContext.Receipts.FirstOrDefaultAsync(r => r.Id == receipt.Id);
+		hidden.Should().BeNull("query filter should exclude soft-deleted receipts");
+
+		// Assert — IgnoreQueryFilters reveals the soft-deleted entity
+		ReceiptEntity? deleted = await readContext.Receipts
+			.IgnoreQueryFilters()
+			.FirstOrDefaultAsync(r => r.Id == receipt.Id);
+		deleted.Should().NotBeNull();
+		deleted!.DeletedAt.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task SoftDelete_Receipt_CascadesToTransactions()
+	{
+		// Arrange — receipt with a child transaction
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		AccountEntity account = AccountEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		context.Accounts.Add(account);
+		await context.SaveChangesAsync();
+
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+		context.Transactions.Add(transaction);
+		await context.SaveChangesAsync();
+
+		// Act — soft-delete the receipt
+		context.Receipts.Remove(receipt);
+		await context.SaveChangesAsync();
+
+		// Assert — transaction should also be soft-deleted (cascade)
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+
+		TransactionEntity? hiddenTx = await readContext.Transactions
+			.FirstOrDefaultAsync(t => t.Id == transaction.Id);
+		hiddenTx.Should().BeNull("query filter should exclude cascade-soft-deleted transactions");
+
+		TransactionEntity? deletedTx = await readContext.Transactions
+			.IgnoreQueryFilters()
+			.FirstOrDefaultAsync(t => t.Id == transaction.Id);
+		deletedTx.Should().NotBeNull();
+		deletedTx!.DeletedAt.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task SoftDelete_Receipt_CascadesToReceiptItems()
+	{
+		// Arrange — receipt with a child receipt item
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
+		context.ReceiptItems.Add(item);
+		await context.SaveChangesAsync();
+
+		// Act — soft-delete the receipt
+		context.Receipts.Remove(receipt);
+		await context.SaveChangesAsync();
+
+		// Assert — receipt item should be cascade soft-deleted
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+
+		ReceiptItemEntity? hiddenItem = await readContext.ReceiptItems
+			.FirstOrDefaultAsync(i => i.Id == item.Id);
+		hiddenItem.Should().BeNull("query filter should exclude cascade-soft-deleted receipt items");
+
+		ReceiptItemEntity? deletedItem = await readContext.ReceiptItems
+			.IgnoreQueryFilters()
+			.FirstOrDefaultAsync(i => i.Id == item.Id);
+		deletedItem.Should().NotBeNull();
+		deletedItem!.DeletedAt.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task SoftDelete_Receipt_CascadesToAdjustments()
+	{
+		// Arrange — receipt with a child adjustment
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		AdjustmentEntity adjustment = AdjustmentEntityGenerator.Generate();
+		adjustment.ReceiptId = receipt.Id;
+		context.Adjustments.Add(adjustment);
+		await context.SaveChangesAsync();
+
+		// Act — soft-delete the receipt
+		context.Receipts.Remove(receipt);
+		await context.SaveChangesAsync();
+
+		// Assert — adjustment should be cascade soft-deleted
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+
+		AdjustmentEntity? hiddenAdj = await readContext.Adjustments
+			.FirstOrDefaultAsync(a => a.Id == adjustment.Id);
+		hiddenAdj.Should().BeNull("query filter should exclude cascade-soft-deleted adjustments");
+
+		AdjustmentEntity? deletedAdj = await readContext.Adjustments
+			.IgnoreQueryFilters()
+			.FirstOrDefaultAsync(a => a.Id == adjustment.Id);
+		deletedAdj.Should().NotBeNull();
+		deletedAdj!.DeletedAt.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task QueryFilter_ExcludesSoftDeletedEntities_InLinqQueries()
+	{
+		// Arrange — create two receipts, soft-delete one
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity activeReceipt = ReceiptEntityGenerator.Generate();
+		ReceiptEntity deletedReceipt = ReceiptEntityGenerator.Generate();
+
+		context.Receipts.AddRange(activeReceipt, deletedReceipt);
+		await context.SaveChangesAsync();
+
+		context.Receipts.Remove(deletedReceipt);
+		await context.SaveChangesAsync();
+
+		// Act — query with filter
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		List<ReceiptEntity> filtered = await readContext.Receipts
+			.Where(r => r.Id == activeReceipt.Id || r.Id == deletedReceipt.Id)
+			.ToListAsync();
+
+		// Assert — only the active receipt should appear
+		filtered.Should().ContainSingle()
+			.Which.Id.Should().Be(activeReceipt.Id);
+	}
+
+	[Fact]
+	public async Task OnlyDeleted_ReturnsOnlySoftDeletedEntities()
+	{
+		// Arrange — create a receipt and soft-delete it
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		context.Receipts.Remove(receipt);
+		await context.SaveChangesAsync();
+
+		// Act
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		ReceiptEntity? onlyDeleted = await readContext.Receipts
+			.OnlyDeleted()
+			.FirstOrDefaultAsync(r => r.Id == receipt.Id);
+
+		// Assert
+		onlyDeleted.Should().NotBeNull();
+		onlyDeleted!.DeletedAt.Should().NotBeNull();
+	}
+}


### PR DESCRIPTION
## Summary
- Add `tests/Infrastructure.IntegrationTests/` project using **Testcontainers.PostgreSql** to run EF Core against real PostgreSQL, catching bugs that InMemory unit tests miss
- Tests cover DateTimeOffset UTC round-trips, column type mappings (decimal, uuid, text, date, enum-to-string, pgvector), soft-delete cascades with query filters, and the full audit log pipeline
- Integration tests are tagged `[Trait("Category", "Integration")]` and excluded from CI unit test step via `--filter "Category!=Integration"`

Resolves RECEIPTS-289

## Test plan
- Run `dotnet test tests/Infrastructure.IntegrationTests --filter "Category=Integration"` locally with Docker running
- Verify all 19 integration tests pass (4 audit, 8 column mapping, 2 DateTimeOffset UTC, 6 soft delete)
- Verify `dotnet test Receipts.slnx --filter "Category!=Integration"` still passes all 1155 unit tests (integration tests excluded)
- Verify `dotnet build Receipts.slnx -p:TreatWarningsAsErrors=true` succeeds with zero warnings