### PR TITLE
fix(client): prevent store names from polluting category list (RECEIPTS-396)

### DIFF
--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -141,7 +141,6 @@ export function ItemTemplateForm({
                     onValueChange={field.onChange}
                     placeholder="Select category..."
                     searchPlaceholder="Search categories..."
-                    allowCustom
                   />
                 </FormControl>
                 <FormMessage />

--- a/src/client/src/components/ReceiptItemForm.test.tsx
+++ b/src/client/src/components/ReceiptItemForm.test.tsx
@@ -338,4 +338,22 @@ describe("ReceiptItemForm", () => {
       expect(screen.getByText("ITM-002")).toBeInTheDocument();
     });
   });
+
+  it("does not allow custom category values (no 'Use' option for arbitrary text)", async () => {
+    const user = userEvent.setup();
+    render(<ReceiptItemForm {...defaultProps} />);
+
+    // Open the category combobox
+    const categoryCombobox = screen.getByLabelText("Category");
+    await user.click(categoryCombobox);
+
+    // Type a non-existent category (like a store name)
+    const searchInput = screen.getByPlaceholderText("Search categories...");
+    await user.type(searchInput, "Costco");
+
+    // Should NOT show a "Use" button for arbitrary text
+    await waitFor(() => {
+      expect(screen.queryByText(/use.*costco/i)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -521,7 +521,6 @@ export function ReceiptItemForm({
                     onValueChange={field.onChange}
                     placeholder="Select category..."
                     searchPlaceholder="Search categories..."
-                    allowCustom
                   />
                 </FormControl>
                 <FormMessage />

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -459,7 +459,6 @@ export function Step3Items({
                       placeholder="Select category..."
                       searchPlaceholder="Search categories..."
                       emptyMessage="No categories found."
-                      allowCustom
                       aria-required="true"
                     />
                   </FormControl>


### PR DESCRIPTION
## Summary
- Removed `allowCustom` from the category Combobox in ReceiptItemForm, Step3Items (wizard), and ItemTemplateForm
- Categories must now be selected from the curated list instead of allowing arbitrary freeform text entry (which enabled store names like "Costco" to appear as categories)
- Subcategory Comboboxes retain `allowCustom` since they have intentional auto-creation logic
- Added a regression test verifying the category Combobox does not offer a "Use" option for arbitrary text

Resolves RECEIPTS-396

## Assumptions
- The store names in the existing categories table are a data quality issue (manually entered). This PR prevents future occurrences by removing the `allowCustom` prop. Existing bad data in the categories table needs to be cleaned up manually or via a separate issue.

## Test plan
- Verify the category dropdown in the wizard Step 3 (Line Items) only shows existing categories and does not allow typing arbitrary values
- Verify the ReceiptItemForm category field on the standalone receipt items page only shows existing categories
- Verify the ItemTemplateForm category field only shows existing categories
- Verify subcategory fields still allow custom values (they should — this is by design)
- Run `npx vitest run src/components/ReceiptItemForm.test.tsx` to confirm the new regression test passes