### PR TITLE
test(client): increase CRUD hook branch coverage to 85%+

### DIFF
--- a/src/client/src/hooks/useAdjustments.test.ts
+++ b/src/client/src/hooks/useAdjustments.test.ts
@@ -222,10 +222,9 @@ describe("useAdjustments", () => {
       { id: "1", type: "discount" },
       { id: "2", type: "surcharge" },
     ];
-    queryClient.setQueryData(
-      ["adjustments", "list", 0, 50, undefined, undefined],
-      { data: adjustments, total: 2, offset: 0, limit: 50 },
-    );
+    const cacheKey = ["adjustments", "list", 0, 50, undefined, undefined];
+    const cacheValue = { data: adjustments, total: 2, offset: 0, limit: 50 };
+    queryClient.setQueryData(cacheKey, cacheValue);
     setQueryDataSpy.mockClear();
 
     (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
@@ -239,8 +238,8 @@ describe("useAdjustments", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(toast.error).toHaveBeenCalledWith("Failed to delete adjustment(s)");
 
-    // Verify rollback was attempted
-    expect(setQueryDataSpy).toHaveBeenCalled();
+    // Verify rollback restored the original data (not just the optimistic update from onMutate)
+    expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
   });
 
   it("delete optimistic update handles undefined cache gracefully", async () => {

--- a/src/client/src/hooks/useAdjustments.test.ts
+++ b/src/client/src/hooks/useAdjustments.test.ts
@@ -179,4 +179,162 @@ describe("useAdjustments", () => {
     });
     expect(toast.success).toHaveBeenCalledWith("Adjustment restored");
   });
+
+  // --- Branch coverage: error callbacks ---
+
+  it("create mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useCreateAdjustment(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ receiptId: "r-1", body: { type: "discount", amount: 5.0 } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to create adjustment");
+  });
+
+  it("update mutation shows error toast on failure", async () => {
+    (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useUpdateAdjustment(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ body: { id: "1", type: "discount", amount: 5.0 } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to update adjustment");
+  });
+
+  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    const adjustments = [
+      { id: "1", type: "discount" },
+      { id: "2", type: "surcharge" },
+    ];
+    queryClient.setQueryData(
+      ["adjustments", "list", 0, 50, undefined, undefined],
+      { data: adjustments, total: 2, offset: 0, limit: 50 },
+    );
+    setQueryDataSpy.mockClear();
+
+    (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useDeleteAdjustments(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to delete adjustment(s)");
+
+    // Verify rollback was attempted
+    expect(setQueryDataSpy).toHaveBeenCalled();
+  });
+
+  it("delete optimistic update handles undefined cache gracefully", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    queryClient.setQueryData(["adjustments", "list", 0, 50, undefined, undefined], undefined);
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteAdjustments(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(toast.success).toHaveBeenCalledWith("Adjustment(s) deleted");
+  });
+
+  it("restore mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useRestoreAdjustment(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to restore adjustment");
+  });
+
+  it("list query throws on API error", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useAdjustments(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("list query passes sort parameters", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: { data: [], total: 0, offset: 0, limit: 50 }, error: undefined });
+
+    const { result } = renderHook(() => useAdjustments(0, 50, "amount", "asc"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/adjustments", {
+      params: { query: { offset: 0, limit: 50, sortBy: "amount", sortDirection: "asc" } },
+    });
+  });
+
+  it("list query returns total of 0 when data is undefined", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "err" } });
+
+    const { result } = renderHook(() => useAdjustments(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.total).toBe(0);
+  });
+
+  it("delete mutation invalidates adjustments, deleted, receipts-with-items, and trips on settled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteAdjustments(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["adjustments"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["adjustments", "deleted"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["receipts-with-items"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["trips"] });
+  });
 });

--- a/src/client/src/hooks/useItemTemplates.test.ts
+++ b/src/client/src/hooks/useItemTemplates.test.ts
@@ -228,10 +228,9 @@ describe("useItemTemplates", () => {
       { id: "1", name: "A" },
       { id: "2", name: "B" },
     ];
-    queryClient.setQueryData(
-      ["itemTemplates", "list", 0, 50, undefined, undefined],
-      { data: templates, total: 2, offset: 0, limit: 50 },
-    );
+    const cacheKey = ["itemTemplates", "list", 0, 50, undefined, undefined];
+    const cacheValue = { data: templates, total: 2, offset: 0, limit: 50 };
+    queryClient.setQueryData(cacheKey, cacheValue);
     setQueryDataSpy.mockClear();
 
     (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
@@ -245,8 +244,8 @@ describe("useItemTemplates", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(toast.error).toHaveBeenCalledWith("Failed to delete item template(s)");
 
-    // Verify rollback was attempted
-    expect(setQueryDataSpy).toHaveBeenCalled();
+    // Verify rollback restored the original data (not just the optimistic update from onMutate)
+    expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
   });
 
   it("delete optimistic update handles undefined cache gracefully", async () => {

--- a/src/client/src/hooks/useItemTemplates.test.ts
+++ b/src/client/src/hooks/useItemTemplates.test.ts
@@ -185,4 +185,160 @@ describe("useItemTemplates", () => {
     });
     expect(toast.success).toHaveBeenCalledWith("Item template restored");
   });
+
+  // --- Branch coverage: error callbacks ---
+
+  it("create mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useCreateItemTemplate(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ name: "Template", description: null });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to create item template");
+  });
+
+  it("update mutation shows error toast on failure", async () => {
+    (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useUpdateItemTemplate(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ id: "1", name: "Template", description: null });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to update item template");
+  });
+
+  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    const templates = [
+      { id: "1", name: "A" },
+      { id: "2", name: "B" },
+    ];
+    queryClient.setQueryData(
+      ["itemTemplates", "list", 0, 50, undefined, undefined],
+      { data: templates, total: 2, offset: 0, limit: 50 },
+    );
+    setQueryDataSpy.mockClear();
+
+    (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useDeleteItemTemplates(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to delete item template(s)");
+
+    // Verify rollback was attempted
+    expect(setQueryDataSpy).toHaveBeenCalled();
+  });
+
+  it("delete optimistic update handles undefined cache gracefully", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    queryClient.setQueryData(["itemTemplates", "list", 0, 50, undefined, undefined], undefined);
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteItemTemplates(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(toast.success).toHaveBeenCalledWith("Item template(s) deleted");
+  });
+
+  it("restore mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useRestoreItemTemplate(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to restore item template");
+  });
+
+  it("list query throws on API error", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useItemTemplates(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("list query passes sort parameters", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: { data: [], total: 0, offset: 0, limit: 50 }, error: undefined });
+
+    const { result } = renderHook(() => useItemTemplates(0, 50, "name", "asc"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/item-templates", {
+      params: { query: { offset: 0, limit: 50, sortBy: "name", sortDirection: "asc" } },
+    });
+  });
+
+  it("list query returns total of 0 when data is undefined", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "err" } });
+
+    const { result } = renderHook(() => useItemTemplates(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.total).toBe(0);
+  });
+
+  it("delete mutation invalidates both list and deleted query keys on settled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteItemTemplates(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["itemTemplates"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["itemTemplates", "deleted"] });
+  });
 });

