### PR TITLE
chore(ci): enforce develop-to-main merge policy

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -14,6 +14,29 @@ env:
   NODE_VERSION: "20"
 
 jobs:
+  source-branch-check:
+    name: Source Branch Policy
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check source branch
+        run: |
+          SOURCE="${{ github.head_ref }}"
+          if [[ "$SOURCE" == "develop" || "$SOURCE" == release-please--* || "$SOURCE" == hotfix/* ]]; then
+            echo "✅ Branch '$SOURCE' is allowed to merge to main."
+          else
+            echo "::error::Branch '$SOURCE' is not allowed to merge directly to main."
+            echo ""
+            echo "Only these branches may target main:"
+            echo "  - develop"
+            echo "  - release-please--*"
+            echo "  - hotfix/*"
+            echo ""
+            echo "Please retarget your PR to 'develop' instead."
+            exit 1
+          fi
+
   pr-title:
     name: Conventional Commits
     if: github.event_name == 'pull_request'

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -21,8 +21,9 @@ jobs:
 
     steps:
       - name: Check source branch
+        env:
+          SOURCE: ${{ github.head_ref }}
         run: |
-          SOURCE="${{ github.head_ref }}"
           if [[ "$SOURCE" == "develop" || "$SOURCE" == release-please--* || "$SOURCE" == hotfix/* ]]; then
             echo "✅ Branch '$SOURCE' is allowed to merge to main."
           else

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,0 +1,41 @@
+name: Sync develop with main
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  sync:
+    name: Create main → develop sync PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if develop is behind main
+        id: check
+        run: |
+          git fetch origin develop
+          BEHIND=$(git rev-list --count origin/develop..origin/main)
+          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
+
+      - name: Create sync PR
+        if: steps.check.outputs.behind != '0'
+        run: |
+          EXISTING=$(gh pr list --base develop --head main --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "Sync PR #$EXISTING already exists — skipping."
+          else
+            gh pr create \
+              --title "chore: sync main into develop" \
+              --body "Automated PR to keep \`develop\` in sync with \`main\` after a release merge." \
+              --base develop \
+              --head main
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create sync PR
         if: steps.check.outputs.behind != '0'
         run: |
-          EXISTING=$(gh pr list --base develop --head main --state open --json number --jq '.[0].number')
+          EXISTING=$(gh pr list --base develop --head main --state open --json number --jq 'if length > 0 then .[0].number | tostring else empty end')
           if [ -n "$EXISTING" ]; then
             echo "Sync PR #$EXISTING already exists — skipping."
           else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ All issue work is tracked in Plane. Project: "Receipts" (identifier: `RECEIPTS`)
 
 ### Branching
 
-Two-tier model: module branches for CI/PR gating, issue branches for individual work. See **[docs/branching.md](docs/branching.md)** for strategy, merge procedures, worktree setup, and directory isolation.
+Two-tier model: module branches for CI/PR gating, issue branches for individual work. **PRs target `develop`, not `main`** — only `develop`, `release-please--*`, and `hotfix/*` branches may merge to `main` (enforced by CI). See **[docs/branching.md](docs/branching.md)** for strategy, merge procedures, worktree setup, and directory isolation.
 
 ### Commits
 

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -1,15 +1,31 @@
 # Branching Strategy
 
-This project uses a hierarchical branching model: **module branches** for CI/PR gating, optional **parent branches** for epics, and **issue branches** for individual work items.
+This project uses a hierarchical branching model with `develop` as the integration branch. Feature work merges into `develop`, and `develop` is promoted to `main` via release cycles.
+
+## Merge Flow
+
+```
+feature/issue branches → develop → main
+                                    ↑
+                          hotfix/* ──┘  (emergency only)
+```
+
+**CI enforces** that only `develop`, `release-please--*`, and `hotfix/*` branches can open PRs to `main`. All other branches must target `develop`.
 
 ## Branch Types
+
+### `develop` — Integration Branch
+
+- All feature/module/parent branches merge into `develop` via PR
+- `develop` is promoted to `main` when a release is cut (via release-please or manual PR)
+- After a release merges to `main`, an automated workflow creates a sync PR (`main → develop`) to keep `develop` up to date
 
 ### Module Branches
 
 One per phase, named `module/phase-N` (e.g., `module/phase-0`):
 - Created when work on a module begins
 - All issue work within that phase merges locally into the module branch
-- When the module is complete, open a **PR from the module branch to `main`**
+- When the module is complete, open a **PR from the module branch to `develop`**
 - The PR triggers CI — this is the safety net that catches issues the agent may have missed
 - After PR merge, delete the module branch
 
@@ -17,28 +33,39 @@ One per phase, named `module/phase-N` (e.g., `module/phase-0`):
 
 When an epic has multiple child issues:
 - Create a parent branch using the epic's identifier (e.g., `feat/receipts-83-description`)
-- Parent branch is created off `main` (or the module branch if one exists)
+- Parent branch is created off `develop` (or the module branch if one exists)
 - Child issue branches are created off the parent branch and squash-merge back into it
-- When all children are complete, the parent branch gets a PR to `main`
-- This keeps related changes grouped and avoids polluting `main` with intermediate work
+- When all children are complete, the parent branch gets a PR to `develop`
+- This keeps related changes grouped and avoids polluting `develop` with intermediate work
 
 ### Issue Branches
 
 One per tracked issue:
-- Branch off the parent branch (if epic) or module branch, NOT `main`
+- Branch off the parent branch (if epic) or module branch, NOT `develop` or `main`
 - Use the issue identifier to form a branch name (e.g., `feat/receipts-123-short-description`)
 - Merge locally into the parent/module branch via squash merge (no PR needed)
 - Delete the issue branch after merge
+
+### Hotfix Branches
+
+For emergency fixes that must bypass `develop`:
+- Branch off `main` as `hotfix/<description>` (e.g., `hotfix/fix-auth-crash`)
+- Open a PR directly to `main`
+- After merge, the sync workflow creates a PR to bring the fix back into `develop`
 
 ### Diagram
 
 ```
 main
-  ├── module/phase-0                                  (PR → main)
+  │
+  ├── (release-please PR from develop)
+  │
+develop
+  ├── module/phase-0                                  (PR → develop)
   │     ├── chore/receipts-90-remove-blazor          (squash-merge into module)
   │     └── fix/receipts-82-update-ci                (squash-merge into module)
   │
-  └── feat/receipts-83-replace-viewmodels            (epic parent, PR → main)
+  └── feat/receipts-83-replace-viewmodels            (epic parent, PR → develop)
         ├── feat/receipts-88-generate-dtos           (squash-merge into parent)
         └── docs/receipts-87-update-docs             (squash-merge into parent)
 ```
@@ -60,33 +87,41 @@ If using a clone for the issue, delete it after merge:
 rm -rf .clones/<branch-name>
 ```
 
-## PR: Parent/Module to Main
+## PR: Parent/Module to develop
 
-When all issues are complete, push the branch and open a PR:
+When all issues are complete, push the branch and open a PR **to `develop`**:
 
 ```bash
 git push -u origin feat/receipts-83-replace-viewmodels
-gh pr create --title "Replace ViewModels with spec-generated DTOs" --body "..."
+gh pr create --base develop --title "Replace ViewModels with spec-generated DTOs" --body "..."
 ```
 
 The PR triggers CI (build + test) — this is the checkpoint that surfaces issues.
 
-After CI passes and the PR is approved, merge into `main`:
+After CI passes and the PR is approved, merge into `develop`:
 
 ```bash
 git branch -d feat/receipts-83-replace-viewmodels
 git push origin --delete feat/receipts-83-replace-viewmodels
-git pull   # update main with the merged PR
+git pull   # update develop with the merged PR
 ```
+
+## Promoting develop to main
+
+When ready for a release:
+1. Release-please (or a manual PR) opens a PR from `develop` to `main`
+2. CI runs; after merge, the `sync-develop` workflow auto-creates a PR to sync any release commits back to `develop`
 
 ## Direct Commits to Main
 
-Only use for non-tracked work like:
+**Do not commit directly to main.** All changes flow through `develop` (or `hotfix/*` for emergencies).
+
+Direct commits to `develop` are acceptable only for non-tracked work like:
 - Trivial typo fixes
 - Documentation updates
 - Tooling/build configuration
 
-**NEVER** commit tracked issue work directly to main. When in doubt, create a branch.
+**NEVER** commit tracked issue work directly to `develop` or `main`. When in doubt, create a branch.
 
 ## Directory Isolation
 

--- a/scripts/worktree-setup.cs
+++ b/scripts/worktree-setup.cs
@@ -87,7 +87,17 @@ return 0;
 
 static async Task<int> RunAsync(string command, string[] arguments, string workingDirectory)
 {
-    ProcessStartInfo psi = new(command, arguments)
+    // On Windows, .cmd/.bat scripts (like npm) require shell execution
+    // since Process.Start with UseShellExecute=false can't resolve them.
+    bool isWindows = OperatingSystem.IsWindows();
+    string resolvedCommand = isWindows && !Path.HasExtension(command) && command != "dotnet" && command != "git"
+        ? "cmd"
+        : command;
+    string[] resolvedArgs = resolvedCommand == "cmd"
+        ? ["/c", command, .. arguments]
+        : arguments;
+
+    ProcessStartInfo psi = new(resolvedCommand, resolvedArgs)
     {
         WorkingDirectory = workingDirectory,
         UseShellExecute = false,


### PR DESCRIPTION
## Summary

- Add `source-branch-check` CI job that blocks PRs to `main` unless they come from `develop`, `release-please--*`, or `hotfix/*`
- Add `sync-develop.yml` workflow to auto-create `main → develop` sync PRs after releases
- Update `docs/branching.md` to document the new `feature → develop → main` flow
- Update `AGENTS.md` branching section to note PRs target `develop`
- Fix `worktree-setup.cs` failing on Windows when `npm` is only available as `npm.cmd`

**Bootstrapping note:** This PR intentionally targets `main` directly. The new `source-branch-check` job will run and _fail_ on this PR (since this branch is not `develop`/`release-please--*`/`hotfix/*`), confirming the check works. It won't block merge because it's not a required status check yet — that happens post-merge via ruleset update.

## Post-merge operational steps

1. Add `Source Branch Policy` as required status check on the `main protection` ruleset (ID 13635502)
2. Rebase `develop` onto `main` to reconcile
3. Verify: test PR from a feature branch to `main` → should be blocked

## Test plan

- [ ] `source-branch-check` job runs and **fails** on this PR (expected — confirms enforcement works)
- [ ] All other CI jobs pass normally
- [ ] After merge + ruleset update: feature branch → main PR is blocked
- [ ] After merge + ruleset update: develop → main PR passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)