### PR TITLE
fix(client): enable scroll on mobile navigation drawer

### DIFF
--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -411,7 +411,7 @@ export function Layout() {
             <SheetTitle>Receipts</SheetTitle>
           </SheetHeader>
           <nav
-            className="flex flex-col gap-1 px-4"
+            className="min-h-0 flex-1 overflow-y-auto flex flex-col gap-1 px-4"
             aria-label="Mobile navigation"
           >
             {navLinks.map(({ to, label }) => mobileNavLink(to, label))}


### PR DESCRIPTION
The nav element inside the Sheet was not scrollable, so users on mobile
couldn't reach items that overflow the viewport. Add flex-1, min-h-0,
and overflow-y-auto to the nav so it scrolls while keeping header and
footer pinned.

https://claude.ai/code/session_01XsbCegtsTjgfwpdVsF3isZ