### PR TITLE
fix(client): block submission of unbalanced receipts (RECEIPTS-395)

### DIFF
--- a/src/client/src/pages/wizard/Step2Transactions.test.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.test.tsx
@@ -110,6 +110,30 @@ describe("Step2Transactions", () => {
     expect(amountInput).toHaveValue("");
   });
 
+  it("shows zero-total warning when transactions sum to zero with tax > 0", () => {
+    const data = [
+      { id: "1", accountId: "acct-1", amount: 0, date: "2024-01-15" },
+    ];
+    renderWithProviders(
+      <Step2Transactions {...defaultProps} data={data} taxAmount={5.25} />,
+    );
+    expect(
+      screen.getByText(/transaction total is \$0\.00 but tax is/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show zero-total warning when tax is zero", () => {
+    const data = [
+      { id: "1", accountId: "acct-1", amount: 0, date: "2024-01-15" },
+    ];
+    renderWithProviders(
+      <Step2Transactions {...defaultProps} data={data} taxAmount={0} />,
+    );
+    expect(
+      screen.queryByText(/transaction total is \$0\.00 but tax is/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("focuses the account combobox after adding a transaction", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithProviders(<Step2Transactions {...defaultProps} />);

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -246,7 +246,7 @@ export function Step2Transactions({
           </Table>
         )}
 
-        {transactions.length > 0 && runningTotal === 0 && taxAmount > 0 && (
+        {transactions.length > 0 && Math.abs(runningTotal) < 0.01 && taxAmount > 0 && (
           <Alert variant="destructive">
             <AlertTriangle className="h-4 w-4" />
             <AlertDescription>

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -29,7 +29,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Plus, Trash2 } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Plus, Trash2, AlertTriangle } from "lucide-react";
 import type { WizardTransaction } from "./wizardReducer";
 
 const txnSchema = z.object({
@@ -243,6 +244,16 @@ export function Step2Transactions({
               ))}
             </TableBody>
           </Table>
+        )}
+
+        {transactions.length > 0 && runningTotal === 0 && taxAmount > 0 && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>
+              Transaction total is $0.00 but tax is{" "}
+              {formatCurrency(taxAmount)}. The receipt will be unbalanced.
+            </AlertDescription>
+          </Alert>
         )}
 
         <div className="flex justify-between pt-4">

--- a/src/client/src/pages/wizard/Step4Review.test.tsx
+++ b/src/client/src/pages/wizard/Step4Review.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult } from "@/test/mock-hooks";
+import "@/test/setup-combobox-polyfills";
 import { Step4Review } from "./Step4Review";
 import type { WizardState } from "./wizardReducer";
 
@@ -81,9 +82,31 @@ describe("Step4Review", () => {
     ).toBeInTheDocument();
   });
 
+  it("disables Submit button when receipt is unbalanced", () => {
+    // Default state: txn total = 50, expected = 7.98 + 5 = 12.98 → unbalanced
+    renderWithProviders(<Step4Review {...defaultProps} />);
+    expect(
+      screen.getByRole("button", { name: /submit receipt/i }),
+    ).toBeDisabled();
+  });
+
+  it("enables Submit button when receipt is balanced", () => {
+    // items subtotal = 2*3.99 = 7.98, tax = 5, expected = 12.98
+    const state = createState({
+      transactions: [{ id: "t1", accountId: "acct-1", amount: 12.98, date: "2024-01-15" }],
+    });
+    renderWithProviders(<Step4Review {...defaultProps} state={state} />);
+    expect(
+      screen.getByRole("button", { name: /submit receipt/i }),
+    ).not.toBeDisabled();
+  });
+
   it("shows Submitting... when isSubmitting is true", () => {
+    const state = createState({
+      transactions: [{ id: "t1", accountId: "acct-1", amount: 12.98, date: "2024-01-15" }],
+    });
     renderWithProviders(
-      <Step4Review {...defaultProps} isSubmitting={true} />,
+      <Step4Review {...defaultProps} state={state} isSubmitting={true} />,
     );
     expect(
       screen.getByRole("button", { name: /submitting/i }),
@@ -116,12 +139,28 @@ describe("Step4Review", () => {
     expect(onBack).toHaveBeenCalled();
   });
 
-  it("calls onSubmit when Submit is clicked", async () => {
+  it("calls onSubmit when Submit is clicked on a balanced receipt", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const onSubmit = vi.fn();
-    renderWithProviders(<Step4Review {...defaultProps} onSubmit={onSubmit} />);
+    const state = createState({
+      transactions: [{ id: "t1", accountId: "acct-1", amount: 12.98, date: "2024-01-15" }],
+    });
+    renderWithProviders(
+      <Step4Review {...defaultProps} state={state} onSubmit={onSubmit} />,
+    );
     await user.click(screen.getByRole("button", { name: /submit receipt/i }));
     expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it("does not call onSubmit when Submit is clicked on an unbalanced receipt", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <Step4Review {...defaultProps} onSubmit={onSubmit} />,
+    );
+    const btn = screen.getByRole("button", { name: /submit receipt/i });
+    await user.click(btn);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("shows balanced status when amounts match", () => {

--- a/src/client/src/pages/wizard/Step4Review.tsx
+++ b/src/client/src/pages/wizard/Step4Review.tsx
@@ -6,6 +6,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   Table,
   TableBody,
   TableCell,
@@ -223,9 +228,27 @@ export function Step4Review({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onSubmit} disabled={isSubmitting}>
-          {isSubmitting ? "Submitting..." : "Submit Receipt"}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-block">
+              <Button
+                onClick={onSubmit}
+                disabled={isSubmitting || !isBalanced}
+                className={!isBalanced ? "pointer-events-none" : ""}
+              >
+                {isSubmitting ? "Submitting..." : "Submit Receipt"}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          {!isBalanced && (
+            <TooltipContent>
+              <p>
+                Receipt is unbalanced by {formatCurrency(balanceDiff)}.
+                Adjust transactions or line items so totals match.
+              </p>
+            </TooltipContent>
+          )}
+        </Tooltip>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Disable Submit on Step 4** when the receipt is unbalanced (transaction total != items subtotal + tax), with a tooltip explaining why
- **Add a destructive alert on Step 2** when transactions sum to $0 but tax > $0, warning the receipt will be unbalanced
- **Update tests** to verify Submit is disabled/enabled based on balance state and the Step 2 warning

Resolves RECEIPTS-395

## Assumptions
- Chose a hard gate (disabled button) over a soft gate (confirmation dialog) since it's the simpler and safer UX -- the backend also rejects unbalanced receipts
- Did not hard-gate Step 2 -> Step 3 progression, only added a visual warning, since zero-total transactions could be legitimate in some edge cases
- No backend changes needed -- the server-side `CreateCompleteReceiptCommandHandler` already validates balance when transactions exist

## Test plan
- [ ] Open the receipt wizard and add transactions that don't match items + tax -- verify Submit is disabled with a tooltip
- [ ] Balance the amounts -- verify Submit becomes enabled
- [ ] On Step 2, add a transaction with $0 amount while tax > $0 -- verify the destructive alert appears
- [ ] Run `npx vitest run src/pages/wizard/` -- all 114 tests pass