### PR TITLE
fix(client): reset pagination on browser back/forward sort change (RECEIPTS-408)

### DIFF
--- a/src/client/src/hooks/useServerPagination.test.ts
+++ b/src/client/src/hooks/useServerPagination.test.ts
@@ -95,4 +95,62 @@ describe("useServerPagination", () => {
     expect(localStorage.getItem("table-page-size")).toBe("50");
     expect(result.current.limit).toBe(50);
   });
+
+  it("resets offset when sortBy changes", () => {
+    const { result, rerender } = renderHook(
+      ({ sortBy }) =>
+        useServerPagination({ defaultPageSize: 10, sortBy, sortDirection: "asc" }),
+      { initialProps: { sortBy: "name" } },
+    );
+    act(() => result.current.setPage(3, 100));
+    expect(result.current.offset).toBe(20);
+
+    rerender({ sortBy: "date" });
+    expect(result.current.offset).toBe(0);
+    expect(result.current.currentPage).toBe(1);
+  });
+
+  it("resets offset when sortDirection changes", () => {
+    const { result, rerender } = renderHook(
+      ({ sortDirection }: { sortDirection: "asc" | "desc" }) =>
+        useServerPagination({ defaultPageSize: 10, sortBy: "name", sortDirection }),
+      { initialProps: { sortDirection: "asc" as "asc" | "desc" } },
+    );
+    act(() => result.current.setPage(3, 100));
+    expect(result.current.offset).toBe(20);
+
+    rerender({ sortDirection: "desc" });
+    expect(result.current.offset).toBe(0);
+    expect(result.current.currentPage).toBe(1);
+  });
+
+  it("does not reset offset on initial mount with sort params", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10, sortBy: "name", sortDirection: "asc" }),
+    );
+    expect(result.current.offset).toBe(0);
+    expect(result.current.currentPage).toBe(1);
+  });
+
+  it("does not reset offset when sort params stay the same", () => {
+    const { result, rerender } = renderHook(
+      ({ sortBy }) =>
+        useServerPagination({ defaultPageSize: 10, sortBy, sortDirection: "asc" }),
+      { initialProps: { sortBy: "name" } },
+    );
+    act(() => result.current.setPage(3, 100));
+    expect(result.current.offset).toBe(20);
+
+    rerender({ sortBy: "name" });
+    expect(result.current.offset).toBe(20);
+  });
+
+  it("works without sort params (backward compatible)", () => {
+    const { result } = renderHook(() =>
+      useServerPagination({ defaultPageSize: 10 }),
+    );
+    act(() => result.current.setPage(3, 100));
+    expect(result.current.offset).toBe(20);
+    expect(result.current.currentPage).toBe(3);
+  });
 });

