### PR TITLE
feat(client): add hide button to item template edit modal

### DIFF
--- a/src/client/src/components/ItemTemplateForm.test.tsx
+++ b/src/client/src/components/ItemTemplateForm.test.tsx
@@ -154,6 +154,75 @@ describe("ItemTemplateForm", () => {
     expect(screen.getByText("Default Item Code (optional)")).toBeInTheDocument();
   });
 
+  it("renders Hide button in edit mode when onHide is provided", () => {
+    render(
+      <ItemTemplateForm
+        {...defaultProps}
+        mode="edit"
+        onHide={vi.fn()}
+        defaultValues={{ name: "Test" }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /^hide$/i })).toBeInTheDocument();
+  });
+
+  it("does not render Hide button when onHide is not provided", () => {
+    render(
+      <ItemTemplateForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Test" }}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /^hide$/i })).not.toBeInTheDocument();
+  });
+
+  it("does not render Hide button in create mode even when onHide is provided", () => {
+    render(
+      <ItemTemplateForm
+        {...defaultProps}
+        mode="create"
+        onHide={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /^hide$/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onHide when Hide button is clicked", async () => {
+    const onHide = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ItemTemplateForm
+        {...defaultProps}
+        mode="edit"
+        onHide={onHide}
+        defaultValues={{ name: "Test" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^hide$/i }));
+
+    expect(onHide).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Hide button and shows spinner when isHiding is true", () => {
+    render(
+      <ItemTemplateForm
+        {...defaultProps}
+        mode="edit"
+        onHide={vi.fn()}
+        isHiding={true}
+        defaultValues={{ name: "Test" }}
+      />,
+    );
+
+    const hideButton = screen.getByRole("button", { name: /hiding/i });
+    expect(hideButton).toBeDisabled();
+  });
+
   it("filters category options via typeahead and selects a filtered result", async () => {
     const onSubmit = vi.fn();
     const user = userEvent.setup();

--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -38,6 +38,8 @@ interface ItemTemplateFormProps {
   onSubmit: (values: ItemTemplateFormValues) => void;
   onCancel: () => void;
   isSubmitting?: boolean;
+  onHide?: () => void;
+  isHiding?: boolean;
 }
 
 export function ItemTemplateForm({
@@ -46,6 +48,8 @@ export function ItemTemplateForm({
   onSubmit,
   onCancel,
   isSubmitting,
+  onHide,
+  isHiding,
 }: ItemTemplateFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
   useFormShortcuts({ formRef });
@@ -224,18 +228,33 @@ export function ItemTemplateForm({
           )}
         />
 
-        <div className="flex justify-end gap-2 pt-4">
-          <Button type="button" variant="outline" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting && <Spinner size="sm" />}
-            {isSubmitting
-              ? "Saving..."
-              : mode === "create"
-                ? "Create Template"
-                : "Update Template"}
-          </Button>
+        <div className="flex justify-between gap-2 pt-4">
+          <div>
+            {mode === "edit" && onHide && (
+              <Button
+                type="button"
+                variant="destructive"
+                disabled={isHiding}
+                onClick={onHide}
+              >
+                {isHiding && <Spinner size="sm" />}
+                {isHiding ? "Hiding..." : "Hide"}
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting && <Spinner size="sm" />}
+              {isSubmitting
+                ? "Saving..."
+                : mode === "create"
+                  ? "Create Template"
+                  : "Update Template"}
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/src/client/src/hooks/useItemTemplates.test.ts
+++ b/src/client/src/hooks/useItemTemplates.test.ts
@@ -24,6 +24,7 @@ import {
   useCreateItemTemplate,
   useUpdateItemTemplate,
   useDeleteItemTemplates,
+  useHideItemTemplate,
   useDeletedItemTemplates,
   useRestoreItemTemplate,
 } from "./useItemTemplates";
@@ -335,6 +336,93 @@ describe("useItemTemplates", () => {
     });
 
     result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["itemTemplates"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["itemTemplates", "deleted"] });
+  });
+
+  // --- useHideItemTemplate ---
+
+  it("hide mutation calls DELETE with single-element array and shows custom toast", async () => {
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useHideItemTemplate(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync("template-1");
+
+    expect(client.DELETE).toHaveBeenCalledWith("/api/item-templates", {
+      body: ["template-1"],
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      "Template hidden. You can restore it from the recycle bin.",
+    );
+  });
+
+  it("hide mutation shows error toast on failure", async () => {
+    (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useHideItemTemplate(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("template-1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to hide item template");
+  });
+
+  it("hide mutation rolls back cache on failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    const templates = [
+      { id: "template-1", name: "A" },
+      { id: "template-2", name: "B" },
+    ];
+    const cacheKey = ["itemTemplates", "list", 0, 50, undefined, undefined];
+    const cacheValue = { data: templates, total: 2, offset: 0, limit: 50 };
+    queryClient.setQueryData(cacheKey, cacheValue);
+    setQueryDataSpy.mockClear();
+
+    (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
+
+    const { result } = renderHook(() => useHideItemTemplate(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate("template-1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith("Failed to hide item template");
+    expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
+  });
+
+  it("hide mutation invalidates both list and deleted query keys on settled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useHideItemTemplate(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate("template-1");
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["itemTemplates"] });

--- a/src/client/src/hooks/useItemTemplates.ts
+++ b/src/client/src/hooks/useItemTemplates.ts
@@ -127,6 +127,45 @@ export function useDeleteItemTemplates() {
   });
 }
 
+export function useHideItemTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await client.DELETE("/api/item-templates", {
+        body: [id],
+      });
+      if (error) throw error;
+    },
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: ["itemTemplates"] });
+      const previous = queryClient.getQueriesData<{ data: { id: string }[]; total: number }>({ queryKey: ["itemTemplates", "list"] });
+      for (const [key] of previous) {
+        queryClient.setQueryData(key, (old: { data: { id: string }[]; total: number; offset: number; limit: number } | undefined) => {
+          if (!old?.data) return old;
+          const filtered = old.data.filter((item) => item.id !== id);
+          return { ...old, data: filtered, total: old.total - (old.data.length - filtered.length) };
+        });
+      }
+      return { previous };
+    },
+    onError: (_err, _id, context) => {
+      for (const [key, data] of context?.previous ?? []) {
+        queryClient.setQueryData(key, data);
+      }
+      toast.error("Failed to hide item template");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["itemTemplates"] });
+      queryClient.invalidateQueries({
+        queryKey: ["itemTemplates", "deleted"],
+      });
+    },
+    onSuccess: () => {
+      toast.success("Template hidden. You can restore it from the recycle bin.");
+    },
+  });
+}
+
 export function useDeletedItemTemplates(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
   const query = useQuery({
     queryKey: ["itemTemplates", "deleted", offset, limit, sortBy, sortDirection],

--- a/src/client/src/pages/ItemTemplates.test.tsx
+++ b/src/client/src/pages/ItemTemplates.test.tsx
@@ -28,6 +28,15 @@ vi.mock("@/hooks/useItemTemplates", () => ({
   useCreateItemTemplate: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateItemTemplate: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useDeleteItemTemplates: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useHideItemTemplate: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/hooks/usePermission", () => ({
+  usePermission: vi.fn(() => ({
+    roles: ["Admin"],
+    hasRole: (role: string) => role === "Admin",
+    isAdmin: () => true,
+  })),
 }));
 
 vi.mock("@/hooks/useFuzzySearch", () => ({
@@ -443,5 +452,124 @@ describe("ItemTemplates", () => {
     expect(
       screen.getByRole("heading", { name: /create item template/i }),
     ).toBeInTheDocument();
+  });
+
+  it("shows Hide button in edit modal when user is admin", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "1", name: "Coffee", description: "Morning coffee", defaultCategory: "Food", defaultSubcategory: "Drinks", defaultUnitPrice: 4.50, defaultUnitPriceCurrency: "USD", defaultPricingMode: "quantity", defaultItemCode: "COF-001" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useItemTemplates } = await import("@/hooks/useItemTemplates");
+    vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: (role: string) => role === "Admin",
+      isAdmin: () => true,
+    });
+
+    renderWithProviders(<ItemTemplates />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(screen.getByRole("heading", { name: /edit item template/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^hide$/i })).toBeInTheDocument();
+  });
+
+  it("does not show Hide button in edit modal when user is not admin", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      { id: "1", name: "Coffee", description: "Morning coffee", defaultCategory: "Food", defaultSubcategory: "Drinks", defaultUnitPrice: 4.50, defaultUnitPriceCurrency: "USD", defaultPricingMode: "quantity", defaultItemCode: "COF-001" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useItemTemplates } = await import("@/hooks/useItemTemplates");
+    vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["User"],
+      hasRole: (role: string) => role === "User",
+      isAdmin: () => false,
+    });
+
+    renderWithProviders(<ItemTemplates />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(screen.getByRole("heading", { name: /edit item template/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^hide$/i })).not.toBeInTheDocument();
+  });
+
+  it("calls hideItemTemplate.mutate when Hide button is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+
+    const items = [
+      { id: "1", name: "Coffee", description: "Morning coffee", defaultCategory: "Food", defaultSubcategory: "Drinks", defaultUnitPrice: 4.50, defaultUnitPriceCurrency: "USD", defaultPricingMode: "quantity", defaultItemCode: "COF-001" },
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useItemTemplates, useHideItemTemplate } = await import("@/hooks/useItemTemplates");
+    vi.mocked(useItemTemplates).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+    vi.mocked(useHideItemTemplate).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: (role: string) => role === "Admin",
+      isAdmin: () => true,
+    });
+
+    renderWithProviders(<ItemTemplates />);
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    await user.click(screen.getByRole("button", { name: /^hide$/i }));
+
+    expect(mockMutate).toHaveBeenCalledWith("1", expect.objectContaining({
+      onSuccess: expect.any(Function),
+    }));
   });
 });

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -4,7 +4,9 @@ import {
   useCreateItemTemplate,
   useUpdateItemTemplate,
   useDeleteItemTemplates,
+  useHideItemTemplate,
 } from "@/hooks/useItemTemplates";
