### PR TITLE
fix(client): refresh auth token after admin self-email change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -324,6 +324,9 @@ src/client/coverage/
 # MCP server config (contains API keys)
 .mcp.json
 
+# SDLC pipeline state files
+.sdlc/
+
 # ONNX model binary (~90MB, downloaded via scripts/download-onnx-model.cs).
 # vocab.txt (227KB) is committed intentionally — it's small, required at runtime,
 # and keeping it in-tree avoids network dependencies for CI and local builds.

--- a/src/client/src/hooks/useUsers.test.ts
+++ b/src/client/src/hooks/useUsers.test.ts
@@ -10,13 +10,14 @@ vi.mock("@/lib/api-client", () => ({
     PUT: vi.fn(),
     DELETE: vi.fn(),
   },
+  attemptTokenRefresh: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
-import client from "@/lib/api-client";
+import client, { attemptTokenRefresh } from "@/lib/api-client";
 import { toast } from "sonner";
 import {
   useUsers,
@@ -142,6 +143,57 @@ describe("useUpdateUser", () => {
       body: { email: "updated@test.com", role: "Admin", isDisabled: false },
     });
     expect(toast.success).toHaveBeenCalledWith("User updated");
+  });
+
+  it("triggers token refresh when admin updates their own account", async () => {
+    (client.PUT as Mock).mockResolvedValue({ error: null });
+
+    const { result } = renderHook(() => useUpdateUser("u1"), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      userId: "u1",
+      body: { email: "newemail@test.com", role: "Admin", isDisabled: false },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(attemptTokenRefresh).toHaveBeenCalled();
+  });
+
+  it("does not trigger token refresh when admin updates a different user", async () => {
+    (client.PUT as Mock).mockResolvedValue({ error: null });
+
+    const { result } = renderHook(() => useUpdateUser("admin-id"), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      userId: "other-user-id",
+      body: { email: "other@test.com", role: "User", isDisabled: false },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(attemptTokenRefresh).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger token refresh when currentUserId is not provided", async () => {
+    (client.PUT as Mock).mockResolvedValue({ error: null });
+
+    const { result } = renderHook(() => useUpdateUser(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      userId: "u1",
+      body: { email: "updated@test.com", role: "Admin", isDisabled: false },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(attemptTokenRefresh).not.toHaveBeenCalled();
   });
 });
 

--- a/src/client/src/hooks/useUsers.ts
+++ b/src/client/src/hooks/useUsers.ts
@@ -4,7 +4,7 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
-import client from "@/lib/api-client";
+import client, { attemptTokenRefresh } from "@/lib/api-client";
 import { toast } from "sonner";
 
 export function useUsers(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
@@ -59,7 +59,7 @@ export function useCreateUser() {
   });
 }
 
-export function useUpdateUser() {
+export function useUpdateUser(currentUserId?: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({
@@ -80,10 +80,14 @@ export function useUpdateUser() {
         body,
       });
       if (error) throw error;
+      return userId;
     },
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["users"] });
       toast.success("User updated");
+      if (currentUserId && variables.userId === currentUserId) {
+        attemptTokenRefresh();
+      }
     },
     onError: () => {
       toast.error("Failed to update user");

--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -35,7 +35,7 @@ export function isNetworkError(error: unknown): boolean {
 
 let refreshPromise: Promise<boolean> | null = null;
 
-async function attemptTokenRefresh(): Promise<boolean> {
+export async function attemptTokenRefresh(): Promise<boolean> {
   const refreshToken = getRefreshToken();
   if (!refreshToken) return false;
 

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -105,7 +105,7 @@ function AdminUsers() {
   }, [toggleSort, resetPage]);
 
   const createUser = useCreateUser();
-  const updateUser = useUpdateUser();
+  const updateUser = useUpdateUser(currentUser?.userId);
   const deleteUser = useDeleteUser();
   const resetPassword = useResetUserPassword();
 


### PR DESCRIPTION
## Summary
- Fixes RECEIPTS-423: After an admin changes their own email, the nav bar now shows the updated email immediately
- Exports `attemptTokenRefresh()` from `api-client.ts` and calls it in `useUpdateUser`'s `onSuccess` when the updated user matches the current user
- The existing token refresh chain (`POST /api/auth/refresh` -> `setTokens` -> `notifyTokenRefresh` -> `AuthProvider` listener -> `setUser`) ensures the auth context and nav bar update automatically

## Changes
- `src/client/src/lib/api-client.ts` — Export `attemptTokenRefresh` (was module-private)
- `src/client/src/hooks/useUsers.ts` — Add `currentUserId` parameter to `useUpdateUser`; trigger token refresh on self-update
- `src/client/src/pages/AdminUsers.tsx` — Pass `currentUser?.userId` to `useUpdateUser()`
- `src/client/src/hooks/useUsers.test.ts` — Add 3 tests for token refresh behavior

## Test plan
- [x] `npm run test` passes (1379 tests)
- [x] `dotnet test` passes (307 unit tests)
- [ ] Admin changes their own email → nav bar updates without re-login
- [ ] Admin changes another user's email → no token refresh triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)