--- a/src/client/src/hooks/useReceiptItems.test.ts
+++ b/src/client/src/hooks/useReceiptItems.test.ts
@@ -296,8 +296,8 @@ describe("useReceiptItems", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(toast.error).toHaveBeenCalledWith("Failed to delete receipt item(s)");
 
-    // Verify rollback was attempted (setQueryData called during onError to restore previous data)
-    expect(setQueryDataSpy).toHaveBeenCalled();
+    // Verify rollback restored the original data (not just the optimistic update from onMutate)
+    expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
   });
 
   it("delete optimistic update handles undefined cache gracefully", async () => {

--- a/src/client/src/hooks/useReceiptItems.test.ts
+++ b/src/client/src/hooks/useReceiptItems.test.ts
@@ -23,6 +23,7 @@ import {
   useReceiptItem,
   useReceiptItemsByReceiptId,
   useCreateReceiptItem,
+  useCreateReceiptItemsBatch,
   useUpdateReceiptItem,
   useDeleteReceiptItems,
   useDeletedReceiptItems,
@@ -199,5 +200,197 @@ describe("useReceiptItems", () => {
       params: { path: { id: "1" } },
     });
     expect(toast.success).toHaveBeenCalledWith("Receipt item restored");
+  });
+
+  // --- Branch coverage: error callbacks ---
+
+  it("create mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useCreateReceiptItem(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ receiptId: "r-1", body: { receiptItemCode: "RI-1", description: "X", quantity: 1, unitPrice: 1, category: "C", subcategory: "S", pricingMode: "quantity" as const } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to create receipt item");
+  });
+
+  it("batch create mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useCreateReceiptItemsBatch(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ receiptId: "r-1", body: [{ receiptItemCode: "RI-1", description: "X", quantity: 1, unitPrice: 1, category: "C", subcategory: "S", pricingMode: "quantity" as const }] });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to create receipt items");
+  });
+
+  it("batch create mutation invalidates cache on success", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.POST as Mock).mockResolvedValue({ data: [{ id: "1" }], error: undefined });
+
+    const { result } = renderHook(() => useCreateReceiptItemsBatch(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate({ receiptId: "r-1", body: [{ receiptItemCode: "RI-1", description: "X", quantity: 1, unitPrice: 1, category: "C", subcategory: "S", pricingMode: "quantity" as const }] });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["receipt-items"] });
+  });
+
+  it("update mutation shows error toast on failure", async () => {
+    (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useUpdateReceiptItem(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ body: { id: "1", receiptItemCode: "RI-1", description: "X", quantity: 1, unitPrice: 1, category: "C", subcategory: "S", pricingMode: "quantity" as const } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to update receipt item");
+  });
+
+  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    // Pre-populate cache with list data
+    const items = [
+      { id: "1", description: "A" },
+      { id: "2", description: "B" },
+    ];
+    const cacheKey = ["receipt-items", "list", 0, 50, undefined, undefined];
+    const cacheValue = { data: items, total: 2, offset: 0, limit: 50 };
+    queryClient.setQueryData(cacheKey, cacheValue);
+    setQueryDataSpy.mockClear();
+
+    (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useDeleteReceiptItems(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to delete receipt item(s)");
+
+    // Verify rollback was attempted (setQueryData called during onError to restore previous data)
+    expect(setQueryDataSpy).toHaveBeenCalled();
+  });
+
+  it("delete optimistic update handles undefined cache gracefully", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    // Set cache to undefined (simulating no prior fetch)
+    queryClient.setQueryData(["receipt-items", "list", 0, 50, undefined, undefined], undefined);
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteReceiptItems(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(toast.success).toHaveBeenCalledWith("Receipt item(s) deleted");
+  });
+
+  it("restore mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useRestoreReceiptItem(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to restore receipt item");
+  });
+
+  it("list query throws on API error", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useReceiptItems(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("list query passes sort parameters", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: { data: [], total: 0, offset: 0, limit: 50 }, error: undefined });
+
+    const { result } = renderHook(() => useReceiptItems(0, 50, "description", "asc"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/receipt-items", {
+      params: { query: { offset: 0, limit: 50, sortBy: "description", sortDirection: "asc" } },
+    });
+  });
+
+  it("list query returns total of 0 when data is undefined", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "err" } });
+
+    const { result } = renderHook(() => useReceiptItems(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.total).toBe(0);
+  });
+
+  it("delete mutation invalidates both list and deleted query keys on settled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteReceiptItems(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["receipt-items"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["receipt-items", "deleted"] });
   });
 });