+import { usePermission } from "@/hooks/usePermission";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
@@ -68,6 +70,8 @@ function ItemTemplates() {
   const createItemTemplate = useCreateItemTemplate();
   const updateItemTemplate = useUpdateItemTemplate();
   const deleteItemTemplates = useDeleteItemTemplates();
+  const hideItemTemplate = useHideItemTemplate();
+  const { isAdmin } = usePermission();
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [createOpen, setCreateOpen] = useState(false);
@@ -368,6 +372,14 @@ function ItemTemplates() {
                   { onSuccess: () => setEditTemplate(null) },
                 );
               }}
+              {...(isAdmin() ? {
+                onHide: () => {
+                  hideItemTemplate.mutate(editTemplate.id, {
+                    onSuccess: () => setEditTemplate(null),
+                  });
+                },
+                isHiding: hideItemTemplate.isPending,
+              } : {})}
             />
           )}
         </DialogContent>


### PR DESCRIPTION
## Summary
- Adds a "Hide" button to the item template edit modal, visible only to admin users
- Uses a dedicated `useHideItemTemplate` hook that calls the existing soft-delete endpoint (`DELETE /api/item-templates`) with a custom toast message ("Template hidden. You can restore it from the recycle bin.")
- Button is left-aligned with destructive styling, shows spinner during pending state, and closes the modal on success

## Test plan
- [x] 12 new tests added across 3 test files (hook, form component, page component)
- [x] All 1391 client tests pass
- [x] All 1301 .NET unit tests pass
- [x] SDLC pipeline passed all 6 phases (Plan, Implement, Review, Security, QA, Accept)

Closes RECEIPTS-413

🤖 Generated with [Claude Code](https://claude.com/claude-code)