### PR TITLE
fix: add atomic composite receipt creation endpoint (RECEIPTS-394)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -971,6 +971,31 @@ paths:
         "404":
           description: Not Found
 
+  /api/receipts/complete:
+    post:
+      operationId: CreateCompleteReceipt
+      tags: [Receipts]
+      summary: Create a receipt with transactions and items atomically
+      description: >
+        Creates a receipt along with its transactions and items in a single
+        atomic operation. If any part fails, nothing is persisted.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCompleteReceiptRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompleteReceiptResponse"
+
   /api/receipts/batch:
     post:
       operationId: CreateReceipts
@@ -3162,6 +3187,36 @@ components:
         limit:
           type: integer
           format: int32
+
+    CreateCompleteReceiptRequest:
+      type: object
+      required: [receipt, transactions, items]
+      properties:
+        receipt:
+          $ref: "#/components/schemas/CreateReceiptRequest"
+        transactions:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateTransactionRequest"
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateReceiptItemRequest"
+
+    CompleteReceiptResponse:
+      type: object
+      required: [receipt, transactions, items]
+      properties:
+        receipt:
+          $ref: "#/components/schemas/ReceiptResponse"
+        transactions:
+          type: array
+          items:
+            $ref: "#/components/schemas/TransactionResponse"
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ReceiptItemResponse"
 
     # ── Receipt Item ─────────────────────────────
 

--- a/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommand.cs
+++ b/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommand.cs
@@ -1,0 +1,26 @@
+using Application.Interfaces;
+
+namespace Application.Commands.Receipt.CreateComplete;
+
+public record CreateCompleteReceiptCommand : ICommand<CreateCompleteReceiptResult>
+{
+	public Domain.Core.Receipt Receipt { get; }
+	public IReadOnlyList<Domain.Core.Transaction> Transactions { get; }
+	public IReadOnlyList<Domain.Core.ReceiptItem> Items { get; }
+
+	public const string ReceiptCannotBeNull = "Receipt cannot be null.";
+
+	public CreateCompleteReceiptCommand(
+		Domain.Core.Receipt receipt,
+		List<Domain.Core.Transaction> transactions,
+		List<Domain.Core.ReceiptItem> items)
+	{
+		ArgumentNullException.ThrowIfNull(receipt, nameof(receipt));
+		ArgumentNullException.ThrowIfNull(transactions, nameof(transactions));
+		ArgumentNullException.ThrowIfNull(items, nameof(items));
+
+		Receipt = receipt;
+		Transactions = transactions.AsReadOnly();
+		Items = items.AsReadOnly();
+	}
+}

--- a/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommand.cs
+++ b/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommand.cs
@@ -8,8 +8,6 @@ public record CreateCompleteReceiptCommand : ICommand<CreateCompleteReceiptResul
 	public IReadOnlyList<Domain.Core.Transaction> Transactions { get; }
 	public IReadOnlyList<Domain.Core.ReceiptItem> Items { get; }
 