--- a/src/client/src/hooks/useReceipts.test.ts
+++ b/src/client/src/hooks/useReceipts.test.ts
@@ -210,10 +210,9 @@ describe("useReceipts", () => {
       { id: "1", location: "A" },
       { id: "2", location: "B" },
     ];
-    queryClient.setQueryData(
-      ["receipts", "list", 0, 50, undefined, undefined],
-      { data: receipts, total: 2, offset: 0, limit: 50 },
-    );
+    const cacheKey = ["receipts", "list", 0, 50, undefined, undefined];
+    const cacheValue = { data: receipts, total: 2, offset: 0, limit: 50 };
+    queryClient.setQueryData(cacheKey, cacheValue);
     setQueryDataSpy.mockClear();
 
     (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
@@ -227,8 +226,8 @@ describe("useReceipts", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(toast.error).toHaveBeenCalledWith("Failed to delete receipt(s)");
 
-    // Verify rollback was attempted
-    expect(setQueryDataSpy).toHaveBeenCalled();
+    // Verify rollback restored the original data (not just the optimistic update from onMutate)
+    expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
   });
 
   it("delete optimistic update handles undefined cache gracefully", async () => {

--- a/src/client/src/hooks/useReceipts.test.ts
+++ b/src/client/src/hooks/useReceipts.test.ts
@@ -167,4 +167,160 @@ describe("useReceipts", () => {
     });
     expect(toast.success).toHaveBeenCalledWith("Receipt restored");
   });
+
+  // --- Branch coverage: error callbacks ---
+
+  it("create mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useCreateReceipt(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ location: "Store", date: "2025-01-01", taxAmount: 1.0 });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to create receipt");
+  });
+
+  it("update mutation shows error toast on failure", async () => {
+    (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useUpdateReceipt(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ id: "1", location: "Store", date: "2025-01-01", taxAmount: 1.0 });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to update receipt");
+  });
+
+  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    const receipts = [
+      { id: "1", location: "A" },
+      { id: "2", location: "B" },
+    ];
+    queryClient.setQueryData(
+      ["receipts", "list", 0, 50, undefined, undefined],
+      { data: receipts, total: 2, offset: 0, limit: 50 },
+    );
+    setQueryDataSpy.mockClear();
+
+    (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useDeleteReceipts(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to delete receipt(s)");
+
+    // Verify rollback was attempted
+    expect(setQueryDataSpy).toHaveBeenCalled();
+  });
+
+  it("delete optimistic update handles undefined cache gracefully", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    queryClient.setQueryData(["receipts", "list", 0, 50, undefined, undefined], undefined);
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteReceipts(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(toast.success).toHaveBeenCalledWith("Receipt(s) deleted");
+  });
+
+  it("restore mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useRestoreReceipt(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to restore receipt");
+  });
+
+  it("list query throws on API error", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useReceipts(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("list query passes sort parameters", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: { data: [], total: 0, offset: 0, limit: 50 }, error: undefined });
+
+    const { result } = renderHook(() => useReceipts(0, 50, "location", "desc"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/receipts", {
+      params: { query: { offset: 0, limit: 50, sortBy: "location", sortDirection: "desc" } },
+    });
+  });
+
+  it("list query returns total of 0 when data is undefined", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "err" } });
+
+    const { result } = renderHook(() => useReceipts(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.total).toBe(0);
+  });
+
+  it("delete mutation invalidates both list and deleted query keys on settled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteReceipts(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["receipts"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["receipts", "deleted"] });
+  });
 });

