### PR TITLE
fix(client): correct LogLevel.None numeric value in SignalR mock

### DIFF
--- a/src/client/src/hooks/useSignalR.test.ts
+++ b/src/client/src/hooks/useSignalR.test.ts
@@ -22,7 +22,7 @@ vi.mock("@microsoft/signalr", () => ({
   HubConnectionBuilder: vi.fn().mockImplementation(function () {
     return mockBuilder;
   }),
-  LogLevel: { Debug: 1, None: 5 },
+  LogLevel: { Debug: 1, Critical: 5, None: 6 },
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -567,7 +567,7 @@ describe("useSignalR", () => {
       await renderEnabled();
 
       // configureLogging should still be called (with LogLevel.None via ternary false branch)
-      expect(mockBuilder.configureLogging).toHaveBeenCalledWith(5); // LogLevel.None
+      expect(mockBuilder.configureLogging).toHaveBeenCalledWith(6); // LogLevel.None
       // No debug output in production
       expect(debugSpy).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## Summary
- Fixed the `@microsoft/signalr` mock in `useSignalR.test.ts` where `LogLevel.None` was mapped to `5` (which is actually `LogLevel.Critical`) instead of the correct value `6`
- Added `Critical: 5` to the mock enum for completeness
- Updated the production-mode test assertion from `5` to `6` to match the corrected mock

Resolves RECEIPTS-389

## Test plan
- All 39 existing tests in `useSignalR.test.ts` pass with the corrected values
- The production-mode test now correctly asserts `configureLogging` is called with `6` (`LogLevel.None`) instead of `5` (`LogLevel.Critical`)