### PR TITLE
feat(client): upgrade receipt detail to Trip aggregate

### DIFF
--- a/src/client/src/App.test.tsx
+++ b/src/client/src/App.test.tsx
@@ -40,6 +40,9 @@ vi.mock("@/pages/ItemTemplates", () => ({
 vi.mock("@/pages/ReceiptDetail", () => ({
   default: () => <div data-testid="page-receipt-detail">ReceiptDetail</div>,
 }));
+vi.mock("@/pages/ReceiptDetailRedirect", () => ({
+  default: () => <div data-testid="page-receipt-detail-redirect">Redirect</div>,
+}));
 vi.mock("@/pages/TransactionDetail", () => ({
   default: () => (
     <div data-testid="page-transaction-detail">TransactionDetail</div>

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -16,6 +16,7 @@ import Transactions from "@/pages/Transactions";
 import Trips from "@/pages/Trips";
 import ItemTemplates from "@/pages/ItemTemplates";
 import ReceiptDetail from "@/pages/ReceiptDetail";
+import ReceiptDetailRedirect from "@/pages/ReceiptDetailRedirect";
 import TransactionDetail from "@/pages/TransactionDetail";
 import AdminUsers from "@/pages/AdminUsers";
 import AuditLog from "@/pages/AuditLog";
@@ -52,7 +53,8 @@ export const routeConfig = [
           { path: "/transactions", element: <Transactions /> },
           { path: "/trips", element: <Trips /> },
           { path: "/item-templates", element: <ItemTemplates /> },
-          { path: "/receipt-detail", element: <ReceiptDetail /> },
+          { path: "/receipts/:id", element: <ReceiptDetail /> },
+          { path: "/receipt-detail", element: <ReceiptDetailRedirect /> },
           { path: "/transaction-detail", element: <TransactionDetail /> },
           { path: "/api-keys", element: <ApiKeys /> },
           { path: "/security", element: <SecurityLog /> },

--- a/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
+++ b/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
@@ -41,7 +41,7 @@ export function RecentReceiptsWidget({ className }: RecentReceiptsWidgetProps) {
         {receipts.map((receipt) => (
           <li key={receipt.id}>
             <Link
-              to={`/receipt-detail?id=${receipt.id}`}
+              to={`/receipts/${receipt.id}`}
               className="flex items-center justify-between rounded-md px-2 py-1.5 transition-colors hover:bg-accent"
             >
               <div className="min-w-0 flex-1">

--- a/src/client/src/hooks/useBreadcrumbs.test.tsx
+++ b/src/client/src/hooks/useBreadcrumbs.test.tsx
@@ -58,14 +58,15 @@ describe("useBreadcrumbs", () => {
     });
   });
 
-  it("maps receipt-detail correctly", () => {
+  it("maps /receipts/:id via segment builder", () => {
     const { result } = renderHook(() => useBreadcrumbs(), {
-      wrapper: createWrapper("/receipt-detail"),
+      wrapper: createWrapper("/receipts/some-uuid"),
     });
-    expect(result.current[1]).toEqual({
-      label: "Receipt Detail",
-      path: "/receipt-detail",
-    });
+    expect(result.current).toEqual([
+      { label: "Home", path: "/" },
+      { label: "Receipts", path: "/receipts" },
+      { label: "Some Uuid", path: "/receipts/some-uuid" },
+    ]);
   });
 
   it("maps categories correctly", () => {

--- a/src/client/src/hooks/useBreadcrumbs.ts
+++ b/src/client/src/hooks/useBreadcrumbs.ts
@@ -11,7 +11,6 @@ const routeLabels: Record<string, string> = {
   "/receipt-items": "Receipt Items",
   "/transactions": "Transactions",
   "/trips": "Trips",
-  "/receipt-detail": "Receipt Detail",
   "/transaction-detail": "Transaction Detail",
   "/api-keys": "API Keys",
   "/security": "Security",

--- a/src/client/src/pages/ReceiptDetail.test.tsx
+++ b/src/client/src/pages/ReceiptDetail.test.tsx
@@ -7,11 +7,17 @@ vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
 }));
 
-vi.mock("@/hooks/useAggregates", () => ({
-  useReceiptWithItems: vi.fn(() => ({
+vi.mock("@/hooks/useTrips", () => ({
+  useTripByReceiptId: vi.fn(() => ({
     data: undefined,
     isLoading: false,
     isError: false,
+  })),
+}));
+
+vi.mock("@/hooks/useEnumMetadata", () => ({
+  useEnumMetadata: vi.fn(() => ({
+    adjustmentTypeLabels: { Coupon: "Coupon", Discount: "Discount" },
   })),
 }));
 
@@ -39,110 +45,196 @@ vi.mock("@/components/ReceiptItemsCard", () => ({
   },
 }));
 
-vi.mock("@/components/AdjustmentsCard", () => ({
-  AdjustmentsCard: function MockAdjustmentsCard() {
-    return null;
-  },
-}));
-
 function renderWithRoutes(initialRoute: string) {
   return render(
     <MemoryRouter initialEntries={[initialRoute]}>
       <Routes>
-        <Route path="/receipt-detail" element={<ReceiptDetail />} />
+        <Route path="/receipts/:id" element={<ReceiptDetail />} />
         <Route path="/receipts" element={<div data-testid="receipts-page">Receipts</div>} />
       </Routes>
     </MemoryRouter>,
   );
 }
 
+const MOCK_TRIP = {
+  receipt: {
+    receipt: {
+      id: "r1",
+      location: "Walmart",
+      date: "2024-01-15",
+      taxAmount: 5.25,
+    },
+    items: [],
+    adjustments: [],
+    subtotal: 50.0,
+    adjustmentTotal: 0,
+    expectedTotal: 55.25,
+    warnings: [],
+  },
+  transactions: [],
+  warnings: [],
+};
+
 describe("ReceiptDetail", () => {
-  it("redirects to /receipts when no id param is present", () => {
-    renderWithRoutes("/receipt-detail");
-    expect(screen.getByTestId("receipts-page")).toBeInTheDocument();
-  });
-
-  it("redirects to /receipts when id param is empty", () => {
-    renderWithRoutes("/receipt-detail?id=");
-    expect(screen.getByTestId("receipts-page")).toBeInTheDocument();
-  });
-
-  it("does not render manual input or Look Up button", () => {
-    renderWithRoutes("/receipt-detail?id=some-uuid");
-    expect(screen.queryByPlaceholderText(/enter receipt uuid/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /look up/i })).not.toBeInTheDocument();
-  });
-
-  it("calls useReceiptWithItems with the id param", async () => {
-    const { useReceiptWithItems } = await import("@/hooks/useAggregates");
-    const mockHook = vi.mocked(useReceiptWithItems);
-    mockHook.mockReturnValue(mockQueryResult({
-      data: undefined,
-      isLoading: false,
-      isError: false,
-    }));
-
-    renderWithRoutes("/receipt-detail?id=some-uuid");
-
-    expect(mockHook).toHaveBeenCalledWith("some-uuid");
-  });
-
   it("renders the page heading when id is present", () => {
-    renderWithRoutes("/receipt-detail?id=some-uuid");
+    renderWithRoutes("/receipts/some-uuid");
     expect(
       screen.getByRole("heading", { name: /receipt details/i }),
     ).toBeInTheDocument();
   });
 
-  it("renders loading skeleton with accessible status when data is loading", async () => {
-    const { useReceiptWithItems } = await import("@/hooks/useAggregates");
-    vi.mocked(useReceiptWithItems).mockReturnValue(mockQueryResult({
-      data: undefined,
-      isLoading: true,
-      isError: false,
-    }));
+  it("calls useTripByReceiptId with the path param", async () => {
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    const mockHook = vi.mocked(useTripByReceiptId);
+    mockHook.mockReturnValue(
+      mockQueryResult({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+      }),
+    );
 
-    const { container } = renderWithRoutes("/receipt-detail?id=some-uuid");
-    expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
+    renderWithRoutes("/receipts/some-uuid");
+
+    expect(mockHook).toHaveBeenCalledWith("some-uuid");
+  });
+
+  it("renders loading skeleton with accessible status when data is loading", async () => {
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    vi.mocked(useTripByReceiptId).mockReturnValue(
+      mockQueryResult({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      }),
+    );
+
+    const { container } = renderWithRoutes("/receipts/some-uuid");
+    expect(
+      container.querySelector("[data-slot='skeleton']"),
+    ).toBeInTheDocument();
     expect(screen.getByRole("status")).toBeInTheDocument();
     expect(screen.getByText(/loading receipt details/i)).toBeInTheDocument();
   });
 
   it("renders receipt data when loaded", async () => {
-    const { useReceiptWithItems } = await import("@/hooks/useAggregates");
-    vi.mocked(useReceiptWithItems).mockReturnValue(mockQueryResult({
-      data: {
-        receipt: {
-          id: "r1",
-          location: "Walmart",
-          date: "2024-01-15",
-          taxAmount: 5.25,
-        },
-        items: [],
-        subtotal: 50.00,
-        adjustmentTotal: 0,
-        adjustments: [],
-        expectedTotal: 55.25,
-        warnings: [],
-      },
-      isLoading: false,
-      isError: false,
-    }));
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    vi.mocked(useTripByReceiptId).mockReturnValue(
+      mockQueryResult({
+        data: MOCK_TRIP,
+        isLoading: false,
+        isError: false,
+      }),
+    );
 
-    renderWithRoutes("/receipt-detail?id=r1");
+    renderWithRoutes("/receipts/r1");
     expect(screen.getByText(/walmart/i)).toBeInTheDocument();
     expect(screen.getByText(/2024-01-15/)).toBeInTheDocument();
   });
 
   it("renders error state with alert role when receipt is not found", async () => {
-    const { useReceiptWithItems } = await import("@/hooks/useAggregates");
-    vi.mocked(useReceiptWithItems).mockReturnValue(mockQueryResult({
-      data: undefined,
-      isLoading: false,
-      isError: true,
-    }));
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    vi.mocked(useTripByReceiptId).mockReturnValue(
+      mockQueryResult({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      }),
+    );
 
-    renderWithRoutes("/receipt-detail?id=bad-id");
-    expect(screen.getByRole("alert")).toHaveTextContent(/no receipt found for this id/i);
+    renderWithRoutes("/receipts/bad-id");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /no receipt found for this id/i,
+    );
+  });
+
+  it("renders transactions section when trip has transactions", async () => {
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    vi.mocked(useTripByReceiptId).mockReturnValue(
+      mockQueryResult({
+        data: {
+          ...MOCK_TRIP,
+          transactions: [
+            {
+              transaction: { id: "t1", amount: 55.25, date: "2024-01-15" },
+              account: {
+                accountCode: "1234",
+                name: "Checking",
+                isActive: true,
+              },
+            },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+      }),
+    );
+
+    renderWithRoutes("/receipts/r1");
+    expect(screen.getByText("Transactions (1)")).toBeInTheDocument();
+    expect(screen.getByText("Checking")).toBeInTheDocument();
+    expect(screen.getByText("1234")).toBeInTheDocument();
+  });
+
+  it("renders adjustments section when trip has adjustments", async () => {
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    vi.mocked(useTripByReceiptId).mockReturnValue(
+      mockQueryResult({
+        data: {
+          ...MOCK_TRIP,
+          receipt: {
+            ...MOCK_TRIP.receipt,
+            adjustments: [
+              {
+                id: "a1",
+                type: "Coupon",
+                description: "10% off",
+                amount: -5.0,
+              },
+            ],
+            adjustmentTotal: -5.0,
+          },
+        },
+        isLoading: false,
+        isError: false,
+      }),
+    );
+
+    renderWithRoutes("/receipts/r1");
+    expect(screen.getByText("Adjustments (1)")).toBeInTheDocument();
+    expect(screen.getByText("Coupon")).toBeInTheDocument();
+    expect(screen.getByText("10% off")).toBeInTheDocument();
+  });
+
+  it("renders empty transactions message when no transactions", async () => {
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    vi.mocked(useTripByReceiptId).mockReturnValue(
+      mockQueryResult({
+        data: MOCK_TRIP,
+        isLoading: false,
+        isError: false,
+      }),
+    );
+
+    renderWithRoutes("/receipts/r1");
+    expect(
+      screen.getByText(/no transactions for this receipt/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders empty adjustments message when no adjustments", async () => {
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    vi.mocked(useTripByReceiptId).mockReturnValue(
+      mockQueryResult({
+        data: MOCK_TRIP,
+        isLoading: false,
+        isError: false,
+      }),
+    );
+
+    renderWithRoutes("/receipts/r1");
+    expect(
+      screen.getByText(/no adjustments for this receipt/i),
+    ).toBeInTheDocument();
   });
 });

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -1,10 +1,11 @@
-import { useSearchParams, Navigate } from "react-router";
-import { useReceiptWithItems } from "@/hooks/useAggregates";
+import { useParams, Navigate } from "react-router";
+import { useTripByReceiptId } from "@/hooks/useTrips";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useEnumMetadata } from "@/hooks/useEnumMetadata";
 import { ValidationWarnings } from "@/components/ValidationWarnings";
 import { BalanceSummaryCard } from "@/components/BalanceSummaryCard";
 import { ReceiptItemsCard } from "@/components/ReceiptItemsCard";
-import { AdjustmentsCard } from "@/components/AdjustmentsCard";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -12,20 +13,46 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { ChangeHistory } from "@/components/ChangeHistory";
 import { CardSkeleton } from "@/components/ui/card-skeleton";
 import { formatCurrency } from "@/lib/format";
 
 function ReceiptDetail() {
   usePageTitle("Receipt Detail");
-  const [searchParams] = useSearchParams();
-  const id = searchParams.get("id");
+  const { id } = useParams<{ id: string }>();
+  const { adjustmentTypeLabels } = useEnumMetadata();
 
-  const { data, isLoading, isError } = useReceiptWithItems(id);
+  const { data: trip, isLoading, isError } = useTripByReceiptId(id ?? null);
 
   if (!id) {
     return <Navigate to="/receipts" replace />;
   }
+
+  const transactionsTotal =
+    trip?.transactions?.reduce(
+      (sum: number, ta: { transaction: { amount: number } }) =>
+        sum + ta.transaction.amount,
+      0,
+    ) ?? 0;
+
+  const subtotal = trip?.receipt?.subtotal ?? 0;
+  const adjustmentTotal = trip?.receipt?.adjustmentTotal ?? 0;
+  const expectedTotal = trip?.receipt?.expectedTotal ?? 0;
+  const taxAmount = trip?.receipt?.receipt?.taxAmount ?? 0;
+
+  const allWarnings = [
+    ...(trip?.receipt?.warnings ?? []),
+    ...(trip?.warnings ?? []),
+  ];
 
   return (
     <div className="space-y-6">
@@ -34,8 +61,9 @@ function ReceiptDetail() {
       {isLoading && (
         <div role="status" aria-live="polite" className="space-y-4">
           <span className="sr-only">Loading receipt details...</span>
-          <CardSkeleton lines={2} />
-          <CardSkeleton lines={4} />
+          <CardSkeleton lines={1} />
+          <CardSkeleton lines={3} />
+          <CardSkeleton lines={3} />
         </div>
       )}
 
@@ -45,43 +73,175 @@ function ReceiptDetail() {
         </div>
       )}
 
-      {data && (
+      {trip && (
         <>
-          {data.warnings && data.warnings.length > 0 && (
-            <ValidationWarnings warnings={data.warnings} />
+          {allWarnings.length > 0 && (
+            <ValidationWarnings warnings={allWarnings} />
           )}
 
+          <BalanceSummaryCard
+            subtotal={subtotal}
+            taxAmount={taxAmount}
+            adjustmentTotal={adjustmentTotal}
+            expectedTotal={expectedTotal}
+            transactionsTotal={transactionsTotal}
+            showBalance={trip.transactions.length > 0}
+          />
+
+          {/* Receipt Info */}
           <Card>
             <CardHeader>
               <CardTitle>Receipt</CardTitle>
               <CardDescription>
-                {data.receipt.location} &mdash; {data.receipt.date}
+                {trip.receipt.receipt.location} &mdash;{" "}
+                {trip.receipt.receipt.date}
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-2">
-              <p className="text-sm text-muted-foreground">
-                Tax: {formatCurrency(data.receipt.taxAmount)}
-              </p>
+          </Card>
+
+          <ReceiptItemsCard
+            items={trip.receipt.items}
+            subtotal={subtotal}
+          />
+
+          {/* Adjustments Table (read-only) */}
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                Adjustments ({trip.receipt.adjustments.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {trip.receipt.adjustments.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No adjustments for this receipt.
+                </p>
+              ) : (
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Type</TableHead>
+                        <TableHead>Description</TableHead>
+                        <TableHead className="text-right">Amount</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {trip.receipt.adjustments.map(
+                        (adj: {
+                          id: string;
+                          type: string;
+                          description?: string | null;
+                          amount: number;
+                        }) => (
+                          <TableRow key={adj.id}>
+                            <TableCell>
+                              <Badge variant="outline">
+                                {adjustmentTypeLabels[adj.type] ?? adj.type}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-muted-foreground">
+                              {adj.description ?? "\u2014"}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              {formatCurrency(adj.amount)}
+                            </TableCell>
+                          </TableRow>
+                        ),
+                      )}
+                    </TableBody>
+                    <TableFooter>
+                      <TableRow>
+                        <TableCell
+                          colSpan={2}
+                          className="text-right font-medium"
+                        >
+                          Adjustment Total
+                        </TableCell>
+                        <TableCell className="text-right font-bold">
+                          {formatCurrency(adjustmentTotal)}
+                        </TableCell>
+                      </TableRow>
+                    </TableFooter>
+                  </Table>
+                </div>
+              )}
             </CardContent>
           </Card>
 
-          <BalanceSummaryCard
-            subtotal={data.subtotal}
-            taxAmount={data.receipt.taxAmount}
-            adjustmentTotal={data.adjustmentTotal}
-            expectedTotal={data.expectedTotal}
-          />
-
-          <ReceiptItemsCard
-            items={data.items}
-            subtotal={data.subtotal}
-          />
-
-          <AdjustmentsCard
-            receiptId={id}
-            adjustments={data.adjustments}
-            adjustmentTotal={data.adjustmentTotal}
-          />
+          {/* Transactions Table */}
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                Transactions ({trip.transactions.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {trip.transactions.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No transactions for this receipt.
+                </p>
+              ) : (
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="text-right">Amount</TableHead>
+                        <TableHead>Date</TableHead>
+                        <TableHead>Account Code</TableHead>
+                        <TableHead>Account Name</TableHead>
+                        <TableHead>Status</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {trip.transactions.map(
+                        (ta: {
+                          transaction: {
+                            id: string;
+                            amount: number;
+                            date: string;
+                          };
+                          account: {
+                            accountCode: string;
+                            name: string;
+                            isActive: boolean;
+                          };
+                        }) => (
+                          <TableRow key={ta.transaction.id}>
+                            <TableCell className="text-right">
+                              {formatCurrency(ta.transaction.amount)}
+                            </TableCell>
+                            <TableCell>{ta.transaction.date}</TableCell>
+                            <TableCell className="font-mono">
+                              {ta.account.accountCode}
+                            </TableCell>
+                            <TableCell>{ta.account.name}</TableCell>
+                            <TableCell>
+                              <Badge
+                                variant={
+                                  ta.account.isActive ? "default" : "secondary"
+                                }
+                              >
+                                {ta.account.isActive ? "Active" : "Inactive"}
+                              </Badge>
+                            </TableCell>
+                          </TableRow>
+                        ),
+                      )}
+                    </TableBody>
+                    <TableFooter>
+                      <TableRow>
+                        <TableCell className="text-right font-bold">
+                          {formatCurrency(transactionsTotal)}
+                        </TableCell>
+                        <TableCell colSpan={4} />
+                      </TableRow>
+                    </TableFooter>
+                  </Table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
           <Card>
             <CardHeader>

--- a/src/client/src/pages/ReceiptDetailRedirect.test.tsx
+++ b/src/client/src/pages/ReceiptDetailRedirect.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router";
+import ReceiptDetailRedirect from "./ReceiptDetailRedirect";
+
+function renderWithRoutes(initialRoute: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <Routes>
+        <Route path="/receipt-detail" element={<ReceiptDetailRedirect />} />
+        <Route path="/receipts/:id" element={<div data-testid="receipt-detail-page">Receipt Detail</div>} />
+        <Route path="/receipts" element={<div data-testid="receipts-page">Receipts</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ReceiptDetailRedirect", () => {
+  it("redirects to /receipts/:id when id query param is present", () => {
+    renderWithRoutes("/receipt-detail?id=some-uuid");
+    expect(screen.getByTestId("receipt-detail-page")).toBeInTheDocument();
+  });
+
+  it("redirects to /receipts when no id query param", () => {
+    renderWithRoutes("/receipt-detail");
+    expect(screen.getByTestId("receipts-page")).toBeInTheDocument();
+  });
+
+  it("redirects to /receipts when id query param is empty", () => {
+    renderWithRoutes("/receipt-detail?id=");
+    expect(screen.getByTestId("receipts-page")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/pages/ReceiptDetailRedirect.tsx
+++ b/src/client/src/pages/ReceiptDetailRedirect.tsx
@@ -1,0 +1,15 @@
+import { useSearchParams, Navigate } from "react-router";
+
+/**
+ * Backward-compatibility redirect: /receipt-detail?id=X -> /receipts/X
+ */
+export default function ReceiptDetailRedirect() {
+  const [searchParams] = useSearchParams();
+  const id = searchParams.get("id");
+
+  if (!id) {
+    return <Navigate to="/receipts" replace />;
+  }
+
+  return <Navigate to={`/receipts/${id}`} replace />;
+}

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -305,7 +305,7 @@ describe("NewReceiptPage", () => {
 
     expect(toast.success).toHaveBeenCalledWith("Receipt created successfully!");
     expect(mockNavigate).toHaveBeenCalledWith(
-      "/receipt-detail?id=receipt-123&highlight=receipt-123",
+      "/receipts/receipt-123",
     );
   });
 

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -158,7 +158,7 @@ export default function NewReceiptPage() {
       const receiptId = (result as { receipt: { id: string } }).receipt.id;
 
       toast.success("Receipt created successfully!");
-      navigate(`/receipt-detail?id=${receiptId}&highlight=${receiptId}`);
+      navigate(`/receipts/${receiptId}`);
     } catch {
       toast.error("Failed to create receipt.");
     } finally {

--- a/src/client/src/pages/wizard/NewReceipt.test.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.test.tsx
@@ -355,7 +355,7 @@ describe("NewReceipt", () => {
       "Receipt created successfully!",
     );
     expect(mockNavigate).toHaveBeenCalledWith(
-      "/receipt-detail?id=receipt-123&highlight=receipt-123",
+      "/receipts/receipt-123",
     );
   });
 

--- a/src/client/src/pages/wizard/NewReceipt.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.tsx
@@ -100,7 +100,7 @@ export default function NewReceipt() {
 
       toast.success("Receipt created successfully!");
       reset();
-      navigate(`/receipt-detail?id=${receiptId}&highlight=${receiptId}`);
+      navigate(`/receipts/${receiptId}`);
     } catch {
       toast.error("Failed to create receipt.");
     } finally {


### PR DESCRIPTION
## Summary
- Upgrade ReceiptDetail page from `useReceiptWithItems` to `useTripByReceiptId` (Trip aggregate)
- Change route from `/receipt-detail?id=X` to `/receipts/:id` (path param)
- Add transactions table, read-only adjustments table, and balance summary using Trip data
- Add backward-compatibility redirect from old `/receipt-detail?id=X` URLs
- Update all navigation links (NewReceiptPage, wizard, dashboard widget) and breadcrumbs

## Test plan
- [x] All 1383 client tests pass (138 test files)
- [x] All 1319 .NET unit tests pass
- [x] ReceiptDetail tests cover route, data loading, transactions, adjustments, loading/error states
- [x] ReceiptDetailRedirect tests cover redirect with id, without id, empty id
- [x] Breadcrumb test updated for `/receipts/:id` pattern
- [x] Navigate assertions updated in NewReceiptPage and wizard tests

Closes RECEIPTS-418

🤖 Generated with [Claude Code](https://claude.com/claude-code)