### PR TITLE
test(infra): increase ApplicationDbContext branch coverage to 95%+ (RECEIPTS-376)

### DIFF
--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -52,6 +52,7 @@ vi.mock("@/hooks/useServerSort", () => ({
 vi.mock("@/hooks/useListKeyboardNav", () => ({
   useListKeyboardNav: vi.fn(() => ({
     focusedId: null,
+    focusedIndex: -1,
     setFocusedIndex: vi.fn(),
     tableRef: { current: null },
   })),
@@ -456,5 +457,200 @@ describe("AdminUsers", () => {
     await vi.waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith("2");
     });
+  });
+
+  it("submits create user form with correct payload", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutateAsync = vi.fn().mockResolvedValue(undefined);
+    const { useCreateUser } = await import("@/hooks/useUsers");
+    vi.mocked(useCreateUser).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateUser>);
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /create user/i }));
+
+    await user.type(screen.getByPlaceholderText("name@example.com"), "new@example.com");
+    await user.type(screen.getByPlaceholderText("At least 8 characters"), "password123");
+
+    const submitButtons = screen.getAllByRole("button", { name: /create user/i });
+    const dialogSubmit = submitButtons.find((btn) => btn.closest("[role='dialog']") !== null);
+    await user.click(dialogSubmit!);
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: "new@example.com",
+          password: "password123",
+          role: "User",
+        }),
+      );
+    });
+  });
+
+  it("submits edit user form with correct payload", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutateAsync = vi.fn().mockResolvedValue(undefined);
+    const { useUsers, useUpdateUser } = await import("@/hooks/useUsers");
+    vi.mocked(useUpdateUser).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateUser>);
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const emailInput = screen.getByDisplayValue("test@example.com");
+    await user.clear(emailInput);
+    await user.type(emailInput, "updated@example.com");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "1",
+          body: expect.objectContaining({ email: "updated@example.com" }),
+        }),
+      );
+    });
+  });
+
+  it("submits reset password form", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutateAsync = vi.fn().mockResolvedValue(undefined);
+    const { useUsers, useResetUserPassword } = await import("@/hooks/useUsers");
+    vi.mocked(useResetUserPassword).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useResetUserPassword>);
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "test@example.com",
+          firstName: "John",
+          lastName: "Doe",
+          roles: ["Admin"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: "2024-01-15",
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByRole("button", { name: /reset pw/i }));
+
+    await user.type(screen.getByPlaceholderText("At least 8 characters"), "newpassword123");
+    await user.click(screen.getByRole("button", { name: /^reset password$/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        userId: "1",
+        newPassword: "newpassword123",
+      });
+    });
+  });
+
+  it("calls setFocusedIndex when a table row is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockSetFocusedIndex = vi.fn();
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: null,
+      focusedIndex: -1,
+      setFocusedIndex: mockSetFocusedIndex,
+      tableRef: { current: null },
+    });
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "click@example.com",
+          firstName: "Click",
+          lastName: "Test",
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    await user.click(screen.getByText("click@example.com"));
+
+    expect(mockSetFocusedIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("shows just first name when last name is null", async () => {
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "jane@example.com",
+          firstName: "Jane",
+          lastName: null,
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    const cells = screen.getAllByRole("cell");
+    expect(cells[0].textContent).toBe("Jane");
+  });
+
+  it("shows secondary badge variant for non-Admin role", async () => {
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "user@example.com",
+          firstName: "Regular",
+          lastName: "User",
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+    const roleBadge = screen.getByText("User", { selector: "[data-slot='badge']" });
+    expect(roleBadge).toBeInTheDocument();
   });
 });

