### PR TITLE
feat(docs): add QA testing skills for smoke, CRUD, and wizard flows

### DIFF
--- a/.claude/skills/qa-crud/SKILL.md
+++ b/.claude/skills/qa-crud/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: qa-crud
+description: >
+  Test CRUD operations for Receipts app entities. Verifies list, create,
+  read, update, validation, and delete flows per entity using agent-browser
+  + Aspire MCP. Produces a per-entity pass/fail report.
+allowed-tools: Bash, Read, Grep, Glob, mcp__aspire__list_resources, mcp__aspire__list_console_logs
+user_invocable: true
+argument: "<entity> | --all — Entity name (accounts, categories, subcategories, item-templates, transactions, receipt-items) or --all for all entities"
+---
+
+# QA CRUD Testing
+
+Test CRUD (Create, Read, Update, Delete) operations for one or all entities in the Receipts app.
+
+**Duration:** ~3 min per entity, ~15 min for `--all`
+
+## Prerequisites
+
+- Aspire must be running (F5 or `dotnet run --project src/Receipts.AppHost`)
+- agent-browser must be installed globally
+
+## References
+
+Before starting, read both reference files:
+- `references/qa-common.md` — Port discovery, login flow, form patterns
+- `references/qa-entity-matrix.md` — Entity fields, test data, dependency order
+
+## Argument Parsing
+
+Parse the argument to determine which entities to test:
+
+| Argument | Entities |
+|----------|----------|
+| `accounts` | accounts only |
+| `categories` | categories only |
+| `subcategories` | subcategories only |
+| `item-templates` | item-templates only |
+| `transactions` | transactions only |
+| `receipt-items` | receipt-items only |
+| `--all` | All entities in dependency order |
+
+**Dependency order** (for `--all`): accounts → categories → subcategories → item-templates → (skip receipts) → transactions → receipt-items
+
+If an unknown entity name is given, list the valid options and abort.
+
+## Phase 1: Port Discovery + Auth
+
+Follow the same process as smoke-test:
+
+1. **Port Discovery:** Call `mcp__aspire__list_console_logs` for `frontend` resource, parse the base URL.
+2. **Login:** Follow the login flow from `qa-common.md` (try `Admin123!@#` first, fall back to `QaTest2024!@#`, handle password change if needed).
+3. **Verify:** Confirm dashboard loads.
+
+## Phase 2: Entity Resolution
+
+Based on the parsed argument, build the list of entities to test. For `--all`, use the dependency order from `qa-entity-matrix.md`.
+
+Warn the user if testing an entity with dependencies (e.g., `subcategories` requires categories to exist).
+
+## Phase 3: CRUD Cycle (Per Entity)
+
+For each entity, perform the following operations. Refer to `qa-entity-matrix.md` for entity-specific field details, test data, and validation expectations.
+
+### 3.1: List (Navigate + Verify Table)
+
+1. Navigate to the entity's route:
+   ```
+   agent-browser open ${BASE_URL}/${entity-route}
+   ```
+2. Wait for load:
+   ```
+   agent-browser wait --load networkidle
+   ```
+3. Snapshot and verify:
+   - H1 matches expected heading
+   - Table structure exists (look for `table`, `columnheader` nodes)
+4. Record: **List — PASS/FAIL**
+
+### 3.2: Create
+
+1. Snapshot to find the "New {Entity}" button:
+   ```
+   agent-browser snapshot -i
+   ```
+2. Click the "New" button (e.g., "New Account", "New Category"):
+   ```
+   agent-browser click @eN
+   ```
+3. Wait for dialog to open, then snapshot:
+   ```
+   agent-browser snapshot -i
+   ```
+4. Verify dialog title matches expected (e.g., "Create Account").
+5. Fill all required fields using test values from `qa-entity-matrix.md`:
+   - For text inputs: `agent-browser fill @eN "value"`
+   - For comboboxes: Click trigger → snapshot → click option
+   - For currency inputs: Try `agent-browser fill` first; use nativeInputValueSetter fallback if needed
+   - For date inputs: `agent-browser fill @eN "YYYY-MM-DD"`
+6. Click the submit/save button:
+   ```
+   agent-browser click @eN
+   ```
+7. Wait for dialog to close:
+   ```
+   agent-browser wait --load networkidle
+   ```
+8. Snapshot and verify:
+   - Dialog closed
+   - Toast message appears (look for success text)
+   - New row appears in table with expected values
+9. Record: **Create — PASS/FAIL**
+
+### 3.3: Read (Verify Created Data)
+
+1. Snapshot the table:
+   ```
+   agent-browser snapshot -i
+   ```
+2. Search the snapshot output for the test values (e.g., "QA-001", "QA Test Account").
+3. Verify the correct values appear in the correct columns.
+4. Record: **Read — PASS/FAIL**
+
+### 3.4: Update
+
+1. Find the Edit button (pencil icon, `aria-label="Edit"`) for the created row:
+   ```
+   agent-browser snapshot -i
+   ```
+   Look for the edit button in the row containing the test data.
+2. Click the Edit button:
+   ```
+   agent-browser click @eN
+   ```
+3. Wait for edit dialog, then snapshot:
+   ```
+   agent-browser snapshot -i
+   ```
+4. Verify the dialog shows "Edit {Entity}" title and pre-filled values.
+5. Change one field to the update value from `qa-entity-matrix.md`:
+   - Clear and fill: `agent-browser fill @eN "new value"`
+6. Click submit/save.
+7. Wait and verify:
+   - Dialog closed
+   - Table row shows updated value
+8. Record: **Update — PASS/FAIL**
+
+### 3.5: Validation
+
+1. Click the "New" button again to open create dialog.
+2. Without filling any fields, click submit immediately.
+3. Snapshot and verify:
+   - Form validation errors appear (look for error messages like "required", "is required")
+   - Dialog stays open (not submitted)
+4. Close the dialog (click Cancel or press Escape):
+   ```
+   agent-browser press Escape
+   ```
+5. Record: **Validation — PASS/FAIL**
+
+### 3.6: Delete (If Applicable)
+
+Only for entities with delete support (item-templates, transactions, receipt-items). See `qa-entity-matrix.md` for which entities support delete.
+
+1. Find the checkbox for the created/updated item:
+   ```
+   agent-browser snapshot -i
+   ```
+2. Check the checkbox:
+   ```
+   agent-browser click @eN
+   ```
+3. Click the "Delete (1)" button:
+   ```
+   agent-browser click @eN
+   ```
+4. Confirm in the delete dialog:
+   ```
+   agent-browser snapshot -i
+   agent-browser click @eN  (the confirm/delete button)
+   ```
+5. Wait and verify:
+   - Item removed from table
+   - Success toast appears
+6. Record: **Delete — PASS/FAIL**
+
+For entities without delete (accounts, categories, subcategories), record: **Delete — N/A**
+
+### 3.7: On Failure
+
+When any operation fails:
+1. Take a screenshot:
+   ```
+   agent-browser screenshot "$TEMP/qa-crud-{entity}-{operation}-fail.png"
+   ```
+2. Continue to the next operation (don't abort the entire entity).
+3. If Create fails, skip Read/Update/Delete (they depend on the created entity).
+
+## Phase 4: Report
+
+Generate and display a markdown report:
+
+```markdown
+# QA CRUD Report
+
+**Date:** YYYY-MM-DD  |  **Base URL:** {BASE_URL}  |  **Result:** {PASS/FAIL}
+
+## Entity: Accounts
+
+| Operation | Status | Details | Screenshot |
+|-----------|--------|---------|------------|
+| List | PASS | H1 "Accounts" found, table rendered | — |
+| Create | PASS | Created QA-001 / QA Test Account | — |
+| Read | PASS | Values verified in table | — |
+| Update | PASS | Updated to QA-001-UPD | — |
+| Validation | PASS | Required field errors shown | — |
+| Delete | N/A | Entity does not support delete | — |
+
+## Entity: Categories
+
+| Operation | Status | Details | Screenshot |
+|-----------|--------|---------|------------|
+| ... | ... | ... | ... |
+
+---
+
+## Summary
+
+| Entity | List | Create | Read | Update | Validation | Delete | Result |
+|--------|------|--------|------|--------|------------|--------|--------|
+| accounts | PASS | PASS | PASS | PASS | PASS | N/A | PASS |
+| categories | PASS | PASS | PASS | PASS | PASS | N/A | PASS |
+| ... | ... | ... | ... | ... | ... | ... | ... |
+
+**Overall: {PASS/FAIL}**
+```
+
+Any single operation FAIL = entity FAIL. Any entity FAIL = overall FAIL.
+
+## Phase 5: Cleanup
+
+```
+agent-browser close
+```
+
+Print summary:
+```
+CRUD tested {N} entities. {P} passed, {F} failed. Overall: {PASS/FAIL}
+```
+
+## Important Rules
+
+- Every `agent-browser` command is a **separate Bash tool call** (no `&&` chaining).
+- Screenshots go to **`$TEMP`** only.
+- Ports are **never hardcoded** — discover via Aspire MCP.
+- After any navigation or dialog open/close, take a fresh snapshot.
+- Use test data prefixed with "QA" to make cleanup easy and avoid conflicts with real data.
+- If a combobox fill doesn't work with `agent-browser fill`, use the click-trigger → snapshot → click-option pattern from `qa-common.md`.

--- a/.claude/skills/qa-crud/references/qa-common.md
+++ b/.claude/skills/qa-crud/references/qa-common.md
@@ -1,0 +1,201 @@
+# QA Common Reference
+
+Shared patterns for all QA skills. Each skill embeds auth inline since agent-browser sessions don't persist across skill invocations.
+
+## Port Discovery
+
+Aspire assigns random ports — never hardcode. Discover the frontend URL before any browser interaction.
+
+### Recipe
+
+1. Call `mcp__aspire__list_console_logs` for the `frontend` resource
+2. Parse logs for the line containing `Local:   http://localhost:XXXX`
+3. Extract the full URL (e.g., `http://localhost:5173`)
+4. Store as `BASE_URL` for the session
+
+If `list_console_logs` returns no output or the frontend resource isn't found, the app is not running. Abort with: "Aspire is not running. Start with F5 or `dotnet run --project src/Receipts.AppHost`."
+
+## Login Flow
+
+### Credentials
+
+| Role  | Email                    | Initial Password | Post-Change Password |
+|-------|--------------------------|------------------|----------------------|
+| Admin | `admin@receipts.local`   | `Admin123!@#`    | `QaTest2024!@#`      |
+
+### Steps
+
+1. Open login page:
+   ```
+   agent-browser open ${BASE_URL}/login
+   ```
+2. Wait for page load:
+   ```
+   agent-browser wait --load networkidle
+   ```
+3. Take snapshot to get form refs:
+   ```
+   agent-browser snapshot -i
+   ```
+4. Fill email field (find the `[input type="email"]` ref):
+   ```
+   agent-browser fill @eN "admin@receipts.local"
+   ```
+5. Fill password field (find the `[input type="password"]` ref):
+   ```
+   agent-browser fill @eN "Admin123!@#"
+   ```
+6. Click the "Sign In" button:
+   ```
+   agent-browser click @eN
+   ```
+7. Wait for navigation:
+   ```
+   agent-browser wait --load networkidle
+   ```
+8. Check current URL:
+   ```
+   agent-browser get url
+   ```
+
+### Password Change Handling
+
+If the URL after login is `/change-password`, the account requires a password reset:
+
+1. Take snapshot to get change-password form refs:
+   ```
+   agent-browser snapshot -i
+   ```
+2. Fill "Current Password":
+   ```
+   agent-browser fill @eN "Admin123!@#"
+   ```
+3. Fill "New Password":
+   ```
+   agent-browser fill @eN "QaTest2024!@#"
+   ```
+4. Fill "Confirm New Password":
+   ```
+   agent-browser fill @eN "QaTest2024!@#"
+   ```
+5. Click "Change Password" button:
+   ```
+   agent-browser click @eN
+   ```
+6. Wait for redirect to dashboard:
+   ```
+   agent-browser wait --load networkidle
+   ```
+
+After password change, use `QaTest2024!@#` for all subsequent logins. If initial login fails with `Admin123!@#`, retry with `QaTest2024!@#` (password may have been changed in a prior session).
+
+### Verifying Auth Success
+
+After login (and optional password change), verify the dashboard loads:
+```
+agent-browser get url
+```
+Expected: URL ends with `/` (dashboard root).
+
+Take a screenshot to confirm:
+```
+agent-browser screenshot "$TEMP/qa-login-success.png"
+```
+
+## Form Fill Patterns
+
+### Standard Text Inputs
+
+Use `agent-browser fill` with the snapshot ref:
+```
+agent-browser fill @eN "value"
+```
+
+### React Controlled Inputs (CurrencyInput, etc.)
+
+If `agent-browser fill` doesn't work (value reverts after React re-render), use the nativeInputValueSetter fallback:
+```
+agent-browser eval "const input = document.querySelector('CSS_SELECTOR'); const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set; nativeSetter.call(input, 'VALUE'); input.dispatchEvent(new Event('input', { bubbles: true }));"
+```
+
+### Combobox Fields (Combobox component)
+
+Comboboxes use a trigger button + popover. To select an option:
+
+1. Click the combobox trigger button (shows as `[button]` with placeholder text):
+   ```
+   agent-browser click @eN
+   ```
+2. Wait for popover to open, then snapshot:
+   ```
+   agent-browser snapshot -i
+   ```
+3. Click the desired option (`[option]` or `[menuitem]` in the list):
+   ```
+   agent-browser click @eN
+   ```
+
+For comboboxes with `allowCustom`, you can type a custom value in the search input that appears after clicking the trigger.
+
+### Date Inputs (DateInput component)
+
+DateInput is a standard `<input type="date">`. Fill with ISO date format:
+```
+agent-browser fill @eN "2026-03-18"
+```
+
+### Checkbox/Switch Toggle
+
+Click the checkbox or switch element:
+```
+agent-browser click @eN
+```
+
+### Form Submission
+
+After filling all fields, click the submit button. Then wait for the response:
+```
+agent-browser click @eN
+agent-browser wait --load networkidle
+```
+
+## Toast Verification
+
+Success toasts appear as `[status]` or `[alert]` nodes in the accessibility tree. After a mutation:
+```
+agent-browser snapshot -i
+```
+Look for toast text like "created successfully" or "updated successfully" in the snapshot output.
+
+## Error Checking
+
+### Console Errors
+
+Check for JavaScript errors:
+```
+agent-browser eval "window.__consoleErrors || []"
+```
+
+Note: This requires prior injection. As an alternative, check the page visually for error boundaries or error alerts.
+
+### Visual Error Detection
+
+Take a screenshot and look for:
+- Red alert banners
+- Error boundary fallback text ("Something went wrong")
+- Blank/white pages (failed to render)
+- Loading spinners that never resolve (take screenshot after waiting)
+
+## Cleanup
+
+Always close the browser at the end of a test run:
+```
+agent-browser close
+```
+
+## Important Rules
+
+- **Separate Bash calls**: Every `agent-browser` command MUST be a separate Bash tool call. Never chain with `&&`.
+- **Screenshots to $TEMP**: Always `agent-browser screenshot "$TEMP/filename.png"`, never to the working directory.
+- **No hardcoded ports**: Always discover via `mcp__aspire__list_console_logs`.
+- **Re-snapshot after navigation**: After any navigation or DOM change, take a fresh `agent-browser snapshot -i` to get updated refs.

--- a/.claude/skills/qa-crud/references/qa-entity-matrix.md
+++ b/.claude/skills/qa-crud/references/qa-entity-matrix.md
@@ -1,0 +1,251 @@
+# Entity CRUD Matrix
+
+Defines the test data, form fields, dependency order, and expected behavior for each entity's CRUD operations.
+
+## Dependency Order
+
+Entities must be created in this order (each depends on prior entities existing):
+
+1. **accounts** — no dependencies
+2. **categories** — no dependencies
+3. **subcategories** — depends on categories
+4. **item-templates** — no dependencies
+5. **receipts** — read-only in list view (created via wizard), skip CRUD
+6. **transactions** — depends on receipts + accounts
+7. **receipt-items** — depends on receipts
+
+When running `--all`, process in this order. When running a single entity, warn if dependencies may not exist.
+
+## Entity Details
+
+### 1. Accounts (`/accounts`)
+
+| Property | Value |
+|----------|-------|
+| H1 | Accounts |
+| New Button | "New Account" |
+| Dialog Title (Create) | Create Account |
+| Dialog Title (Edit) | Edit Account |
+| Has Delete | No (soft-delete via isActive toggle) |
+| Has Select/Bulk | No |
+
+**Create Fields:**
+
+| Label | Type | Test Value | Update Value |
+|-------|------|-----------|--------------|
+| Account Code | text input | `QA-001` | `QA-001-UPD` |
+| Name | text input | `QA Test Account` | `QA Test Account Updated` |
+| Active | checkbox/switch | checked (default) | — |
+
+**Validation:** Submit empty form → expect "Account Code" and "Name" required errors.
+
+**Verify Create:** New row shows `QA-001` in Account Code column and `QA Test Account` in Name column.
+
+**Verify Update:** Row shows updated values.
+
+---
+
+### 2. Categories (`/categories`)
+
+| Property | Value |
+|----------|-------|
+| H1 | Categories |
+| New Button | "New Category" |
+| Dialog Title (Create) | Create Category |
+| Dialog Title (Edit) | Edit Category |
+| Has Delete | No |
+| Has Select/Bulk | No |
+
+**Create Fields:**
+
+| Label | Type | Test Value | Update Value |
+|-------|------|-----------|--------------|
+| Name | text input | `QA Category` | `QA Category Updated` |
+| Description (optional) | text input | `Test category for QA` | `Updated description` |
+
+**Validation:** Submit empty form → expect "Name" required error.
+
+**Verify Create:** New row shows `QA Category` in Name column.
+
+---
+
+### 3. Subcategories (`/subcategories`)
+
+| Property | Value |
+|----------|-------|
+| H1 | Subcategories |
+| New Button | "New Subcategory" |
+| Dialog Title (Create) | Create Subcategory |
+| Dialog Title (Edit) | Edit Subcategory |
+| Has Delete | No |
+| Has Select/Bulk | No |
+
+**Create Fields:**
+
+| Label | Type | Test Value | Update Value |
+|-------|------|-----------|--------------|
+| Name | text input | `QA Subcategory` | `QA Sub Updated` |
+| Category | combobox (select existing) | select first available | — |
+| Description (optional) | text input | `Test subcategory` | `Updated sub desc` |
+
+**Combobox Interaction (Category):**
+1. Click the Category combobox trigger
+2. Snapshot to see options
+3. Click the first option in the list
+
+**Validation:** Submit empty form → expect "Name" and "Category" required errors.
+
+**Verify Create:** Subcategory appears under its category group (may need to click "Expand All" first).
+
+---
+
+### 4. Item Templates (`/item-templates`)
+
+| Property | Value |
+|----------|-------|
+| H1 | Item Templates |
+| New Button | "New Template" |
+| Dialog Title (Create) | Create Item Template |
+| Dialog Title (Edit) | Edit Item Template |
+| Has Delete | Yes (bulk select + "Delete" button) |
+| Has Select/Bulk | Yes (checkboxes) |
+
+**Create Fields:**
+
+| Label | Type | Test Value | Update Value |
+|-------|------|-----------|--------------|
+| Name | text input | `QA Template` | `QA Template Updated` |
+| Description (optional) | text input | `Test template` | — |
+| Default Category (optional) | combobox | — (leave empty) | — |
+| Default Subcategory (optional) | combobox | — (leave empty) | — |
+| Default Unit Price (optional) | currency input | `9.99` | `12.50` |
+| Default Pricing Mode (optional) | combobox | — (leave empty) | — |
+| Default Item Code (optional) | text input | `QA-TMPL` | — |
+
+**Validation:** Submit empty form → expect "Name" required error.
+
+**Verify Create:** New row shows `QA Template` in Name column.
+
+**Delete Flow:**
+1. Check the checkbox for the created template
+2. Click "Delete (1)" button
+3. Confirm in the delete dialog
+4. Verify row is removed from table
+
+---
+
+### 5. Receipts (`/receipts`) — READ ONLY
+
+Receipts are created via the wizard (`/receipts/new`), not through the list page. The receipts list page is read-only.
+
+**Smoke Check:**
+- Navigate to `/receipts`, verify the table renders
+- Verify the H1 says "Receipts"
+- If receipts exist, verify rows show location, date, and tax amount
+
+---
+
+### 6. Transactions (`/transactions`)
+
+| Property | Value |
+|----------|-------|
+| H1 | Transactions |
+| New Button | "New Transaction" |
+| Dialog Title (Create) | Create Transaction |
+| Dialog Title (Edit) | Edit Transaction |
+| Has Delete | Yes (bulk select + "Delete" button) |
+| Has Select/Bulk | Yes (checkboxes) |
+
+**Prerequisites:** At least one receipt and one account must exist.
+
+**Create Fields:**
+
+| Label | Type | Test Value | Update Value |
+|-------|------|-----------|--------------|
+| Receipt | combobox | select first available | — |
+| Account | combobox | select first available | — |
+| Amount | currency input | `25.50` | `30.00` |
+| Date | date input | today's date (YYYY-MM-DD) | — |
+
+**Combobox Interaction (Receipt & Account):** Same pattern as subcategory — click trigger, snapshot, click option.
+
+**Validation:** Submit empty form → expect required field errors.
+
+**Verify Create:** New row shows amount `$25.50` and the selected account/receipt.
+
+**Delete Flow:**
+1. Check the checkbox for the created transaction
+2. Click "Delete (1)" button
+3. Confirm deletion
+4. Verify row removed
+
+---
+
+### 7. Receipt Items (`/receipt-items`)
+
+| Property | Value |
+|----------|-------|
+| H1 | Receipt Items |
+| New Button | "New Item" |
+| Dialog Title (Create) | Create Receipt Item |
+| Dialog Title (Edit) | Edit Receipt Item |
+| Has Delete | Yes (bulk select + "Delete" button) |
+| Has Select/Bulk | Yes (checkboxes) |
+
+**Prerequisites:** At least one receipt must exist.
+
+**Create Fields:**
+
+| Label | Type | Test Value | Update Value |
+|-------|------|-----------|--------------|
+| Receipt | combobox | select first available | — |
+| Item Code | text input | `QA-ITEM-1` | `QA-ITEM-UPD` |
+| Description | text input | `QA Test Item` | `QA Item Updated` |
+| Pricing Mode | combobox | `Quantity` | — |
+| Quantity | number input | `2` | `3` |
+| Unit Price | currency input | `10.00` | `15.00` |
+| Category | combobox | select first available | — |
+| Subcategory | combobox (optional) | — (leave empty) | — |
+
+**Validation:** Submit empty form → expect "Description", "Category", "Receipt" required errors.
+
+**Verify Create:** New row shows `QA Test Item` in Description, `$10.00` in Unit Price, `2` in Qty.
+
+**Delete Flow:**
+1. Check the checkbox for the created item
+2. Click "Delete (1)" button
+3. Confirm deletion
+4. Verify row removed
+
+## Common Patterns
+
+### Opening Create Dialog
+
+All entity pages use a "New {Entity}" button in the top-right area:
+```
+agent-browser snapshot -i
+```
+Find the button with text like "New Account", "New Category", etc. Click it.
+
+### Edit Flow
+
+1. Find the pencil icon button (aria-label="Edit") in the row
+2. Click it to open the Edit dialog
+3. Modify one field
+4. Click the submit button (usually "Save" or "Update")
+5. Verify the table row updates
+
+### Verifying Table Content
+
+After create/update, the table should reflect changes. Take a snapshot:
+```
+agent-browser snapshot -i
+```
+Search the output for the expected values (e.g., "QA-001", "QA Test Account").
+
+### Toast Messages
+
+After successful create/update/delete, look for toast messages in the snapshot:
+- Create: "created successfully" or similar
+- Update: "updated successfully" or similar
+- Delete: "deleted successfully" or similar

--- a/.claude/skills/qa-wizard/SKILL.md
+++ b/.claude/skills/qa-wizard/SKILL.md
@@ -1,0 +1,465 @@
+---
+name: qa-wizard
+description: >
+  End-to-end test of the 4-step receipt creation wizard, admin flows
+  (audit log, recycle bin, user management), and error handling.
+  Uses agent-browser + Aspire MCP. Produces a comprehensive pass/fail report.
+allowed-tools: Bash, Read, Grep, Glob, mcp__aspire__list_resources, mcp__aspire__list_console_logs
+user_invocable: true
+argument: ""
+---
+
+# QA Wizard Testing
+
+End-to-end test of the receipt creation wizard, admin-only features, and error handling flows.
+
+**Duration:** ~5 minutes
+
+## Prerequisites
+
+- Aspire must be running (F5 or `dotnet run --project src/Receipts.AppHost`)
+- agent-browser must be installed globally
+- At least one account and one category must exist (for the wizard to reference). If not, create them first via `/qa-crud accounts` and `/qa-crud categories`.
+
+## References
+
+Before starting, read the reference file:
+- `references/qa-common.md` — Port discovery, login flow, form patterns
+
+## Phase 1: Port Discovery + Auth
+
+1. **Port Discovery:** Call `mcp__aspire__list_console_logs` for `frontend` resource, parse the base URL.
+2. **Login:** Follow the login flow from `qa-common.md` (try `Admin123!@#` first, fall back to `QaTest2024!@#`, handle password change if needed).
+3. **Verify:** Confirm dashboard loads.
+
+## Phase 2: Wizard Happy Path
+
+Navigate through all 4 steps of the receipt creation wizard.
+
+### Step 1: Trip Details
+
+1. Navigate to the wizard:
+   ```
+   agent-browser open ${BASE_URL}/receipts/new
+   ```
+2. Wait and snapshot:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser snapshot -i
+   ```
+3. Verify:
+   - H1 says "New Receipt"
+   - Card title says "Trip Details"
+   - Stepper shows Step 1 as active
+
+4. Fill **Location** (Combobox with `allowCustom`):
+   - Click the Location combobox trigger button
+   - Snapshot to see the popover
+   - Type a custom value in the search input: `agent-browser fill @eN "QA Store"`
+   - The combobox should show "QA Store" as a custom option or accept it
+   - If there's a create/select option for "QA Store", click it; otherwise press Enter
+
+5. Fill **Date** (DateInput):
+   ```
+   agent-browser fill @eN "2026-03-18"
+   ```
+
+6. Fill **Tax Amount** (CurrencyInput):
+   - Try `agent-browser fill @eN "1.50"` first
+   - If the value doesn't stick, use the nativeInputValueSetter pattern from `qa-common.md`
+
+7. Click **Next** button:
+   ```
+   agent-browser click @eN
+   ```
+
+8. Wait and verify Step 2 loads:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser snapshot -i
+   ```
+   Verify card title says "Transactions".
+
+9. Record: **Step 1 — PASS/FAIL**
+
+### Step 2: Transactions
+
+1. Fill **Account** (Combobox — select existing):
+   - Click the Account combobox trigger
+   - Snapshot to see options
+   - Click the first available account option
+
+2. Fill **Amount** (CurrencyInput):
+   - Fill with `11.50`
+
+3. Fill **Date** (DateInput — should be pre-filled with receipt date):
+   - Verify it's pre-filled; if not, fill with `2026-03-18`
+
+4. Click **Add Transaction** button:
+   ```
+   agent-browser click @eN
+   ```
+
+5. Verify the transaction appears in the table below the form:
+   ```
+   agent-browser snapshot -i
+   ```
+   Look for the account name and `$11.50` in the table.
+
+6. Click **Next** button:
+   ```
+   agent-browser click @eN
+   ```
+
+7. Verify Step 3 loads (card title: "Line Items").
+
+8. Record: **Step 2 — PASS/FAIL**
+
+### Step 3: Line Items
+
+1. Fill **Item Code** (optional, text input):
+   ```
+   agent-browser fill @eN "QA-1"
+   ```
+
+2. Fill **Description** (text input with autocomplete popover):
+   ```
+   agent-browser fill @eN "QA Test Item"
+   ```
+   - If a suggestions popover appears, dismiss it by pressing Escape or clicking elsewhere:
+     ```
+     agent-browser press Escape
+     ```
+
+3. Fill **Quantity** (number input — should default to 1):
+   - Verify it shows `1`; if not, fill with `1`
+
+4. Fill **Unit Price** (CurrencyInput):
+   - Fill with `10.00`
+
+5. Fill **Category** (Combobox):
+   - Click the Category combobox trigger
+   - Snapshot to see options
+   - Click the first available category
+
+6. Skip **Subcategory** (optional).
+
+7. Click **Add Item** button:
+   ```
+   agent-browser click @eN
+   ```
+
+8. Verify the item appears in the table:
+   ```
+   agent-browser snapshot -i
+   ```
+   Look for "QA Test Item" and `$10.00` in the table.
+
+9. Click **Next** button:
+   ```
+   agent-browser click @eN
+   ```
+
+10. Verify Step 4 loads (review step).
+
+11. Record: **Step 3 — PASS/FAIL**
+
+### Step 4: Review & Submit
+
+1. Snapshot the review page:
+   ```
+   agent-browser snapshot -i
+   ```
+
+2. Verify review data:
+   - Location: "QA Store"
+   - Date: "2026-03-18" (or formatted equivalent)
+   - Tax: "$1.50"
+   - Transaction: account name, $11.50
+   - Item: "QA Test Item", qty 1, $10.00
+
+3. Click **Submit** (or "Create Receipt") button:
+   ```
+   agent-browser click @eN
+   ```
+
+4. Wait for redirect:
+   ```
+   agent-browser wait --load networkidle
+   ```
+
+5. Check URL:
+   ```
+   agent-browser get url
+   ```
+   Expected: URL contains `/receipt-detail?id=`
+
+6. Verify receipt detail page loads:
+   ```
+   agent-browser snapshot
+   ```
+   Look for "Receipt Details" heading.
+
+7. Screenshot:
+   ```
+   agent-browser screenshot "$TEMP/qa-wizard-receipt-created.png"
+   ```
+
+8. Record: **Step 4 / Submit — PASS/FAIL**
+
+## Phase 3: Wizard Cancel/Discard
+
+1. Navigate to wizard again:
+   ```
+   agent-browser open ${BASE_URL}/receipts/new
+   ```
+
+2. Wait and snapshot:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser snapshot -i
+   ```
+
+3. Fill the Location field with something (to trigger "has data" state):
+   - Click Location combobox, type "Discard Test"
+
+4. Click the **X** (close/cancel) button in the top-right:
+   ```
+   agent-browser snapshot -i
+   agent-browser click @eN  (the X button with sr-only "Cancel")
+   ```
+
+5. Verify the discard confirmation dialog appears:
+   ```
+   agent-browser snapshot -i
+   ```
+   Look for "Discard receipt?" title and "Continue editing" / "Discard" buttons.
+
+6. Click **Discard**:
+   ```
+   agent-browser click @eN
+   ```
+
+7. Wait and verify redirect to `/receipts`:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser get url
+   ```
+   Expected: URL ends with `/receipts`
+
+8. Record: **Cancel/Discard — PASS/FAIL**
+
+## Phase 4: Admin Flows
+
+Test admin-only features.
+
+### 4.1: Audit Log
+
+1. Navigate to audit log:
+   ```
+   agent-browser open ${BASE_URL}/audit
+   ```
+
+2. Wait and snapshot:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser snapshot
+   ```
+
+3. Verify:
+   - H1 says "Audit Log"
+   - Table with audit entries renders
+   - Look for entries related to the receipt created in Phase 2
+
+4. Record: **Audit Log — PASS/FAIL**
+
+### 4.2: Recycle Bin
+
+1. First, soft-delete a receipt to test with. Navigate to the receipts list and find one with a delete option. If no delete option is available on the list page, navigate to a receipt detail and look for a delete button there.
+
+   Alternative approach if direct delete isn't available:
+   - Soft-delete a receipt item via `/receipt-items` (check a checkbox, click Delete, confirm)
+   - Then verify it appears in the recycle bin
+
+2. Navigate to recycle bin:
+   ```
+   agent-browser open ${BASE_URL}/trash
+   ```
+
+3. Wait and snapshot:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser snapshot
+   ```
+
+4. Verify:
+   - H1 says "Recycle Bin"
+   - Page renders with tabs for different entity types
+   - Look for the soft-deleted item
+
+5. If a deleted item is found, test restore:
+   - Find the restore button for the item
+   - Click it
+   - Verify the item is removed from the trash list
+
+6. Record: **Recycle Bin — PASS/FAIL**
+
+### 4.3: User Management
+
+1. Navigate to user management:
+   ```
+   agent-browser open ${BASE_URL}/admin/users
+   ```
+
+2. Wait and snapshot:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser snapshot
+   ```
+
+3. Verify:
+   - H1 says "User Management"
+   - Table of users renders
+   - Admin user (`admin@receipts.local`) appears in the list
+
+4. Record: **User Management — PASS/FAIL**
+
+## Phase 5: Error Handling
+
+### 5.1: 404 Page
+
+1. Navigate to a non-existent route:
+   ```
+   agent-browser open ${BASE_URL}/this-does-not-exist
+   ```
+
+2. Wait and snapshot:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser snapshot
+   ```
+
+3. Verify:
+   - "Page Not Found" heading appears
+   - Page renders without JS errors
+
+4. Record: **404 Page — PASS/FAIL**
+
+### 5.2: Unauthorized Redirect
+
+1. Clear auth:
+   ```
+   agent-browser eval "localStorage.clear(); sessionStorage.clear();"
+   ```
+
+2. Navigate to protected route:
+   ```
+   agent-browser open ${BASE_URL}/receipts
+   ```
+
+3. Wait and check:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser get url
+   ```
+
+4. Verify redirect to `/login`.
+
+5. Record: **Unauth Redirect — PASS/FAIL**
+
+### 5.3: Wizard Validation
+
+1. Log back in (follow login flow from `qa-common.md` using `QaTest2024!@#` or `Admin123!@#`).
+
+2. Navigate to wizard:
+   ```
+   agent-browser open ${BASE_URL}/receipts/new
+   ```
+
+3. Wait and snapshot:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser snapshot -i
+   ```
+
+4. Without filling any fields, click **Next**:
+   ```
+   agent-browser click @eN  (the Next button)
+   ```
+
+5. Snapshot and verify validation errors appear:
+   ```
+   agent-browser snapshot -i
+   ```
+   Look for "Location is required", "Date is required" error messages.
+
+6. Record: **Wizard Validation — PASS/FAIL**
+
+## Phase 6: Report
+
+Generate and display a comprehensive markdown report:
+
+```markdown
+# QA Wizard Report
+
+**Date:** YYYY-MM-DD  |  **Base URL:** {BASE_URL}  |  **Result:** {PASS/FAIL}
+
+## Wizard Happy Path
+
+| Phase | Status | Details | Screenshot |
+|-------|--------|---------|------------|
+| Step 1: Trip Details | PASS | Location, date, tax filled | — |
+| Step 2: Transactions | PASS | Transaction added ($11.50) | — |
+| Step 3: Line Items | PASS | Item added (QA Test Item, $10.00) | — |
+| Step 4: Review & Submit | PASS | Receipt created, redirected to detail | $TEMP/qa-wizard-receipt-created.png |
+
+## Wizard Cancel/Discard
+
+| Test | Status | Details |
+|------|--------|---------|
+| Cancel with data | PASS | Discard dialog shown, redirected to /receipts |
+
+## Admin Flows
+
+| Feature | Status | Details |
+|---------|--------|---------|
+| Audit Log | PASS | Entries rendered, wizard actions found |
+| Recycle Bin | PASS | Deleted items shown, restore works |
+| User Management | PASS | User list rendered, admin visible |
+
+## Error Handling
+
+| Test | Status | Details |
+|------|--------|---------|
+| 404 Page | PASS | "Page Not Found" rendered |
+| Unauth Redirect | PASS | Redirected to /login |
+| Wizard Validation | PASS | Required field errors shown |
+
+## Summary
+
+- Wizard: {N}/{N} steps passed
+- Admin: {N}/{N} flows passed
+- Error handling: {N}/{N} tests passed
+
+**Overall: {PASS/FAIL}**
+```
+
+## Phase 7: Cleanup
+
+```
+agent-browser close
+```
+
+Print summary:
+```
+QA wizard: {steps_passed} wizard steps, {admin_passed} admin flows, {error_passed} error tests. Overall: {PASS/FAIL}
+```
+
+## Important Rules
+
+- Every `agent-browser` command is a **separate Bash tool call** (no `&&` chaining).
+- Screenshots go to **`$TEMP`** only.
+- Ports are **never hardcoded** — discover via Aspire MCP.
+- After any navigation or form interaction, take a fresh snapshot.
+- The wizard creates real data (receipts, transactions, items). This is expected for QA testing.
+- If the wizard submit fails due to missing accounts/categories, note it in the report and suggest running `/qa-crud accounts` and `/qa-crud categories` first.

--- a/.claude/skills/qa-wizard/references/qa-common.md
+++ b/.claude/skills/qa-wizard/references/qa-common.md
@@ -1,0 +1,201 @@
+# QA Common Reference
+
+Shared patterns for all QA skills. Each skill embeds auth inline since agent-browser sessions don't persist across skill invocations.
+
+## Port Discovery
+
+Aspire assigns random ports — never hardcode. Discover the frontend URL before any browser interaction.
+
+### Recipe
+
+1. Call `mcp__aspire__list_console_logs` for the `frontend` resource
+2. Parse logs for the line containing `Local:   http://localhost:XXXX`
+3. Extract the full URL (e.g., `http://localhost:5173`)
+4. Store as `BASE_URL` for the session
+
+If `list_console_logs` returns no output or the frontend resource isn't found, the app is not running. Abort with: "Aspire is not running. Start with F5 or `dotnet run --project src/Receipts.AppHost`."
+
+## Login Flow
+
+### Credentials
+
+| Role  | Email                    | Initial Password | Post-Change Password |
+|-------|--------------------------|------------------|----------------------|
+| Admin | `admin@receipts.local`   | `Admin123!@#`    | `QaTest2024!@#`      |
+
+### Steps
+
+1. Open login page:
+   ```
+   agent-browser open ${BASE_URL}/login
+   ```
+2. Wait for page load:
+   ```
+   agent-browser wait --load networkidle
+   ```
+3. Take snapshot to get form refs:
+   ```
+   agent-browser snapshot -i
+   ```
+4. Fill email field (find the `[input type="email"]` ref):
+   ```
+   agent-browser fill @eN "admin@receipts.local"
+   ```
+5. Fill password field (find the `[input type="password"]` ref):
+   ```
+   agent-browser fill @eN "Admin123!@#"
+   ```
+6. Click the "Sign In" button:
+   ```
+   agent-browser click @eN
+   ```
+7. Wait for navigation:
+   ```
+   agent-browser wait --load networkidle
+   ```
+8. Check current URL:
+   ```
+   agent-browser get url
+   ```
+
+### Password Change Handling
+
+If the URL after login is `/change-password`, the account requires a password reset:
+
+1. Take snapshot to get change-password form refs:
+   ```
+   agent-browser snapshot -i
+   ```
+2. Fill "Current Password":
+   ```
+   agent-browser fill @eN "Admin123!@#"
+   ```
+3. Fill "New Password":
+   ```
+   agent-browser fill @eN "QaTest2024!@#"
+   ```
+4. Fill "Confirm New Password":
+   ```
+   agent-browser fill @eN "QaTest2024!@#"
+   ```
+5. Click "Change Password" button:
+   ```
+   agent-browser click @eN
+   ```
+6. Wait for redirect to dashboard:
+   ```
+   agent-browser wait --load networkidle
+   ```
+
+After password change, use `QaTest2024!@#` for all subsequent logins. If initial login fails with `Admin123!@#`, retry with `QaTest2024!@#` (password may have been changed in a prior session).
+
+### Verifying Auth Success
+
+After login (and optional password change), verify the dashboard loads:
+```
+agent-browser get url
+```
+Expected: URL ends with `/` (dashboard root).
+
+Take a screenshot to confirm:
+```
+agent-browser screenshot "$TEMP/qa-login-success.png"
+```
+
+## Form Fill Patterns
+
+### Standard Text Inputs
+
+Use `agent-browser fill` with the snapshot ref:
+```
+agent-browser fill @eN "value"
+```
+
+### React Controlled Inputs (CurrencyInput, etc.)
+
+If `agent-browser fill` doesn't work (value reverts after React re-render), use the nativeInputValueSetter fallback:
+```
+agent-browser eval "const input = document.querySelector('CSS_SELECTOR'); const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set; nativeSetter.call(input, 'VALUE'); input.dispatchEvent(new Event('input', { bubbles: true }));"
+```
+
+### Combobox Fields (Combobox component)
+
+Comboboxes use a trigger button + popover. To select an option:
+
+1. Click the combobox trigger button (shows as `[button]` with placeholder text):
+   ```
+   agent-browser click @eN
+   ```
+2. Wait for popover to open, then snapshot:
+   ```
+   agent-browser snapshot -i
+   ```
+3. Click the desired option (`[option]` or `[menuitem]` in the list):
+   ```
+   agent-browser click @eN
+   ```
+
+For comboboxes with `allowCustom`, you can type a custom value in the search input that appears after clicking the trigger.
+
+### Date Inputs (DateInput component)
+
+DateInput is a standard `<input type="date">`. Fill with ISO date format:
+```
+agent-browser fill @eN "2026-03-18"
+```
+
+### Checkbox/Switch Toggle
+
+Click the checkbox or switch element:
+```
+agent-browser click @eN
+```
+
+### Form Submission
+
+After filling all fields, click the submit button. Then wait for the response:
+```
+agent-browser click @eN
+agent-browser wait --load networkidle
+```
+
+## Toast Verification
+
+Success toasts appear as `[status]` or `[alert]` nodes in the accessibility tree. After a mutation:
+```
+agent-browser snapshot -i
+```
+Look for toast text like "created successfully" or "updated successfully" in the snapshot output.
+
+## Error Checking
+
+### Console Errors
+
+Check for JavaScript errors:
+```
+agent-browser eval "window.__consoleErrors || []"
+```
+
+Note: This requires prior injection. As an alternative, check the page visually for error boundaries or error alerts.
+
+### Visual Error Detection
+
+Take a screenshot and look for:
+- Red alert banners
+- Error boundary fallback text ("Something went wrong")
+- Blank/white pages (failed to render)
+- Loading spinners that never resolve (take screenshot after waiting)
+
+## Cleanup
+
+Always close the browser at the end of a test run:
+```
+agent-browser close
+```
+
+## Important Rules
+
+- **Separate Bash calls**: Every `agent-browser` command MUST be a separate Bash tool call. Never chain with `&&`.
+- **Screenshots to $TEMP**: Always `agent-browser screenshot "$TEMP/filename.png"`, never to the working directory.
+- **No hardcoded ports**: Always discover via `mcp__aspire__list_console_logs`.
+- **Re-snapshot after navigation**: After any navigation or DOM change, take a fresh `agent-browser snapshot -i` to get updated refs.

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: smoke-test
+description: >
+  Smoke test every route in the Receipts app. Verifies pages load,
+  expected headings exist, no JS errors, and auth guards work.
+  Uses agent-browser + Aspire MCP. Produces a markdown pass/fail report.
+allowed-tools: Bash, Read, Grep, Glob, mcp__aspire__list_resources, mcp__aspire__list_console_logs
+user_invocable: true
+argument: ""
+---
+
+# Smoke Test
+
+Verify every route in the Receipts app loads correctly, displays the expected heading, and has no JavaScript errors. Also test auth guards (unauthenticated redirect, non-admin redirect).
+
+**Duration:** ~2 minutes
+
+## Prerequisites
+
+- Aspire must be running (F5 or `dotnet run --project src/Receipts.AppHost`)
+- agent-browser must be installed globally (`agent-browser --version`)
+
+## References
+
+Before starting, read both reference files:
+- `references/qa-common.md` — Port discovery, login flow, form patterns
+- `references/qa-routes.md` — Complete route matrix with expected headings
+
+## Phase 1: Port Discovery
+
+1. Call `mcp__aspire__list_console_logs` for the `frontend` resource.
+2. Parse the logs for `Local:   http://localhost:XXXX` to get the base URL.
+3. If no frontend resource or no URL found, abort: "Aspire is not running."
+4. Store the URL as `BASE_URL`.
+
+## Phase 2: Auth Bootstrap
+
+Follow the login flow from `qa-common.md`:
+
+1. Open `${BASE_URL}/login`
+2. Wait for network idle
+3. Snapshot to get form refs
+4. Fill email: `admin@receipts.local`
+5. Fill password: `Admin123!@#` (fall back to `QaTest2024!@#` if login fails)
+6. Click "Sign In"
+7. Wait for navigation
+8. Check URL — if `/change-password`, follow the password change flow from `qa-common.md`
+9. Verify dashboard loads (URL ends with `/`)
+10. Screenshot: `$TEMP/smoke-login-success.png`
+
+## Phase 3: Route Crawl
+
+For each of the 19 routes listed in `qa-routes.md` (skip `/login` and `/change-password` — already tested in Phase 2), perform these steps:
+
+### Per-Route Steps
+
+1. **Navigate:**
+   ```
+   agent-browser open ${BASE_URL}${path}
+   ```
+
+2. **Wait for load:**
+   ```
+   agent-browser wait --load networkidle
+   ```
+
+3. **Snapshot** (full accessibility tree, no `-i`):
+   ```
+   agent-browser snapshot
+   ```
+
+4. **Check heading:** Search the snapshot output for the expected H1 text from `qa-routes.md`. Mark PASS if found, FAIL if not.
+
+5. **Check for errors:** Look for error indicators in the snapshot:
+   - Error boundary text ("Something went wrong")
+   - Blank page (very few nodes in tree)
+   - Alert with "error" or "failed" text
+
+6. **On FAIL:** Take a screenshot for debugging:
+   ```
+   agent-browser screenshot "$TEMP/smoke-fail-{path-slug}.png"
+   ```
+
+### Route-Specific Notes
+
+- **`/` (Dashboard):** May take a moment to load data. Wait for networkidle.
+- **`/receipts/new`:** Verify "Trip Details" card title appears (it's the Step 1 heading).
+- **`/receipt-detail`:** Without `?id=` param, verify page loads without crashing. May show empty state.
+- **`/transaction-detail`:** Same as receipt-detail — verify no crash without params.
+- **`/audit`, `/trash`, `/admin/users`:** These are admin routes. The seeded admin user should have access.
+
+### Tracking
+
+Maintain a results list:
+```
+results = [{ route, status, headingFound, errors, screenshot }]
+```
+
+## Phase 4: Auth Guard Tests
+
+### Test 1: Unauthenticated Access
+
+1. Clear auth state by evaluating:
+   ```
+   agent-browser eval "localStorage.clear(); sessionStorage.clear();"
+   ```
+
+2. Navigate to a protected route:
+   ```
+   agent-browser open ${BASE_URL}/accounts
+   ```
+
+3. Wait and check URL:
+   ```
+   agent-browser wait --load networkidle
+   agent-browser get url
+   ```
+
+4. **PASS** if redirected to `/login`. **FAIL** if the accounts page loads.
+
+### Test 2: Non-Admin Access to Admin Route
+
+This test is only possible if a non-admin user exists. If the seeded admin is the only user, skip this test and note it in the report as "SKIPPED — no non-admin user available."
+
+If a non-admin user exists:
+1. Log in as the non-admin user
+2. Navigate to `${BASE_URL}/audit`
+3. Verify redirect to `/` (dashboard)
+
+## Phase 5: Report
+
+Generate and display a markdown report:
+
+```markdown
+# Smoke Test Report
+
+**Date:** YYYY-MM-DD  |  **Base URL:** {BASE_URL}  |  **Result:** {PASS/FAIL}
+
+## Route Results
+
+| # | Route | Status | Heading | Errors | Screenshot |
+|---|-------|--------|---------|--------|------------|
+| 1 | / | PASS | Dashboard | None | — |
+| 2 | /accounts | PASS | Accounts | None | — |
+| ... | ... | ... | ... | ... | ... |
+
+## Auth Guard Results
+
+| Test | Status | Details |
+|------|--------|---------|
+| Unauth → /accounts | PASS | Redirected to /login |
+| Non-admin → /audit | SKIPPED | No non-admin user |
+
+## Summary
+
+- Routes tested: {N}
+- Passed: {N}
+- Failed: {N}
+- Auth guard tests: {N passed} / {N total}
+
+**Overall: {PASS/FAIL}**
+```
+
+A single route failure or auth guard failure = overall FAIL.
+
+## Phase 6: Cleanup
+
+```
+agent-browser close
+```
+
+Print the summary line:
+```
+Smoke tested {N} routes. {P} passed, {F} failed. Auth guards: {pass/fail}. Overall: {PASS/FAIL}
+```
+
+## Important Rules
+
+- Every `agent-browser` command is a **separate Bash tool call** (no `&&` chaining).
+- Screenshots go to **`$TEMP`** only, never the working directory.
+- Ports are **never hardcoded** — always discover via Aspire MCP.
+- After any navigation, take a fresh snapshot before checking content.
+- Do not modify any application data during smoke testing.

--- a/.claude/skills/smoke-test/references/qa-common.md
+++ b/.claude/skills/smoke-test/references/qa-common.md
@@ -1,0 +1,201 @@
+# QA Common Reference
+
+Shared patterns for all QA skills. Each skill embeds auth inline since agent-browser sessions don't persist across skill invocations.
+
+## Port Discovery
+
+Aspire assigns random ports — never hardcode. Discover the frontend URL before any browser interaction.
+
+### Recipe
+
+1. Call `mcp__aspire__list_console_logs` for the `frontend` resource
+2. Parse logs for the line containing `Local:   http://localhost:XXXX`
+3. Extract the full URL (e.g., `http://localhost:5173`)
+4. Store as `BASE_URL` for the session
+
+If `list_console_logs` returns no output or the frontend resource isn't found, the app is not running. Abort with: "Aspire is not running. Start with F5 or `dotnet run --project src/Receipts.AppHost`."
+
+## Login Flow
+
+### Credentials
+
+| Role  | Email                    | Initial Password | Post-Change Password |
+|-------|--------------------------|------------------|----------------------|
+| Admin | `admin@receipts.local`   | `Admin123!@#`    | `QaTest2024!@#`      |
+
+### Steps
+
+1. Open login page:
+   ```
+   agent-browser open ${BASE_URL}/login
+   ```
+2. Wait for page load:
+   ```
+   agent-browser wait --load networkidle
+   ```
+3. Take snapshot to get form refs:
+   ```
+   agent-browser snapshot -i
+   ```
+4. Fill email field (find the `[input type="email"]` ref):
+   ```
+   agent-browser fill @eN "admin@receipts.local"
+   ```
+5. Fill password field (find the `[input type="password"]` ref):
+   ```
+   agent-browser fill @eN "Admin123!@#"
+   ```
+6. Click the "Sign In" button:
+   ```
+   agent-browser click @eN
+   ```
+7. Wait for navigation:
+   ```
+   agent-browser wait --load networkidle
+   ```
+8. Check current URL:
+   ```
+   agent-browser get url
+   ```
+
+### Password Change Handling
+
+If the URL after login is `/change-password`, the account requires a password reset:
+
+1. Take snapshot to get change-password form refs:
+   ```
+   agent-browser snapshot -i
+   ```
+2. Fill "Current Password":
+   ```
+   agent-browser fill @eN "Admin123!@#"
+   ```
+3. Fill "New Password":
+   ```
+   agent-browser fill @eN "QaTest2024!@#"
+   ```
+4. Fill "Confirm New Password":
+   ```
+   agent-browser fill @eN "QaTest2024!@#"
+   ```
+5. Click "Change Password" button:
+   ```
+   agent-browser click @eN
+   ```
+6. Wait for redirect to dashboard:
+   ```
+   agent-browser wait --load networkidle
+   ```
+
+After password change, use `QaTest2024!@#` for all subsequent logins. If initial login fails with `Admin123!@#`, retry with `QaTest2024!@#` (password may have been changed in a prior session).
+
+### Verifying Auth Success
+
+After login (and optional password change), verify the dashboard loads:
+```
+agent-browser get url
+```
+Expected: URL ends with `/` (dashboard root).
+
+Take a screenshot to confirm:
+```
+agent-browser screenshot "$TEMP/qa-login-success.png"
+```
+
+## Form Fill Patterns
+
+### Standard Text Inputs
+
+Use `agent-browser fill` with the snapshot ref:
+```
+agent-browser fill @eN "value"
+```
+
+### React Controlled Inputs (CurrencyInput, etc.)
+
+If `agent-browser fill` doesn't work (value reverts after React re-render), use the nativeInputValueSetter fallback:
+```
+agent-browser eval "const input = document.querySelector('CSS_SELECTOR'); const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set; nativeSetter.call(input, 'VALUE'); input.dispatchEvent(new Event('input', { bubbles: true }));"
+```
+
+### Combobox Fields (Combobox component)
+
+Comboboxes use a trigger button + popover. To select an option:
+
+1. Click the combobox trigger button (shows as `[button]` with placeholder text):
+   ```
+   agent-browser click @eN
+   ```
+2. Wait for popover to open, then snapshot:
+   ```
+   agent-browser snapshot -i
+   ```
+3. Click the desired option (`[option]` or `[menuitem]` in the list):
+   ```
+   agent-browser click @eN
+   ```
+
+For comboboxes with `allowCustom`, you can type a custom value in the search input that appears after clicking the trigger.
+
+### Date Inputs (DateInput component)
+
+DateInput is a standard `<input type="date">`. Fill with ISO date format:
+```
+agent-browser fill @eN "2026-03-18"
+```
+
+### Checkbox/Switch Toggle
+
+Click the checkbox or switch element:
+```
+agent-browser click @eN
+```
+
+### Form Submission
+
+After filling all fields, click the submit button. Then wait for the response:
+```
+agent-browser click @eN
+agent-browser wait --load networkidle
+```
+
+## Toast Verification
+
+Success toasts appear as `[status]` or `[alert]` nodes in the accessibility tree. After a mutation:
+```
+agent-browser snapshot -i
+```
+Look for toast text like "created successfully" or "updated successfully" in the snapshot output.
+
+## Error Checking
+
+### Console Errors
+
+Check for JavaScript errors:
+```
+agent-browser eval "window.__consoleErrors || []"
+```
+
+Note: This requires prior injection. As an alternative, check the page visually for error boundaries or error alerts.
+
+### Visual Error Detection
+
+Take a screenshot and look for:
+- Red alert banners
+- Error boundary fallback text ("Something went wrong")
+- Blank/white pages (failed to render)
+- Loading spinners that never resolve (take screenshot after waiting)
+
+## Cleanup
+
+Always close the browser at the end of a test run:
+```
+agent-browser close
+```
+
+## Important Rules
+
+- **Separate Bash calls**: Every `agent-browser` command MUST be a separate Bash tool call. Never chain with `&&`.
+- **Screenshots to $TEMP**: Always `agent-browser screenshot "$TEMP/filename.png"`, never to the working directory.
+- **No hardcoded ports**: Always discover via `mcp__aspire__list_console_logs`.
+- **Re-snapshot after navigation**: After any navigation or DOM change, take a fresh `agent-browser snapshot -i` to get updated refs.

--- a/.claude/skills/smoke-test/references/qa-routes.md
+++ b/.claude/skills/smoke-test/references/qa-routes.md
@@ -1,0 +1,51 @@
+# Route Matrix
+
+All 19 routes in the Receipts app with their expected headings, access levels, and layout contexts.
+
+## Public Routes (PublicLayout)
+
+| # | Path | Page | Expected H1 | Access |
+|---|------|------|-------------|--------|
+| 1 | `/login` | Login | Sign In | Public |
+| 2 | `/change-password` | ChangePassword | Change Password | Authenticated (must-reset only) |
+
+## Protected Routes (Layout, requires auth)
+
+| # | Path | Page | Expected H1 | Access |
+|---|------|------|-------------|--------|
+| 3 | `/` | Dashboard | Dashboard | User |
+| 4 | `/accounts` | Accounts | Accounts | User |
+| 5 | `/categories` | Categories | Categories | User |
+| 6 | `/subcategories` | Subcategories | Subcategories | User |
+| 7 | `/receipts` | Receipts | Receipts | User |
+| 8 | `/receipts/new` | NewReceipt | New Receipt | User |
+| 9 | `/receipt-items` | ReceiptItems | Receipt Items | User |
+| 10 | `/transactions` | Transactions | Transactions | User |
+| 11 | `/trips` | Trips | Trips | User |
+| 12 | `/item-templates` | ItemTemplates | Item Templates | User |
+| 13 | `/receipt-detail` | ReceiptDetail | Receipt Details | User |
+| 14 | `/transaction-detail` | TransactionDetail | Transaction Details | User |
+| 15 | `/api-keys` | ApiKeys | API Keys | User |
+| 16 | `/security` | SecurityLog | Security Log | User |
+
+## Admin Routes (AdminRoute, requires admin role)
+
+| # | Path | Page | Expected H1 | Access |
+|---|------|------|-------------|--------|
+| 17 | `/audit` | AuditLog | Audit Log | Admin |
+| 18 | `/trash` | RecycleBin | Recycle Bin | Admin |
+| 19 | `/admin/users` | AdminUsers | User Management | Admin |
+
+## Catch-All
+
+| Path | Page | Expected H1 |
+|------|------|-------------|
+| `/*` (any unmatched) | NotFound | Page Not Found |
+
+## Route Notes
+
+- **`/change-password`** only renders the form when `mustResetPassword` is true. If the user doesn't need a password change, it redirects to `/`. For smoke testing, just verify the URL doesn't error — don't expect the form to be visible.
+- **`/receipt-detail`** and **`/transaction-detail`** require query params (`?id=...`) to show data. Without params, they show an empty state or placeholder. Verify the page loads without errors.
+- **`/receipts/new`** is the 4-step wizard. For smoke testing, just verify step 1 loads with the "Trip Details" card.
+- **Admin routes** (`/audit`, `/trash`, `/admin/users`) require the logged-in user to have an admin role. The seeded `admin@receipts.local` user is an admin.
+- **Auth guard behavior**: Unauthenticated access to protected routes redirects to `/login`. Non-admin access to admin routes redirects to `/` (dashboard).


### PR DESCRIPTION
## Summary

- Add three agent-browser-based QA skills to `.claude/skills/` for manual testing the Receipts app before 1.0
- **smoke-test**: crawls all 19 routes, verifies expected headings, checks for JS errors, and tests auth guards (unauth redirect, non-admin redirect)
- **qa-crud**: parameterized CRUD testing per entity (`/qa-crud accounts`, `/qa-crud --all`) with dependency-aware ordering, covering list/create/read/update/validation/delete flows
- **qa-wizard**: end-to-end receipt creation wizard (all 4 steps), cancel/discard flow, admin features (audit log, recycle bin, user management), and error handling (404, unauth redirect, validation)
- Each skill embeds auth inline and includes shared references for port discovery, login flow, form fill patterns, route matrix, and entity field definitions

## Test plan

- [ ] Verify Aspire is running, then invoke `/smoke-test` and confirm markdown report with pass/fail per route
- [ ] Invoke `/qa-crud accounts` and verify CRUD operations produce accurate pass/fail report
- [ ] Invoke `/qa-wizard` and verify wizard happy path, cancel flow, admin flows, and error handling report

🤖 Generated with [Claude Code](https://claude.com/claude-code)