### PR TITLE
fix(client): replace highlight toast useEffect with derived render logic

### DIFF
--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -37,8 +37,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { toast } from "sonner";
-import { Pencil } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Info, Pencil } from "lucide-react";
 
 interface AccountResponse {
   id: string;
@@ -112,11 +112,8 @@ function Accounts() {
     return map;
   }, [results]);
 
-  useEffect(() => {
-    if (linkParams.highlight && data.length > 0 && !data.some((a) => a.id === linkParams.highlight)) {
-      toast.info("The highlighted item is not on this page.");
-    }
-  }, [linkParams.highlight, data]);
+  const highlightMissing =
+    linkParams.highlight && data.length > 0 && !data.some((a) => a.id === linkParams.highlight);
 
   const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
     items: filteredResults,
@@ -152,6 +149,13 @@ function Accounts() {
           <TabsTrigger value="all">All</TabsTrigger>
         </TabsList>
       </Tabs>
+
+      {highlightMissing && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription>The highlighted item is not on this page.</AlertDescription>
+        </Alert>
+      )}
 
       {filteredResults.length === 0 ? (
         search ? (

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -36,8 +36,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
-import { toast } from "sonner";
-import { Pencil } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Info, Pencil } from "lucide-react";
 
 interface CategoryResponse {
   id: string;
@@ -97,11 +97,8 @@ function Categories() {
     return map;
   }, [results]);
 
-  useEffect(() => {
-    if (linkParams.highlight && data.length > 0 && !data.some((c) => c.id === linkParams.highlight)) {
-      toast.info("The highlighted item is not on this page.");
-    }
-  }, [linkParams.highlight, data]);
+  const highlightMissing =
+    linkParams.highlight && data.length > 0 && !data.some((c) => c.id === linkParams.highlight);
 
   const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
     items: filteredResults,
@@ -129,6 +126,13 @@ function Categories() {
         />
         <Button onClick={() => setCreateOpen(true)}>New Category</Button>
       </div>
+
+      {highlightMissing && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription>The highlighted item is not on this page.</AlertDescription>
+        </Alert>
+      )}
 
       {filteredResults.length === 0 ? (
         search ? (

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -44,8 +44,8 @@ import {
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
-import { toast } from "sonner";
-import { Pencil } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Info, Pencil } from "lucide-react";
 
 interface ReceiptResponse {
   id: string;
@@ -126,11 +126,8 @@ function Receipts() {
     return map;
   }, [results]);
 
-  useEffect(() => {
-    if (linkParams.highlight && data.length > 0 && !data.some((r) => r.id === linkParams.highlight)) {
-      toast.info("The highlighted item is not on this page.");
-    }
-  }, [linkParams.highlight, data]);
+  const highlightMissing =
+    linkParams.highlight && data.length > 0 && !data.some((r) => r.id === linkParams.highlight);
 
   function toggleSelect(id: string) {
     setSelected((prev) => {
@@ -211,6 +208,13 @@ function Receipts() {
           setFilterValues(preset.values as FilterValues)
         }
       />
+
+      {highlightMissing && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription>The highlighted item is not on this page.</AlertDescription>
+        </Alert>
+      )}
 
       {filteredResults.length === 0 ? (
         search ? (


### PR DESCRIPTION
## Summary
- Replace imperative `useEffect` + `toast.info()` with a derived `highlightMissing` const computed during render in Receipts, Categories, and Accounts list pages
- Show an inline `<Alert>` banner instead of a toast when the highlighted item is not on the current page
- Eliminates spurious repeated toasts caused by SignalR-triggered React Query invalidations re-firing the Effect

Resolves RECEIPTS-404

## Test plan
- Navigate to a list page (Receipts, Categories, or Accounts) with a `?highlight=<id>` param where the ID exists on the current page -- verify the row gets the highlight ring and no alert banner appears
- Navigate with a `?highlight=<id>` for an item NOT on the current page -- verify the inline alert banner "The highlighted item is not on this page." renders above the table
- Verify no toast notifications appear in either scenario
- Confirm the alert disappears when navigating to a page where the highlighted item exists