--- a/src/client/src/pages/ApiKeys.test.tsx
+++ b/src/client/src/pages/ApiKeys.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/hooks/usePageTitle", () => ({
 vi.mock("@/hooks/useListKeyboardNav", () => ({
   useListKeyboardNav: vi.fn(() => ({
     focusedId: null,
+    focusedIndex: -1,
     setFocusedIndex: vi.fn(),
     tableRef: { current: null },
   })),
@@ -220,10 +221,9 @@ describe("ApiKeys", () => {
     const confirmButton = dialogButtons.find(
       (btn) => btn.closest("[role='dialog']") !== null,
     );
-    if (confirmButton) {
-      await user.click(confirmButton);
-      expect(mockMutate).toHaveBeenCalledWith("key-1");
-    }
+    expect(confirmButton).toBeDefined();
+    await user.click(confirmButton!);
+    expect(mockMutate).toHaveBeenCalledWith("key-1");
   });
 
   it("opens create dialog on shortcut:new-item event", async () => {
@@ -299,6 +299,7 @@ describe("ApiKeys", () => {
   it("copies key to clipboard when Copy to Clipboard button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useMutation } = await import("@tanstack/react-query");
+    const originalClipboard = navigator.clipboard;
     const mockWriteText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText: mockWriteText },
@@ -325,6 +326,12 @@ describe("ApiKeys", () => {
     await user.click(screen.getByRole("button", { name: /copy to clipboard/i }));
 
     expect(mockWriteText).toHaveBeenCalledWith("copy-me-key");
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
   });
 
   it("cancels revoke dialog when Cancel button is clicked", async () => {
@@ -399,5 +406,349 @@ describe("ApiKeys", () => {
     const cells = screen.getAllByRole("cell");
     const dashCells = cells.filter((c) => c.textContent === "-");
     expect(dashCells.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("calls setFocusedIndex when a table row is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockSetFocusedIndex = vi.fn();
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: null,
+      focusedIndex: -1,
+      setFocusedIndex: mockSetFocusedIndex,
+      tableRef: { current: null },
+    });
+    const { useQuery } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "key-1",
+          name: "Click Row Key",
+          createdAt: "2024-01-01T00:00:00Z",
+          lastUsedAt: null,
+          expiresAt: null,
+          isRevoked: false,
+        },
+      ],
+      isLoading: false,
+    }));
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByText("Click Row Key"));
+
+    expect(mockSetFocusedIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("shows error toast when clipboard copy fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const { showError } = await import("@/lib/toast");
+    const originalClipboard = navigator.clipboard;
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockRejectedValue(new Error("copy failed")) },
+      writable: true,
+      configurable: true,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess({ rawKey: "fail-copy-key" }, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "Fail Copy");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await screen.findByRole("heading", { name: /api key created/i });
+    await user.click(screen.getByRole("button", { name: /copy to clipboard/i }));
+
+    await vi.waitFor(() => {
+      expect(showError).toHaveBeenCalledWith("Failed to copy to clipboard.");
+    });
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("shows error toast when create mutation fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const { showError } = await import("@/lib/toast");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn(() => {
+        if (opts?.onError) {
+          opts.onError(new Error("fail"), undefined, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "Error Key");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await vi.waitFor(() => {
+      expect(showError).toHaveBeenCalledWith("Failed to create API key.");
+    });
+  });
+
+  it("shows error toast when revoke mutation fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useQuery, useMutation } = await import("@tanstack/react-query");
+    const { showError } = await import("@/lib/toast");
+
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "key-1",
+          name: "Revoke Fail Key",
+          createdAt: "2024-01-01T00:00:00Z",
+          lastUsedAt: null,
+          expiresAt: null,
+          isRevoked: false,
+        },
+      ],
+      isLoading: false,
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn(() => {
+        if (opts?.onError) {
+          opts.onError(new Error("fail"), undefined, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    const dialogButtons = screen.getAllByRole("button", { name: /revoke/i });
+    const confirmButton = dialogButtons.find(
+      (btn) => btn.closest("[role='dialog']") !== null,
+    );
+    expect(confirmButton).toBeDefined();
+    await user.click(confirmButton!);
+    await vi.waitFor(() => {
+      expect(showError).toHaveBeenCalledWith("Failed to revoke API key.");
+    });
+  });
+
+  it("closes created key dialog when dismissed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess({ rawKey: "dismiss-key" }, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "Dismiss Test");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await screen.findByRole("heading", { name: /api key created/i });
+    await user.keyboard("{Escape}");
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /api key created/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not show created key dialog when create mutation returns no data", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess(undefined, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "No Data Key");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /api key created/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows success toast when revoke mutation succeeds", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useQuery, useMutation } = await import("@tanstack/react-query");
+    const { showSuccess } = await import("@/lib/toast");
+
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [{
+        id: "key-1", name: "Success Revoke Key", createdAt: "2024-01-01T00:00:00Z",
+        lastUsedAt: null, expiresAt: null, isRevoked: false,
+      }],
+      isLoading: false,
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn(() => {
+        if (opts?.onSuccess) {
+          opts.onSuccess(undefined, undefined, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    const dialogButtons = screen.getAllByRole("button", { name: /revoke/i });
+    const confirmButton = dialogButtons.find(
+      (btn) => btn.closest("[role='dialog']") !== null,
+    );
+    await user.click(confirmButton!);
+
+    await vi.waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith("API key revoked.");
+    });
+  });
+
+  it("closes revoke dialog via Escape key", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useQuery } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [{
+        id: "key-1", name: "Esc Key", createdAt: "2024-01-01T00:00:00Z",
+        lastUsedAt: null, expiresAt: null, isRevoked: false,
+      }],
+      isLoading: false,
+    }));
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+    expect(screen.getByRole("heading", { name: /revoke api key/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /revoke api key/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("highlights focused row with bg-accent class", async () => {
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: "key-1",
+      focusedIndex: 0,
+      setFocusedIndex: vi.fn(),
+      tableRef: { current: null },
+    });
+    const { useQuery } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [{
+        id: "key-1", name: "Focused Key", createdAt: "2024-01-01T00:00:00Z",
+        lastUsedAt: null, expiresAt: null, isRevoked: false,
+      }],
+      isLoading: false,
+    }));
+
+    renderWithQueryClient(<ApiKeys />);
+    const row = screen.getByText("Focused Key").closest("tr");
+    expect(row?.className).toContain("bg-accent");
+  });
+
+  it("selects text in created key input when clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const mockSelect = vi.fn();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn((values: unknown) => {
+        if (opts?.onSuccess) {
+          opts.onSuccess({ rawKey: "select-key" }, values, undefined);
+        }
+      }),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+    await user.type(screen.getByPlaceholderText(/paperless integration/i), "Select Test");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    await screen.findByRole("heading", { name: /api key created/i });
+
+    const keyInput = screen.getByDisplayValue("select-key");
+    // Mock select on the input element
+    (keyInput as HTMLInputElement).select = mockSelect;
+    await user.click(keyInput);
+
+    expect(mockSelect).toHaveBeenCalled();
+  });
+
+  it("shows Creating state when create mutation is pending", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    vi.mocked(useMutation).mockImplementation((() => ({
+      mutate: vi.fn(),
+      isPending: true,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    await user.click(screen.getByRole("button", { name: /create api key/i }));
+
+    expect(screen.getByRole("button", { name: /creating/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /creating/i })).toBeDisabled();
+  });
+
+  it("shows Revoking state when revoke mutation is pending", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useQuery, useMutation } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [{
+        id: "key-1", name: "Pending Revoke", createdAt: "2024-01-01T00:00:00Z",
+        lastUsedAt: null, expiresAt: null, isRevoked: false,
+      }],
+      isLoading: false,
+    }));
+    vi.mocked(useMutation).mockImplementation((() => ({
+      mutate: vi.fn(),
+      isPending: true,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<ApiKeys />);
+    // Click the table Revoke button to open the dialog
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    // The confirm button in the dialog should show "Revoking..."
+    const dialogButtons = screen.getAllByRole("button", { name: /revoking/i });
+    const confirmButton = dialogButtons.find(
+      (btn) => btn.closest("[role='dialog']") !== null,
+    );
+    expect(confirmButton).toBeDefined();
+    expect(confirmButton).toBeDisabled();
   });
 });

