### PR TITLE
feat(client): use native date picker on mobile (RECEIPTS-393)

### DIFF
--- a/src/client/src/components/ui/date-input.test.tsx
+++ b/src/client/src/components/ui/date-input.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef, useState } from "react";
@@ -32,8 +32,26 @@ describe("DateInput", () => {
     onChange: vi.fn(),
   };
 
+  let originalMatchMedia: typeof window.matchMedia;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    originalMatchMedia = window.matchMedia;
+    // Default: desktop (pointer: fine) — existing tests rely on this
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: "(pointer: coarse)",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
   });
 
   it("renders with placeholder when value is empty", () => {
@@ -426,5 +444,98 @@ describe("DateInput", () => {
     await user.tab();
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  describe("touch / mobile path", () => {
+    let originalMatchMedia: typeof window.matchMedia;
+
+    beforeEach(() => {
+      originalMatchMedia = window.matchMedia;
+      window.matchMedia = vi.fn().mockReturnValue({
+        matches: true,
+        media: "(pointer: coarse)",
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      });
+    });
+
+    afterEach(() => {
+      window.matchMedia = originalMatchMedia;
+    });
+
+    it("renders a native date input on touch devices", () => {
+      render(<DateInput {...defaultProps} />);
+
+      const input = screen.getByDisplayValue("");
+      expect(input).toHaveAttribute("type", "date");
+    });
+
+    it("does not render the Popover/Calendar button on touch devices", () => {
+      render(<DateInput {...defaultProps} />);
+
+      expect(
+        screen.queryByRole("button", { name: "Pick a date" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("passes value through as wire format", () => {
+      render(<DateInput {...defaultProps} value="2024-03-15" />);
+
+      const input = screen.getByDisplayValue("2024-03-15");
+      expect(input).toHaveAttribute("type", "date");
+    });
+
+    it("calls onChange with the native input value", () => {
+      const onChange = vi.fn();
+      render(<DateInput value="" onChange={onChange} />);
+
+      const input = document.querySelector('input[type="date"]')!;
+      fireEvent.change(input, { target: { value: "2024-06-15" } });
+
+      expect(onChange).toHaveBeenCalledWith("2024-06-15");
+    });
+
+    it("passes min and max to the native input", () => {
+      render(
+        <DateInput
+          {...defaultProps}
+          min="2024-01-01"
+          max="2024-12-31"
+        />,
+      );
+
+      const input = document.querySelector('input[type="date"]')!;
+      expect(input).toHaveAttribute("min", "2024-01-01");
+      expect(input).toHaveAttribute("max", "2024-12-31");
+    });
+
+    it("disables the native input when disabled", () => {
+      render(<DateInput {...defaultProps} disabled />);
+
+      const input = document.querySelector('input[type="date"]')!;
+      expect(input).toBeDisabled();
+    });
+
+    it("fires onBlur on the native input", () => {
+      const onBlur = vi.fn();
+      render(<DateInput {...defaultProps} onBlur={onBlur} />);
+
+      const input = document.querySelector('input[type="date"]')!;
+      fireEvent.blur(input);
+
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards ref to the native date input", () => {
+      const ref = createRef<HTMLInputElement>();
+      render(<DateInput {...defaultProps} ref={ref} />);
+
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+      expect(ref.current?.type).toBe("date");
+    });
   });
 });

--- a/src/client/src/components/ui/date-input.test.tsx
+++ b/src/client/src/components/ui/date-input.test.tsx
@@ -447,10 +447,9 @@ describe("DateInput", () => {
   });
 
   describe("touch / mobile path", () => {
-    let originalMatchMedia: typeof window.matchMedia;
-
+    // Override the outer desktop mock to simulate a touch device.
+    // The outer afterEach restores the real window.matchMedia.
     beforeEach(() => {
-      originalMatchMedia = window.matchMedia;
       window.matchMedia = vi.fn().mockReturnValue({
         matches: true,
         media: "(pointer: coarse)",
@@ -461,10 +460,6 @@ describe("DateInput", () => {
         removeListener: vi.fn(),
         dispatchEvent: vi.fn(),
       });
-    });
-
-    afterEach(() => {
-      window.matchMedia = originalMatchMedia;
     });
 
     it("renders a native date input on touch devices", () => {

--- a/src/client/src/components/ui/date-input.tsx
+++ b/src/client/src/components/ui/date-input.tsx
@@ -6,6 +6,7 @@ import {
   type ComponentProps,
   type Ref,
 } from "react";
+import { useIsTouchDevice } from "@/hooks/useIsTouchDevice";
 import { format, parse, isValid, isAfter, isBefore } from "date-fns";
 import { CalendarIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -94,6 +95,7 @@ export function DateInput({
   disabled,
   ...props
 }: DateInputProps) {
+  const isTouchDevice = useIsTouchDevice();
   const internalRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);
   const [focused, setFocused] = useState(false);
@@ -205,6 +207,28 @@ export function DateInput({
 
   // Convert wire value to Date for the calendar's `selected` prop
   const selectedDate = value ? (tryParseDate(value) ?? undefined) : undefined;
+
+  if (isTouchDevice) {
+    return (
+      <input
+        ref={mergedRef}
+        type="date"
+        data-slot="input"
+        value={value || ""}
+        min={min}
+        max={max}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={onBlur}
+        disabled={disabled}
+        className={cn(
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          className,
+        )}
+        {...props}
+      />
+    );
+  }
 
   return (
     <div className="relative flex items-center">

--- a/src/client/src/hooks/useIsTouchDevice.test.ts
+++ b/src/client/src/hooks/useIsTouchDevice.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useIsTouchDevice } from "./useIsTouchDevice";
+
+type ChangeListener = (event: { matches: boolean }) => void;
+
+function createMockMatchMedia(initialMatches: boolean) {
+  const listeners: ChangeListener[] = [];
+  let matches = initialMatches;
+
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: "(pointer: coarse)",
+    addEventListener: vi.fn((_event: string, cb: ChangeListener) => {
+      listeners.push(cb);
+    }),
+    removeEventListener: vi.fn((_event: string, cb: ChangeListener) => {
+      const idx = listeners.indexOf(cb);
+      if (idx >= 0) listeners.splice(idx, 1);
+    }),
+    // Not used but required by MediaQueryList interface
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+
+  return {
+    mql,
+    listeners,
+    setMatches(value: boolean) {
+      matches = value;
+      for (const cb of listeners) cb({ matches: value });
+    },
+    matchMedia: vi.fn(() => mql),
+  };
+}
+
+describe("useIsTouchDevice", () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("returns false when pointer is not coarse", () => {
+    const mock = createMockMatchMedia(false);
+    window.matchMedia = mock.matchMedia as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useIsTouchDevice());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when pointer is coarse", () => {
+    const mock = createMockMatchMedia(true);
+    window.matchMedia = mock.matchMedia as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useIsTouchDevice());
+    expect(result.current).toBe(true);
+  });
+
+  it("updates when the media query changes", () => {
+    const mock = createMockMatchMedia(false);
+    window.matchMedia = mock.matchMedia as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useIsTouchDevice());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      mock.setMatches(true);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      mock.setMatches(false);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("cleans up the listener on unmount", () => {
+    const mock = createMockMatchMedia(false);
+    window.matchMedia = mock.matchMedia as unknown as typeof window.matchMedia;
+
+    const { unmount } = renderHook(() => useIsTouchDevice());
+    expect(mock.mql.addEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function),
+    );
+
+    unmount();
+    expect(mock.mql.removeEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function),
+    );
+  });
+});

--- a/src/client/src/hooks/useIsTouchDevice.ts
+++ b/src/client/src/hooks/useIsTouchDevice.ts
@@ -1,0 +1,25 @@
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(pointer: coarse)";
+
+function subscribe(onStoreChange: () => void): () => void {
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener("change", onStoreChange);
+  return () => mql.removeEventListener("change", onStoreChange);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+/**
+ * Returns `true` when the primary pointer is coarse (touch device).
+ * Reacts to changes (e.g. detaching a tablet keyboard).
+ */
+export function useIsTouchDevice(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/client/src/test/setup.ts
+++ b/src/client/src/test/setup.ts
@@ -1,6 +1,21 @@
 /// <reference types="vitest/globals" />
 import "@testing-library/jest-dom/vitest";
 
+// Polyfill matchMedia for jsdom (used by useIsTouchDevice hook)
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}
+
 // Polyfill localStorage for jsdom environments where it's not properly initialized
 if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.setItem !== 'function') {
   const store: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- Detect touch devices via `(pointer: coarse)` media query using a new `useIsTouchDevice` hook built on `useSyncExternalStore`
- On touch devices, render a native `<input type="date">` instead of the Radix Popover + react-day-picker calendar, eliminating the jarring popover flip caused by Floating UI on mobile
- Desktop path is completely unchanged — existing behavior preserved

Resolves RECEIPTS-393

## Test plan
- 4 new tests for `useIsTouchDevice` hook (true/false/change/cleanup)
- 8 new tests for DateInput touch path (native input renders, no popover, value/onChange/min/max/disabled/onBlur/ref)
- All 28 existing desktop DateInput tests pass unchanged (jsdom defaults to non-touch)
- Run: `npx --prefix src/client vitest run src/client/src/hooks/useIsTouchDevice.test.ts src/client/src/components/ui/date-input.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)