--- a/src/client/src/hooks/useTransactions.test.ts
+++ b/src/client/src/hooks/useTransactions.test.ts
@@ -258,10 +258,9 @@ describe("useTransactions", () => {
       { id: "1", amount: 100 },
       { id: "2", amount: 200 },
     ];
-    queryClient.setQueryData(
-      ["transactions", "list", 0, 50, undefined, undefined],
-      { data: transactions, total: 2, offset: 0, limit: 50 },
-    );
+    const cacheKey = ["transactions", "list", 0, 50, undefined, undefined];
+    const cacheValue = { data: transactions, total: 2, offset: 0, limit: 50 };
+    queryClient.setQueryData(cacheKey, cacheValue);
     setQueryDataSpy.mockClear();
 
     (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
@@ -275,8 +274,8 @@ describe("useTransactions", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(toast.error).toHaveBeenCalledWith("Failed to delete transaction(s)");
 
-    // Verify rollback was attempted
-    expect(setQueryDataSpy).toHaveBeenCalled();
+    // Verify rollback restored the original data (not just the optimistic update from onMutate)
+    expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
   });
 
   it("delete optimistic update handles undefined cache gracefully", async () => {

--- a/src/client/src/hooks/useTransactions.test.ts
+++ b/src/client/src/hooks/useTransactions.test.ts
@@ -23,6 +23,7 @@ import {
   useTransaction,
   useTransactionsByReceiptId,
   useCreateTransaction,
+  useCreateTransactionsBatch,
   useUpdateTransaction,
   useDeleteTransactions,
   useDeletedTransactions,
@@ -178,5 +179,196 @@ describe("useTransactions", () => {
       params: { path: { id: "1" } },
     });
     expect(toast.success).toHaveBeenCalledWith("Transaction restored");
+  });
+
+  // --- Branch coverage: error callbacks ---
+
+  it("create mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useCreateTransaction(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ receiptId: "r-1", body: { amount: 100, date: "2025-01-01", accountId: "acc-1" } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to create transaction");
+  });
+
+  it("batch create mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useCreateTransactionsBatch(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ receiptId: "r-1", body: [{ amount: 100, date: "2025-01-01", accountId: "acc-1" }] });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to create transactions");
+  });
+
+  it("batch create mutation invalidates cache on success", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.POST as Mock).mockResolvedValue({ data: [{ id: "1" }], error: undefined });
+
+    const { result } = renderHook(() => useCreateTransactionsBatch(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate({ receiptId: "r-1", body: [{ amount: 100, date: "2025-01-01", accountId: "acc-1" }] });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["transactions"] });
+  });
+
+  it("update mutation shows error toast on failure", async () => {
+    (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useUpdateTransaction(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ body: { id: "1", amount: 100, date: "2025-01-01", accountId: "acc-1" } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to update transaction");
+  });
+
+  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    const transactions = [
+      { id: "1", amount: 100 },
+      { id: "2", amount: 200 },
+    ];
+    queryClient.setQueryData(
+      ["transactions", "list", 0, 50, undefined, undefined],
+      { data: transactions, total: 2, offset: 0, limit: 50 },
+    );
+    setQueryDataSpy.mockClear();
+
+    (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useDeleteTransactions(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to delete transaction(s)");
+
+    // Verify rollback was attempted
+    expect(setQueryDataSpy).toHaveBeenCalled();
+  });
+
+  it("delete optimistic update handles undefined cache gracefully", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    queryClient.setQueryData(["transactions", "list", 0, 50, undefined, undefined], undefined);
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteTransactions(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(toast.success).toHaveBeenCalledWith("Transaction(s) deleted");
+  });
+
+  it("restore mutation shows error toast on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useRestoreTransaction(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to restore transaction");
+  });
+
+  it("list query throws on API error", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useTransactions(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("list query passes sort parameters", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: { data: [], total: 0, offset: 0, limit: 50 }, error: undefined });
+
+    const { result } = renderHook(() => useTransactions(0, 50, "amount", "desc"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/transactions", {
+      params: { query: { offset: 0, limit: 50, sortBy: "amount", sortDirection: "desc" } },
+    });
+  });
+
+  it("list query returns total of 0 when data is undefined", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "err" } });
+
+    const { result } = renderHook(() => useTransactions(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.total).toBe(0);
+  });
+
+  it("delete mutation invalidates both list and deleted query keys on settled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteTransactions(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["transactions"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["transactions", "deleted"] });
   });
 });

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -52,6 +52,7 @@ vi.mock("@/hooks/useServerSort", () => ({
 vi.mock("@/hooks/useListKeyboardNav", () => ({
   useListKeyboardNav: vi.fn(() => ({
     focusedId: null,
+    focusedIndex: -1,
     setFocusedIndex: vi.fn(),
     tableRef: { current: null },
   })),
@@ -456,5 +457,200 @@ describe("AdminUsers", () => {
     await vi.waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith("2");
     });
+  });
+
+  it("submits create user form with correct payload", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutateAsync = vi.fn().mockResolvedValue(undefined);
+    const { useCreateUser } = await import("@/hooks/useUsers");
+    vi.mocked(useCreateUser).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateUser>);
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /create user/i }));
+
+    await user.type(screen.getByPlaceholderText("name@example.com"), "new@example.com");
+    await user.type(screen.getByPlaceholderText("At least 8 characters"), "password123");
+
+    const submitButtons = screen.getAllByRole("button", { name: /create user/i });
+    const dialogSubmit = submitButtons.find((btn) => btn.closest("[role='dialog']") !== null);
+    await user.click(dialogSubmit!);
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: "new@example.com",
+          password: "password123",
+          role: "User",
+        }),
+      );
+    });
+  });
+
+  it("submits edit user form with correct payload", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutateAsync = vi.fn().mockResolvedValue(undefined);
+    const { useUsers, useUpdateUser } = await import("@/hooks/useUsers");
+    vi.mocked(useUpdateUser).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateUser>);
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const emailInput = screen.getByDisplayValue("test@example.com");
+    await user.clear(emailInput);
+    await user.type(emailInput, "updated@example.com");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "1",
+          body: expect.objectContaining({ email: "updated@example.com" }),
+        }),
+      );
+    });
+  });
+
+  it("submits reset password form", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutateAsync = vi.fn().mockResolvedValue(undefined);
+    const { useUsers, useResetUserPassword } = await import("@/hooks/useUsers");
+    vi.mocked(useResetUserPassword).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useResetUserPassword>);
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /reset pw/i }));
+
+    await user.type(screen.getByPlaceholderText("At least 8 characters"), "newpassword123");
+    await user.click(screen.getByRole("button", { name: /^reset password$/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        userId: "1",
+        newPassword: "newpassword123",
+      });
+    });
+  });
+
+  it("calls setFocusedIndex when a table row is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockSetFocusedIndex = vi.fn();
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: null,
+      focusedIndex: -1,
+      setFocusedIndex: mockSetFocusedIndex,
+      tableRef: { current: null },
+    });
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "click@example.com",
+          firstName: "Click",
+          lastName: "Test",
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByText("click@example.com"));
+
+    expect(mockSetFocusedIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("shows just first name when last name is null", async () => {
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "jane@example.com",
+          firstName: "Jane",
+          lastName: null,
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    const cells = screen.getAllByRole("cell");
+    expect(cells[0].textContent).toBe("Jane");
+  });
+
+  it("shows secondary badge variant for non-Admin role", async () => {
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "user@example.com",
+          firstName: "Regular",
+          lastName: "User",
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    const roleBadge = screen.getByText("User", { selector: "[data-slot='badge']" });
+    expect(roleBadge).toBeInTheDocument();
   });
 });

