### PR TITLE
fix(client): clear combobox search on popover close (RECEIPTS-406)

### DIFF
--- a/src/client/src/components/ui/combobox.test.tsx
+++ b/src/client/src/components/ui/combobox.test.tsx
@@ -162,6 +162,35 @@ describe("Combobox", () => {
     });
   });
 
+  it("clears search when popover closes without selection", async () => {
+    const user = userEvent.setup();
+    render(<Combobox {...defaultProps} />);
+
+    // Open and type to filter
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => {
+      expect(screen.getByText("Apple")).toBeInTheDocument();
+    });
+    await user.type(screen.getByPlaceholderText("Search fruit..."), "ban");
+
+    await waitFor(() => {
+      expect(screen.getByText("Banana")).toBeInTheDocument();
+      expect(screen.queryByText("Apple")).not.toBeInTheDocument();
+    });
+
+    // Close without selecting (press Escape)
+    await user.keyboard("{Escape}");
+
+    // Reopen — all options should be visible (search was cleared)
+    await user.click(screen.getByRole("combobox"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Apple")).toBeInTheDocument();
+      expect(screen.getByText("Banana")).toBeInTheDocument();
+      expect(screen.getByText("Cherry")).toBeInTheDocument();
+    });
+  });
+
   it("filters by sublabel when present", async () => {
     const optionsWithSublabels: ComboboxOption[] = [
       { value: "milk", label: "Milk", sublabel: "Dairy" },

--- a/src/client/src/components/ui/combobox.tsx
+++ b/src/client/src/components/ui/combobox.tsx
@@ -59,7 +59,13 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
     const selected = options.find((o) => o.value === value);
 
     return (
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover
+        open={open}
+        onOpenChange={(isOpen) => {
+          setOpen(isOpen);
+          if (!isOpen) setSearch("");
+        }}
+      >
         <PopoverTrigger asChild>
           <Button
             ref={ref}


### PR DESCRIPTION
## Summary
- Clear the combobox search input when the popover closes without a selection, fixing stale search state that caused the filtered results to persist on the next open
- Add a test verifying that closing the popover via Escape resets the search and shows all options on reopen

Resolves RECEIPTS-406

## Test plan
1. Open any combobox in the app (e.g., category or account selectors)
2. Type a search query to filter the options
3. Close the popover without selecting (press Escape or click outside)
4. Reopen the combobox -- all options should be visible, not filtered
5. Run `npx vitest run src/components/ui/combobox.test.tsx` -- all 11 tests pass