### PR TITLE
fix(client): align action button heights in admin users table

### DIFF
--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -298,10 +298,10 @@ function AdminUsers() {
                       <TableCell>{formatDate(user.createdAt)}</TableCell>
                       <TableCell>{formatDate(user.lastLoginAt)}</TableCell>
                       <TableCell>
-                        <div className="flex gap-1">
+                        <div className="flex items-center gap-1">
                           <Button
                             variant="outline"
-                            size="icon"
+                            size="icon-sm"
                             aria-label="Edit"
                             onClick={() => openEdit(user)}
                           >


### PR DESCRIPTION
## Summary
- Fix vertical misalignment of action buttons in the Admin Users table
- Change edit icon button from `size="icon"` (36px) to `size="icon-sm"` (32px) to match adjacent `size="sm"` text buttons
- Add `items-center` to the flex container for symmetrical vertical centering

Fixes RECEIPTS-416

## Test plan
- [x] TypeScript type-check passes
- [x] Vite build succeeds
- [x] All 1376 client tests pass (23 AdminUsers-specific)
- [x] Design system verified: `icon-sm` = `size-8` (32px) matches `sm` = `h-8` (32px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)