-	public const string ReceiptCannotBeNull = "Receipt cannot be null.";
-
 	public CreateCompleteReceiptCommand(
 		Domain.Core.Receipt receipt,
 		List<Domain.Core.Transaction> transactions,

--- a/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandHandler.cs
+++ b/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandHandler.cs
@@ -1,0 +1,43 @@
+using Application.Interfaces.Services;
+using Domain.Aggregates;
+using FluentValidation;
+using FluentValidation.Results;
+using MediatR;
+
+namespace Application.Commands.Receipt.CreateComplete;
+
+public class CreateCompleteReceiptCommandHandler(
+	ICompleteReceiptService completeReceiptService) : IRequestHandler<CreateCompleteReceiptCommand, CreateCompleteReceiptResult>
+{
+	public async Task<CreateCompleteReceiptResult> Handle(CreateCompleteReceiptCommand request, CancellationToken cancellationToken)
+	{
+		if (request.Transactions.Count > 0 && request.Items.Count > 0)
+		{
+			ReceiptWithItems receiptWithItems = new()
+			{
+				Receipt = request.Receipt,
+				Items = [.. request.Items],
+				Adjustments = []
+			};
+
+			decimal expectedTotal = receiptWithItems.ExpectedTotal.Amount;
+			decimal transactionTotal = request.Transactions.Sum(t => t.Amount.Amount);
+
+			if (expectedTotal != transactionTotal)
+			{
+				throw new ValidationException(
+				[
+					new ValidationFailure("Transactions",
+						string.Format(Trip.BalanceEquationViolation,
+							expectedTotal, transactionTotal))
+				]);
+			}
+		}
+
+		return await completeReceiptService.CreateAsync(
+			request.Receipt,
+			[.. request.Transactions],
+			[.. request.Items],
+			cancellationToken);
+	}
+}

--- a/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandHandler.cs
+++ b/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandHandler.cs
@@ -11,7 +11,7 @@ public class CreateCompleteReceiptCommandHandler(
 {
 	public async Task<CreateCompleteReceiptResult> Handle(CreateCompleteReceiptCommand request, CancellationToken cancellationToken)
 	{
-		if (request.Transactions.Count > 0 && request.Items.Count > 0)
+		if (request.Transactions.Count > 0)
 		{
 			ReceiptWithItems receiptWithItems = new()
 			{

--- a/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptResult.cs
+++ b/src/Application/Commands/Receipt/CreateComplete/CreateCompleteReceiptResult.cs
@@ -1,0 +1,6 @@
+namespace Application.Commands.Receipt.CreateComplete;
+
+public record CreateCompleteReceiptResult(
+	Domain.Core.Receipt Receipt,
+	List<Domain.Core.Transaction> Transactions,
+	List<Domain.Core.ReceiptItem> Items);

--- a/src/Application/Interfaces/Services/ICompleteReceiptService.cs
+++ b/src/Application/Interfaces/Services/ICompleteReceiptService.cs
@@ -1,0 +1,12 @@
+using Application.Commands.Receipt.CreateComplete;
+
+namespace Application.Interfaces.Services;
+
+public interface ICompleteReceiptService
+{
+	Task<CreateCompleteReceiptResult> CreateAsync(
+		Domain.Core.Receipt receipt,
+		List<Domain.Core.Transaction> transactions,
+		List<Domain.Core.ReceiptItem> items,
+		CancellationToken cancellationToken);
+}

--- a/src/Infrastructure/Services/CompleteReceiptService.cs
+++ b/src/Infrastructure/Services/CompleteReceiptService.cs
@@ -1,0 +1,61 @@
+using Application.Commands.Receipt.CreateComplete;
+using Application.Interfaces.Services;
+using Domain.Core;
+using Infrastructure.Entities.Core;
+using Infrastructure.Mapping;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Services;
+
+public class CompleteReceiptService(
+	IDbContextFactory<ApplicationDbContext> contextFactory,
+	ReceiptMapper receiptMapper,
+	TransactionMapper transactionMapper,
+	ReceiptItemMapper receiptItemMapper) : ICompleteReceiptService
+{
+	public async Task<CreateCompleteReceiptResult> CreateAsync(
+		Receipt receipt,
+		List<Transaction> transactions,
+		List<ReceiptItem> items,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		// Map receipt and pre-generate ID for FK assignment
+		ReceiptEntity receiptEntity = receiptMapper.ToEntity(receipt);
+		receiptEntity.Id = Guid.NewGuid();
+
+		// Map transactions, assigning FK and AccountId
+		List<TransactionEntity> transactionEntities = transactions.Select(t =>
+		{
+			TransactionEntity entity = transactionMapper.ToEntity(t);
+			entity.Id = Guid.NewGuid();
+			entity.ReceiptId = receiptEntity.Id;
+			entity.AccountId = t.AccountId;
+			return entity;
+		}).ToList();
+
+		// Map receipt items, assigning FK
+		List<ReceiptItemEntity> itemEntities = items.Select(i =>
+		{
+			ReceiptItemEntity entity = receiptItemMapper.ToEntity(i);
+			entity.Id = Guid.NewGuid();
+			entity.ReceiptId = receiptEntity.Id;
+			return entity;
+		}).ToList();
+
+		// Add all to context and persist in a single SaveChangesAsync (implicit transaction)
+		context.Set<ReceiptEntity>().Add(receiptEntity);
+		context.Set<TransactionEntity>().AddRange(transactionEntities);
+		context.Set<ReceiptItemEntity>().AddRange(itemEntities);
+
+		await context.SaveChangesAsync(cancellationToken);
+
+		// Map back to domain
+		Receipt createdReceipt = receiptMapper.ToDomain(receiptEntity);
+		List<Transaction> createdTransactions = transactionEntities.Select(transactionMapper.ToDomain).ToList();
+		List<ReceiptItem> createdItems = itemEntities.Select(receiptItemMapper.ToDomain).ToList();
+
+		return new CreateCompleteReceiptResult(createdReceipt, createdTransactions, createdItems);
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -119,6 +119,7 @@ public static class InfrastructureService
 			.AddScoped<ITransactionService, TransactionService>()
 			.AddScoped<IAdjustmentService, AdjustmentService>()
 			.AddScoped<IReceiptItemService, ReceiptItemService>()
+			.AddScoped<ICompleteReceiptService, CompleteReceiptService>()
 			.AddScoped<IItemTemplateService, ItemTemplateService>()
 			.AddScoped<IItemTemplateSimilarityService, ItemTemplateSimilarityService>()
 			.AddScoped<IReceiptRepository, ReceiptRepository>()

--- a/src/Presentation/API/Controllers/Core/ReceiptsController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptsController.cs
@@ -2,6 +2,7 @@ using API.Generated.Dtos;
 using API.Mapping.Core;
 using API.Services;
 using Application.Commands.Receipt.Create;
+using Application.Commands.Receipt.CreateComplete;
 using Application.Commands.Receipt.Delete;
 using Application.Commands.Receipt.Restore;
 using Application.Commands.Receipt.Update;
@@ -24,12 +25,15 @@ namespace API.Controllers.Core;
 public class ReceiptsController(
 	IMediator mediator,
 	ReceiptMapper mapper,
+	TransactionMapper transactionMapper,
+	ReceiptItemMapper receiptItemMapper,
 	ILogger<ReceiptsController> logger,
 	IEntityChangeNotifier notifier) : ControllerBase
 {
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
 	public const string RouteCreate = "";
+	public const string RouteCreateComplete = "complete";
 	public const string RouteCreateBatch = "batch";
 	public const string RouteUpdate = "{id}";
 	public const string RouteUpdateBatch = "batch";
@@ -138,6 +142,36 @@ public class ReceiptsController(
 		List<Receipt> receipts = await mediator.Send(command);
 		ReceiptResponse response = mapper.ToResponse(receipts[0]);
 		await notifier.NotifyCreated("receipt", receipts[0].Id);
+		return TypedResults.Ok(response);
+	}
+
+	[HttpPost(RouteCreateComplete)]
+	[EndpointSummary("Create a receipt with transactions and items atomically")]
+	[EndpointDescription("Creates a receipt along with its transactions and items in a single atomic operation. If any part fails, nothing is persisted.")]
+	public async Task<Ok<CompleteReceiptResponse>> CreateCompleteReceipt([FromBody] CreateCompleteReceiptRequest model)
+	{
+		Receipt receipt = mapper.ToDomain(model.Receipt);
+
+		List<Transaction> transactions = [.. model.Transactions.Select(m =>
+		{
+			Transaction t = transactionMapper.ToDomain(m);
+			t.AccountId = m.AccountId;
+			return t;
+		})];
+
+		List<ReceiptItem> items = [.. model.Items.Select(receiptItemMapper.ToDomain)];
+
+		CreateCompleteReceiptCommand command = new(receipt, transactions, items);
+		CreateCompleteReceiptResult result = await mediator.Send(command);
+
+		CompleteReceiptResponse response = new()
+		{
+			Receipt = mapper.ToResponse(result.Receipt),
+			Transactions = [.. result.Transactions.Select(transactionMapper.ToResponse)],
+			Items = [.. result.Items.Select(receiptItemMapper.ToResponse)],
+		};
+
+		await notifier.NotifyCreated("receipt", result.Receipt.Id);
 		return TypedResults.Ok(response);
 	}
 

--- a/src/client/src/hooks/useReceipts.ts
+++ b/src/client/src/hooks/useReceipts.ts
@@ -129,6 +129,38 @@ export function useDeletedReceipts(offset = 0, limit = 50, sortBy?: string | nul
   return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
 }
 
+export function useCreateCompleteReceipt() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: {
+      receipt: { location: string; date: string; taxAmount: number };
+      transactions: { amount: number; date: string; accountId: string }[];
+      items: {
+        receiptItemCode: string;
+        description: string;
+        quantity: number;
+        unitPrice: number;
+        category: string;
+        subcategory: string;
+        pricingMode: "quantity" | "flat";
+      }[];
+    }) => {
+      const { data, error } = await client.POST("/api/receipts/complete", { body });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["receipts"] });
+      queryClient.invalidateQueries({ queryKey: ["transactions"] });
+      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
+      toast.success("Receipt created");
+    },
+    onError: () => {
+      toast.error("Failed to create receipt");
+    },
+  });
+}
+
 export function useRestoreReceipt() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/client/src/hooks/useReceipts.ts
+++ b/src/client/src/hooks/useReceipts.ts
@@ -153,10 +153,6 @@ export function useCreateCompleteReceipt() {
       queryClient.invalidateQueries({ queryKey: ["receipts"] });
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
-      toast.success("Receipt created");
-    },
-    onError: () => {
-      toast.error("Failed to create receipt");
     },
   });
 }

