### PR TITLE
refactor(client): eliminate pagination-reset useEffect chain (RECEIPTS-403)

### DIFF
--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { Link } from "react-router";
 import {
   useAccounts,
@@ -84,7 +84,10 @@ function Accounts() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (accountsData as AccountResponse[] | undefined) ?? [];
 
@@ -180,9 +183,9 @@ function Accounts() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <SortableTableHead column="accountCode" label="Account Code" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
-                  <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
-                  <SortableTableHead column="isActive" label="Status" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
+                  <SortableTableHead column="accountCode" label="Account Code" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
+                  <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
+                  <SortableTableHead column="isActive" label="Status" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <TableHead>Related</TableHead>
                   <TableHead className="w-24">Actions</TableHead>
                 </TableRow>

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -99,7 +99,10 @@ function AdminUsers() {
   const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ defaultPageSize: 20 });
   const { data: usersData, total: serverTotal, isLoading } = useUsers(offset, limit, sortBy, sortDirection);
 
-  useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const createUser = useCreateUser();
   const updateUser = useUpdateUser();
@@ -240,11 +243,11 @@ function AdminUsers() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <SortableTableHead column="firstName" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
-                  <SortableTableHead column="email" label="Email" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
+                  <SortableTableHead column="firstName" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
+                  <SortableTableHead column="email" label="Email" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <TableHead>Role</TableHead>
                   <TableHead>Status</TableHead>