--- a/src/client/src/hooks/useServerPagination.ts
+++ b/src/client/src/hooks/useServerPagination.ts
@@ -1,8 +1,10 @@
-import { useReducer, useMemo, useCallback } from "react";
+import { useReducer, useMemo, useCallback, useRef, useEffect } from "react";
 import { getPersistedPageSize, persistPageSize } from "@/lib/page-size";
 
 interface UseServerPaginationOptions {
   defaultPageSize?: number;
+  sortBy?: string | null;
+  sortDirection?: "asc" | "desc";
 }
 
 interface UseServerPaginationReturn {
@@ -38,11 +40,24 @@ function reducer(state: State, action: Action): State {
 
 export function useServerPagination({
   defaultPageSize = 25,
+  sortBy,
+  sortDirection,
 }: UseServerPaginationOptions = {}): UseServerPaginationReturn {
   const [state, dispatch] = useReducer(reducer, {
     offset: 0,
     limit: getPersistedPageSize() ?? defaultPageSize,
   });
+
+  // Reset to page 1 when sort params change (e.g. browser back/forward).
+  // Skip the initial mount so we don't dispatch a redundant reset.
+  const prevSortRef = useRef({ sortBy, sortDirection });
+  useEffect(() => {
+    const prev = prevSortRef.current;
+    if (prev.sortBy !== sortBy || prev.sortDirection !== sortDirection) {
+      prevSortRef.current = { sortBy, sortDirection };
+      dispatch({ type: "SET_OFFSET", offset: 0 });
+    }
+  }, [sortBy, sortDirection]);
 
   const currentPage = useMemo(
     () => Math.floor(state.offset / state.limit) + 1,

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { Link } from "react-router";
 import {
   useAccounts,
@@ -63,7 +63,7 @@ function Accounts() {
   usePageTitle("Accounts");
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ sortBy, sortDirection });
   const { data: accountsData, total: serverTotal, isLoading } = useAccounts(offset, limit, sortBy, sortDirection);
   const createAccount = useCreateAccount();
   const updateAccount = useUpdateAccount();
@@ -84,7 +84,10 @@ function Accounts() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = toggleSort;
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (accountsData as AccountResponse[] | undefined) ?? [];
 

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Link } from "react-router";
 import {
   useAccounts,
@@ -63,7 +63,7 @@ function Accounts() {
   usePageTitle("Accounts");
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
   const { data: accountsData, total: serverTotal, isLoading } = useAccounts(offset, limit, sortBy, sortDirection);
   const createAccount = useCreateAccount();
   const updateAccount = useUpdateAccount();
@@ -84,10 +84,7 @@ function Accounts() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = useCallback((column: string) => {
-    toggleSort(column);
-    resetPage();
-  }, [toggleSort, resetPage]);
+  const handleSort = toggleSort;
 
   const data = (accountsData as AccountResponse[] | undefined) ?? [];
 

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -96,10 +96,13 @@ function AdminUsers() {
   const { user: currentUser } = useAuth();
 
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "email", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ defaultPageSize: 20, sortBy, sortDirection });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ defaultPageSize: 20, sortBy, sortDirection });
   const { data: usersData, total: serverTotal, isLoading } = useUsers(offset, limit, sortBy, sortDirection);
 
-  const handleSort = toggleSort;
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const createUser = useCreateUser();
   const updateUser = useUpdateUser();

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -96,13 +96,10 @@ function AdminUsers() {
   const { user: currentUser } = useAuth();
 
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "email", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ defaultPageSize: 20 });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ defaultPageSize: 20, sortBy, sortDirection });
   const { data: usersData, total: serverTotal, isLoading } = useUsers(offset, limit, sortBy, sortDirection);
 
-  const handleSort = useCallback((column: string) => {
-    toggleSort(column);
-    resetPage();
-  }, [toggleSort, resetPage]);
+  const handleSort = toggleSort;
 
   const createUser = useCreateUser();
   const updateUser = useUpdateUser();