--- a/src/client/src/pages/ApiKeys.test.tsx
+++ b/src/client/src/pages/ApiKeys.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/hooks/usePageTitle", () => ({
 vi.mock("@/hooks/useListKeyboardNav", () => ({
   useListKeyboardNav: vi.fn(() => ({
     focusedId: null,
+    focusedIndex: -1,
     setFocusedIndex: vi.fn(),
     tableRef: { current: null },
   })),
@@ -220,10 +221,9 @@ describe("ApiKeys", () => {
     const confirmButton = dialogButtons.find(
       (btn) => btn.closest("[role='dialog']") !== null,
     );
-    if (confirmButton) {
-      await user.click(confirmButton);
-      expect(mockMutate).toHaveBeenCalledWith("key-1");
-    }
+    expect(confirmButton).toBeDefined();
+    await user.click(confirmButton!);
+    expect(mockMutate).toHaveBeenCalledWith("key-1");
   });
 
   it("opens create dialog on shortcut:new-item event", async () => {
@@ -299,6 +299,7 @@ describe("ApiKeys", () => {
   it("copies key to clipboard when Copy to Clipboard button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useMutation } = await import("@tanstack/react-query");
+    const originalClipboard = navigator.clipboard;
     const mockWriteText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText: mockWriteText },
@@ -325,6 +326,12 @@ describe("ApiKeys", () => {
     await user.click(screen.getByRole("button", { name: /copy to clipboard/i }));
 
     expect(mockWriteText).toHaveBeenCalledWith("copy-me-key");
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
   });
 
   it("cancels revoke dialog when Cancel button is clicked", async () => {
@@ -399,5 +406,349 @@ describe("ApiKeys", () => {
     const cells = screen.getAllByRole("cell");
     const dashCells = cells.filter((c) => c.textContent === "-");
     expect(dashCells.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("calls setFocusedIndex when a table row is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockSetFocusedIndex = vi.fn();
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: null,
+      focusedIndex: -1,
+      setFocusedIndex: mockSetFocusedIndex,
+      tableRef: { current: null },
+    });
+    const { useQuery } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "key-1",
+          name: "Click Row Key",
+          createdAt: "2024-01-01T00:00:00Z",
+          lastUsedAt: null,
+          expiresAt: null,
+          isRevoked: false,
+        },
+      ],
+      isLoading: false,
+    }));
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByText("Click Row Key"));
+
+    expect(mockSetFocusedIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("shows error toast when clipboard copy fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const { showError } = await import("@/lib/toast");
+    const originalClipboard = navigator.clipboard;
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockRejectedValue(new Error("copy failed")) },
+      writable: true,
+      configurable: true,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess({ rawKey: "fail-copy-key" }, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "Fail Copy");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await screen.findByRole("heading", { name: /api key created/i });
+    await user.click(screen.getByRole("button", { name: /copy to clipboard/i }));
+
+    await vi.waitFor(() => {
+      expect(showError).toHaveBeenCalledWith("Failed to copy to clipboard.");
+    });
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("shows error toast when create mutation fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const { showError } = await import("@/lib/toast");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn(() => {
+        if (opts?.onError) {
+          opts.onError(new Error("fail"), undefined, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "Error Key");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await vi.waitFor(() => {
+      expect(showError).toHaveBeenCalledWith("Failed to create API key.");
+    });
+  });
+
+  it("shows error toast when revoke mutation fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useQuery, useMutation } = await import("@tanstack/react-query");
+    const { showError } = await import("@/lib/toast");
+
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "key-1",
+          name: "Revoke Fail Key",
+          createdAt: "2024-01-01T00:00:00Z",
+          lastUsedAt: null,
+          expiresAt: null,
+          isRevoked: false,
+        },
+      ],
+      isLoading: false,
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn(() => {
+        if (opts?.onError) {
+          opts.onError(new Error("fail"), undefined, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    const dialogButtons = screen.getAllByRole("button", { name: /revoke/i });
+    const confirmButton = dialogButtons.find(
+      (btn) => btn.closest("[role='dialog']") !== null,
+    );
+    expect(confirmButton).toBeDefined();
+    await user.click(confirmButton!);
+    await vi.waitFor(() => {
+      expect(showError).toHaveBeenCalledWith("Failed to revoke API key.");
+    });
+  });
+
+  it("closes created key dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess({ rawKey: "dismiss-key" }, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "Dismiss Test");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await screen.findByRole("heading", { name: /api key created/i });
+    await user.keyboard("{Escape}");
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /api key created/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not show created key dialog when create mutation returns no data", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess(undefined, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "No Data Key");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /api key created/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows success toast when revoke mutation succeeds", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useQuery, useMutation } = await import("@tanstack/react-query");
+    const { showSuccess } = await import("@/lib/toast");
+
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [{
+        id: "key-1", name: "Success Revoke Key", createdAt: "2024-01-01T00:00:00Z",
+        lastUsedAt: null, expiresAt: null, isRevoked: false,
+      }],
+      isLoading: false,
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn(() => {
+        if (opts?.onSuccess) {
+          opts.onSuccess(undefined, undefined, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    const dialogButtons = screen.getAllByRole("button", { name: /revoke/i });
+    const confirmButton = dialogButtons.find(
+      (btn) => btn.closest("[role='dialog']") !== null,
+    );
+    await user.click(confirmButton!);
+
+    await vi.waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith("API key revoked.");
+    });
+  });
+
+  it("closes revoke dialog via Escape key", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useQuery } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [{
+        id: "key-1", name: "Esc Key", createdAt: "2024-01-01T00:00:00Z",
+        lastUsedAt: null, expiresAt: null, isRevoked: false,
+      }],
+      isLoading: false,
+    }));
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+    expect(screen.getByRole("heading", { name: /revoke api key/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /revoke api key/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("highlights focused row with bg-accent class", async () => {
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: "key-1",
+      focusedIndex: 0,
+      setFocusedIndex: vi.fn(),
+      tableRef: { current: null },
+    });
+    const { useQuery } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [{
+        id: "key-1", name: "Focused Key", createdAt: "2024-01-01T00:00:00Z",
+        lastUsedAt: null, expiresAt: null, isRevoked: false,
+      }],
+      isLoading: false,
+    }));
+
+    renderWithQueryClient(<ApiKeys />);
+    const row = screen.getByText("Focused Key").closest("tr");
+    expect(row?.className).toContain("bg-accent");
+  });
+
+  it("selects text in created key input when clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const mockSelect = vi.fn();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess({ rawKey: "select-key" }, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "Select Test");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await screen.findByRole("heading", { name: /api key created/i });
+
+    const keyInput = screen.getByDisplayValue("select-key");
+    // Mock select on the input element
+    (keyInput as HTMLInputElement).select = mockSelect;
+    await user.click(keyInput);
+
+    expect(mockSelect).toHaveBeenCalled();
+  });
+
+  it("shows Creating state when create mutation is pending", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    vi.mocked(useMutation).mockImplementation((() => ({
+      mutate: vi.fn(),
+      isPending: true,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+
+    expect(screen.getByRole("button", { name: /creating/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /creating/i })).toBeDisabled();
+  });
+
+  it("shows Revoking state when revoke mutation is pending", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useQuery, useMutation } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [{
+        id: "key-1", name: "Pending Revoke", createdAt: "2024-01-01T00:00:00Z",
+        lastUsedAt: null, expiresAt: null, isRevoked: false,
+      }],
+      isLoading: false,
+    }));
+    vi.mocked(useMutation).mockImplementation((() => ({
+      mutate: vi.fn(),
+      isPending: true,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    // Click the table Revoke button to open the dialog
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    // The confirm button in the dialog should show "Revoking..."
+    const dialogButtons = screen.getAllByRole("button", { name: /revoking/i });
+    const confirmButton = dialogButtons.find(
+      (btn) => btn.closest("[role='dialog']") !== null,
+    );
+    expect(confirmButton).toBeDefined();
+    expect(confirmButton).toBeDisabled();
   });
 });

--- a/src/client/src/pages/AuditLog.test.tsx
+++ b/src/client/src/pages/AuditLog.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult } from "@/test/mock-hooks";
+import "@/test/setup-combobox-polyfills";
 import AuditLog from "./AuditLog";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -66,9 +67,9 @@ vi.mock("@/components/AuditLogTable", () => ({
 }));
 
 vi.mock("@/components/Pagination", () => ({
-  Pagination: function MockPagination() {
+  Pagination: vi.fn(function MockPagination() {
     return <div data-testid="pagination">Pagination</div>;
-  },
+  }),
 }));
 
 describe("AuditLog", () => {
@@ -240,5 +241,287 @@ describe("AuditLog", () => {
         limit: expect.any(Number),
       }),
     );
+  });
+
+  it("renders entity type and action options when enum data exists", async () => {
+    const { useEnumMetadata } = await import("@/hooks/useEnumMetadata");
+    vi.mocked(useEnumMetadata).mockReturnValue({
+      adjustmentTypes: [],
+      authEventTypes: [],
+      pricingModes: [],
+      auditActions: [{ value: "Create", label: "Create" }, { value: "Update", label: "Update" }],
+      entityTypes: [{ value: "Account", label: "Account" }, { value: "Receipt", label: "Receipt" }],
+      adjustmentTypeLabels: {},
+      authEventLabels: {},
+      pricingModeLabels: {},
+      auditActionLabels: {},
+      entityTypeLabels: { Account: "Account", Receipt: "Receipt" },
+      isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithProviders(<AuditLog />);
+    // Combobox triggers should be present for entity type and action filters
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("resets pagination when search input changes", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockResetPage = vi.fn();
+    const { useServerPagination } = await import("@/hooks/useServerPagination");
+    vi.mocked(useServerPagination).mockReturnValue({
+      offset: 0,
+      limit: 50,
+      currentPage: 1,
+      pageSize: 50,
+      totalPages: () => 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+      resetPage: mockResetPage,
+    });
+
+    renderWithProviders(<AuditLog />);
+    const searchInput = screen.getByLabelText(/search audit log/i);
+    await user.type(searchInput, "test");
+
+    expect(mockResetPage).toHaveBeenCalled();
+  });
+
+  it("disables Export CSV button when no logs exist", () => {
+    renderWithProviders(<AuditLog />);
+    expect(screen.getByRole("button", { name: /export csv/i })).toBeDisabled();
+  });
+
+  it("handles CSV export with special characters in data", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useRecentAuditLogs } = await import("@/hooks/useAudit");
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "has,comma",
+          action: 'has"quote',
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: "user-1",
+          changedByApiKeyId: null,
+          ipAddress: "127.0.0.1",
+          changesJson: '{"key":"value"}',
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    const mockClick = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string, options?: ElementCreationOptions) => {
+      if (tag === "a") {
+        return { href: "", download: "", click: mockClick } as unknown as HTMLAnchorElement;
+      }
+      return originalCreateElement(tag, options);
+    });
+    const mockCreateObjectURL = vi.fn(() => "blob:csv-url");
+    const mockRevokeObjectURL = vi.fn();
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = mockRevokeObjectURL;
+
+    renderWithProviders(<AuditLog />);
+    await user.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(mockClick).toHaveBeenCalled();
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+
+    URL.createObjectURL = origCreate;
+    URL.revokeObjectURL = origRevoke;
+    vi.restoreAllMocks();
+  });
+
+  it("exports CSV with null fields correctly", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useRecentAuditLogs } = await import("@/hooks/useAudit");
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "abc-123",
+          action: "Create",
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: null,
+          changedByApiKeyId: "apikey-1",
+          ipAddress: null,
+          changesJson: "{}",
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    const mockClick = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string, options?: ElementCreationOptions) => {
+      if (tag === "a") {
+        return { href: "", download: "", click: mockClick } as unknown as HTMLAnchorElement;
+      }
+      return originalCreateElement(tag, options);
+    });
+    const mockCreateObjectURL = vi.fn(() => "blob:null-url");
+    const mockRevokeObjectURL = vi.fn();
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = mockRevokeObjectURL;
+
+    renderWithProviders(<AuditLog />);
+    await user.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(mockClick).toHaveBeenCalled();
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+
+    URL.createObjectURL = origCreate;
+    URL.revokeObjectURL = origRevoke;
+    vi.restoreAllMocks();
+  });
+
+  it("filters by entity type when combobox option is selected", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockResetPage = vi.fn();
+    const { useServerPagination } = await import("@/hooks/useServerPagination");
+    vi.mocked(useServerPagination).mockReturnValue({
+      offset: 0,
+      limit: 50,
+      currentPage: 1,
+      pageSize: 50,
+      totalPages: () => 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+      resetPage: mockResetPage,
+    });
+
+    const { useEnumMetadata } = await import("@/hooks/useEnumMetadata");
+    vi.mocked(useEnumMetadata).mockReturnValue({
+      adjustmentTypes: [],
+      authEventTypes: [],
+      pricingModes: [],
+      auditActions: [{ value: "Create", label: "Create" }],
+      entityTypes: [{ value: "Account", label: "Account" }],
+      adjustmentTypeLabels: {},
+      authEventLabels: {},
+      pricingModeLabels: {},
+      auditActionLabels: {},
+      entityTypeLabels: { Account: "Account" },
+      isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithProviders(<AuditLog />);
+
+    // Click the entity type combobox trigger (first combobox)
+    const triggers = screen.getAllByRole("combobox");
+    await user.click(triggers[0]);
+
+    // Select "Account" option
+    const accountOption = await screen.findByRole("option", { name: "Account" });
+    await user.click(accountOption);
+
+    // handleEntityTypeChange should call resetPage
+    expect(mockResetPage).toHaveBeenCalled();
+  });
+
+  it("filters by action when combobox option is selected", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockResetPage = vi.fn();
+    const { useServerPagination } = await import("@/hooks/useServerPagination");
+    vi.mocked(useServerPagination).mockReturnValue({
+      offset: 0,
+      limit: 50,
+      currentPage: 1,
+      pageSize: 50,
+      totalPages: () => 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+      resetPage: mockResetPage,
+    });
+
+    const { useEnumMetadata } = await import("@/hooks/useEnumMetadata");
+    vi.mocked(useEnumMetadata).mockReturnValue({
+      adjustmentTypes: [],
+      authEventTypes: [],
+      pricingModes: [],
+      auditActions: [{ value: "Create", label: "Create" }, { value: "Update", label: "Update" }],
+      entityTypes: [{ value: "Account", label: "Account" }],
+      adjustmentTypeLabels: {},
+      authEventLabels: {},
+      pricingModeLabels: {},
+      auditActionLabels: {},
+      entityTypeLabels: { Account: "Account" },
+      isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithProviders(<AuditLog />);
+
+    // Click the action combobox trigger (second combobox)
+    const triggers = screen.getAllByRole("combobox");
+    await user.click(triggers[1]);
+
+    // Select "Create" option
+    const createOption = await screen.findByRole("option", { name: "Create" });
+    await user.click(createOption);
+
+    // handleActionChange should call resetPage
+    expect(mockResetPage).toHaveBeenCalled();
+  });
+
+  it("calls setPage when pagination page changes", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockSetPage = vi.fn();
+    const { useServerPagination } = await import("@/hooks/useServerPagination");
+    vi.mocked(useServerPagination).mockReturnValue({
+      offset: 0,
+      limit: 50,
+      currentPage: 1,
+      pageSize: 50,
+      totalPages: () => 2,
+      setPage: mockSetPage,
+      setPageSize: vi.fn(),
+      resetPage: vi.fn(),
+    });
+
+    const { useRecentAuditLogs } = await import("@/hooks/useAudit");
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "abc-123",
+          action: "Create",
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: "user-1",
+          changedByApiKeyId: null,
+          ipAddress: "127.0.0.1",
+          changesJson: "{}",
+        },
+      ],
+      total: 100,
+      isLoading: false,
+    }));
+
+    const { Pagination } = await import("@/components/Pagination");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(Pagination).mockImplementation(({ onPageChange }: any) => (
+      <div data-testid="pagination">
+        <button data-testid="next-page" onClick={() => onPageChange(2)}>Next</button>
+      </div>
+    ));
+
+    renderWithProviders(<AuditLog />);
+    await user.click(screen.getByTestId("next-page"));
+
+    expect(mockSetPage).toHaveBeenCalledWith(2, 100);
   });
 });