-                  <SortableTableHead column="createdAt" label="Created" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
+                  <SortableTableHead column="createdAt" label="Created" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <TableHead>Last Login</TableHead>
                   <TableHead className="w-[200px]">Actions</TableHead>
                 </TableRow>

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { Link } from "react-router";
 import {
   useCategories,
@@ -77,7 +77,10 @@ function Categories() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (categoriesData as CategoryResponse[] | undefined) ?? [];
   useSavedFilters("categories");
@@ -157,7 +160,7 @@ function Categories() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
+                  <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <TableHead>Description</TableHead>
                   <TableHead>Related</TableHead>
                   <TableHead className="w-24">Actions</TableHead>

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import {
   useItemTemplates,
   useCreateItemTemplate,
@@ -86,7 +86,10 @@ function ItemTemplates() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (itemTemplatesData as ItemTemplateResponse[] | undefined) ?? [];
   useSavedFilters("itemTemplates");
@@ -201,7 +204,7 @@ function ItemTemplates() {
                       className="h-4 w-4 rounded border-gray-300"
                     />
                   </TableHead>
-                  <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
+                  <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <TableHead>Category</TableHead>
                   <TableHead>Subcategory</TableHead>
                   <TableHead>Unit Price</TableHead>

--- a/src/client/src/pages/ReceiptItems.tsx
+++ b/src/client/src/pages/ReceiptItems.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -110,7 +110,10 @@ function ReceiptItems() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = useMemo(
     () => (itemsData as ReceiptItemResponse[] | undefined) ?? [],
@@ -305,12 +308,12 @@ function ReceiptItems() {
                     />
                   </TableHead>
                   <TableHead>Code</TableHead>
-                  <SortableTableHead column="description" label="Description" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
+                  <SortableTableHead column="description" label="Description" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <TableHead>Mode</TableHead>
-                  <SortableTableHead column="quantity" label="Qty" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} className="text-right" />
-                  <SortableTableHead column="unitPrice" label="Unit Price" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} className="text-right" />
-                  <SortableTableHead column="totalAmount" label="Total" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} className="text-right" />
-                  <SortableTableHead column="category" label="Category" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
+                  <SortableTableHead column="quantity" label="Qty" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" />
+                  <SortableTableHead column="unitPrice" label="Unit Price" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" />
+                  <SortableTableHead column="totalAmount" label="Total" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" />
+                  <SortableTableHead column="category" label="Category" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <TableHead>Subcategory</TableHead>
                   <TableHead>Receipt</TableHead>
                   <TableHead className="w-24">Actions</TableHead>

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -98,7 +98,10 @@ function Receipts() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (receiptsData as ReceiptResponse[] | undefined) ?? [];
 
@@ -251,9 +254,9 @@ function Receipts() {
                       className="h-4 w-4 rounded border-gray-300"
                     />
                   </TableHead>
-                  <SortableTableHead column="location" label="Location" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
-                  <SortableTableHead column="date" label="Date" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
-                  <SortableTableHead column="taxAmount" label="Tax Amount" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} className="text-right" />
+                  <SortableTableHead column="location" label="Location" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
+                  <SortableTableHead column="date" label="Date" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
+                  <SortableTableHead column="taxAmount" label="Tax Amount" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" />
                   <TableHead>Related</TableHead>
                   <TableHead className="w-24">Actions</TableHead>
                 </TableRow>

--- a/src/client/src/pages/SecurityLog.tsx
+++ b/src/client/src/pages/SecurityLog.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback } from "react";
 import {
   useMyAuthAuditLog,
   useRecentAuthAuditLogs,
@@ -24,15 +24,20 @@ function SecurityLog() {
   const recentPagination = useServerPagination();
   const failedPagination = useServerPagination();
 
+  const { resetPage: resetMyPage } = myPagination;
+  const { resetPage: resetRecentPage } = recentPagination;
+  const { resetPage: resetFailedPage } = failedPagination;
+
   const myLogs = useMyAuthAuditLog(myPagination.offset, myPagination.limit, sortBy, sortDirection);
   const recentLogs = useRecentAuthAuditLogs(recentPagination.offset, recentPagination.limit, sortBy, sortDirection);
   const failedLogs = useFailedAuthAttempts(failedPagination.offset, failedPagination.limit, sortBy, sortDirection);
 
-  useEffect(() => {
-    myPagination.resetPage();
-    recentPagination.resetPage();
-    failedPagination.resetPage();
-  }, [sortBy, sortDirection, myPagination.resetPage, recentPagination.resetPage, failedPagination.resetPage]);
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetMyPage();
+    resetRecentPage();
+    resetFailedPage();
+  }, [toggleSort, resetMyPage, resetRecentPage, resetFailedPage]);
 
   const myTotal = myLogs.total;
   const recentTotal = recentLogs.total;
@@ -59,7 +64,7 @@ function SecurityLog() {
             isLoading={myLogs.isLoading}
             sortBy={sortBy}
             sortDirection={sortDirection}
-            onToggleSort={toggleSort}
+            onToggleSort={handleSort}
             authEventLabels={authEventLabels}
           />
           <Pagination
@@ -80,7 +85,7 @@ function SecurityLog() {
               showUsername
               sortBy={sortBy}
               sortDirection={sortDirection}
-              onToggleSort={toggleSort}
+              onToggleSort={handleSort}
               authEventLabels={authEventLabels}
             />
             <Pagination
@@ -102,7 +107,7 @@ function SecurityLog() {
               showUsername
               sortBy={sortBy}
               sortDirection={sortDirection}
-              onToggleSort={toggleSort}
+              onToggleSort={handleSort}
               authEventLabels={authEventLabels}
             />
             <Pagination

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useMemo, useEffect } from "react";
+import { Fragment, useState, useMemo, useEffect, useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -101,7 +101,10 @@ function Subcategories() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (subcategoriesData as SubcategoryResponse[] | undefined) ?? [];
 
@@ -299,7 +302,7 @@ function Subcategories() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
+                  <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <TableHead>Category</TableHead>
                   <TableHead>Description</TableHead>
                   <TableHead>Related</TableHead>

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -134,7 +134,10 @@ function Transactions() {
     return map;
   }, [receiptsData]);
 
-  useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage]);
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data: EnrichedTransaction[] = useMemo(() => {
     const list = (transactionsData as TransactionResponse[] | undefined) ?? [];
@@ -304,9 +307,9 @@ function Transactions() {
                   <TableHead>Account</TableHead>
                   <TableHead>Receipt</TableHead>
                   <TableHead>Location</TableHead>
-                  <SortableTableHead column="amount" label="Amount" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} className="text-right" />
+                  <SortableTableHead column="amount" label="Amount" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" />
                   <TableHead>Receipt Date</TableHead>
-                  <SortableTableHead column="date" label="Transaction Date" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={toggleSort} />
+                  <SortableTableHead column="date" label="Transaction Date" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <TableHead className="w-24">Actions</TableHead>
                 </TableRow>
               </TableHeader>


### PR DESCRIPTION
## Summary
- Replace `useEffect(() => { resetPage(); }, [sortBy, sortDirection, resetPage])` with a `handleSort` event handler wrapper across 9 list pages
- The new `handleSort` callback calls both `toggleSort(column)` and `resetPage()` synchronously, eliminating the Effect chain anti-pattern that caused a double render on every sort click
- SecurityLog.tsx: destructured `resetPage` from all three pagination instances to satisfy React Compiler's memoization requirements

Resolves RECEIPTS-403

## Test plan
- Verify sort column clicks reset pagination to page 1 on all 9 pages: Transactions, Receipts, ReceiptItems, Subcategories, ItemTemplates, Categories, AdminUsers, Accounts, SecurityLog
- Confirm toggling sort direction on the same column also resets to page 1
- Confirm no double renders on sort clicks (React DevTools Profiler)
- All 307 backend tests pass; TypeScript and ESLint clean