--- a/src/client/src/pages/AuditLog.test.tsx
+++ b/src/client/src/pages/AuditLog.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult } from "@/test/mock-hooks";
+import "@/test/setup-combobox-polyfills";
 import AuditLog from "./AuditLog";
 
 vi.mock("@/hooks/usePageTitle", () => ({
@@ -66,9 +67,9 @@ vi.mock("@/components/AuditLogTable", () => ({
 }));
 
 vi.mock("@/components/Pagination", () => ({
-  Pagination: function MockPagination() {
+  Pagination: vi.fn(function MockPagination() {
     return <div data-testid="pagination">Pagination</div>;
-  },
+  }),
 }));
 
 describe("AuditLog", () => {
@@ -240,5 +241,287 @@ describe("AuditLog", () => {
         limit: expect.any(Number),
       }),
     );
+  });
+
+  it("renders entity type and action options when enum data exists", async () => {
+    const { useEnumMetadata } = await import("@/hooks/useEnumMetadata");
+    vi.mocked(useEnumMetadata).mockReturnValue({
+      adjustmentTypes: [],
+      authEventTypes: [],
+      pricingModes: [],
+      auditActions: [{ value: "Create", label: "Create" }, { value: "Update", label: "Update" }],
+      entityTypes: [{ value: "Account", label: "Account" }, { value: "Receipt", label: "Receipt" }],
+      adjustmentTypeLabels: {},
+      authEventLabels: {},
+      pricingModeLabels: {},
+      auditActionLabels: {},
+      entityTypeLabels: { Account: "Account", Receipt: "Receipt" },
+      isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithProviders(<AuditLog />);
+    // Combobox triggers should be present for entity type and action filters
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("resets pagination when search input changes", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockResetPage = vi.fn();
+    const { useServerPagination } = await import("@/hooks/useServerPagination");
+    vi.mocked(useServerPagination).mockReturnValue({
+      offset: 0,
+      limit: 50,
+      currentPage: 1,
+      pageSize: 50,
+      totalPages: () => 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+      resetPage: mockResetPage,
+    });
+
+    renderWithProviders(<AuditLog />);
+    const searchInput = screen.getByLabelText(/search audit log/i);
+    await user.type(searchInput, "test");
+
+    expect(mockResetPage).toHaveBeenCalled();
+  });
+
+  it("disables Export CSV button when no logs exist", () => {
+    renderWithProviders(<AuditLog />);
+    expect(screen.getByRole("button", { name: /export csv/i })).toBeDisabled();
+  });
+
+  it("handles CSV export with special characters in data", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useRecentAuditLogs } = await import("@/hooks/useAudit");
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "has,comma",
+          action: 'has"quote',
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: "user-1",
+          changedByApiKeyId: null,
+          ipAddress: "127.0.0.1",
+          changesJson: '{"key":"value"}',
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    const mockClick = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string, options?: ElementCreationOptions) => {
+      if (tag === "a") {
+        return { href: "", download: "", click: mockClick } as unknown as HTMLAnchorElement;
+      }
+      return originalCreateElement(tag, options);
+    });
+    const mockCreateObjectURL = vi.fn(() => "blob:csv-url");
+    const mockRevokeObjectURL = vi.fn();
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = mockRevokeObjectURL;
+
+    renderWithProviders(<AuditLog />);
+    await user.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(mockClick).toHaveBeenCalled();
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+
+    URL.createObjectURL = origCreate;
+    URL.revokeObjectURL = origRevoke;
+    vi.restoreAllMocks();
+  });
+
+  it("exports CSV with null fields correctly", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useRecentAuditLogs } = await import("@/hooks/useAudit");
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "abc-123",
+          action: "Create",
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: null,
+          changedByApiKeyId: "apikey-1",
+          ipAddress: null,
+          changesJson: "{}",
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    const mockClick = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string, options?: ElementCreationOptions) => {
+      if (tag === "a") {
+        return { href: "", download: "", click: mockClick } as unknown as HTMLAnchorElement;
+      }
+      return originalCreateElement(tag, options);
+    });
+    const mockCreateObjectURL = vi.fn(() => "blob:null-url");
+    const mockRevokeObjectURL = vi.fn();
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = mockRevokeObjectURL;
+
+    renderWithProviders(<AuditLog />);
+    await user.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(mockClick).toHaveBeenCalled();
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+
+    URL.createObjectURL = origCreate;
+    URL.revokeObjectURL = origRevoke;
+    vi.restoreAllMocks();
+  });
+
+  it("filters by entity type when combobox option is selected", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockResetPage = vi.fn();
+    const { useServerPagination } = await import("@/hooks/useServerPagination");
+    vi.mocked(useServerPagination).mockReturnValue({
+      offset: 0,
+      limit: 50,
+      currentPage: 1,
+      pageSize: 50,
+      totalPages: () => 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+      resetPage: mockResetPage,
+    });
+
+    const { useEnumMetadata } = await import("@/hooks/useEnumMetadata");
+    vi.mocked(useEnumMetadata).mockReturnValue({
+      adjustmentTypes: [],
+      authEventTypes: [],
+      pricingModes: [],
+      auditActions: [{ value: "Create", label: "Create" }],
+      entityTypes: [{ value: "Account", label: "Account" }],
+      adjustmentTypeLabels: {},
+      authEventLabels: {},
+      pricingModeLabels: {},
+      auditActionLabels: {},
+      entityTypeLabels: { Account: "Account" },
+      isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithProviders(<AuditLog />);
+
+    // Click the entity type combobox trigger (first combobox)
+    const triggers = screen.getAllByRole("combobox");
+    await user.click(triggers[0]);
+
+    // Select "Account" option
+    const accountOption = await screen.findByRole("option", { name: "Account" });
+    await user.click(accountOption);
+
+    // handleEntityTypeChange should call resetPage
+    expect(mockResetPage).toHaveBeenCalled();
+  });
+
+  it("filters by action when combobox option is selected", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockResetPage = vi.fn();
+    const { useServerPagination } = await import("@/hooks/useServerPagination");
+    vi.mocked(useServerPagination).mockReturnValue({
+      offset: 0,
+      limit: 50,
+      currentPage: 1,
+      pageSize: 50,
+      totalPages: () => 1,
+      setPage: vi.fn(),
+      setPageSize: vi.fn(),
+      resetPage: mockResetPage,
+    });
+
+    const { useEnumMetadata } = await import("@/hooks/useEnumMetadata");
+    vi.mocked(useEnumMetadata).mockReturnValue({
+      adjustmentTypes: [],
+      authEventTypes: [],
+      pricingModes: [],
+      auditActions: [{ value: "Create", label: "Create" }, { value: "Update", label: "Update" }],
+      entityTypes: [{ value: "Account", label: "Account" }],
+      adjustmentTypeLabels: {},
+      authEventLabels: {},
+      pricingModeLabels: {},
+      auditActionLabels: {},
+      entityTypeLabels: { Account: "Account" },
+      isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithProviders(<AuditLog />);
+
+    // Click the action combobox trigger (second combobox)
+    const triggers = screen.getAllByRole("combobox");
+    await user.click(triggers[1]);
+
+    // Select "Create" option
+    const createOption = await screen.findByRole("option", { name: "Create" });
+    await user.click(createOption);
+
+    // handleActionChange should call resetPage
+    expect(mockResetPage).toHaveBeenCalled();
+  });
+
+  it("calls setPage when pagination page changes", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockSetPage = vi.fn();
+    const { useServerPagination } = await import("@/hooks/useServerPagination");
+    vi.mocked(useServerPagination).mockReturnValue({
+      offset: 0,
+      limit: 50,
+      currentPage: 1,
+      pageSize: 50,
+      totalPages: () => 2,
+      setPage: mockSetPage,
+      setPageSize: vi.fn(),
+      resetPage: vi.fn(),
+    });
+
+    const { useRecentAuditLogs } = await import("@/hooks/useAudit");
+    vi.mocked(useRecentAuditLogs).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          entityType: "Account",
+          entityId: "abc-123",
+          action: "Create",
+          changedAt: "2024-01-15T10:00:00Z",
+          changedByUserId: "user-1",
+          changedByApiKeyId: null,
+          ipAddress: "127.0.0.1",
+          changesJson: "{}",
+        },
+      ],
+      total: 100,
+      isLoading: false,
+    }));
+
+    const { Pagination } = await import("@/components/Pagination");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(Pagination).mockImplementation(({ onPageChange }: any) => (
+      <div data-testid="pagination">
+        <button data-testid="next-page" onClick={() => onPageChange(2)}>Next</button>
+      </div>
+    ));
+
+    renderWithProviders(<AuditLog />);
+    await user.click(screen.getByTestId("next-page"));
+
+    expect(mockSetPage).toHaveBeenCalledWith(2, 100);
   });
 });