--- a/src/client/src/pages/AuditLog.tsx
+++ b/src/client/src/pages/AuditLog.tsx
@@ -147,11 +147,11 @@ function AuditLog() {
 
   const debouncedSearch = useDebouncedValue(search, 300);
 
-  const pagination = useServerPagination();
   const { sortBy, sortDirection, toggleSort } = useServerSort({
     defaultSortBy: "changedAt",
     defaultSortDirection: "desc",
   });
+  const pagination = useServerPagination({ sortBy, sortDirection });
 
   // Reset pagination when filters change
   const handleEntityTypeChange = useCallback(

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Link } from "react-router";
 import {
   useCategories,
@@ -58,7 +58,7 @@ function Categories() {
   usePageTitle("Categories");
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
   const { data: categoriesData, total: serverTotal, isLoading } = useCategories(offset, limit, sortBy, sortDirection);
   const createCategory = useCreateCategory();
   const updateCategory = useUpdateCategory();
@@ -77,10 +77,7 @@ function Categories() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = useCallback((column: string) => {
-    toggleSort(column);
-    resetPage();
-  }, [toggleSort, resetPage]);
+  const handleSort = toggleSort;
 
   const data = (categoriesData as CategoryResponse[] | undefined) ?? [];
   useSavedFilters("categories");

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { Link } from "react-router";
 import {
   useCategories,
@@ -58,7 +58,7 @@ function Categories() {
   usePageTitle("Categories");
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ sortBy, sortDirection });
   const { data: categoriesData, total: serverTotal, isLoading } = useCategories(offset, limit, sortBy, sortDirection);
   const createCategory = useCreateCategory();
   const updateCategory = useUpdateCategory();
@@ -77,7 +77,10 @@ function Categories() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = toggleSort;
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (categoriesData as CategoryResponse[] | undefined) ?? [];
   useSavedFilters("categories");

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   useItemTemplates,
   useCreateItemTemplate,
@@ -63,7 +63,7 @@ const SEARCH_CONFIG: FuseSearchConfig<ItemTemplateResponse> = {
 function ItemTemplates() {
   usePageTitle("Item Templates");
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
   const { data: itemTemplatesData, total: serverTotal, isLoading } = useItemTemplates(offset, limit, sortBy, sortDirection);
   const createItemTemplate = useCreateItemTemplate();
   const updateItemTemplate = useUpdateItemTemplate();
@@ -86,10 +86,7 @@ function ItemTemplates() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = useCallback((column: string) => {
-    toggleSort(column);
-    resetPage();
-  }, [toggleSort, resetPage]);
+  const handleSort = toggleSort;
 
   const data = (itemTemplatesData as ItemTemplateResponse[] | undefined) ?? [];
   useSavedFilters("itemTemplates");

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import {
   useItemTemplates,
   useCreateItemTemplate,
@@ -63,7 +63,7 @@ const SEARCH_CONFIG: FuseSearchConfig<ItemTemplateResponse> = {
 function ItemTemplates() {
   usePageTitle("Item Templates");
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ sortBy, sortDirection });
   const { data: itemTemplatesData, total: serverTotal, isLoading } = useItemTemplates(offset, limit, sortBy, sortDirection);
   const createItemTemplate = useCreateItemTemplate();
   const updateItemTemplate = useUpdateItemTemplate();
@@ -86,7 +86,10 @@ function ItemTemplates() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = toggleSort;
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (itemTemplatesData as ItemTemplateResponse[] | undefined) ?? [];
   useSavedFilters("itemTemplates");

--- a/src/client/src/pages/ReceiptItems.tsx
+++ b/src/client/src/pages/ReceiptItems.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -81,7 +81,7 @@ const FILTER_PARAMS = ["receiptId", "subcategory"] as const;
 function ReceiptItems() {
   usePageTitle("Receipt Items");
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "description", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ sortBy, sortDirection });
   const { params: linkParams, clearParams, hasActiveFilter } = useEntityLinkParams(FILTER_PARAMS);
   const allItemsQuery = useReceiptItems(offset, limit, sortBy, sortDirection);
   const filteredItemsQuery = useReceiptItemsByReceiptId(linkParams.receiptId ?? null, offset, limit, sortBy, sortDirection);
@@ -110,7 +110,10 @@ function ReceiptItems() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = toggleSort;
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = useMemo(
     () => (itemsData as ReceiptItemResponse[] | undefined) ?? [],

--- a/src/client/src/pages/ReceiptItems.tsx
+++ b/src/client/src/pages/ReceiptItems.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -81,7 +81,7 @@ const FILTER_PARAMS = ["receiptId", "subcategory"] as const;
 function ReceiptItems() {
   usePageTitle("Receipt Items");
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "description", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
   const { params: linkParams, clearParams, hasActiveFilter } = useEntityLinkParams(FILTER_PARAMS);
   const allItemsQuery = useReceiptItems(offset, limit, sortBy, sortDirection);
   const filteredItemsQuery = useReceiptItemsByReceiptId(linkParams.receiptId ?? null, offset, limit, sortBy, sortDirection);
@@ -110,10 +110,7 @@ function ReceiptItems() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = useCallback((column: string) => {
-    toggleSort(column);
-    resetPage();
-  }, [toggleSort, resetPage]);
+  const handleSort = toggleSort;
 
   const data = useMemo(
     () => (itemsData as ReceiptItemResponse[] | undefined) ?? [],

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -76,7 +76,7 @@ function Receipts() {
   usePageTitle("Receipts");
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "date", defaultSortDirection: "desc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ sortBy, sortDirection });
   const { data: receiptsData, total: serverTotal, isLoading } = useReceipts(offset, limit, sortBy, sortDirection);
   const createReceipt = useCreateReceipt();
   const updateReceipt = useUpdateReceipt();
@@ -98,7 +98,10 @@ function Receipts() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = toggleSort;
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (receiptsData as ReceiptResponse[] | undefined) ?? [];
 

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -76,7 +76,7 @@ function Receipts() {
   usePageTitle("Receipts");
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "date", defaultSortDirection: "desc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
   const { data: receiptsData, total: serverTotal, isLoading } = useReceipts(offset, limit, sortBy, sortDirection);
   const createReceipt = useCreateReceipt();
   const updateReceipt = useUpdateReceipt();
@@ -98,10 +98,7 @@ function Receipts() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = useCallback((column: string) => {
-    toggleSort(column);
-    resetPage();
-  }, [toggleSort, resetPage]);
+  const handleSort = toggleSort;
 
   const data = (receiptsData as ReceiptResponse[] | undefined) ?? [];
 

--- a/src/client/src/pages/SecurityLog.tsx
+++ b/src/client/src/pages/SecurityLog.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import {
   useMyAuthAuditLog,
   useRecentAuthAuditLogs,
@@ -23,11 +24,20 @@ function SecurityLog() {
   const recentPagination = useServerPagination({ sortBy, sortDirection });
   const failedPagination = useServerPagination({ sortBy, sortDirection });
 
+  const { resetPage: resetMyPage } = myPagination;
+  const { resetPage: resetRecentPage } = recentPagination;
+  const { resetPage: resetFailedPage } = failedPagination;
+
   const myLogs = useMyAuthAuditLog(myPagination.offset, myPagination.limit, sortBy, sortDirection);
   const recentLogs = useRecentAuthAuditLogs(recentPagination.offset, recentPagination.limit, sortBy, sortDirection);
   const failedLogs = useFailedAuthAttempts(failedPagination.offset, failedPagination.limit, sortBy, sortDirection);
 
-  const handleSort = toggleSort;
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetMyPage();
+    resetRecentPage();
+    resetFailedPage();
+  }, [toggleSort, resetMyPage, resetRecentPage, resetFailedPage]);
 
   const myTotal = myLogs.total;
   const recentTotal = recentLogs.total;

--- a/src/client/src/pages/SecurityLog.tsx
+++ b/src/client/src/pages/SecurityLog.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import {
   useMyAuthAuditLog,
   useRecentAuthAuditLogs,
@@ -20,24 +19,15 @@ function SecurityLog() {
   const { authEventLabels } = useEnumMetadata();
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "timestamp", defaultSortDirection: "desc" });
 
-  const myPagination = useServerPagination();
-  const recentPagination = useServerPagination();
-  const failedPagination = useServerPagination();
-
-  const { resetPage: resetMyPage } = myPagination;
-  const { resetPage: resetRecentPage } = recentPagination;
-  const { resetPage: resetFailedPage } = failedPagination;
+  const myPagination = useServerPagination({ sortBy, sortDirection });
+  const recentPagination = useServerPagination({ sortBy, sortDirection });
+  const failedPagination = useServerPagination({ sortBy, sortDirection });
 
   const myLogs = useMyAuthAuditLog(myPagination.offset, myPagination.limit, sortBy, sortDirection);
   const recentLogs = useRecentAuthAuditLogs(recentPagination.offset, recentPagination.limit, sortBy, sortDirection);
   const failedLogs = useFailedAuthAttempts(failedPagination.offset, failedPagination.limit, sortBy, sortDirection);
 
-  const handleSort = useCallback((column: string) => {
-    toggleSort(column);
-    resetMyPage();
-    resetRecentPage();
-    resetFailedPage();
-  }, [toggleSort, resetMyPage, resetRecentPage, resetFailedPage]);
+  const handleSort = toggleSort;
 
   const myTotal = myLogs.total;
   const recentTotal = recentLogs.total;

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useMemo, useEffect } from "react";
+import { Fragment, useState, useMemo, useEffect, useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -71,7 +71,7 @@ function Subcategories() {
   usePageTitle("Subcategories");
   const { params: linkParams, clearParams, hasActiveFilter } = useEntityLinkParams(FILTER_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ sortBy, sortDirection });
   const allSubcatQuery = useSubcategories(offset, limit, sortBy, sortDirection);
   const filteredSubcatQuery = useSubcategoriesByCategoryId(linkParams.categoryId ?? null, offset, limit, sortBy, sortDirection);
   const activeSubcatQuery = linkParams.categoryId ? filteredSubcatQuery : allSubcatQuery;
@@ -101,7 +101,10 @@ function Subcategories() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = toggleSort;
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data = (subcategoriesData as SubcategoryResponse[] | undefined) ?? [];
 

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useMemo, useEffect, useCallback } from "react";
+import { Fragment, useState, useMemo, useEffect } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -71,7 +71,7 @@ function Subcategories() {
   usePageTitle("Subcategories");
   const { params: linkParams, clearParams, hasActiveFilter } = useEntityLinkParams(FILTER_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
   const allSubcatQuery = useSubcategories(offset, limit, sortBy, sortDirection);
   const filteredSubcatQuery = useSubcategoriesByCategoryId(linkParams.categoryId ?? null, offset, limit, sortBy, sortDirection);
   const activeSubcatQuery = linkParams.categoryId ? filteredSubcatQuery : allSubcatQuery;
@@ -101,10 +101,7 @@ function Subcategories() {
     return () => window.removeEventListener("shortcut:new-item", onNewItem);
   }, []);
 
-  const handleSort = useCallback((column: string) => {
-    toggleSort(column);
-    resetPage();
-  }, [toggleSort, resetPage]);
+  const handleSort = toggleSort;
 
   const data = (subcategoriesData as SubcategoryResponse[] | undefined) ?? [];
 

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -91,7 +91,7 @@ const FILTER_PARAMS = ["receiptId", "accountId"] as const;
 function Transactions() {
   usePageTitle("Transactions");
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "date", defaultSortDirection: "desc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination();
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
   const { params: linkParams, clearParams, hasActiveFilter } = useEntityLinkParams(FILTER_PARAMS);
   const allTxnQuery = useTransactions(offset, limit, sortBy, sortDirection);
   const filteredTxnQuery = useTransactionsByReceiptId(linkParams.receiptId ?? null, offset, limit, sortBy, sortDirection);
@@ -134,10 +134,7 @@ function Transactions() {
     return map;
   }, [receiptsData]);
 
-  const handleSort = useCallback((column: string) => {
-    toggleSort(column);
-    resetPage();
-  }, [toggleSort, resetPage]);
+  const handleSort = toggleSort;
 
   const data: EnrichedTransaction[] = useMemo(() => {
     const list = (transactionsData as TransactionResponse[] | undefined) ?? [];

--- a/src/client/src/pages/Transactions.tsx
+++ b/src/client/src/pages/Transactions.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -91,7 +91,7 @@ const FILTER_PARAMS = ["receiptId", "accountId"] as const;
 function Transactions() {
   usePageTitle("Transactions");
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "date", defaultSortDirection: "desc" });
-  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize } = useServerPagination({ sortBy, sortDirection });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ sortBy, sortDirection });
   const { params: linkParams, clearParams, hasActiveFilter } = useEntityLinkParams(FILTER_PARAMS);
   const allTxnQuery = useTransactions(offset, limit, sortBy, sortDirection);
   const filteredTxnQuery = useTransactionsByReceiptId(linkParams.receiptId ?? null, offset, limit, sortBy, sortDirection);
@@ -134,7 +134,10 @@ function Transactions() {
     return map;
   }, [receiptsData]);
 
-  const handleSort = toggleSort;
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
 
   const data: EnrichedTransaction[] = useMemo(() => {
     const list = (transactionsData as TransactionResponse[] | undefined) ?? [];


### PR DESCRIPTION
## Summary
- `useServerPagination` now accepts optional `sortBy`/`sortDirection` params and automatically resets offset to 0 when they change, fixing the bug where browser back/forward would change sort URL params but leave pagination stuck on a stale page
- All 10 page components (Accounts, AdminUsers, AuditLog, Categories, ItemTemplates, ReceiptItems, Receipts, SecurityLog, Subcategories, Transactions) now pass sort state into `useServerPagination`, removing the manual `handleSort` wrappers that only handled click-triggered sort changes
- Added 5 new unit tests covering sort-triggered pagination reset, initial mount stability, same-value no-op, and backward compatibility

Resolves RECEIPTS-408

## Test plan
- Verify `useServerPagination` tests pass (15 tests including 5 new ones)
- Verify all page component tests pass (191 tests across 12 files)
- Manual: navigate to a list page, go to page 3, click a sort header, go to page 2, press browser Back — pagination should reset to page 1 when sort params revert