### PR TITLE
feat(client): replace receipt wizard with single-page form

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -21,7 +21,7 @@ import AdminUsers from "@/pages/AdminUsers";
 import AuditLog from "@/pages/AuditLog";
 import SecurityLog from "@/pages/SecurityLog";
 import RecycleBin from "@/pages/RecycleBin";
-import NewReceipt from "@/pages/wizard/NewReceipt";
+import NewReceipt from "@/pages/new-receipt/NewReceiptPage";
 import NotFound from "@/pages/NotFound";
 
 export const routeConfig = [

--- a/src/client/src/components/ui/date-input.tsx
+++ b/src/client/src/components/ui/date-input.tsx
@@ -220,6 +220,7 @@ export function DateInput({
         onChange={(e) => onChange(e.target.value)}
         onBlur={onBlur}
         disabled={disabled}
+        aria-invalid={isInvalid || undefined}
         className={cn(
           "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -186,7 +186,7 @@ function Receipts() {
             </Button>
           )}
           <Button variant="outline" asChild>
-            <Link to="/receipts/new">New Receipt (Wizard)</Link>
+            <Link to="/receipts/new">New Receipt</Link>
           </Button>
           <Button onClick={() => setCreateOpen(true)}>Quick Add</Button>
         </div>

--- a/src/client/src/pages/new-receipt/BalanceSidebar.test.tsx
+++ b/src/client/src/pages/new-receipt/BalanceSidebar.test.tsx
@@ -1,0 +1,85 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { BalanceSidebar } from "./BalanceSidebar";
+
+describe("BalanceSidebar", () => {
+  const defaultProps = {
+    subtotal: 50,
+    taxAmount: 5,
+    transactionTotal: 55,
+    isSubmitting: false,
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it("renders balance summary values", () => {
+    renderWithProviders(<BalanceSidebar {...defaultProps} />);
+    expect(screen.getByText("Balance")).toBeInTheDocument();
+    expect(screen.getByText("$50.00")).toBeInTheDocument(); // subtotal
+    expect(screen.getByText("$5.00")).toBeInTheDocument(); // tax
+  });
+
+  it("shows Balanced badge when balanced", () => {
+    renderWithProviders(<BalanceSidebar {...defaultProps} />);
+    expect(screen.getByText("Balanced")).toBeInTheDocument();
+  });
+
+  it("shows Unbalanced badge when not balanced", () => {
+    renderWithProviders(
+      <BalanceSidebar {...defaultProps} transactionTotal={40} />,
+    );
+    expect(screen.getByText("Unbalanced by $15.00")).toBeInTheDocument();
+  });
+
+  it("enables submit button when balanced", () => {
+    renderWithProviders(<BalanceSidebar {...defaultProps} />);
+    expect(
+      screen.getByRole("button", { name: /submit receipt/i }),
+    ).toBeEnabled();
+  });
+
+  it("disables submit button when unbalanced", () => {
+    renderWithProviders(
+      <BalanceSidebar {...defaultProps} transactionTotal={40} />,
+    );
+    expect(
+      screen.getByRole("button", { name: /submit receipt/i }),
+    ).toBeDisabled();
+  });
+
+  it("disables submit button when submitting", () => {
+    renderWithProviders(
+      <BalanceSidebar {...defaultProps} isSubmitting={true} />,
+    );
+    expect(screen.getByText("Submitting...")).toBeDisabled();
+  });
+
+  it("calls onSubmit when submit button clicked", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <BalanceSidebar {...defaultProps} onSubmit={onSubmit} />,
+    );
+    await user.click(screen.getByRole("button", { name: /submit receipt/i }));
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it("calls onCancel when cancel button clicked", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    renderWithProviders(
+      <BalanceSidebar {...defaultProps} onCancel={onCancel} />,
+    );
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("displays expected total and transaction total", () => {
+    renderWithProviders(<BalanceSidebar {...defaultProps} />);
+    // Expected total = subtotal + tax = 55
+    // Transaction total = 55
+    const fiftyFives = screen.getAllByText("$55.00");
+    expect(fiftyFives).toHaveLength(2);
+  });
+});

--- a/src/client/src/pages/new-receipt/BalanceSidebar.tsx
+++ b/src/client/src/pages/new-receipt/BalanceSidebar.tsx
@@ -1,0 +1,93 @@
+import { formatCurrency } from "@/lib/format";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface BalanceSidebarProps {
+  subtotal: number;
+  taxAmount: number;
+  transactionTotal: number;
+  isSubmitting: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+export function BalanceSidebar({
+  subtotal,
+  taxAmount,
+  transactionTotal,
+  isSubmitting,
+  onSubmit,
+  onCancel,
+}: BalanceSidebarProps) {
+  const expectedTotal = subtotal + taxAmount;
+  const balanceDiff = Math.abs(expectedTotal - transactionTotal);
+  const isBalanced = balanceDiff < 0.01;
+
+  return (
+    <div className="sticky top-6 space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Balance</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-y-2 text-sm">
+            <span className="text-muted-foreground">Subtotal</span>
+            <span className="text-right">{formatCurrency(subtotal)}</span>
+            <span className="text-muted-foreground">Tax</span>
+            <span className="text-right">{formatCurrency(taxAmount)}</span>
+            <Separator className="col-span-2 my-1" />
+            <span className="font-medium">Expected Total</span>
+            <span className="text-right font-medium">
+              {formatCurrency(expectedTotal)}
+            </span>
+            <span className="font-medium">Transaction Total</span>
+            <span className="text-right font-medium">
+              {formatCurrency(transactionTotal)}
+            </span>
+          </div>
+          <div className="mt-3 text-right">
+            <Badge variant={isBalanced ? "default" : "destructive"}>
+              {isBalanced
+                ? "Balanced"
+                : `Unbalanced by ${formatCurrency(balanceDiff)}`}
+            </Badge>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-block w-full">
+              <Button
+                className={`w-full ${!isBalanced ? "pointer-events-none" : ""}`}
+                onClick={onSubmit}
+                disabled={isSubmitting || !isBalanced}
+              >
+                {isSubmitting ? "Submitting..." : "Submit Receipt"}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          {!isBalanced && (
+            <TooltipContent>
+              <p>
+                Receipt is unbalanced by {formatCurrency(balanceDiff)}. Adjust
+                transactions or line items so totals match.
+              </p>
+            </TooltipContent>
+          )}
+        </Tooltip>
+        <Button variant="ghost" className="w-full" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/client/src/pages/new-receipt/BalanceSidebar.tsx
+++ b/src/client/src/pages/new-receipt/BalanceSidebar.tsx
@@ -37,22 +37,22 @@ export function BalanceSidebar({
           <CardTitle className="text-lg">Balance</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-2 gap-y-2 text-sm">
-            <span className="text-muted-foreground">Subtotal</span>
-            <span className="text-right">{formatCurrency(subtotal)}</span>
-            <span className="text-muted-foreground">Tax</span>
-            <span className="text-right">{formatCurrency(taxAmount)}</span>
+          <dl className="grid grid-cols-2 gap-y-2 text-sm">
+            <dt className="text-muted-foreground">Subtotal</dt>
+            <dd className="text-right">{formatCurrency(subtotal)}</dd>
+            <dt className="text-muted-foreground">Tax</dt>
+            <dd className="text-right">{formatCurrency(taxAmount)}</dd>
             <Separator className="col-span-2 my-1" />
-            <span className="font-medium">Expected Total</span>
-            <span className="text-right font-medium">
+            <dt className="font-medium">Expected Total</dt>
+            <dd className="text-right font-medium">
               {formatCurrency(expectedTotal)}
-            </span>
-            <span className="font-medium">Transaction Total</span>
-            <span className="text-right font-medium">
+            </dd>
+            <dt className="font-medium">Transaction Total</dt>
+            <dd className="text-right font-medium">
               {formatCurrency(transactionTotal)}
-            </span>
-          </div>
-          <div className="mt-3 text-right">
+            </dd>
+          </dl>
+          <div className="mt-3 text-right" role="status" aria-live="polite">
             <Badge variant={isBalanced ? "default" : "destructive"}>
               {isBalanced
                 ? "Balanced"
@@ -67,7 +67,7 @@ export function BalanceSidebar({
           <TooltipTrigger asChild>
             <span className="inline-block w-full">
               <Button
-                className={`w-full ${!isBalanced ? "pointer-events-none" : ""}`}
+                className="w-full"
                 onClick={onSubmit}
                 disabled={isSubmitting || !isBalanced}
               >

--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -1,0 +1,171 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
+import "@/test/setup-combobox-polyfills";
+import { LineItemsSection, type ReceiptLineItem } from "./LineItemsSection";
+
+vi.mock("@/hooks/useCategories", () => ({
+  useCategories: vi.fn(() =>
+    mockQueryResult({
+      data: [
+        { id: "cat-1", name: "Food" },
+        { id: "cat-2", name: "Household" },
+      ],
+      isLoading: false,
+      isSuccess: true,
+    }),
+  ),
+}));
+
+vi.mock("@/hooks/useSubcategories", () => ({
+  useSubcategoriesByCategoryId: vi.fn(() =>
+    mockQueryResult({
+      data: [],
+      isLoading: false,
+      isSuccess: true,
+    }),
+  ),
+  useCreateSubcategory: vi.fn(() => mockMutationResult()),
+}));
+
+vi.mock("@/hooks/useSimilarItems", () => ({
+  useSimilarItems: vi.fn(() =>
+    mockQueryResult({
+      data: [],
+      isFetching: false,
+    }),
+  ),
+  useCategoryRecommendations: vi.fn(() =>
+    mockQueryResult({
+      data: [],
+    }),
+  ),
+}));
+
+describe("LineItemsSection", () => {
+  const defaultProps = {
+    items: [] as ReceiptLineItem[],
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the card title", () => {
+    renderWithProviders(<LineItemsSection {...defaultProps} />);
+    expect(screen.getByText("Line Items")).toBeInTheDocument();
+  });
+
+  it("renders the form fields", () => {
+    renderWithProviders(<LineItemsSection {...defaultProps} />);
+    expect(screen.getByPlaceholderText("Item description")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("e.g. MILK-GAL")).toBeInTheDocument();
+  });
+
+  it("renders Add Item button", () => {
+    renderWithProviders(<LineItemsSection {...defaultProps} />);
+    expect(
+      screen.getByRole("button", { name: /add item/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("displays subtotal", () => {
+    renderWithProviders(<LineItemsSection {...defaultProps} />);
+    expect(screen.getByText("Subtotal: $0.00")).toBeInTheDocument();
+  });
+
+  it("renders existing items", () => {
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity",
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+    expect(screen.getByText("$3.50")).toBeInTheDocument();
+    expect(screen.getByText("$7.00")).toBeInTheDocument(); // line total
+    expect(screen.getByText("Food")).toBeInTheDocument();
+  });
+
+  it("displays subtotal with existing items", () => {
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity",
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+      {
+        id: "2",
+        receiptItemCode: "",
+        description: "Bread",
+        pricingMode: "flat",
+        quantity: 1,
+        unitPrice: 4.0,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+    expect(screen.getByText("Subtotal: $11.00")).toBeInTheDocument();
+  });
+
+  it("calls onChange when an item is removed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity",
+        quantity: 1,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection items={items} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("shows category/subcategory for items", () => {
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Soap",
+        pricingMode: "flat",
+        quantity: 1,
+        unitPrice: 5,
+        category: "Household",
+        subcategory: "Cleaning",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+    expect(screen.getByText("Household / Cleaning")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -1,0 +1,575 @@
+import { useState, useMemo, useCallback, useRef } from "react";
+import { generateId } from "@/lib/id";
+import { useForm } from "react-hook-form";
+import { z } from "zod/v4";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCategories } from "@/hooks/useCategories";
+import {
+  useSubcategoriesByCategoryId,
+  useCreateSubcategory,
+} from "@/hooks/useSubcategories";
+import {
+  useSimilarItems,
+  useCategoryRecommendations,
+} from "@/hooks/useSimilarItems";
+import { formatCurrency } from "@/lib/format";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverAnchor,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Combobox } from "@/components/ui/combobox";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import { Badge } from "@/components/ui/badge";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Plus, Trash2, Loader2, Sparkles } from "lucide-react";
+
+const itemSchema = z
+  .object({
+    receiptItemCode: z.string().optional().default(""),
+    description: z.string().min(1, "Description is required"),
+    pricingMode: z.enum(["quantity", "flat"]),
+    quantity: z.number().positive("Quantity must be positive"),
+    unitPrice: z.number().min(0, "Unit price must be non-negative"),
+    category: z.string().min(1, "Category is required"),
+    subcategory: z.string().optional().default(""),
+  })
+  .refine((data) => data.pricingMode !== "flat" || data.quantity === 1, {
+    message: "Quantity must be 1 for flat pricing",
+    path: ["quantity"],
+  });
+
+type ItemFormValues = z.output<typeof itemSchema>;
+
+export interface ReceiptLineItem {
+  id: string;
+  receiptItemCode: string;
+  description: string;
+  pricingMode: "quantity" | "flat";
+  quantity: number;
+  unitPrice: number;
+  category: string;
+  subcategory: string;
+}
+
+interface LineItemsSectionProps {
+  items: ReceiptLineItem[];
+  onChange: (items: ReceiptLineItem[]) => void;
+}
+
+export function LineItemsSection({ items, onChange }: LineItemsSectionProps) {
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const suggestionsListId = "new-receipt-suggestions-list";
+  const { data: categories } = useCategories();
+
+  const categoryOptions = useMemo(
+    () =>
+      (
+        (categories as { id: string; name: string }[] | undefined) ?? []
+      ).map((c) => ({ value: c.name, label: c.name })),
+    [categories],
+  );
+
+  const form = useForm<ItemFormValues>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: zodResolver(itemSchema) as any,
+    defaultValues: {
+      receiptItemCode: "",
+      description: "",
+      pricingMode: "quantity",
+      quantity: 1,
+      unitPrice: 0,
+      category: "",
+      subcategory: "",
+    },
+  });
+
+  const description = form.watch("description");
+  const selectedCategory = form.watch("category");
+  const pricingMode = form.watch("pricingMode");
+
+  const { data: similarItems, isFetching: isFetchingSimilar } =
+    useSimilarItems(description, { enabled: showSuggestions });
+
+  const hasResults = similarItems && similarItems.length > 0;
+  const hasNoResultsMessage =
+    description.length >= 2 &&
+    !isFetchingSimilar &&
+    similarItems &&
+    similarItems.length === 0;
+  const isSuggestionsOpen =
+    showSuggestions && (hasResults || hasNoResultsMessage);
+
+  const { data: categoryRecs } = useCategoryRecommendations(description, {
+    enabled: description.length >= 2 && !selectedCategory,
+  });
+
+  const selectedCategoryObj = useMemo(
+    () =>
+      (
+        (categories as { id: string; name: string }[] | undefined) ?? []
+      ).find((c) => c.name === selectedCategory),
+    [categories, selectedCategory],
+  );
+
+  const { data: subcategories } = useSubcategoriesByCategoryId(
+    selectedCategoryObj?.id ?? "",
+  );
+  const createSubcategory = useCreateSubcategory();
+  const pendingSubcategories = useRef(new Set<string>());
+
+  const subcategoryOptions = useMemo(
+    () =>
+      (
+        (subcategories as { id: string; name: string }[] | undefined) ?? []
+      ).map((s) => ({ value: s.name, label: s.name })),
+    [subcategories],
+  );
+
+  const subtotal = useMemo(
+    () => items.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0),
+    [items],
+  );
+
+  const applySuggestion = useCallback(
+    (suggestion: NonNullable<typeof similarItems>[number]) => {
+      form.setValue("description", suggestion.name);
+      if (suggestion.defaultCategory) {
+        form.setValue("category", suggestion.defaultCategory);
+      }
+      if (suggestion.defaultSubcategory) {
+        form.setValue("subcategory", suggestion.defaultSubcategory);
+      }
+      if (suggestion.defaultUnitPrice != null) {
+        form.setValue("unitPrice", suggestion.defaultUnitPrice);
+      }
+      if (
+        suggestion.defaultPricingMode === "quantity" ||
+        suggestion.defaultPricingMode === "flat"
+      ) {
+        form.setValue("pricingMode", suggestion.defaultPricingMode);
+        if (suggestion.defaultPricingMode === "flat") {
+          form.setValue("quantity", 1);
+        }
+      }
+      if (suggestion.defaultItemCode) {
+        form.setValue("receiptItemCode", suggestion.defaultItemCode);
+      }
+      setShowSuggestions(false);
+    },
+    [form],
+  );
+
+  const applyCategoryRec = useCallback(
+    (rec: NonNullable<typeof categoryRecs>[number]) => {
+      form.setValue("category", rec.category);
+      if (rec.subcategory) {
+        form.setValue("subcategory", rec.subcategory);
+      }
+    },
+    [form],
+  );
+
+  const handleDescriptionKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        setShowSuggestions(false);
+      } else if (e.key === "ArrowDown" && isSuggestionsOpen) {
+        e.preventDefault();
+        const list = document.getElementById(suggestionsListId);
+        const firstItem = list?.querySelector(
+          "[cmdk-item]",
+        ) as HTMLElement | null;
+        firstItem?.focus();
+      }
+    },
+    [isSuggestionsOpen, suggestionsListId],
+  );
+
+  const handleAdd = useCallback(
+    (values: ItemFormValues) => {
+      const newItem: ReceiptLineItem = {
+        id: generateId(),
+        receiptItemCode: values.receiptItemCode ?? "",
+        description: values.description,
+        pricingMode: values.pricingMode,
+        quantity: values.quantity,
+        unitPrice: values.unitPrice,
+        category: values.category,
+        subcategory: values.subcategory ?? "",
+      };
+      onChange([...items, newItem]);
+      form.reset({
+        receiptItemCode: "",
+        description: "",
+        pricingMode: "quantity",
+        quantity: 1,
+        unitPrice: 0,
+        category: values.category,
+        subcategory: "",
+      });
+      setShowSuggestions(false);
+    },
+    [form, items, onChange],
+  );
+
+  const handleRemove = useCallback(
+    (id: string) => {
+      onChange(items.filter((item) => item.id !== id));
+    },
+    [items, onChange],
+  );
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">Line Items</CardTitle>
+          <span className="text-sm text-muted-foreground">
+            Subtotal: {formatCurrency(subtotal)}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleAdd)}
+            className="space-y-4"
+          >
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <Popover
+                      open={isSuggestionsOpen}
+                      onOpenChange={setShowSuggestions}
+                    >
+                      <PopoverAnchor asChild>
+                        <FormControl>
+                          <div className="relative">
+                            <Input
+                              role="combobox"
+                              placeholder="Item description"
+                              aria-required="true"
+                              aria-autocomplete="list"
+                              aria-expanded={isSuggestionsOpen}
+                              aria-controls={suggestionsListId}
+                              autoComplete="off"
+                              {...field}
+                              onFocus={() => setShowSuggestions(true)}
+                              onKeyDown={handleDescriptionKeyDown}
+                            />
+                            {isFetchingSimilar && description.length >= 2 && (
+                              <Loader2 className="absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+                            )}
+                          </div>
+                        </FormControl>
+                      </PopoverAnchor>
+                      <PopoverContent
+                        className="w-[--radix-popover-trigger-width] p-0"
+                        align="start"
+                        onOpenAutoFocus={(e) => e.preventDefault()}
+                        onInteractOutside={() => setShowSuggestions(false)}
+                      >
+                        <Command shouldFilter={false}>
+                          <CommandList id={suggestionsListId}>
+                            <CommandEmpty>No similar items found</CommandEmpty>
+                            {similarItems?.map((item) => (
+                              <CommandItem
+                                key={`${item.name}-${item.source}`}
+                                value={`${item.name} ${item.source}`}
+                                onSelect={() => applySuggestion(item)}
+                              >
+                                <div className="flex w-full items-center justify-between">
+                                  <div className="flex flex-col gap-0.5">
+                                    <span className="font-medium">
+                                      {item.name}
+                                    </span>
+                                    {item.defaultCategory && (
+                                      <span className="text-xs text-muted-foreground">
+                                        {item.defaultCategory}
+                                        {item.defaultSubcategory
+                                          ? ` / ${item.defaultSubcategory}`
+                                          : ""}
+                                        {item.defaultUnitPrice != null
+                                          ? ` · ${formatCurrency(item.defaultUnitPrice)}`
+                                          : ""}
+                                      </span>
+                                    )}
+                                  </div>
+                                  <div className="flex items-center gap-1.5">
+                                    <Badge
+                                      variant="outline"
+                                      className="text-[10px] px-1.5 py-0"
+                                    >
+                                      {item.source === "template"
+                                        ? "Template"
+                                        : "History"}
+                                    </Badge>
+                                    <span className="text-[10px] text-muted-foreground">
+                                      {Math.round(item.combinedScore * 100)}%
+                                    </span>
+                                  </div>
+                                </div>
+                              </CommandItem>
+                            ))}
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="category"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Category</FormLabel>
+                    <FormControl>
+                      <Combobox
+                        options={categoryOptions}
+                        value={field.value}
+                        onValueChange={(v) => {
+                          field.onChange(v);
+                          form.setValue("subcategory", "");
+                        }}
+                        placeholder="Select category..."
+                        searchPlaceholder="Search categories..."
+                        emptyMessage="No categories found."
+                        aria-required="true"
+                      />
+                    </FormControl>
+                    {categoryRecs &&
+                      categoryRecs.length > 0 &&
+                      !selectedCategory && (
+                        <div className="flex flex-wrap gap-1 pt-1">
+                          <Sparkles className="h-3 w-3 text-muted-foreground mt-0.5" />
+                          {categoryRecs.map((rec) => (
+                            <button
+                              key={`${rec.category}-${rec.subcategory ?? ""}`}
+                              type="button"
+                              className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                              onClick={() => applyCategoryRec(rec)}
+                            >
+                              {rec.category}
+                              {rec.subcategory ? ` / ${rec.subcategory}` : ""}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="subcategory"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Subcategory (optional)</FormLabel>
+                    <FormControl>
+                      <Combobox
+                        options={subcategoryOptions}
+                        value={field.value ?? ""}
+                        onValueChange={(v: string) => {
+                          field.onChange(v);
+                          const isExisting = subcategoryOptions.some(
+                            (o) => o.value === v,
+                          );
+                          if (
+                            !isExisting &&
+                            v &&
+                            selectedCategoryObj?.id &&
+                            !pendingSubcategories.current.has(v)
+                          ) {
+                            pendingSubcategories.current.add(v);
+                            createSubcategory.mutate(
+                              {
+                                categoryId: selectedCategoryObj.id,
+                                name: v,
+                              },
+                              {
+                                onSettled: () => {
+                                  pendingSubcategories.current.delete(v);
+                                },
+                              },
+                            );
+                          }
+                        }}
+                        placeholder="Select subcategory..."
+                        searchPlaceholder="Search subcategories..."
+                        emptyMessage="No subcategories found."
+                        allowCustom
+                        disabled={!selectedCategory}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-[auto_auto_auto_auto_1fr] sm:items-end">
+              <FormField
+                control={form.control}
+                name="receiptItemCode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Item Code</FormLabel>
+                    <FormControl>
+                      <Input placeholder="e.g. MILK-GAL" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="pricingMode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Pricing</FormLabel>
+                    <FormControl>
+                      <Combobox
+                        options={[
+                          { value: "quantity", label: "Quantity" },
+                          { value: "flat", label: "Flat" },
+                        ]}
+                        value={field.value}
+                        onValueChange={(v) => {
+                          field.onChange(v);
+                          if (v === "flat") form.setValue("quantity", 1);
+                        }}
+                        placeholder="Mode..."
+                        searchPlaceholder="Search modes..."
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="quantity"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Qty</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="any"
+                        min="0.01"
+                        className="w-20"
+                        disabled={pricingMode === "flat"}
+                        {...field}
+                        onChange={(e) => field.onChange(Number(e.target.value))}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="unitPrice"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {pricingMode === "flat" ? "Price" : "Unit Price"}
+                    </FormLabel>
+                    <FormControl>
+                      <CurrencyInput {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-end sm:mb-0.5">
+                <Button type="submit" variant="secondary" size="sm">
+                  <Plus className="mr-1 h-4 w-4" />
+                  Add Item
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Form>
+
+        {items.length > 0 && (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Description</TableHead>
+                <TableHead>Qty</TableHead>
+                <TableHead>Unit Price</TableHead>
+                <TableHead>Line Total</TableHead>
+                <TableHead>Category</TableHead>
+                <TableHead className="w-12" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell>{item.description}</TableCell>
+                  <TableCell>{item.quantity}</TableCell>
+                  <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
+                  <TableCell>
+                    {formatCurrency(item.quantity * item.unitPrice)}
+                  </TableCell>
+                  <TableCell>
+                    {item.category}
+                    {item.subcategory ? ` / ${item.subcategory}` : ""}
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemove(item.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      <span className="sr-only">Remove</span>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -287,7 +287,10 @@ export function LineItemsSection({ items, onChange }: LineItemsSectionProps) {
                               onKeyDown={handleDescriptionKeyDown}
                             />
                             {isFetchingSimilar && description.length >= 2 && (
-                              <Loader2 className="absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+                              <>
+                                <Loader2 className="absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" aria-hidden="true" />
+                                <span className="sr-only" role="status">Loading suggestions...</span>
+                              </>
                             )}
                           </div>
                         </FormControl>
@@ -372,13 +375,13 @@ export function LineItemsSection({ items, onChange }: LineItemsSectionProps) {
                     {categoryRecs &&
                       categoryRecs.length > 0 &&
                       !selectedCategory && (
-                        <div className="flex flex-wrap gap-1 pt-1">
-                          <Sparkles className="h-3 w-3 text-muted-foreground mt-0.5" />
+                        <div className="flex flex-wrap gap-1 pt-1" role="group" aria-label="Suggested categories">
+                          <Sparkles className="h-3 w-3 text-muted-foreground mt-1" aria-hidden="true" />
                           {categoryRecs.map((rec) => (
                             <button
                               key={`${rec.category}-${rec.subcategory ?? ""}`}
                               type="button"
-                              className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                              className="inline-flex items-center rounded-full border px-3 py-1 text-xs min-h-[24px] text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
                               onClick={() => applyCategoryRec(rec)}
                             >
                               {rec.category}
@@ -422,6 +425,9 @@ export function LineItemsSection({ items, onChange }: LineItemsSectionProps) {
                               {
                                 onSettled: () => {
                                   pendingSubcategories.current.delete(v);
+                                },
+                                onError: () => {
+                                  field.onChange("");
                                 },
                               },
                             );
@@ -538,7 +544,9 @@ export function LineItemsSection({ items, onChange }: LineItemsSectionProps) {
                 <TableHead>Unit Price</TableHead>
                 <TableHead>Line Total</TableHead>
                 <TableHead>Category</TableHead>
-                <TableHead className="w-12" />
+                <TableHead className="w-12">
+                  <span className="sr-only">Actions</span>
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -300,7 +300,6 @@ describe("NewReceiptPage", () => {
             }),
           ],
         }),
-        { onSuccess: undefined, onError: undefined },
       );
     });
 

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -1,0 +1,343 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { mockMutationResult } from "@/test/mock-hooks";
+import "@/test/setup-combobox-polyfills";
+import NewReceiptPage from "./NewReceiptPage";
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+const mockCreateCompleteReceiptAsync = vi.fn();
+
+vi.mock("@/hooks/useReceipts", () => ({
+  useCreateCompleteReceipt: vi.fn(() =>
+    mockMutationResult({ mutateAsync: mockCreateCompleteReceiptAsync }),
+  ),
+}));
+
+vi.mock("@/hooks/useLocationHistory", () => ({
+  useLocationHistory: vi.fn(() => ({
+    locations: [],
+    options: [{ value: "Walmart", label: "Walmart" }],
+    add: vi.fn(),
+    clear: vi.fn(),
+  })),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useNavigate: vi.fn(() => mockNavigate),
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// Mock child sections to isolate page logic
+vi.mock("./TransactionsSection", () => ({
+  TransactionsSection: ({
+    onChange,
+  }: {
+    transactions: unknown[];
+    receiptDate: string;
+    onChange: (data: unknown[]) => void;
+  }) => (
+    <div data-testid="transactions-section">
+      <button
+        onClick={() =>
+          onChange([
+            { id: "t1", accountId: "acct-1", amount: 55, date: "2024-01-15" },
+          ])
+        }
+      >
+        Add Transaction
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("./LineItemsSection", () => ({
+  LineItemsSection: ({
+    onChange,
+  }: {
+    items: unknown[];
+    onChange: (data: unknown[]) => void;
+  }) => (
+    <div data-testid="line-items-section">
+      <button
+        onClick={() =>
+          onChange([
+            {
+              id: "i1",
+              receiptItemCode: "",
+              description: "Milk",
+              pricingMode: "quantity",
+              quantity: 1,
+              unitPrice: 50,
+              category: "Food",
+              subcategory: "",
+            },
+          ])
+        }
+      >
+        Add Item
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("./BalanceSidebar", () => ({
+  BalanceSidebar: ({
+    onSubmit,
+    onCancel,
+    isSubmitting,
+  }: {
+    subtotal: number;
+    taxAmount: number;
+    transactionTotal: number;
+    isSubmitting: boolean;
+    onSubmit: () => void;
+    onCancel: () => void;
+  }) => (
+    <div data-testid="balance-sidebar">
+      <button onClick={onSubmit} disabled={isSubmitting}>
+        {isSubmitting ? "Submitting..." : "Submit Receipt"}
+      </button>
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}));
+
+describe("NewReceiptPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateCompleteReceiptAsync.mockResolvedValue({
+      receipt: { id: "receipt-123" },
+      transactions: [],
+      items: [],
+    });
+  });
+
+  it("renders the page heading", () => {
+    renderWithProviders(<NewReceiptPage />);
+    expect(
+      screen.getByRole("heading", { name: /new receipt/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all three sections", () => {
+    renderWithProviders(<NewReceiptPage />);
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByTestId("transactions-section")).toBeInTheDocument();
+    expect(screen.getByTestId("line-items-section")).toBeInTheDocument();
+  });
+
+  it("renders balance sidebar", () => {
+    renderWithProviders(<NewReceiptPage />);
+    expect(screen.getAllByTestId("balance-sidebar").length).toBeGreaterThan(0);
+  });
+
+  it("navigates directly to /receipts when cancel clicked with no data", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Click the first cancel button (there are two — desktop and mobile)
+    const cancelButtons = screen.getAllByText("Cancel");
+    await user.click(cancelButtons[0]);
+    expect(mockNavigate).toHaveBeenCalledWith("/receipts");
+  });
+
+  it("shows discard dialog when cancel clicked after entering data", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Add a transaction to make the form dirty
+    await user.click(screen.getAllByText("Add Transaction")[0]);
+
+    // Click cancel
+    const cancelButtons = screen.getAllByText("Cancel");
+    await user.click(cancelButtons[0]);
+
+    expect(screen.getByText("Discard receipt?")).toBeInTheDocument();
+  });
+
+  it("discards and navigates when Discard is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Add data
+    await user.click(screen.getAllByText("Add Transaction")[0]);
+
+    // Open discard dialog
+    const cancelButtons = screen.getAllByText("Cancel");
+    await user.click(cancelButtons[0]);
+
+    // Click Discard
+    await user.click(screen.getByText("Discard"));
+    expect(mockNavigate).toHaveBeenCalledWith("/receipts");
+  });
+
+  it("continues editing when Continue editing is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Add data
+    await user.click(screen.getAllByText("Add Transaction")[0]);
+
+    // Open discard dialog
+    const cancelButtons = screen.getAllByText("Cancel");
+    await user.click(cancelButtons[0]);
+
+    // Click Continue editing
+    await user.click(screen.getByText("Continue editing"));
+    expect(screen.queryByText("Discard receipt?")).not.toBeInTheDocument();
+  });
+
+  it("shows error toast when submitting without transactions", async () => {
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Fill header (location is a combobox — select Walmart)
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const walmart = await screen.findByText("Walmart");
+    await user.click(walmart);
+
+    // Fill date
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(dateInput);
+    await user.type(dateInput, "01/15/2024");
+
+    // Add an item but no transaction
+    await user.click(screen.getAllByText("Add Item")[0]);
+
+    // Submit
+    const submitButtons = screen.getAllByText("Submit Receipt");
+    await user.click(submitButtons[0]);
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Add at least one transaction.",
+      );
+    });
+  });
+
+  it("shows error toast when submitting without line items", async () => {
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Fill header
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const walmart = await screen.findByText("Walmart");
+    await user.click(walmart);
+
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(dateInput);
+    await user.type(dateInput, "01/15/2024");
+
+    // Add a transaction but no items
+    await user.click(screen.getAllByText("Add Transaction")[0]);
+
+    // Submit
+    const submitButtons = screen.getAllByText("Submit Receipt");
+    await user.click(submitButtons[0]);
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Add at least one line item.",
+      );
+    });
+  });
+
+  it("submits receipt successfully with all data", async () => {
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Fill header
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const walmart = await screen.findByText("Walmart");
+    await user.click(walmart);
+
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(dateInput);
+    await user.type(dateInput, "01/15/2024");
+
+    // Add transaction and item
+    await user.click(screen.getAllByText("Add Transaction")[0]);
+    await user.click(screen.getAllByText("Add Item")[0]);
+
+    // Submit
+    const submitButtons = screen.getAllByText("Submit Receipt");
+    await user.click(submitButtons[0]);
+
+    await vi.waitFor(() => {
+      expect(mockCreateCompleteReceiptAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          receipt: expect.objectContaining({
+            location: "Walmart",
+          }),
+          transactions: [
+            expect.objectContaining({
+              accountId: "acct-1",
+              amount: 55,
+            }),
+          ],
+          items: [
+            expect.objectContaining({
+              description: "Milk",
+              category: "Food",
+            }),
+          ],
+        }),
+        { onSuccess: undefined, onError: undefined },
+      );
+    });
+
+    expect(toast.success).toHaveBeenCalledWith("Receipt created successfully!");
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "/receipt-detail?id=receipt-123&highlight=receipt-123",
+    );
+  });
+
+  it("shows error toast when submission fails", async () => {
+    const { toast } = await import("sonner");
+    mockCreateCompleteReceiptAsync.mockRejectedValueOnce(
+      new Error("Server error"),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Fill header
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const walmart = await screen.findByText("Walmart");
+    await user.click(walmart);
+
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(dateInput);
+    await user.type(dateInput, "01/15/2024");
+
+    // Add transaction and item
+    await user.click(screen.getAllByText("Add Transaction")[0]);
+    await user.click(screen.getAllByText("Add Item")[0]);
+
+    // Submit
+    const submitButtons = screen.getAllByText("Submit Receipt");
+    await user.click(submitButtons[0]);
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to create receipt.");
+    });
+  });
+});

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -73,6 +73,7 @@ export default function NewReceiptPage() {
     },
   });
 
+  const location = form.watch("location");
   const taxAmount = form.watch("taxAmount");
   const receiptDate = form.watch("date");
 
@@ -92,9 +93,9 @@ export default function NewReceiptPage() {
   );
 
   const hasData =
-    form.getValues("location") !== "" ||
-    form.getValues("date") !== "" ||
-    form.getValues("taxAmount") !== 0 ||
+    location !== "" ||
+    receiptDate !== "" ||
+    taxAmount !== 0 ||
     transactions.length > 0 ||
     items.length > 0;
 
@@ -132,30 +133,27 @@ export default function NewReceiptPage() {
     try {
       addLocation(headerValues.location);
 
-      const result = await createCompleteReceiptAsync(
-        {
-          receipt: {
-            location: headerValues.location,
-            date: headerValues.date,
-            taxAmount: headerValues.taxAmount,
-          },
-          transactions: transactions.map((txn) => ({
-            accountId: txn.accountId,
-            amount: txn.amount,
-            date: txn.date,
-          })),
-          items: items.map((item) => ({
-            receiptItemCode: item.receiptItemCode,
-            description: item.description,
-            quantity: item.quantity,
-            unitPrice: item.unitPrice,
-            category: item.category,
-            subcategory: item.subcategory,
-            pricingMode: item.pricingMode,
-          })),
+      const result = await createCompleteReceiptAsync({
+        receipt: {
+          location: headerValues.location,
+          date: headerValues.date,
+          taxAmount: headerValues.taxAmount,
         },
-        { onSuccess: undefined, onError: undefined },
-      );
+        transactions: transactions.map((txn) => ({
+          accountId: txn.accountId,
+          amount: txn.amount,
+          date: txn.date,
+        })),
+        items: items.map((item) => ({
+          receiptItemCode: item.receiptItemCode,
+          description: item.description,
+          quantity: item.quantity,
+          unitPrice: item.unitPrice,
+          category: item.category,
+          subcategory: item.subcategory,
+          pricingMode: item.pricingMode,
+        })),
+      });
 
       const receiptId = (result as { receipt: { id: string } }).receipt.id;
 
@@ -246,20 +244,20 @@ export default function NewReceiptPage() {
           {/* Transactions */}
           <TransactionsSection
             transactions={transactions}
-            receiptDate={receiptDate}
+            defaultDate={receiptDate}
             onChange={setTransactions}
           />
 
           {/* Balance warning between sections */}
           {transactions.length > 0 &&
-            Math.abs(transactionTotal) < 0.01 &&
-            taxAmount > 0 && (
+            items.length > 0 &&
+            Math.abs(subtotal + taxAmount - transactionTotal) >= 0.01 && (
               <Alert variant="destructive">
                 <AlertTriangle className="h-4 w-4" />
                 <AlertDescription>
-                  Transaction total is {formatCurrency(transactionTotal)} but
-                  tax is {formatCurrency(taxAmount)}. The receipt will be
-                  unbalanced.
+                  Items + tax total ({formatCurrency(subtotal + taxAmount)}) does
+                  not match transaction total (
+                  {formatCurrency(transactionTotal)}). The receipt is unbalanced.
                 </AlertDescription>
               </Alert>
             )}

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -1,0 +1,315 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useNavigate } from "react-router";
+import { useForm } from "react-hook-form";
+import { z } from "zod/v4";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { useCreateCompleteReceipt } from "@/hooks/useReceipts";
+import { useLocationHistory } from "@/hooks/useLocationHistory";
+import { formatCurrency } from "@/lib/format";
+import {
+  TransactionsSection,
+  type ReceiptTransaction,
+} from "./TransactionsSection";
+import { LineItemsSection, type ReceiptLineItem } from "./LineItemsSection";
+import { BalanceSidebar } from "./BalanceSidebar";
+import { Combobox } from "@/components/ui/combobox";
+import { DateInput } from "@/components/ui/date-input";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+
+const headerSchema = z.object({
+  location: z
+    .string()
+    .min(1, "Location is required")
+    .max(200, "Location must be 200 characters or fewer"),
+  date: z.string().min(1, "Date is required"),
+  taxAmount: z.number().min(0, "Tax amount must be non-negative"),
+});
+
+type HeaderFormValues = z.output<typeof headerSchema>;
+
+export default function NewReceiptPage() {
+  usePageTitle("New Receipt");
+  const navigate = useNavigate();
+  const locationRef = useRef<HTMLButtonElement>(null);
+  const { options: locationOptions, add: addLocation } = useLocationHistory();
+
+  const [transactions, setTransactions] = useState<ReceiptTransaction[]>([]);
+  const [items, setItems] = useState<ReceiptLineItem[]>([]);
+  const [showDiscard, setShowDiscard] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { mutateAsync: createCompleteReceiptAsync } =
+    useCreateCompleteReceipt();
+
+  const form = useForm<HeaderFormValues>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: zodResolver(headerSchema) as any,
+    defaultValues: {
+      location: "",
+      date: "",
+      taxAmount: 0,
+    },
+  });
+
+  const taxAmount = form.watch("taxAmount");
+  const receiptDate = form.watch("date");
+
+  // Auto-focus location on mount
+  useEffect(() => {
+    locationRef.current?.focus();
+  }, []);
+
+  const subtotal = useMemo(
+    () => items.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0),
+    [items],
+  );
+
+  const transactionTotal = useMemo(
+    () => transactions.reduce((sum, t) => sum + t.amount, 0),
+    [transactions],
+  );
+
+  const hasData =
+    form.getValues("location") !== "" ||
+    form.getValues("date") !== "" ||
+    form.getValues("taxAmount") !== 0 ||
+    transactions.length > 0 ||
+    items.length > 0;
+
+  const handleCancel = useCallback(() => {
+    if (hasData) {
+      setShowDiscard(true);
+    } else {
+      navigate("/receipts");
+    }
+  }, [hasData, navigate]);
+
+  const handleDiscard = useCallback(() => {
+    setShowDiscard(false);
+    navigate("/receipts");
+  }, [navigate]);
+
+  const handleSubmit = useCallback(async () => {
+    // Validate header form first
+    const valid = await form.trigger();
+    if (!valid) return;
+
+    const headerValues = form.getValues();
+
+    if (transactions.length === 0) {
+      toast.error("Add at least one transaction.");
+      return;
+    }
+
+    if (items.length === 0) {
+      toast.error("Add at least one line item.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      addLocation(headerValues.location);
+
+      const result = await createCompleteReceiptAsync(
+        {
+          receipt: {
+            location: headerValues.location,
+            date: headerValues.date,
+            taxAmount: headerValues.taxAmount,
+          },
+          transactions: transactions.map((txn) => ({
+            accountId: txn.accountId,
+            amount: txn.amount,
+            date: txn.date,
+          })),
+          items: items.map((item) => ({
+            receiptItemCode: item.receiptItemCode,
+            description: item.description,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            category: item.category,
+            subcategory: item.subcategory,
+            pricingMode: item.pricingMode,
+          })),
+        },
+        { onSuccess: undefined, onError: undefined },
+      );
+
+      const receiptId = (result as { receipt: { id: string } }).receipt.id;
+
+      toast.success("Receipt created successfully!");
+      navigate(`/receipt-detail?id=${receiptId}&highlight=${receiptId}`);
+    } catch {
+      toast.error("Failed to create receipt.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    form,
+    transactions,
+    items,
+    createCompleteReceiptAsync,
+    addLocation,
+    navigate,
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">New Receipt</h1>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_280px]">
+        {/* Left column — form sections */}
+        <div className="space-y-6">
+          {/* Receipt Header */}
+          <Form {...form}>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <FormField
+                control={form.control}
+                name="location"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Location</FormLabel>
+                    <FormControl>
+                      <Combobox
+                        ref={locationRef}
+                        options={locationOptions}
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        placeholder="e.g. Walmart, Target, Costco"
+                        searchPlaceholder="Search locations..."
+                        emptyMessage="No saved locations."
+                        allowCustom
+                        aria-required="true"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Date</FormLabel>
+                    <FormControl>
+                      <DateInput
+                        aria-required="true"
+                        max={new Date().toISOString().split("T")[0]}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="taxAmount"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Tax Amount</FormLabel>
+                    <FormControl>
+                      <CurrencyInput {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </Form>
+
+          {/* Transactions */}
+          <TransactionsSection
+            transactions={transactions}
+            receiptDate={receiptDate}
+            onChange={setTransactions}
+          />
+
+          {/* Balance warning between sections */}
+          {transactions.length > 0 &&
+            Math.abs(transactionTotal) < 0.01 &&
+            taxAmount > 0 && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  Transaction total is {formatCurrency(transactionTotal)} but
+                  tax is {formatCurrency(taxAmount)}. The receipt will be
+                  unbalanced.
+                </AlertDescription>
+              </Alert>
+            )}
+
+          {/* Line Items */}
+          <LineItemsSection items={items} onChange={setItems} />
+        </div>
+
+        {/* Right column — sticky balance sidebar */}
+        <div className="hidden lg:block">
+          <BalanceSidebar
+            subtotal={subtotal}
+            taxAmount={taxAmount}
+            transactionTotal={transactionTotal}
+            isSubmitting={isSubmitting}
+            onSubmit={handleSubmit}
+            onCancel={handleCancel}
+          />
+        </div>
+      </div>
+
+      {/* Mobile-only bottom bar (visible on small screens) */}
+      <div className="lg:hidden">
+        <BalanceSidebar
+          subtotal={subtotal}
+          taxAmount={taxAmount}
+          transactionTotal={transactionTotal}
+          isSubmitting={isSubmitting}
+          onSubmit={handleSubmit}
+          onCancel={handleCancel}
+        />
+      </div>
+
+      <AlertDialog open={showDiscard} onOpenChange={setShowDiscard}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard receipt?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have unsaved receipt data. Are you sure you want to discard it?
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Continue editing</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDiscard}>
+              Discard
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@/hooks/useAccounts", () => ({
 describe("TransactionsSection", () => {
   const defaultProps = {
     transactions: [] as { id: string; accountId: string; amount: number; date: string }[],
-    receiptDate: "2024-01-15",
+    defaultDate: "2024-01-15",
     onChange: vi.fn(),
   };
 

--- a/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
@@ -1,0 +1,131 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
+import "@/test/setup-combobox-polyfills";
+import { TransactionsSection } from "./TransactionsSection";
+
+vi.mock("@/hooks/useFormShortcuts", () => ({
+  useFormShortcuts: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() =>
+    mockQueryResult({
+      data: [
+        { id: "acct-1", name: "Checking", accountCode: "CHK" },
+        { id: "acct-2", name: "Credit Card", accountCode: "CC" },
+      ],
+      total: 2,
+      isLoading: false,
+      isSuccess: true,
+    }),
+  ),
+}));
+
+describe("TransactionsSection", () => {
+  const defaultProps = {
+    transactions: [] as { id: string; accountId: string; amount: number; date: string }[],
+    receiptDate: "2024-01-15",
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the card title", () => {
+    renderWithProviders(<TransactionsSection {...defaultProps} />);
+    expect(screen.getByText("Transactions")).toBeInTheDocument();
+  });
+
+  it("renders the form fields", () => {
+    renderWithProviders(<TransactionsSection {...defaultProps} />);
+    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument();
+    expect(screen.getByText(/^date$/i)).toBeInTheDocument();
+  });
+
+  it("renders Add button", () => {
+    renderWithProviders(<TransactionsSection {...defaultProps} />);
+    expect(
+      screen.getByRole("button", { name: /add/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("displays running total", () => {
+    renderWithProviders(<TransactionsSection {...defaultProps} />);
+    expect(screen.getByText("Total: $0.00")).toBeInTheDocument();
+  });
+
+  it("renders existing transactions", () => {
+    const transactions = [
+      { id: "1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
+    ];
+    renderWithProviders(
+      <TransactionsSection {...defaultProps} transactions={transactions} />,
+    );
+    expect(screen.getByText("$25.50")).toBeInTheDocument();
+    expect(screen.getByText("Checking")).toBeInTheDocument();
+  });
+
+  it("calls onChange when a transaction is added via form submit", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <TransactionsSection {...defaultProps} onChange={onChange} />,
+    );
+
+    // Select account via combobox
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const checkingOption = await screen.findByText("Checking");
+    await user.click(checkingOption);
+
+    // Type amount
+    const amountInput = screen.getByLabelText(/amount/i);
+    await user.click(amountInput);
+    await user.type(amountInput, "42.50");
+
+    // Press Enter to submit
+    await user.keyboard("{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: "acct-1",
+          amount: 42.5,
+          date: "2024-01-15",
+        }),
+      ]),
+    );
+  });
+
+  it("calls onChange when a transaction is removed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const transactions = [
+      { id: "1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
+    ];
+    renderWithProviders(
+      <TransactionsSection
+        {...defaultProps}
+        transactions={transactions}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("displays running total with existing transactions", () => {
+    const transactions = [
+      { id: "1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
+      { id: "2", accountId: "acct-2", amount: 10.0, date: "2024-01-15" },
+    ];
+    renderWithProviders(
+      <TransactionsSection {...defaultProps} transactions={transactions} />,
+    );
+    expect(screen.getByText("Total: $35.50")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -47,13 +47,13 @@ export interface ReceiptTransaction {
 
 interface TransactionsSectionProps {
   transactions: ReceiptTransaction[];
-  receiptDate: string;
+  defaultDate: string;
   onChange: (transactions: ReceiptTransaction[]) => void;
 }
 
 export function TransactionsSection({
   transactions,
-  receiptDate,
+  defaultDate,
   onChange,
 }: TransactionsSectionProps) {
   const formRef = useRef<HTMLFormElement>(null);
@@ -85,7 +85,7 @@ export function TransactionsSection({
     defaultValues: {
       accountId: "",
       amount: 0,
-      date: receiptDate,
+      date: defaultDate,
     },
   });
 
@@ -102,20 +102,19 @@ export function TransactionsSection({
       };
       onChange([...transactions, newTxn]);
       (document.activeElement as HTMLElement)?.blur?.();
-      form.reset({ accountId: "", amount: 0, date: receiptDate });
+      form.reset({ accountId: "", amount: 0, date: defaultDate });
     },
-    [form, receiptDate, transactions, onChange],
+    [form, defaultDate, transactions, onChange],
   );
 
-  // Focus the account field after adding a transaction for rapid entry
-  const transactionCount = transactions.length;
-  const prevCountRef = useRef(transactionCount);
+  // Focus account field after adding a transaction for rapid entry
+  const prevCountRef = useRef(transactions.length);
   useEffect(() => {
-    if (transactionCount > prevCountRef.current) {
+    if (transactions.length > prevCountRef.current) {
       accountRef.current?.focus();
     }
-    prevCountRef.current = transactionCount;
-  }, [transactionCount]);
+    prevCountRef.current = transactions.length;
+  }, [transactions.length]);
 
   const handleRemove = useCallback(
     (id: string) => {
@@ -206,7 +205,9 @@ export function TransactionsSection({
                 <TableHead>Account</TableHead>
                 <TableHead>Amount</TableHead>
                 <TableHead>Date</TableHead>
-                <TableHead className="w-12" />
+                <TableHead className="w-12">
+                  <span className="sr-only">Actions</span>
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -1,0 +1,238 @@
+import { useMemo, useCallback, useRef, useEffect } from "react";
+import { generateId } from "@/lib/id";
+import { useForm } from "react-hook-form";
+import { z } from "zod/v4";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useFormShortcuts } from "@/hooks/useFormShortcuts";
+import { useAccounts } from "@/hooks/useAccounts";
+import { accountToOption } from "@/lib/combobox-options";
+import { formatCurrency } from "@/lib/format";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DateInput } from "@/components/ui/date-input";
+import { Combobox } from "@/components/ui/combobox";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Plus, Trash2 } from "lucide-react";
+
+const txnSchema = z.object({
+  accountId: z.string().min(1, "Account is required"),
+  amount: z.number().refine((v) => v !== 0, "Amount is required"),
+  date: z.string().min(1, "Date is required"),
+});
+
+type TxnFormValues = z.output<typeof txnSchema>;
+
+export interface ReceiptTransaction {
+  id: string;
+  accountId: string;
+  amount: number;
+  date: string;
+}
+
+interface TransactionsSectionProps {
+  transactions: ReceiptTransaction[];
+  receiptDate: string;
+  onChange: (transactions: ReceiptTransaction[]) => void;
+}
+
+export function TransactionsSection({
+  transactions,
+  receiptDate,
+  onChange,
+}: TransactionsSectionProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const accountRef = useRef<HTMLButtonElement>(null);
+  const { data: accounts } = useAccounts();
+  useFormShortcuts({ formRef });
+
+  const accountOptions = useMemo(
+    () =>
+      (
+        (accounts as
+          | { id: string; name: string; accountCode: string }[]
+          | undefined) ?? []
+      ).map(accountToOption),
+    [accounts],
+  );
+
+  const accountNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const opt of accountOptions) {
+      map.set(opt.value, opt.label);
+    }
+    return map;
+  }, [accountOptions]);
+
+  const form = useForm<TxnFormValues>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: zodResolver(txnSchema) as any,
+    defaultValues: {
+      accountId: "",
+      amount: 0,
+      date: receiptDate,
+    },
+  });
+
+  const runningTotal = useMemo(
+    () => transactions.reduce((sum, t) => sum + t.amount, 0),
+    [transactions],
+  );
+
+  const handleAdd = useCallback(
+    (values: TxnFormValues) => {
+      const newTxn: ReceiptTransaction = {
+        id: generateId(),
+        ...values,
+      };
+      onChange([...transactions, newTxn]);
+      (document.activeElement as HTMLElement)?.blur?.();
+      form.reset({ accountId: "", amount: 0, date: receiptDate });
+    },
+    [form, receiptDate, transactions, onChange],
+  );
+
+  // Focus the account field after adding a transaction for rapid entry
+  const transactionCount = transactions.length;
+  const prevCountRef = useRef(transactionCount);
+  useEffect(() => {
+    if (transactionCount > prevCountRef.current) {
+      accountRef.current?.focus();
+    }
+    prevCountRef.current = transactionCount;
+  }, [transactionCount]);
+
+  const handleRemove = useCallback(
+    (id: string) => {
+      onChange(transactions.filter((t) => t.id !== id));
+    },
+    [transactions, onChange],
+  );
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">Transactions</CardTitle>
+          <span className="text-sm text-muted-foreground">
+            Total: {formatCurrency(runningTotal)}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Form {...form}>
+          <form
+            ref={formRef}
+            onSubmit={form.handleSubmit(handleAdd)}
+            className="grid grid-cols-1 gap-4 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end"
+          >
+            <FormField
+              control={form.control}
+              name="accountId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Account</FormLabel>
+                  <FormControl>
+                    <Combobox
+                      ref={accountRef}
+                      options={accountOptions}
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      placeholder="Select account..."
+                      searchPlaceholder="Search accounts..."
+                      emptyMessage="No accounts found."
+                      aria-required="true"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="amount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Amount</FormLabel>
+                  <FormControl>
+                    <CurrencyInput {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="date"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Date</FormLabel>
+                  <FormControl>
+                    <DateInput aria-required="true" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <Button type="submit" variant="secondary" size="sm" className="sm:mb-0.5">
+              <Plus className="mr-1 h-4 w-4" />
+              Add
+            </Button>
+          </form>
+        </Form>
+
+        {transactions.length > 0 && (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Account</TableHead>
+                <TableHead>Amount</TableHead>
+                <TableHead>Date</TableHead>
+                <TableHead className="w-12" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {transactions.map((txn) => (
+                <TableRow key={txn.id}>
+                  <TableCell>
+                    {accountNameMap.get(txn.accountId) ?? txn.accountId}
+                  </TableCell>
+                  <TableCell>{formatCurrency(txn.amount)}</TableCell>
+                  <TableCell>{txn.date}</TableCell>
+                  <TableCell>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemove(txn.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      <span className="sr-only">Remove</span>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the 4-step receipt wizard with a single-page form where all sections (receipt header, transactions, line items) are visible and editable simultaneously
- Adds a sticky balance sidebar with real-time subtotal/tax/total feedback and submit button
- Preserves all existing features: location history, item suggestions, category recommendations, subcategory auto-create, balance validation
- 36 unit tests across 4 new test files (BalanceSidebar, TransactionsSection, LineItemsSection, NewReceiptPage)

## Test plan
- [ ] Verify the new receipt form loads at `/receipts/new`
- [ ] Add transactions and line items — confirm balance sidebar updates in real-time
- [ ] Test submit with balanced receipt — should create and redirect to detail page
- [ ] Test submit with unbalanced receipt — submit button should be disabled with tooltip
- [ ] Test submit without transactions — should show error toast
- [ ] Test submit without line items — should show error toast
- [ ] Test discard dialog when navigating away with data entered
- [ ] Test location autocomplete from history
- [ ] Test item description suggestions and category recommendations
- [ ] Verify responsive layout: two-column on desktop, stacked on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)