--- a/src/client/src/pages/wizard/NewReceipt.test.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.test.tsx
@@ -10,25 +10,11 @@ vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
 }));
 
-const mockCreateReceiptAsync = vi.fn();
-const mockCreateTransactionsBatchAsync = vi.fn();
-const mockCreateReceiptItemsBatchAsync = vi.fn();
+const mockCreateCompleteReceiptAsync = vi.fn();
 
 vi.mock("@/hooks/useReceipts", () => ({
-  useCreateReceipt: vi.fn(() =>
-    mockMutationResult({ mutateAsync: mockCreateReceiptAsync }),
-  ),
-}));
-
-vi.mock("@/hooks/useTransactions", () => ({
-  useCreateTransactionsBatch: vi.fn(() =>
-    mockMutationResult({ mutateAsync: mockCreateTransactionsBatchAsync }),
-  ),
-}));
-
-vi.mock("@/hooks/useReceiptItems", () => ({
-  useCreateReceiptItemsBatch: vi.fn(() =>
-    mockMutationResult({ mutateAsync: mockCreateReceiptItemsBatchAsync }),
+  useCreateCompleteReceipt: vi.fn(() =>
+    mockMutationResult({ mutateAsync: mockCreateCompleteReceiptAsync }),
   ),
 }));
 
@@ -145,9 +131,11 @@ vi.mock("./Step4Review", () => ({
 describe("NewReceipt", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateReceiptAsync.mockResolvedValue({ id: "receipt-123" });
-    mockCreateTransactionsBatchAsync.mockResolvedValue([]);
-    mockCreateReceiptItemsBatchAsync.mockResolvedValue([]);
+    mockCreateCompleteReceiptAsync.mockResolvedValue({
+      receipt: { id: "receipt-123" },
+      transactions: [],
+      items: [],
+    });
     // Reset configurable mock data
     step2TransactionData = [
       { id: "t1", accountId: "acct-1", amount: 55, date: "2024-01-15" },
@@ -337,41 +325,31 @@ describe("NewReceipt", () => {
     await user.click(screen.getByText("Submit Receipt"));
 
     await vi.waitFor(() => {
-      expect(mockCreateReceiptAsync).toHaveBeenCalledWith(
+      expect(mockCreateCompleteReceiptAsync).toHaveBeenCalledWith(
         {
-          location: "Walmart",
-          date: "2024-01-15",
-          taxAmount: 5,
+          receipt: {
+            location: "Walmart",
+            date: "2024-01-15",
+            taxAmount: 5,
+          },
+          transactions: [
+            { accountId: "acct-1", amount: 55, date: "2024-01-15" },
+          ],
+          items: [
+            {
+              receiptItemCode: "",
+              description: "Milk",
+              quantity: 1,
+              unitPrice: 50,
+              category: "Food",
+              subcategory: "",
+              pricingMode: "quantity",
+            },
+          ],
         },
         { onSuccess: undefined, onError: undefined },
       );
     });
-
-    expect(mockCreateTransactionsBatchAsync).toHaveBeenCalledWith(
-      {
-        receiptId: "receipt-123",
-        body: [{ accountId: "acct-1", amount: 55, date: "2024-01-15" }],
-      },
-      { onSuccess: undefined, onError: undefined },
-    );
-
-    expect(mockCreateReceiptItemsBatchAsync).toHaveBeenCalledWith(
-      {
-        receiptId: "receipt-123",
-        body: [
-          {
-            receiptItemCode: "",
-            description: "Milk",
-            quantity: 1,
-            unitPrice: 50,
-            category: "Food",
-            subcategory: "",
-            pricingMode: "quantity",
-          },
-        ],
-      },
-      { onSuccess: undefined, onError: undefined },
-    );
 
     expect(toast.success).toHaveBeenCalledWith(
       "Receipt created successfully!",
@@ -383,7 +361,9 @@ describe("NewReceipt", () => {
 
   it("shows error toast when submission fails", async () => {
     const { toast } = await import("sonner");
-    mockCreateReceiptAsync.mockRejectedValueOnce(new Error("Server error"));
+    mockCreateCompleteReceiptAsync.mockRejectedValueOnce(
+      new Error("Server error"),
+    );
     const user = userEvent.setup();
     renderWithProviders(<NewReceipt />);
 
@@ -397,12 +377,12 @@ describe("NewReceipt", () => {
 
     await vi.waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        "Failed to create receipt. The receipt may have been partially created — check the receipts list.",
+        "Failed to create receipt.",
       );
     });
   });
 
-  it("skips transaction batch when no transactions", async () => {
+  it("sends empty transactions array when no transactions", async () => {
     const user = userEvent.setup();
 
     // Configure Step2 to return empty transactions
@@ -416,14 +396,14 @@ describe("NewReceipt", () => {
     await user.click(screen.getByText("Submit Receipt"));
 
     await vi.waitFor(() => {
-      expect(mockCreateReceiptAsync).toHaveBeenCalled();
+      expect(mockCreateCompleteReceiptAsync).toHaveBeenCalled();
     });
 
-    // Transaction batch should NOT be called since there are no transactions
-    expect(mockCreateTransactionsBatchAsync).not.toHaveBeenCalled();
+    const call = mockCreateCompleteReceiptAsync.mock.calls[0][0];
+    expect(call.transactions).toEqual([]);
   });
 
-  it("skips item batch when no items", async () => {
+  it("sends empty items array when no items", async () => {
     const user = userEvent.setup();
 
     // Configure Step3 to return empty items
@@ -437,16 +417,16 @@ describe("NewReceipt", () => {
     await user.click(screen.getByText("Submit Receipt"));
 
     await vi.waitFor(() => {
-      expect(mockCreateReceiptAsync).toHaveBeenCalled();
+      expect(mockCreateCompleteReceiptAsync).toHaveBeenCalled();
     });
 
-    // Items batch should NOT be called since there are no items
-    expect(mockCreateReceiptItemsBatchAsync).not.toHaveBeenCalled();
+    const call = mockCreateCompleteReceiptAsync.mock.calls[0][0];
+    expect(call.items).toEqual([]);
   });
 
   it("disables submit button while submitting", async () => {
     // Make the receipt creation hang
-    mockCreateReceiptAsync.mockImplementation(
+    mockCreateCompleteReceiptAsync.mockImplementation(
       () => new Promise(() => {}), // Never resolves
     );
     const user = userEvent.setup();

--- a/src/client/src/pages/wizard/NewReceipt.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.tsx
@@ -1,9 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { useCreateReceipt } from "@/hooks/useReceipts";
-import { useCreateTransactionsBatch } from "@/hooks/useTransactions";
-import { useCreateReceiptItemsBatch } from "@/hooks/useReceiptItems";
+import { useCreateCompleteReceipt } from "@/hooks/useReceipts";
 import { useWizard } from "./useWizard";
 import { WizardStepper } from "./WizardStepper";
 import { Step1TripDetails } from "./Step1TripDetails";
@@ -42,9 +40,7 @@ export default function NewReceipt() {
   const [showDiscard, setShowDiscard] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { mutateAsync: createReceiptAsync } = useCreateReceipt();
-  const { mutateAsync: createTransactionsBatchAsync } = useCreateTransactionsBatch();
-  const { mutateAsync: createReceiptItemsBatchAsync } = useCreateReceiptItemsBatch();
+  const { mutateAsync: createCompleteReceiptAsync } = useCreateCompleteReceipt();
 
   const hasData =
     state.receipt.location !== "" ||
@@ -75,70 +71,42 @@ export default function NewReceipt() {
   const handleSubmit = useCallback(async () => {
     setIsSubmitting(true);
     try {
-      // 1. Create the receipt
-      const receipt = await createReceiptAsync(
+      const result = await createCompleteReceiptAsync(
         {
-          location: state.receipt.location,
-          date: state.receipt.date,
-          taxAmount: state.receipt.taxAmount,
+          receipt: {
+            location: state.receipt.location,
+            date: state.receipt.date,
+            taxAmount: state.receipt.taxAmount,
+          },
+          transactions: state.transactions.map((txn) => ({
+            accountId: txn.accountId,
+            amount: txn.amount,
+            date: txn.date,
+          })),
+          items: state.items.map((item) => ({
+            receiptItemCode: item.receiptItemCode,
+            description: item.description,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            category: item.category,
+            subcategory: item.subcategory,
+            pricingMode: item.pricingMode,
+          })),
         },
         { onSuccess: undefined, onError: undefined },
       );
 
-      const receiptId = (receipt as { id: string }).id;
-
-      // 2. Create transactions in batch
-      if (state.transactions.length > 0) {
-        await createTransactionsBatchAsync(
-          {
-            receiptId,
-            body: state.transactions.map((txn) => ({
-              accountId: txn.accountId,
-              amount: txn.amount,
-              date: txn.date,
-            })),
-          },
-          { onSuccess: undefined, onError: undefined },
-        );
-      }
-
-      // 3. Create receipt items in batch
-      if (state.items.length > 0) {
-        await createReceiptItemsBatchAsync(
-          {
-            receiptId,
-            body: state.items.map((item) => ({
-              receiptItemCode: item.receiptItemCode,
-              description: item.description,
-              quantity: item.quantity,
-              unitPrice: item.unitPrice,
-              category: item.category,
-              subcategory: item.subcategory,
-              pricingMode: item.pricingMode,
-            })),
-          },
-          { onSuccess: undefined, onError: undefined },
-        );
-      }
+      const receiptId = (result as { receipt: { id: string } }).receipt.id;
 
       toast.success("Receipt created successfully!");
       reset();
       navigate(`/receipt-detail?id=${receiptId}&highlight=${receiptId}`);
     } catch {
-      toast.error(
-        "Failed to create receipt. The receipt may have been partially created — check the receipts list.",
-      );
+      toast.error("Failed to create receipt.");
     } finally {
       setIsSubmitting(false);
     }
-  }, [
-    state,
-    createReceiptAsync,
-    createTransactionsBatchAsync,
-    createReceiptItemsBatchAsync,
-    reset,
-    navigate,
-  ]);
+  }, [state, createCompleteReceiptAsync, reset, navigate]);
 
   return (
     <div className="space-y-6">

--- a/tests/Application.Tests/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandHandlerTests.cs
@@ -107,11 +107,34 @@ public class CreateCompleteReceiptCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task Handle_WithTransactionsButNoItems_DelegatesToService()
+	public async Task Handle_WithTransactionsButNoItems_Unbalanced_ThrowsValidationException()
 	{
-		// Arrange: transactions but no items — balance check skipped since no items
-		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
-		List<Domain.Core.Transaction> transactions = TransactionGenerator.GenerateList(1);
+		// Arrange: no items means ExpectedTotal = TaxAmount ($10), but transaction is $100
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate(); // TaxAmount = $10
+		List<Domain.Core.Transaction> transactions = TransactionGenerator.GenerateList(1); // Amount = $100
+
+		CreateCompleteReceiptCommand command = new(receipt, transactions, []);
+
+		// Act & Assert — $100 != $10, should throw
+		await Assert.ThrowsAsync<ValidationException>(() =>
+			_handler.Handle(command, CancellationToken.None));
+
+		_mockService.Verify(s => s.CreateAsync(
+			It.IsAny<Domain.Core.Receipt>(),
+			It.IsAny<List<Domain.Core.Transaction>>(),
+			It.IsAny<List<Domain.Core.ReceiptItem>>(),
+			It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_WithTransactionsMatchingTaxOnly_NoItems_DelegatesToService()
+	{
+		// Arrange: no items, so ExpectedTotal = TaxAmount ($10); transaction matches
+		Domain.Core.Receipt receipt = new(Guid.NewGuid(), "Test", DateOnly.FromDateTime(DateTime.Now), new Money(10));
+		List<Domain.Core.Transaction> transactions =
+		[
+			new Domain.Core.Transaction(Guid.NewGuid(), new Money(10), DateOnly.FromDateTime(DateTime.Now))
+		];
 		CreateCompleteReceiptResult expectedResult = new(receipt, transactions, []);
 
 		_mockService.Setup(s => s.CreateAsync(

--- a/tests/Application.Tests/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandHandlerTests.cs
@@ -1,0 +1,156 @@
+using Application.Commands.Receipt.CreateComplete;
+using Application.Interfaces.Services;
+using Domain;
+using Domain.Core;
+using FluentAssertions;
+using FluentValidation;
+using Moq;
+using SampleData.Domain.Core;
+
+namespace Application.Tests.Commands.Receipt.CreateComplete;
+
+public class CreateCompleteReceiptCommandHandlerTests
+{
+	private readonly Mock<ICompleteReceiptService> _mockService = new();
+	private readonly CreateCompleteReceiptCommandHandler _handler;
+
+	public CreateCompleteReceiptCommandHandlerTests()
+	{
+		_handler = new CreateCompleteReceiptCommandHandler(_mockService.Object);
+	}
+
+	[Fact]
+	public async Task Handle_WithBalancedTransactions_DelegatesToService()
+	{
+		// Arrange: receipt with $10 tax, 2 items at $5 each = $20 expected total
+		Domain.Core.Receipt receipt = new(Guid.NewGuid(), "Test", DateOnly.FromDateTime(DateTime.Now), new Money(10));
+		List<Domain.Core.ReceiptItem> items = ReceiptItemGenerator.GenerateList(2); // 2 x $5 = $10 subtotal
+		decimal expectedTotal = items.Sum(i => i.TotalAmount.Amount) + receipt.TaxAmount.Amount; // $10 + $10 = $20
+
+		List<Domain.Core.Transaction> transactions =
+		[
+			new Domain.Core.Transaction(Guid.NewGuid(), new Money(expectedTotal), DateOnly.FromDateTime(DateTime.Now))
+		];
+
+		CreateCompleteReceiptResult expectedResult = new(receipt, transactions, items);
+		_mockService.Setup(s => s.CreateAsync(
+				It.IsAny<Domain.Core.Receipt>(),
+				It.IsAny<List<Domain.Core.Transaction>>(),
+				It.IsAny<List<Domain.Core.ReceiptItem>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		CreateCompleteReceiptCommand command = new(receipt, transactions, items);
+
+		// Act
+		CreateCompleteReceiptResult result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+		_mockService.Verify(s => s.CreateAsync(
+			It.IsAny<Domain.Core.Receipt>(),
+			It.IsAny<List<Domain.Core.Transaction>>(),
+			It.IsAny<List<Domain.Core.ReceiptItem>>(),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_WithUnbalancedTransactions_ThrowsValidationException()
+	{
+		// Arrange: items total $10, tax $10, expected $20, but transactions total $15
+		Domain.Core.Receipt receipt = new(Guid.NewGuid(), "Test", DateOnly.FromDateTime(DateTime.Now), new Money(10));
+		List<Domain.Core.ReceiptItem> items = ReceiptItemGenerator.GenerateList(2); // 2 x $5 = $10 subtotal
+		List<Domain.Core.Transaction> transactions =
+		[
+			new Domain.Core.Transaction(Guid.NewGuid(), new Money(15), DateOnly.FromDateTime(DateTime.Now))
+		];
+
+		CreateCompleteReceiptCommand command = new(receipt, transactions, items);
+
+		// Act & Assert
+		await Assert.ThrowsAsync<ValidationException>(() =>
+			_handler.Handle(command, CancellationToken.None));
+
+		_mockService.Verify(s => s.CreateAsync(
+			It.IsAny<Domain.Core.Receipt>(),
+			It.IsAny<List<Domain.Core.Transaction>>(),
+			It.IsAny<List<Domain.Core.ReceiptItem>>(),
+			It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_WithNoTransactionsOrItems_DelegatesToService()
+	{
+		// Arrange: receipt only, no transactions or items — should not validate balance
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
+		CreateCompleteReceiptResult expectedResult = new(receipt, [], []);
+
+		_mockService.Setup(s => s.CreateAsync(
+				It.IsAny<Domain.Core.Receipt>(),
+				It.IsAny<List<Domain.Core.Transaction>>(),
+				It.IsAny<List<Domain.Core.ReceiptItem>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		CreateCompleteReceiptCommand command = new(receipt, [], []);
+
+		// Act
+		CreateCompleteReceiptResult result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+		_mockService.Verify(s => s.CreateAsync(
+			It.IsAny<Domain.Core.Receipt>(),
+			It.IsAny<List<Domain.Core.Transaction>>(),
+			It.IsAny<List<Domain.Core.ReceiptItem>>(),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_WithTransactionsButNoItems_DelegatesToService()
+	{
+		// Arrange: transactions but no items — balance check skipped since no items
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
+		List<Domain.Core.Transaction> transactions = TransactionGenerator.GenerateList(1);
+		CreateCompleteReceiptResult expectedResult = new(receipt, transactions, []);
+
+		_mockService.Setup(s => s.CreateAsync(
+				It.IsAny<Domain.Core.Receipt>(),
+				It.IsAny<List<Domain.Core.Transaction>>(),
+				It.IsAny<List<Domain.Core.ReceiptItem>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		CreateCompleteReceiptCommand command = new(receipt, transactions, []);
+
+		// Act
+		CreateCompleteReceiptResult result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+	}
+
+	[Fact]
+	public async Task Handle_WithItemsButNoTransactions_DelegatesToService()
+	{
+		// Arrange: items but no transactions — balance check skipped since no transactions
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
+		List<Domain.Core.ReceiptItem> items = ReceiptItemGenerator.GenerateList(2);
+		CreateCompleteReceiptResult expectedResult = new(receipt, [], items);
+
+		_mockService.Setup(s => s.CreateAsync(
+				It.IsAny<Domain.Core.Receipt>(),
+				It.IsAny<List<Domain.Core.Transaction>>(),
+				It.IsAny<List<Domain.Core.ReceiptItem>>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		CreateCompleteReceiptCommand command = new(receipt, [], items);
+
+		// Act
+		CreateCompleteReceiptResult result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+	}
+}

--- a/tests/Application.Tests/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/CreateComplete/CreateCompleteReceiptCommandTests.cs
@@ -1,0 +1,94 @@
+using Application.Commands.Receipt.CreateComplete;
+using FluentAssertions;
+using SampleData.Domain.Core;
+
+namespace Application.Tests.Commands.Receipt.CreateComplete;
+
+public class CreateCompleteReceiptCommandTests
+{
+	[Fact]
+	public void Command_WithNullReceipt_ThrowsArgumentNullException()
+	{
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+		Domain.Core.Receipt receipt = null;
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+#pragma warning disable CS8604 // Possible null reference argument.
+		Assert.Throws<ArgumentNullException>(() =>
+			new CreateCompleteReceiptCommand(receipt, [], []));
+#pragma warning restore CS8604 // Possible null reference argument.
+	}
+
+	[Fact]
+	public void Command_WithNullTransactions_ThrowsArgumentNullException()
+	{
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+		List<Domain.Core.Transaction> transactions = null;
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
+#pragma warning disable CS8604 // Possible null reference argument.
+		Assert.Throws<ArgumentNullException>(() =>
+			new CreateCompleteReceiptCommand(receipt, transactions, []));
+#pragma warning restore CS8604 // Possible null reference argument.
+	}
+
+	[Fact]
+	public void Command_WithNullItems_ThrowsArgumentNullException()
+	{
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+		List<Domain.Core.ReceiptItem> items = null;
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
+#pragma warning disable CS8604 // Possible null reference argument.
+		Assert.Throws<ArgumentNullException>(() =>
+			new CreateCompleteReceiptCommand(receipt, [], items));
+#pragma warning restore CS8604 // Possible null reference argument.
+	}
+
+	[Fact]
+	public void Command_WithValidData_SetsProperties()
+	{
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
+		List<Domain.Core.Transaction> transactions = TransactionGenerator.GenerateList(1);
+		List<Domain.Core.ReceiptItem> items = ReceiptItemGenerator.GenerateList(1);
+
+		CreateCompleteReceiptCommand command = new(receipt, transactions, items);
+
+		command.Receipt.Should().BeSameAs(receipt);
+		command.Transactions.Should().BeEquivalentTo(transactions);
+		command.Items.Should().BeEquivalentTo(items);
+	}
+
+	[Fact]
+	public void Command_WithEmptyTransactionsAndItems_Succeeds()
+	{
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
+
+		CreateCompleteReceiptCommand command = new(receipt, [], []);
+
+		command.Receipt.Should().BeSameAs(receipt);
+		command.Transactions.Should().BeEmpty();
+		command.Items.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Transactions_ShouldBeImmutable()
+	{
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
+		List<Domain.Core.Transaction> transactions = TransactionGenerator.GenerateList(2);
+
+		CreateCompleteReceiptCommand command = new(receipt, transactions, []);
+
+		Assert.IsAssignableFrom<IReadOnlyList<Domain.Core.Transaction>>(command.Transactions);
+	}
+
+	[Fact]
+	public void Items_ShouldBeImmutable()
+	{
+		Domain.Core.Receipt receipt = ReceiptGenerator.Generate();
+		List<Domain.Core.ReceiptItem> items = ReceiptItemGenerator.GenerateList(2);
+
+		CreateCompleteReceiptCommand command = new(receipt, [], items);
+
+		Assert.IsAssignableFrom<IReadOnlyList<Domain.Core.ReceiptItem>>(command.Items);
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptsControllerTests.cs
@@ -23,6 +23,8 @@ namespace Presentation.API.Tests.Controllers.Core;
 public class ReceiptsControllerTests
 {
 	private readonly ReceiptMapper _mapper;
+	private readonly TransactionMapper _transactionMapper;
+	private readonly ReceiptItemMapper _receiptItemMapper;
 	private readonly Mock<IMediator> _mediatorMock;
 	private readonly Mock<ILogger<ReceiptsController>> _loggerMock;
 	private readonly Mock<IEntityChangeNotifier> _notifierMock;
@@ -32,10 +34,12 @@ public class ReceiptsControllerTests
 	{
 		_mediatorMock = new Mock<IMediator>();
 		_mapper = new ReceiptMapper();
+		_transactionMapper = new TransactionMapper();
+		_receiptItemMapper = new ReceiptItemMapper();
 		_loggerMock = ControllerTestHelpers.GetLoggerMock<ReceiptsController>();
 		_notifierMock = new Mock<IEntityChangeNotifier>();
 
-		_controller = new ReceiptsController(_mediatorMock.Object, _mapper, _loggerMock.Object, _notifierMock.Object);
+		_controller = new ReceiptsController(_mediatorMock.Object, _mapper, _transactionMapper, _receiptItemMapper, _loggerMock.Object, _notifierMock.Object);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary
- Add `POST /api/receipts/complete` endpoint that atomically creates a receipt with its transactions and items in a single DB transaction, preventing orphan records when downstream calls fail
- Update the wizard (`NewReceipt.tsx`) to use this single composite endpoint instead of 3 sequential API calls
- Add balance equation validation in the command handler (items + tax must equal transaction total)

## Test plan
- [x] `dotnet build Receipts.slnx` compiles
- [x] `dotnet test --filter "Category!=Integration"` — 1,303 backend tests pass (12 new)
- [x] `npx vitest run` — 1,329 frontend tests pass (19 updated)
- [x] `npm run lint:spec` — spec valid
- [x] `npm run check:drift` — no drift
- [ ] Manual: create a receipt via wizard, verify single API call in network tab
- [ ] Manual: verify validation error (balance mismatch) returns 400 with no orphan records

🤖 Generated with [Claude Code](https://claude.com/claude-code)