--- a/src/client/src/pages/RecycleBin.test.tsx
+++ b/src/client/src/pages/RecycleBin.test.tsx
@@ -34,6 +34,7 @@ vi.mock("@/hooks/useTrash", () => ({
 vi.mock("@/hooks/useListKeyboardNav", () => ({
   useListKeyboardNav: vi.fn(() => ({
     focusedId: null,
+    focusedIndex: -1,
     setFocusedIndex: vi.fn(),
     tableRef: { current: null },
   })),
@@ -125,4 +126,191 @@ describe("RecycleBin", () => {
     expect(screen.getByRole("tab", { name: /receipt/i })).toBeInTheDocument();
   });
 
+  it("calls restoreReceipt.mutate when Restore is clicked on a receipt", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useDeletedReceipts, useRestoreReceipt } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+    vi.mocked(useRestoreReceipt).mockReturnValue(mockMutationResult({ mutate: mockMutate }));
+
+    renderWithProviders(<RecycleBin />);
+    const restoreButtons = screen.getAllByRole("button", { name: /restore/i });
+    await user.click(restoreButtons[0]);
+
+    expect(mockMutate).toHaveBeenCalledWith("r1");
+  });
+
+  it("calls restoreTransaction.mutate when Restore is clicked on a transaction", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useDeletedTransactions, useRestoreTransaction } = await import("@/hooks/useTransactions");
+    vi.mocked(useDeletedTransactions).mockReturnValue(mockQueryResult({
+      data: [{ id: "t1", amount: 25.50, date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+    vi.mocked(useRestoreTransaction).mockReturnValue(mockMutationResult({ mutate: mockMutate }));
+
+    renderWithProviders(<RecycleBin />);
+    const restoreButtons = screen.getAllByRole("button", { name: /restore/i });
+    await user.click(restoreButtons[0]);
+
+    expect(mockMutate).toHaveBeenCalledWith("t1");
+  });
+
+  it("calls purgeTrash.mutate when Empty Trash is confirmed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { usePurgeTrash } = await import("@/hooks/useTrash");
+    vi.mocked(usePurgeTrash).mockReturnValue(mockMutationResult({ mutate: mockMutate }));
+
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    await user.click(screen.getByRole("button", { name: /empty trash/i }));
+
+    expect(screen.getByRole("heading", { name: /empty trash\?/i })).toBeInTheDocument();
+
+    const confirmButtons = screen.getAllByRole("button", { name: /empty trash/i });
+    const confirmButton = confirmButtons.find(
+      (btn) => btn.closest("[role='alertdialog']") !== null,
+    );
+    await user.click(confirmButton!);
+
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it("renders deleted transaction items with amount and date", async () => {
+    const { useDeletedTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useDeletedTransactions).mockReturnValue(mockQueryResult({
+      data: [{ id: "t1", amount: 42.50, date: "2026-03-15" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    expect(screen.getByText("$42.50 - 2026-03-15")).toBeInTheDocument();
+    expect(screen.getByText("Transaction")).toBeInTheDocument();
+  });
+
+  it("renders deleted receipt items with receipt item code", async () => {
+    const { useDeletedReceiptItems } = await import("@/hooks/useReceiptItems");
+    vi.mocked(useDeletedReceiptItems).mockReturnValue(mockQueryResult({
+      data: [{ id: "ri1", description: "Widget", receiptItemCode: "W-001" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    expect(screen.getByText("Widget (W-001)")).toBeInTheDocument();
+  });
+
+  it("shows filtered items when entity type tab is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    const { useDeletedItemTemplates } = await import("@/hooks/useItemTemplates");
+    vi.mocked(useDeletedItemTemplates).mockReturnValue(mockQueryResult({
+      data: [{ id: "it1", name: "Template" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+
+    // Click the Item Template tab (use exact match to avoid ambiguity with Receipt/Receipt Item)
+    const tabs = screen.getAllByRole("tab");
+    const templateTab = tabs.find((t) => t.textContent?.includes("Item Template"));
+    expect(templateTab).toBeDefined();
+    await user.click(templateTab!);
+
+    // Template should be visible in the tab content
+    expect(screen.getByText("Template")).toBeInTheDocument();
+  });
+
+  it("renders receipt item with null code as N/A", async () => {
+    const { useDeletedReceiptItems } = await import("@/hooks/useReceiptItems");
+    vi.mocked(useDeletedReceiptItems).mockReturnValue(mockQueryResult({
+      data: [{ id: "ri1", description: "No Code Item", receiptItemCode: null }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    expect(screen.getByText("No Code Item (N/A)")).toBeInTheDocument();
+  });
+
+  it("calls setFocusedIndex when row is clicked in All tab", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockSetFocusedIndex = vi.fn();
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: null,
+      focusedIndex: -1,
+      setFocusedIndex: mockSetFocusedIndex,
+      tableRef: { current: null },
+    });
+
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Click Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    await user.click(screen.getByText("Click Store - 2026-01-01"));
+
+    expect(mockSetFocusedIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("highlights focused row with bg-accent class", async () => {
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: "Receipt:r1",
+      focusedIndex: 0,
+      setFocusedIndex: vi.fn(),
+      tableRef: { current: null },
+    });
+
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Focused Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    const row = screen.getByText("Focused Store - 2026-01-01").closest("tr");
+    expect(row?.className).toContain("bg-accent");
+  });
+
+  it("shows Emptying state when purge is pending", async () => {
+    const { usePurgeTrash } = await import("@/hooks/useTrash");
+    vi.mocked(usePurgeTrash).mockReturnValue(mockMutationResult({ isPending: true }));
+
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    expect(screen.getByText(/emptying/i)).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/Transactions.test.tsx
+++ b/src/client/src/pages/Transactions.test.tsx
@@ -455,4 +455,186 @@ describe("Transactions", () => {
       screen.getByRole("heading", { name: /create transaction/i }),
     ).toBeInTheDocument();
   });
+
+  it("shows ActiveFilterBanner when receiptId link param is present", async () => {
+    const { useTransactionsByReceiptId } = await import("@/hooks/useTransactions");
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    vi.mocked(useTransactionsByReceiptId).mockReturnValue(mockQueryResult({
+      data: items,
+      total: 1,
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Transactions />, { route: "/transactions?receiptId=r1" });
+
+    expect(screen.getByText(/showing transactions for receipt/i)).toBeInTheDocument();
+  });
+
+  it('shows "Unknown" for transaction with unresolved account', async () => {
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "unknown-acc", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />);
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it('shows "Receipt" fallback for transaction with unresolved receipt', async () => {
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "unknown-rcpt", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />);
+    // The receipt link shows "Receipt" when receiptId is not in receiptMap
+    const receiptLink = screen.getByRole("link", { name: "Receipt" });
+    expect(receiptLink).toBeInTheDocument();
+    expect(receiptLink).toHaveAttribute("href", "/receipts?highlight=unknown-rcpt");
+  });
+
+  it("deselects all when select-all is toggled off", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+      mockTransactionResponse({ id: "t2", receiptId: "r2", accountId: "a2", amount: 100.00, date: "2024-01-20" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />);
+
+    // Select all
+    await user.click(screen.getByLabelText("Select all rows"));
+    expect(screen.getByRole("button", { name: /delete \(2\)/i })).toBeInTheDocument();
+
+    // Deselect all
+    await user.click(screen.getByLabelText("Select all rows"));
+
+    // Delete button should disappear
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("closes delete dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />);
+    await user.click(screen.getByLabelText("Select transaction t1"));
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(screen.getByRole("heading", { name: /delete transactions/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /delete transactions/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows ActiveFilterBanner with account filter message", async () => {
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />, { route: "/transactions?accountId=a1" });
+
+    expect(screen.getByText(/showing transactions for account/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Add branch coverage tests for 5 CRUD hooks: useReceiptItems, useReceipts, useAdjustments, useTransactions, useItemTemplates
- Cover mutation error callbacks (onError toast), optimistic delete rollback, undefined cache guards in onMutate, batch create mutations, sort parameter pass-through, and onSettled cache invalidation
- Branch coverage improved from 67-70% to 86-88% across all 5 hooks (49 new tests, 92 total)

Resolves RECEIPTS-383

## Test plan
- All 92 tests pass across the 5 hook test files
- Full suite of 1239 tests passes with 0 failures
- Coverage verified: useAdjustments 86.36%, useItemTemplates 88.23%, useReceiptItems 86.95%, useReceipts 88.23%, useTransactions 86.95% (all above 85% target)