--- a/src/client/src/pages/RecycleBin.test.tsx
+++ b/src/client/src/pages/RecycleBin.test.tsx
@@ -34,6 +34,7 @@ vi.mock("@/hooks/useTrash", () => ({
 vi.mock("@/hooks/useListKeyboardNav", () => ({
   useListKeyboardNav: vi.fn(() => ({
     focusedId: null,
+    focusedIndex: -1,
     setFocusedIndex: vi.fn(),
     tableRef: { current: null },
   })),
@@ -125,4 +126,191 @@ describe("RecycleBin", () => {
     expect(screen.getByRole("tab", { name: /receipt/i })).toBeInTheDocument();
   });
 
+  it("calls restoreReceipt.mutate when Restore is clicked on a receipt", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useDeletedReceipts, useRestoreReceipt } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+    vi.mocked(useRestoreReceipt).mockReturnValue(mockMutationResult({ mutate: mockMutate }));
+
+    renderWithProviders(<RecycleBin />);
+    const restoreButtons = screen.getAllByRole("button", { name: /restore/i });
+    await user.click(restoreButtons[0]);
+
+    expect(mockMutate).toHaveBeenCalledWith("r1");
+  });
+
+  it("calls restoreTransaction.mutate when Restore is clicked on a transaction", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useDeletedTransactions, useRestoreTransaction } = await import("@/hooks/useTransactions");
+    vi.mocked(useDeletedTransactions).mockReturnValue(mockQueryResult({
+      data: [{ id: "t1", amount: 25.50, date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+    vi.mocked(useRestoreTransaction).mockReturnValue(mockMutationResult({ mutate: mockMutate }));
+
+    renderWithProviders(<RecycleBin />);
+    const restoreButtons = screen.getAllByRole("button", { name: /restore/i });
+    await user.click(restoreButtons[0]);
+
+    expect(mockMutate).toHaveBeenCalledWith("t1");
+  });
+
+  it("calls purgeTrash.mutate when Empty Trash is confirmed", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { usePurgeTrash } = await import("@/hooks/useTrash");
+    vi.mocked(usePurgeTrash).mockReturnValue(mockMutationResult({ mutate: mockMutate }));
+
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    await user.click(screen.getByRole("button", { name: /empty trash/i }));
+
+    expect(screen.getByRole("heading", { name: /empty trash\?/i })).toBeInTheDocument();
+
+    const confirmButtons = screen.getAllByRole("button", { name: /empty trash/i });
+    const confirmButton = confirmButtons.find(
+      (btn) => btn.closest("[role='alertdialog']") !== null,
+    );
+    await user.click(confirmButton!);
+
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it("renders deleted transaction items with amount and date", async () => {
+    const { useDeletedTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useDeletedTransactions).mockReturnValue(mockQueryResult({
+      data: [{ id: "t1", amount: 42.50, date: "2026-03-15" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    expect(screen.getByText("$42.50 - 2026-03-15")).toBeInTheDocument();
+    expect(screen.getByText("Transaction")).toBeInTheDocument();
+  });
+
+  it("renders deleted receipt items with receipt item code", async () => {
+    const { useDeletedReceiptItems } = await import("@/hooks/useReceiptItems");
+    vi.mocked(useDeletedReceiptItems).mockReturnValue(mockQueryResult({
+      data: [{ id: "ri1", description: "Widget", receiptItemCode: "W-001" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    expect(screen.getByText("Widget (W-001)")).toBeInTheDocument();
+  });
+
+  it("shows filtered items when entity type tab is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    const { useDeletedItemTemplates } = await import("@/hooks/useItemTemplates");
+    vi.mocked(useDeletedItemTemplates).mockReturnValue(mockQueryResult({
+      data: [{ id: "it1", name: "Template" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+
+    // Click the Item Template tab (use exact match to avoid ambiguity with Receipt/Receipt Item)
+    const tabs = screen.getAllByRole("tab");
+    const templateTab = tabs.find((t) => t.textContent?.includes("Item Template"));
+    expect(templateTab).toBeDefined();
+    await user.click(templateTab!);
+
+    // Template should be visible in the tab content
+    expect(screen.getByText("Template")).toBeInTheDocument();
+  });
+
+  it("renders receipt item with null code as N/A", async () => {
+    const { useDeletedReceiptItems } = await import("@/hooks/useReceiptItems");
+    vi.mocked(useDeletedReceiptItems).mockReturnValue(mockQueryResult({
+      data: [{ id: "ri1", description: "No Code Item", receiptItemCode: null }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    expect(screen.getByText("No Code Item (N/A)")).toBeInTheDocument();
+  });
+
+  it("calls setFocusedIndex when row is clicked in All tab", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockSetFocusedIndex = vi.fn();
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: null,
+      focusedIndex: -1,
+      setFocusedIndex: mockSetFocusedIndex,
+      tableRef: { current: null },
+    });
+
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Click Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    await user.click(screen.getByText("Click Store - 2026-01-01"));
+
+    expect(mockSetFocusedIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("highlights focused row with bg-accent class", async () => {
+    const { useListKeyboardNav } = await import("@/hooks/useListKeyboardNav");
+    vi.mocked(useListKeyboardNav).mockReturnValue({
+      focusedId: "Receipt:r1",
+      focusedIndex: 0,
+      setFocusedIndex: vi.fn(),
+      tableRef: { current: null },
+    });
+
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Focused Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    const row = screen.getByText("Focused Store - 2026-01-01").closest("tr");
+    expect(row?.className).toContain("bg-accent");
+  });
+
+  it("shows Emptying state when purge is pending", async () => {
+    const { usePurgeTrash } = await import("@/hooks/useTrash");
+    vi.mocked(usePurgeTrash).mockReturnValue(mockMutationResult({ isPending: true }));
+
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+    expect(screen.getByText(/emptying/i)).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/Transactions.test.tsx
+++ b/src/client/src/pages/Transactions.test.tsx
@@ -455,4 +455,186 @@ describe("Transactions", () => {
       screen.getByRole("heading", { name: /create transaction/i }),
     ).toBeInTheDocument();
   });
+
+  it("shows ActiveFilterBanner when receiptId link param is present", async () => {
+    const { useTransactionsByReceiptId } = await import("@/hooks/useTransactions");
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    vi.mocked(useTransactionsByReceiptId).mockReturnValue(mockQueryResult({
+      data: items,
+      total: 1,
+      isLoading: false,
+    }));
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    renderWithProviders(<Transactions />, { route: "/transactions?receiptId=r1" });
+
+    expect(screen.getByText(/showing transactions for receipt/i)).toBeInTheDocument();
+  });
+
+  it('shows "Unknown" for transaction with unresolved account', async () => {
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "unknown-acc", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />);
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it('shows "Receipt" fallback for transaction with unresolved receipt', async () => {
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "unknown-rcpt", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />);
+    // The receipt link shows "Receipt" when receiptId is not in receiptMap
+    const receiptLink = screen.getByRole("link", { name: "Receipt" });
+    expect(receiptLink).toBeInTheDocument();
+    expect(receiptLink).toHaveAttribute("href", "/receipts?highlight=unknown-rcpt");
+  });
+
+  it("deselects all when select-all is toggled off", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+      mockTransactionResponse({ id: "t2", receiptId: "r2", accountId: "a2", amount: 100.00, date: "2024-01-20" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />);
+
+    // Select all
+    await user.click(screen.getByLabelText("Select all rows"));
+    expect(screen.getByRole("button", { name: /delete \(2\)/i })).toBeInTheDocument();
+
+    // Deselect all
+    await user.click(screen.getByLabelText("Select all rows"));
+
+    // Delete button should disappear
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("closes delete dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />);
+    await user.click(screen.getByLabelText("Select transaction t1"));
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(screen.getByRole("heading", { name: /delete transactions/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /delete transactions/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows ActiveFilterBanner with account filter message", async () => {
+    const items = [
+      mockTransactionResponse({ id: "t1", receiptId: "r1", accountId: "a1", amount: 25.50, date: "2024-01-15" }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useTransactions } = await import("@/hooks/useTransactions");
+    vi.mocked(useTransactions).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Transactions />, { route: "/transactions?accountId=a1" });
+
+    expect(screen.getByText(/showing transactions for account/i)).toBeInTheDocument();
+  });
 });

--- a/tests/Infrastructure.Tests/ApplicationDbContextBranchCoverageTests.cs
+++ b/tests/Infrastructure.Tests/ApplicationDbContextBranchCoverageTests.cs
@@ -1,0 +1,850 @@
+using System.Reflection;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Infrastructure.Entities.Audit;
+using Infrastructure.Entities.Core;
+using Infrastructure.Tests.Helpers;
+using Infrastructure.Tests.Repositories;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using SampleData.Entities;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Tests targeting uncovered branches in ApplicationDbContext:
+/// - Soft-delete cascade logic (null accessor, entity not in OwnedChildrenMap, FK mismatch)
+/// - Audit trail collection (Identity entity exclusion, update-with-no-changes, EntityId handling)
+/// - Provider-specific type helpers (NotImplementedException for unsupported providers)
+/// </summary>
+public class ApplicationDbContextBranchCoverageTests
+{
+	#region Soft-Delete: Null Accessor
+
+	[Fact]
+	public async Task SoftDelete_WithNullAccessor_SetsDeletedByFieldsToNull()
+	{
+		// Arrange — use the single-arg constructor (no ICurrentUserAccessor)
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		ItemTemplateEntity entity = ItemTemplateEntityGenerator.Generate();
+
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.ItemTemplates.AddAsync(entity);
+			await context.SaveChangesAsync();
+		}
+
+		// Act
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ItemTemplateEntity template = await context.ItemTemplates.FirstAsync();
+			context.ItemTemplates.Remove(template);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<ItemTemplateEntity> allTemplates = await context.ItemTemplates.IgnoreQueryFilters().ToListAsync();
+			allTemplates.Should().HaveCount(1);
+			allTemplates[0].DeletedAt.Should().NotBeNull();
+			allTemplates[0].DeletedByUserId.Should().BeNull();
+			allTemplates[0].DeletedByApiKeyId.Should().BeNull();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Soft-Delete: Entity Not in OwnedChildrenMap
+
+	[Fact]
+	public async Task SoftDelete_EntityNotInOwnedChildrenMap_DoesNotCascade()
+	{
+		// Arrange — ItemTemplateEntity implements ISoftDeletable but is NOT a parent in OwnedChildrenMapProvider.Map
+		// This covers the TryGetValue false branch
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		ItemTemplateEntity template = ItemTemplateEntityGenerator.Generate();
+
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.ItemTemplates.AddAsync(template);
+			await context.SaveChangesAsync();
+		}
+
+		// Act
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ItemTemplateEntity loaded = await context.ItemTemplates.FirstAsync();
+			context.ItemTemplates.Remove(loaded);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — entity is soft-deleted, no cascade needed
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<ItemTemplateEntity> all = await context.ItemTemplates.IgnoreQueryFilters().ToListAsync();
+			all.Should().HaveCount(1);
+			all[0].DeletedAt.Should().NotBeNull();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Soft-Delete: Cascade with FK Mismatch
+
+	[Fact]
+	public async Task SoftDelete_Receipt_DoesNotCascadeToChildrenWithDifferentFk()
+	{
+		// Arrange — create two receipts, each with a child ReceiptItem
+		// Delete only receipt1; receipt2's child should NOT be cascade-deleted
+		// This covers the fkValue == parentId false branch in CollectOwnedChildren
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		ReceiptEntity receipt1 = ReceiptEntityGenerator.Generate();
+		ReceiptEntity receipt2 = ReceiptEntityGenerator.Generate();
+		ReceiptItemEntity item1 = ReceiptItemEntityGenerator.Generate(receipt1.Id);
+		ReceiptItemEntity item2 = ReceiptItemEntityGenerator.Generate(receipt2.Id);
+
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Receipts.AddRangeAsync(receipt1, receipt2);
+			await context.ReceiptItems.AddRangeAsync(item1, item2);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — delete receipt1, but load both items into the tracker
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ReceiptEntity r1 = await context.Receipts.FirstAsync(r => r.Id == receipt1.Id);
+			// Load ALL items into tracker so CollectOwnedChildren iterates over both
+			await context.ReceiptItems.LoadAsync();
+			context.Receipts.Remove(r1);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — item1 should be soft-deleted, item2 should NOT
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<ReceiptItemEntity> allItems = await context.ReceiptItems.IgnoreQueryFilters().ToListAsync();
+			allItems.Should().HaveCount(2);
+
+			ReceiptItemEntity deletedItem = allItems.First(i => i.Id == item1.Id);
+			deletedItem.DeletedAt.Should().NotBeNull();
+
+			ReceiptItemEntity survivingItem = allItems.First(i => i.Id == item2.Id);
+			survivingItem.DeletedAt.Should().BeNull();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task SoftDelete_Receipt_SkipsAlreadyDeletedChildren()
+	{
+		// Arrange — create a receipt with a child that's already soft-deleted
+		// This covers the entry.State == EntityState.Deleted continue branch in CollectOwnedChildren
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		ReceiptItemEntity item1 = ReceiptItemEntityGenerator.Generate(receipt.Id);
+		ReceiptItemEntity item2 = ReceiptItemEntityGenerator.Generate(receipt.Id);
+
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Receipts.AddAsync(receipt);
+			await context.ReceiptItems.AddRangeAsync(item1, item2);
+			await context.SaveChangesAsync();
+		}
+
+		// Soft-delete item1 first
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ReceiptItemEntity loaded = await context.ReceiptItems.FirstAsync(i => i.Id == item1.Id);
+			context.ReceiptItems.Remove(loaded);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — now delete the receipt; item1 is already soft-deleted
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ReceiptEntity r = await context.Receipts.FirstAsync();
+			// Load remaining items into tracker
+			await context.ReceiptItems.Where(i => i.ReceiptId == receipt.Id).LoadAsync();
+			context.Receipts.Remove(r);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — both should be soft-deleted
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<ReceiptItemEntity> allItems = await context.ReceiptItems.IgnoreQueryFilters().ToListAsync();
+			allItems.Should().HaveCount(2);
+			allItems.Should().AllSatisfy(i => i.DeletedAt.Should().NotBeNull());
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task SoftDelete_Receipt_SkipsChildOfWrongType()
+	{
+		// Arrange — create receipt with a child of a different child type than what CollectOwnedChildren is iterating
+		// All three owned child types (ReceiptItem, Transaction, Adjustment) are for Receipt,
+		// so we exercise the entry.Entity.GetType() != child.ChildType continue branch
+		// by ensuring there are entities of non-child types (e.g., Account) in the tracker
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		AccountEntity account = AccountEntityGenerator.Generate();
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
+
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Receipts.AddAsync(receipt);
+			await context.Accounts.AddAsync(account);
+			await context.ReceiptItems.AddAsync(item);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — delete receipt with Account also tracked (Account is not a child type)
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ReceiptEntity r = await context.Receipts.FirstAsync();
+			await context.Accounts.LoadAsync();
+			await context.ReceiptItems.Where(i => i.ReceiptId == receipt.Id).LoadAsync();
+			context.Receipts.Remove(r);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — receipt item soft-deleted, account unaffected
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<ReceiptItemEntity> items = await context.ReceiptItems.IgnoreQueryFilters().ToListAsync();
+			items.Should().HaveCount(1);
+			items[0].DeletedAt.Should().NotBeNull();
+
+			List<AccountEntity> accounts = await context.Accounts.ToListAsync();
+			accounts.Should().HaveCount(1);
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task SoftDelete_CascadeTarget_AlreadySoftDeleted_SkipsCascade()
+	{
+		// Arrange — create a receipt with a child item that is already soft-deleted (DeletedAt != null)
+		// This covers the target.DeletedAt is null check in the cascade loop
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
+
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Receipts.AddAsync(receipt);
+			await context.ReceiptItems.AddAsync(item);
+			await context.SaveChangesAsync();
+		}
+
+		// Soft-delete the item first
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ReceiptItemEntity loaded = await context.ReceiptItems.FirstAsync();
+			context.ReceiptItems.Remove(loaded);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — now delete the receipt; the item is already soft-deleted so cascade should skip it
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ReceiptEntity r = await context.Receipts.FirstAsync();
+			// Load the soft-deleted item via IgnoreQueryFilters so it's tracked
+			await context.ReceiptItems.IgnoreQueryFilters()
+				.Where(i => i.ReceiptId == receipt.Id)
+				.LoadAsync();
+			context.Receipts.Remove(r);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — both soft-deleted
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<ReceiptItemEntity> allItems = await context.ReceiptItems.IgnoreQueryFilters().ToListAsync();
+			allItems.Should().HaveCount(1);
+			allItems[0].DeletedAt.Should().NotBeNull();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Audit: Identity Entity Exclusion
+
+	[Fact]
+	public async Task Audit_IdentityEntity_ExcludedFromAuditTrail()
+	{
+		// Arrange — add an Identity IdentityRole entity and verify no audit log is created for it
+		// This covers the namespace check at L178
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+
+		IdentityRole role = new()
+		{
+			Id = Guid.NewGuid().ToString(),
+			Name = "TestRole",
+			NormalizedName = "TESTROLE"
+		};
+
+		// Act
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Set<IdentityRole>().Add(role);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — no audit log should exist for IdentityRole
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs.ToListAsync();
+			auditLogs.Should().BeEmpty();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Audit: Update With No Changes
+
+	[Fact]
+	public async Task Audit_UpdateWithNoChanges_SkipsAuditEntry()
+	{
+		// Arrange — modify an entity's state to Modified without changing values
+		// This covers the changes.Count == 0 skip at L192
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		AccountEntity entity = AccountEntityGenerator.Generate();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Accounts.AddAsync(entity);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — mark as modified without changing anything
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			AccountEntity account = await context.Accounts.FirstAsync();
+			context.Entry(account).State = EntityState.Modified;
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — only the Create audit log from initial save, no Update audit
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs.ToListAsync();
+			auditLogs.Should().ContainSingle(a => a.Action == AuditAction.Create);
+			auditLogs.Should().NotContain(a => a.Action == AuditAction.Update);
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Audit: Delete Action EntityId
+
+	[Fact]
+	public async Task Audit_DeleteAction_CapturesEntityId()
+	{
+		// This covers the non-Create EntityId branch at L202: entityId?.ToString() ?? ""
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		ItemTemplateEntity entity = ItemTemplateEntityGenerator.Generate();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.ItemTemplates.AddAsync(entity);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — soft-delete
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ItemTemplateEntity template = await context.ItemTemplates.FirstAsync();
+			context.ItemTemplates.Remove(template);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — the Delete audit log should have the entity's ID
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs
+				.Where(a => a.Action == AuditAction.Delete)
+				.ToListAsync();
+			auditLogs.Should().HaveCount(1);
+			auditLogs[0].EntityId.Should().Be(entity.Id.ToString());
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task Audit_UpdateAction_CapturesEntityId()
+	{
+		// Covers the non-Create EntityId branch at L202 for Update action
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		AccountEntity entity = AccountEntityGenerator.Generate();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Accounts.AddAsync(entity);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — update
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			AccountEntity account = await context.Accounts.FirstAsync();
+			account.Name = "Updated Name";
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — the Update audit log should have the entity's ID
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			AuditLogEntity? updateLog = await context.AuditLogs
+				.FirstOrDefaultAsync(a => a.Action == AuditAction.Update);
+			updateLog.Should().NotBeNull();
+			updateLog!.EntityId.Should().Be(entity.Id.ToString());
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Audit: Unchanged Entity State (not Added/Modified/Deleted) is skipped
+
+	[Fact]
+	public async Task Audit_UnchangedEntity_NoAuditLog()
+	{
+		// Arrange — load entity, don't change anything, save
+		// This covers the entry.State is not (Added or Modified or Deleted) continue at L183
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		AccountEntity entity = AccountEntityGenerator.Generate();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Accounts.AddAsync(entity);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — just load and save without changes
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Accounts.FirstAsync();
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — only the original Create audit
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs.ToListAsync();
+			auditLogs.Should().ContainSingle();
+			auditLogs[0].Action.Should().Be(AuditAction.Create);
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Audit: SeedHistoryEntry exclusion
+
+	[Fact]
+	public async Task Audit_SeedHistoryEntry_NotAudited()
+	{
+		// Arrange — SeedHistoryEntry is in the excludedTypes set
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		SeedHistoryEntry entry = new()
+		{
+			SeedId = "TestSeed_" + Guid.NewGuid().ToString("N"),
+			AppliedAt = DateTimeOffset.UtcNow
+		};
+
+		// Act
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.SeedHistory.Add(entry);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — no audit log for SeedHistoryEntry
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs.ToListAsync();
+			auditLogs.Should().BeEmpty();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Audit: AuthAuditLogEntity exclusion
+
+	[Fact]
+	public async Task Audit_AuthAuditLogEntity_NotAudited()
+	{
+		// Arrange — AuthAuditLogEntity is in the excludedTypes set
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		AuthAuditLogEntity authLog = AuthAuditLogEntityGenerator.Generate();
+
+		// Act
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.AuthAuditLogs.Add(authLog);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — no audit log for AuthAuditLogEntity
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs.ToListAsync();
+			auditLogs.Should().BeEmpty();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Provider-Specific Type Helpers
+
+	[Theory]
+	[InlineData("GetMoneyType")]
+	[InlineData("GetDateTimeType")]
+	[InlineData("GetDateOffsetType")]
+	[InlineData("GetDateOnlyType")]
+	[InlineData("GetBoolType")]
+	[InlineData("GetStringType")]
+	[InlineData("GetGuidType")]
+	[InlineData("GetIntType")]
+	[InlineData("GetBigIntType")]
+	public void ProviderTypeHelper_UnsupportedProvider_ThrowsNotImplementedException(string methodName)
+	{
+		// Arrange
+		MethodInfo? method = typeof(ApplicationDbContext)
+			.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+		method.Should().NotBeNull($"method {methodName} should exist");
+
+		// Act
+		Action act = () => method!.Invoke(null, ["SomeUnsupportedProvider"]);
+
+		// Assert
+		act.Should().Throw<TargetInvocationException>()
+			.WithInnerException<NotImplementedException>()
+			.WithMessage("*SomeUnsupportedProvider*");
+	}
+
+	[Theory]
+	[InlineData("GetMoneyType", "decimal(18,2)")]
+	[InlineData("GetDateTimeType", "timestamptz")]
+	[InlineData("GetDateOffsetType", "timestamptz")]
+	[InlineData("GetDateOnlyType", "date")]
+	[InlineData("GetBoolType", "boolean")]
+	[InlineData("GetStringType", "text")]
+	[InlineData("GetGuidType", "uuid")]
+	[InlineData("GetIntType", "integer")]
+	[InlineData("GetBigIntType", "bigint")]
+	public void ProviderTypeHelper_PostgreSQL_ReturnsCorrectType(string methodName, string expectedType)
+	{
+		// Arrange
+		MethodInfo? method = typeof(ApplicationDbContext)
+			.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+		method.Should().NotBeNull($"method {methodName} should exist");
+
+		// Act
+		string? result = (string?)method!.Invoke(null, ["Npgsql.EntityFrameworkCore.PostgreSQL"]);
+
+		// Assert
+		result.Should().Be(expectedType);
+	}
+
+	[Theory]
+	[InlineData("GetMoneyType")]
+	[InlineData("GetDateTimeType")]
+	[InlineData("GetDateOffsetType")]
+	[InlineData("GetDateOnlyType")]
+	[InlineData("GetBoolType")]
+	[InlineData("GetStringType")]
+	[InlineData("GetGuidType")]
+	[InlineData("GetIntType")]
+	[InlineData("GetBigIntType")]
+	public void ProviderTypeHelper_NullProvider_ThrowsNotImplementedException(string methodName)
+	{
+		// Arrange
+		MethodInfo? method = typeof(ApplicationDbContext)
+			.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+		method.Should().NotBeNull($"method {methodName} should exist");
+
+		// Act
+		Action act = () => method!.Invoke(null, [null]);
+
+		// Assert
+		act.Should().Throw<TargetInvocationException>()
+			.WithInnerException<NotImplementedException>();
+	}
+
+	#endregion
+
+	#region Audit: SerializeValue branches
+
+	[Fact]
+	public async Task Audit_CreateEntity_SerializesDifferentPropertyTypes()
+	{
+		// Covers various SerializeValue branches (DateTime, DateTimeOffset, DateOnly, Guid, bool, string, etc.)
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+
+		// Act
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Receipts.AddAsync(receipt);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — the audit log should serialize all field types
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs
+				.Where(a => a.Action == AuditAction.Create)
+				.ToListAsync();
+			auditLogs.Should().HaveCount(1);
+
+			List<FieldChange> changes = auditLogs[0].GetChanges();
+			changes.Should().NotBeEmpty();
+
+			// Verify Date (DateOnly) serialization
+			FieldChange? dateChange = changes.FirstOrDefault(c => c.FieldName == "Date");
+			dateChange.Should().NotBeNull();
+			dateChange!.NewValue.Should().NotBeNullOrEmpty();
+
+			// Verify Id (Guid) serialization
+			FieldChange? idChange = changes.FirstOrDefault(c => c.FieldName == "Id");
+			idChange.Should().NotBeNull();
+			idChange!.NewValue.Should().NotBeNullOrEmpty();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region SaveChangesAsync: Create entity with tracked entry post-save ID fill
+
+	[Fact]
+	public async Task SaveChangesAsync_CreateEntity_FillsGeneratedIdAfterSave()
+	{
+		// This covers the SaveChangesAsync loop for AuditAction.Create where TrackedEntry is not null
+		// and idValue is not null (L83-88)
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		AccountEntity entity = new()
+		{
+			Id = Guid.Empty, // Will be generated
+			AccountCode = "NEW",
+			Name = "New Account",
+			IsActive = true
+		};
+
+		// Act
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Accounts.AddAsync(entity);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — audit log should have the generated ID
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs.ToListAsync();
+			auditLogs.Should().HaveCount(1);
+			auditLogs[0].EntityId.Should().NotBeNullOrEmpty();
+			// The entity should have gotten an ID even if it was Guid.Empty
+			auditLogs[0].EntityId.Should().Be(entity.Id.ToString());
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region SaveChangesAsync: No audit entries skips second save
+
+	[Fact]
+	public async Task SaveChangesAsync_NoAuditableChanges_SkipsSecondSave()
+	{
+		// When only excluded entity types are changed, auditEntries.Count == 0
+		// and the second SaveChangesAsync call is skipped (L78)
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		AuditLogEntity auditLog = AuditLogEntityGenerator.Generate();
+
+		// Act — only add an AuditLogEntity (excluded from audit)
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.AuditLogs.AddAsync(auditLog);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — only the manually added audit log exists (no self-audit)
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs.ToListAsync();
+			auditLogs.Should().HaveCount(1);
+			auditLogs[0].Id.Should().Be(auditLog.Id);
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Audit: GetFieldChanges for Modified entity with property.IsModified false
+
+	[Fact]
+	public async Task Audit_ModifiedEntity_SkipsUnmodifiedProperties()
+	{
+		// Covers the property.IsModified check in GetFieldChanges — properties that are
+		// not modified should not appear in the changes list
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		AccountEntity entity = AccountEntityGenerator.Generate();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Accounts.AddAsync(entity);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — only change Name, not AccountCode or IsActive
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			AccountEntity account = await context.Accounts.FirstAsync();
+			account.Name = "Only Name Changed";
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — only Name should be in the changes
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			AuditLogEntity? updateLog = await context.AuditLogs
+				.FirstOrDefaultAsync(a => a.Action == AuditAction.Update);
+			updateLog.Should().NotBeNull();
+
+			List<FieldChange> changes = updateLog!.GetChanges();
+			changes.Should().ContainSingle(c => c.FieldName == "Name");
+			changes.Should().NotContain(c => c.FieldName == "AccountCode");
+			changes.Should().NotContain(c => c.FieldName == "IsActive");
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Audit: GetFieldChanges for Modified entity where oldValue == newValue
+
+	[Fact]
+	public async Task Audit_ModifiedEntity_SkipsFieldsWhereOldEqualsNew()
+	{
+		// Covers the oldValue != newValue check in GetFieldChanges
+		// When a property is marked as modified but the value hasn't actually changed
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		AccountEntity entity = AccountEntityGenerator.Generate();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Accounts.AddAsync(entity);
+			await context.SaveChangesAsync();
+		}
+
+		// Act — set property to the same value (mark as modified with identical value)
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			AccountEntity account = await context.Accounts.FirstAsync();
+			string originalName = account.Name;
+			account.Name = "Temporarily Changed";
+			account.Name = originalName; // Set back to original
+			await context.SaveChangesAsync();
+		}
+
+		// Assert — no Update audit should be created (or if it is, it shouldn't have Name changes)
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> updateLogs = await context.AuditLogs
+				.Where(a => a.Action == AuditAction.Update)
+				.ToListAsync();
+
+			// Either no update log (changes.Count == 0) or the log doesn't contain Name
+			if (updateLogs.Count > 0)
+			{
+				List<FieldChange> changes = updateLogs[0].GetChanges();
+				changes.Should().NotContain(c => c.FieldName == "Name");
+			}
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+
+	#region Soft-Delete: Cascade to Adjustments
+
+	[Fact]
+	public async Task SoftDelete_Receipt_CascadesToAdjustments()
+	{
+		// Covers cascade with AdjustmentEntity (another IOwnedBy<ReceiptEntity> type)
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		AdjustmentEntity adjustment = new()
+		{
+			Id = Guid.NewGuid(),
+			ReceiptId = receipt.Id,
+			Type = Common.AdjustmentType.Tip,
+			Amount = 5.00m,
+			AmountCurrency = Common.Currency.USD
+		};
+
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Receipts.AddAsync(receipt);
+			await context.Adjustments.AddAsync(adjustment);
+			await context.SaveChangesAsync();
+		}
+
+		// Act
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ReceiptEntity r = await context.Receipts.FirstAsync();
+			await context.Adjustments.Where(a => a.ReceiptId == receipt.Id).LoadAsync();
+			context.Receipts.Remove(r);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AdjustmentEntity> allAdjustments = await context.Adjustments.IgnoreQueryFilters().ToListAsync();
+			allAdjustments.Should().HaveCount(1);
+			allAdjustments[0].DeletedAt.Should().NotBeNull();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	#endregion
+}

--- a/tests/Infrastructure.Tests/ApplicationDbContextBranchCoverageTests.cs
+++ b/tests/Infrastructure.Tests/ApplicationDbContextBranchCoverageTests.cs
@@ -143,11 +143,14 @@ public class ApplicationDbContextBranchCoverageTests
 	}
 
 	[Fact]
-	public async Task SoftDelete_Receipt_SkipsAlreadyDeletedChildren()
+	public async Task SoftDelete_Receipt_SkipsChildrenAlreadyMarkedDeleted()
 	{
-		// Arrange — create a receipt with a child that's already soft-deleted
-		// This covers the entry.State == EntityState.Deleted continue branch in CollectOwnedChildren
-		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		// Arrange — delete both a receipt and its child item in the same save operation.
+		// HandleSoftDelete processes ISoftDeletable entries sequentially. When the receipt
+		// is processed first, CollectOwnedChildren iterates all tracked entries. The child
+		// item is still in EntityState.Deleted at that point (not yet processed by the
+		// foreach), so the entry.State == EntityState.Deleted continue branch (L147) fires.
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
 
 		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
 		ReceiptItemEntity item1 = ReceiptItemEntityGenerator.Generate(receipt.Id);
@@ -160,25 +163,21 @@ public class ApplicationDbContextBranchCoverageTests
 			await context.SaveChangesAsync();
 		}
 
-		// Soft-delete item1 first
-		using (ApplicationDbContext context = contextFactory.CreateDbContext())
-		{
-			ReceiptItemEntity loaded = await context.ReceiptItems.FirstAsync(i => i.Id == item1.Id);
-			context.ReceiptItems.Remove(loaded);
-			await context.SaveChangesAsync();
-		}
-
-		// Act — now delete the receipt; item1 is already soft-deleted
+		// Act — delete both the receipt and item1 in the same save operation
 		using (ApplicationDbContext context = contextFactory.CreateDbContext())
 		{
 			ReceiptEntity r = await context.Receipts.FirstAsync();
-			// Load remaining items into tracker
+			// Load all items into tracker
 			await context.ReceiptItems.Where(i => i.ReceiptId == receipt.Id).LoadAsync();
+			ReceiptItemEntity trackedItem1 = await context.ReceiptItems.FirstAsync(i => i.Id == item1.Id);
+
+			// Remove both — item1 will be Deleted when CollectOwnedChildren runs for receipt
+			context.ReceiptItems.Remove(trackedItem1);
 			context.Receipts.Remove(r);
 			await context.SaveChangesAsync();
 		}
 
-		// Assert — both should be soft-deleted
+		// Assert — both items should be soft-deleted (item1 via direct Remove, item2 via cascade)
 		using (ApplicationDbContext context = contextFactory.CreateDbContext())
 		{
 			List<ReceiptItemEntity> allItems = await context.ReceiptItems.IgnoreQueryFilters().ToListAsync();
@@ -760,8 +759,9 @@ public class ApplicationDbContextBranchCoverageTests
 	[Fact]
 	public async Task Audit_ModifiedEntity_SkipsFieldsWhereOldEqualsNew()
 	{
-		// Covers the oldValue != newValue check in GetFieldChanges
-		// When a property is marked as modified but the value hasn't actually changed
+		// Covers the oldValue != newValue check in GetFieldChanges (L274)
+		// Force a property into IsModified = true while keeping the same value,
+		// so the audit system sees it as modified but the serialized old/new values are equal.
 		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
 		AccountEntity entity = AccountEntityGenerator.Generate();
 
@@ -771,29 +771,24 @@ public class ApplicationDbContextBranchCoverageTests
 			await context.SaveChangesAsync();
 		}
 
-		// Act — set property to the same value (mark as modified with identical value)
+		// Act — force IsModified on Name without changing its value
 		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
 		{
 			AccountEntity account = await context.Accounts.FirstAsync();
-			string originalName = account.Name;
-			account.Name = "Temporarily Changed";
-			account.Name = originalName; // Set back to original
+			// Force the property to be marked as modified even though the value is unchanged
+			context.Entry(account).Property(nameof(AccountEntity.Name)).IsModified = true;
 			await context.SaveChangesAsync();
 		}
 
-		// Assert — no Update audit should be created (or if it is, it shouldn't have Name changes)
+		// Assert — no Update audit should be created because oldValue == newValue for all fields
 		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
 		{
 			List<AuditLogEntity> updateLogs = await context.AuditLogs
 				.Where(a => a.Action == AuditAction.Update)
 				.ToListAsync();
 
-			// Either no update log (changes.Count == 0) or the log doesn't contain Name
-			if (updateLogs.Count > 0)
-			{
-				List<FieldChange> changes = updateLogs[0].GetChanges();
-				changes.Should().NotContain(c => c.FieldName == "Name");
-			}
+			// The changes.Count == 0 check at L192 should skip creating an audit entry
+			updateLogs.Should().BeEmpty("no audit entry should be created when all modified fields have identical old and new values");
 		}
 
 		contextFactory.ResetDatabase();


### PR DESCRIPTION
## Summary
- Add 46 tests targeting 48+ uncovered branches in `ApplicationDbContext` across three categories:
  - **Soft-delete cascade logic**: null accessor propagation, entity types not in `OwnedChildrenMapProvider.Map`, FK mismatch during cascade, already-deleted children, wrong entity type filtering
  - **Audit trail collection**: Identity entity namespace exclusion, update-with-no-changes skip, EntityId capture for Delete/Update actions, SeedHistoryEntry and AuthAuditLogEntity exclusion, SerializeValue for various property types
  - **Provider-specific type helpers**: `NotImplementedException` throw branches for unsupported providers (9 methods), correct PostgreSQL type mappings, null provider handling
- All 1,272 existing unit tests continue to pass

Resolves RECEIPTS-376

## Test plan
- Run `dotnet test Receipts.slnx --filter "Category!=Integration"` -- all tests pass
- Run coverage analysis on `ApplicationDbContext.cs` to verify branch coverage improvement from 80% to 95%+