### PR TITLE
feat(client): add inline transaction CRUD to receipt detail

### DIFF
--- a/src/client/src/components/ReceiptTransactionForm.tsx
+++ b/src/client/src/components/ReceiptTransactionForm.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useRef } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod/v4";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useFormShortcuts } from "@/hooks/useFormShortcuts";
+import { useAccounts } from "@/hooks/useAccounts";
+import { accountToOption } from "@/lib/combobox-options";
+import { Button } from "@/components/ui/button";
+import { DateInput } from "@/components/ui/date-input";
+import { Combobox } from "@/components/ui/combobox";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Spinner } from "@/components/ui/spinner";
+
+const receiptTransactionSchema = z.object({
+  accountId: z.string().min(1, "Account is required"),
+  amount: z.number().refine((v) => v !== 0, "Amount is required"),
+  date: z.string().min(1, "Date is required"),
+});
+
+export type ReceiptTransactionFormValues = z.output<
+  typeof receiptTransactionSchema
+>;
+
+interface ReceiptTransactionFormProps {
+  mode: "create" | "edit";
+  defaultValues?: Partial<ReceiptTransactionFormValues>;
+  onSubmit: (values: ReceiptTransactionFormValues) => void;
+  onCancel: () => void;
+  isSubmitting?: boolean;
+  serverErrors?: Record<string, string>;
+}
+
+export function ReceiptTransactionForm({
+  mode,
+  defaultValues,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  serverErrors,
+}: ReceiptTransactionFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  useFormShortcuts({ formRef });
+
+  const { data: accounts, isLoading: accountsLoading } = useAccounts();
+
+  const accountOptions = useMemo(
+    () =>
+      (
+        (accounts as
+          | { id: string; name: string; accountCode: string }[]
+          | undefined) ?? []
+      ).map(accountToOption),
+    [accounts],
+  );
+
+  const form = useForm<ReceiptTransactionFormValues>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: zodResolver(receiptTransactionSchema) as any,
+    defaultValues: {
+      accountId: "",
+      amount: 0,
+      date: "",
+      ...defaultValues,
+    },
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        ref={formRef}
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4"
+      >
+        <FormField
+          control={form.control}
+          name="accountId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Account</FormLabel>
+              <FormControl>
+                <Combobox
+                  options={accountOptions}
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  placeholder="Select an account..."
+                  searchPlaceholder="Search accounts..."
+                  emptyMessage="No accounts found."
+                  loading={accountsLoading}
+                  aria-required="true"
+                />
+              </FormControl>
+              <FormMessage />
+              {serverErrors?.accountId && (
+                <p className="text-sm font-medium text-destructive">
+                  {serverErrors.accountId}
+                </p>
+              )}
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="amount"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Amount</FormLabel>
+              <FormControl>
+                <CurrencyInput {...field} />
+              </FormControl>
+              <FormMessage />
+              {serverErrors?.amount && (
+                <p className="text-sm font-medium text-destructive">
+                  {serverErrors.amount}
+                </p>
+              )}
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="date"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Date</FormLabel>
+              <FormControl>
+                <DateInput aria-required="true" {...field} />
+              </FormControl>
+              <FormMessage />
+              {serverErrors?.date && (
+                <p className="text-sm font-medium text-destructive">
+                  {serverErrors.date}
+                </p>
+              )}
+            </FormItem>
+          )}
+        />
+
+        <div className="flex justify-end gap-2 pt-4">
+          <Button type="button" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting && <Spinner size="sm" />}
+            {isSubmitting
+              ? "Saving..."
+              : mode === "create"
+                ? "Add Transaction"
+                : "Update Transaction"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/client/src/components/ReceiptTransactionsCard.test.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.test.tsx
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReceiptTransactionsCard } from "./ReceiptTransactionsCard";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { mockMutationResult } from "@/test/mock-hooks";
+
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() => ({
+    data: [
+      { id: "acc-1", name: "Checking", accountCode: "1001" },
+      { id: "acc-2", name: "Savings", accountCode: "2001" },
+    ],
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/hooks/useTransactions", () => ({
+  useCreateTransaction: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useUpdateTransaction: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDeleteTransactions: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+const mockTransactions = [
+  {
+    transaction: { id: "txn-1", amount: 50.0, date: "2024-01-15" },
+    account: {
+      id: "acc-1",
+      accountCode: "1001",
+      name: "Checking",
+      isActive: true,
+    },
+  },
+  {
+    transaction: { id: "txn-2", amount: 25.5, date: "2024-01-16" },
+    account: {
+      id: "acc-2",
+      accountCode: "2001",
+      name: "Savings",
+      isActive: false,
+    },
+  },
+];
+
+describe("ReceiptTransactionsCard", () => {
+  it("renders empty state when there are no transactions", () => {
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={[]}
+        transactionsTotal={0}
+      />,
+    );
+    expect(
+      screen.getByText("No transactions for this receipt."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Transactions (0)")).toBeInTheDocument();
+  });
+
+  it("renders transaction rows with data", () => {
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    expect(screen.getByText("Transactions (2)")).toBeInTheDocument();
+    expect(screen.getByText("Checking")).toBeInTheDocument();
+    expect(screen.getByText("Savings")).toBeInTheDocument();
+    expect(screen.getByText("1001")).toBeInTheDocument();
+    expect(screen.getByText("2001")).toBeInTheDocument();
+  });
+
+  it("renders table headers when transactions exist", () => {
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    expect(screen.getByText("Amount")).toBeInTheDocument();
+    expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Account Code")).toBeInTheDocument();
+    expect(screen.getByText("Account Name")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+  });
+
+  it("renders the transaction total in the footer", () => {
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    expect(screen.getByText("Transaction Total")).toBeInTheDocument();
+    expect(screen.getByText("$75.50")).toBeInTheDocument();
+  });
+
+  it("renders Add Transaction button", () => {
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /add transaction/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders edit buttons for each transaction row", () => {
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    const editButtons = screen.getAllByRole("button", { name: /edit/i });
+    expect(editButtons).toHaveLength(2);
+  });
+
+  it("renders active/inactive badges for accounts", () => {
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+  });
+
+  it("toggles individual row selection checkbox", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    const checkingCheckbox = screen.getByLabelText(
+      "Select Checking transaction",
+    );
+    expect(checkingCheckbox).not.toBeChecked();
+    await user.click(checkingCheckbox);
+    expect(checkingCheckbox).toBeChecked();
+    await user.click(checkingCheckbox);
+    expect(checkingCheckbox).not.toBeChecked();
+  });
+
+  it("select-all checkbox selects and deselects all transactions", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    const selectAll = screen.getByLabelText("Select all transactions");
+    expect(selectAll).not.toBeChecked();
+    await user.click(selectAll);
+    expect(selectAll).toBeChecked();
+    expect(
+      screen.getByLabelText("Select Checking transaction"),
+    ).toBeChecked();
+    expect(
+      screen.getByLabelText("Select Savings transaction"),
+    ).toBeChecked();
+    await user.click(selectAll);
+    expect(selectAll).not.toBeChecked();
+    expect(
+      screen.getByLabelText("Select Checking transaction"),
+    ).not.toBeChecked();
+    expect(
+      screen.getByLabelText("Select Savings transaction"),
+    ).not.toBeChecked();
+  });
+
+  it("shows Delete button with count when items are selected", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /delete/i }),
+    ).not.toBeInTheDocument();
+    await user.click(
+      screen.getByLabelText("Select Checking transaction"),
+    );
+    expect(
+      screen.getByRole("button", { name: /delete \(1\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens delete confirmation dialog and calls deleteTransactions.mutate on confirm", async () => {
+    const { useDeleteTransactions } = await import(
+      "@/hooks/useTransactions"
+    );
+    const mockDeleteMutate = vi.fn();
+    vi.mocked(useDeleteTransactions).mockReturnValue(
+      mockMutationResult({
+        mutate: mockDeleteMutate,
+        isPending: false,
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    await user.click(
+      screen.getByLabelText("Select Checking transaction"),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /delete \(1\)/i }),
+    );
+    expect(screen.getByText("Delete Transactions")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /are you sure you want to delete 1 transaction/i,
+      ),
+    ).toBeInTheDocument();
+    const confirmDelete = screen.getByRole("button", { name: "Delete" });
+    await user.click(confirmDelete);
+    expect(mockDeleteMutate).toHaveBeenCalledWith(["txn-1"]);
+  });
+
+  it("opens create dialog when Add Transaction is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /add transaction/i }),
+    );
+    expect(
+      screen.getByText("Add Transaction", { selector: "[id]" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens edit dialog when Edit button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    const editButtons = screen.getAllByRole("button", { name: /edit/i });
+    await user.click(editButtons[0]);
+    expect(screen.getByText("Edit Transaction")).toBeInTheDocument();
+  });
+
+  it("renders create form with submit button in create dialog", async () => {
+    const { useCreateTransaction } = await import(
+      "@/hooks/useTransactions"
+    );
+    const mockCreateMutate = vi.fn();
+    vi.mocked(useCreateTransaction).mockReturnValue(
+      mockMutationResult({
+        mutate: mockCreateMutate,
+        isPending: false,
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /add transaction/i }),
+    );
+    const submitButton = screen.getByRole("button", {
+      name: "Add Transaction",
+    });
+    expect(submitButton).toBeInTheDocument();
+  });
+
+  it("renders edit form with update button in edit dialog", async () => {
+    const { useUpdateTransaction } = await import(
+      "@/hooks/useTransactions"
+    );
+    const mockUpdateMutate = vi.fn();
+    vi.mocked(useUpdateTransaction).mockReturnValue(
+      mockMutationResult({
+        mutate: mockUpdateMutate,
+        isPending: false,
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    const editButtons = screen.getAllByRole("button", { name: /edit/i });
+    await user.click(editButtons[0]);
+    const submitButton = screen.getByRole("button", {
+      name: "Update Transaction",
+    });
+    expect(submitButton).toBeInTheDocument();
+  });
+
+  it("cancels delete dialog without deleting", async () => {
+    const { useDeleteTransactions } = await import(
+      "@/hooks/useTransactions"
+    );
+    const mockDeleteMutate = vi.fn();
+    vi.mocked(useDeleteTransactions).mockReturnValue(
+      mockMutationResult({
+        mutate: mockDeleteMutate,
+        isPending: false,
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    await user.click(
+      screen.getByLabelText("Select Checking transaction"),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /delete \(1\)/i }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockDeleteMutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/client/src/components/ReceiptTransactionsCard.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.tsx
@@ -1,0 +1,325 @@
+import { useState } from "react";
+import {
+  useCreateTransaction,
+  useUpdateTransaction,
+  useDeleteTransactions,
+} from "@/hooks/useTransactions";
+import {
+  ReceiptTransactionForm,
+  type ReceiptTransactionFormValues,
+} from "@/components/ReceiptTransactionForm";
+import {
+  parseProblemDetails,
+  extractFieldErrors,
+} from "@/lib/problem-details";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatCurrency } from "@/lib/format";
+import { Pencil } from "lucide-react";
+
+interface TransactionRow {
+  transaction: {
+    id: string;
+    amount: number;
+    date: string;
+  };
+  account: {
+    id: string;
+    accountCode: string;
+    name: string;
+    isActive: boolean;
+  };
+}
+
+interface ReceiptTransactionsCardProps {
+  receiptId: string;
+  transactions: TransactionRow[];
+  transactionsTotal: number;
+}
+
+export function ReceiptTransactionsCard({
+  receiptId,
+  transactions,
+  transactionsTotal,
+}: ReceiptTransactionsCardProps) {
+  const createTransaction = useCreateTransaction();
+  const updateTransaction = useUpdateTransaction();
+  const deleteTransactions = useDeleteTransactions();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTxn, setEditTxn] = useState<TransactionRow | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [selectedTxns, setSelectedTxns] = useState<Set<string>>(new Set());
+  const [serverErrors, setServerErrors] = useState<Record<string, string>>({});
+
+  function handleCreate(values: ReceiptTransactionFormValues) {
+    setServerErrors({});
+    createTransaction.mutate(
+      {
+        receiptId,
+        body: {
+          accountId: values.accountId,
+          amount: values.amount,
+          date: values.date,
+        },
+      },
+      {
+        onSuccess: () => setCreateOpen(false),
+        onError: (error) => {
+          const problem = parseProblemDetails(error);
+          if (problem) setServerErrors(extractFieldErrors(problem));
+        },
+      },
+    );
+  }
+
+  function handleUpdate(values: ReceiptTransactionFormValues) {
+    if (!editTxn) return;
+    setServerErrors({});
+    updateTransaction.mutate(
+      {
+        body: {
+          id: editTxn.transaction.id,
+          accountId: values.accountId,
+          amount: values.amount,
+          date: values.date,
+        },
+      },
+      {
+        onSuccess: () => setEditTxn(null),
+        onError: (error) => {
+          const problem = parseProblemDetails(error);
+          if (problem) setServerErrors(extractFieldErrors(problem));
+        },
+      },
+    );
+  }
+
+  function toggleSelect(id: string) {
+    setSelectedTxns((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Transactions ({transactions.length})</CardTitle>
+            <div className="flex gap-2">
+              {selectedTxns.size > 0 && (
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  Delete ({selectedTxns.size})
+                </Button>
+              )}
+              <Button size="sm" onClick={() => { setServerErrors({}); setCreateOpen(true); }}>
+                Add Transaction
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {transactions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No transactions for this receipt.
+            </p>
+          ) : (
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-12">
+                      <input
+                        type="checkbox"
+                        aria-label="Select all transactions"
+                        checked={
+                          selectedTxns.size === transactions.length &&
+                          transactions.length > 0
+                        }
+                        onChange={() => {
+                          if (selectedTxns.size === transactions.length) {
+                            setSelectedTxns(new Set());
+                          } else {
+                            setSelectedTxns(
+                              new Set(transactions.map((t) => t.transaction.id)),
+                            );
+                          }
+                        }}
+                        className="h-4 w-4 rounded border-gray-300"
+                      />
+                    </TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Account Code</TableHead>
+                    <TableHead>Account Name</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="w-24">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {transactions.map((ta) => (
+                    <TableRow key={ta.transaction.id}>
+                      <TableCell>
+                        <input
+                          type="checkbox"
+                          aria-label={`Select ${ta.account.name} transaction`}
+                          checked={selectedTxns.has(ta.transaction.id)}
+                          onChange={() => toggleSelect(ta.transaction.id)}
+                          className="h-4 w-4 rounded border-gray-300"
+                        />
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(ta.transaction.amount)}
+                      </TableCell>
+                      <TableCell>{ta.transaction.date}</TableCell>
+                      <TableCell className="font-mono">
+                        {ta.account.accountCode}
+                      </TableCell>
+                      <TableCell>{ta.account.name}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            ta.account.isActive ? "default" : "secondary"
+                          }
+                        >
+                          {ta.account.isActive ? "Active" : "Inactive"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label="Edit"
+                          onClick={() => {
+                            setServerErrors({});
+                            setEditTxn(ta);
+                          }}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+                <TableFooter>
+                  <TableRow>
+                    <TableCell className="text-right font-medium">
+                      Transaction Total
+                    </TableCell>
+                    <TableCell className="text-right font-bold">
+                      {formatCurrency(transactionsTotal)}
+                    </TableCell>
+                    <TableCell colSpan={5} />
+                  </TableRow>
+                </TableFooter>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Create Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Transaction</DialogTitle>
+          </DialogHeader>
+          <ReceiptTransactionForm
+            mode="create"
+            isSubmitting={createTransaction.isPending}
+            serverErrors={serverErrors}
+            onCancel={() => setCreateOpen(false)}
+            onSubmit={handleCreate}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog
+        open={editTxn !== null}
+        onOpenChange={(open) => !open && setEditTxn(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Transaction</DialogTitle>
+          </DialogHeader>
+          {editTxn && (
+            <ReceiptTransactionForm
+              mode="edit"
+              defaultValues={{
+                accountId: editTxn.account.id,
+                amount: editTxn.transaction.amount,
+                date: editTxn.transaction.date,
+              }}
+              isSubmitting={updateTransaction.isPending}
+              serverErrors={serverErrors}
+              onCancel={() => setEditTxn(null)}
+              onSubmit={handleUpdate}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Transactions</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete {selectedTxns.size} transaction(s)?
+            This action can be undone by restoring.
+          </p>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteTransactions.isPending}
+              onClick={() => {
+                const ids = [...selectedTxns];
+                setSelectedTxns(new Set());
+                setDeleteOpen(false);
+                deleteTransactions.mutate(ids);
+              }}
+            >
+              {deleteTransactions.isPending && <Spinner size="sm" />}
+              {deleteTransactions.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/client/src/hooks/useTransactions.test.ts
+++ b/src/client/src/hooks/useTransactions.test.ts
@@ -370,4 +370,92 @@ describe("useTransactions", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["transactions"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["transactions", "deleted"] });
   });
+
+  it("create mutation invalidates trips query on success", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.POST as Mock).mockResolvedValue({ data: { id: "1" }, error: undefined });
+
+    const { result } = renderHook(() => useCreateTransaction(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate({ receiptId: "r-1", body: { amount: 100, date: "2025-01-01", accountId: "acc-1" } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["trips"] });
+  });
+
+  it("update mutation invalidates trips query on success", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.PUT as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useUpdateTransaction(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate({ body: { id: "1", amount: 100, date: "2025-01-01", accountId: "acc-1" } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["trips"] });
+  });
+
+  it("delete mutation invalidates trips query on settled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.DELETE as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useDeleteTransactions(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate(["1"]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["trips"] });
+  });
+
+  it("restore mutation invalidates trips query on success", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    (client.POST as Mock).mockResolvedValue({ error: undefined });
+
+    const { result } = renderHook(() => useRestoreTransaction(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate("1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["trips"] });
+  });
 });

--- a/src/client/src/hooks/useTransactions.ts
+++ b/src/client/src/hooks/useTransactions.ts
@@ -65,6 +65,7 @@ export function useCreateTransaction() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
+      queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Transaction created");
     },
     onError: () => {
@@ -115,6 +116,7 @@ export function useUpdateTransaction() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
+      queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Transaction updated");
     },
     onError: () => {
@@ -153,6 +155,7 @@ export function useDeleteTransactions() {
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["transactions", "deleted"] });
+      queryClient.invalidateQueries({ queryKey: ["trips"] });
     },
     onSuccess: () => {
       toast.success("Transaction(s) deleted");
@@ -186,6 +189,7 @@ export function useRestoreTransaction() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["transactions", "deleted"] });
+      queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Transaction restored");
     },
     onError: () => {

--- a/src/client/src/pages/ReceiptDetail.test.tsx
+++ b/src/client/src/pages/ReceiptDetail.test.tsx
@@ -45,6 +45,18 @@ vi.mock("@/components/ReceiptItemsCard", () => ({
   },
 }));
 
+vi.mock("@/components/ReceiptTransactionsCard", () => ({
+  ReceiptTransactionsCard: function MockReceiptTransactionsCard(props: {
+    transactions: unknown[];
+  }) {
+    return (
+      <div data-testid="receipt-transactions-card">
+        Transactions ({props.transactions.length})
+      </div>
+    );
+  },
+}));
+
 function renderWithRoutes(initialRoute: string) {
   return render(
     <MemoryRouter initialEntries={[initialRoute]}>
@@ -148,7 +160,7 @@ describe("ReceiptDetail", () => {
     );
   });
 
-  it("renders transactions section when trip has transactions", async () => {
+  it("renders transactions card when trip has transactions", async () => {
     const { useTripByReceiptId } = await import("@/hooks/useTrips");
     vi.mocked(useTripByReceiptId).mockReturnValue(
       mockQueryResult({
@@ -171,9 +183,8 @@ describe("ReceiptDetail", () => {
     );
 
     renderWithRoutes("/receipts/r1");
+    expect(screen.getByTestId("receipt-transactions-card")).toBeInTheDocument();
     expect(screen.getByText("Transactions (1)")).toBeInTheDocument();
-    expect(screen.getByText("Checking")).toBeInTheDocument();
-    expect(screen.getByText("1234")).toBeInTheDocument();
   });
 
   it("renders adjustments section when trip has adjustments", async () => {
@@ -206,7 +217,7 @@ describe("ReceiptDetail", () => {
     expect(screen.getByText("10% off")).toBeInTheDocument();
   });
 
-  it("renders empty transactions message when no transactions", async () => {
+  it("renders transactions card when trip has no transactions", async () => {
     const { useTripByReceiptId } = await import("@/hooks/useTrips");
     vi.mocked(useTripByReceiptId).mockReturnValue(
       mockQueryResult({
@@ -217,9 +228,8 @@ describe("ReceiptDetail", () => {
     );
 
     renderWithRoutes("/receipts/r1");
-    expect(
-      screen.getByText(/no transactions for this receipt/i),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("receipt-transactions-card")).toBeInTheDocument();
+    expect(screen.getByText("Transactions (0)")).toBeInTheDocument();
   });
 
   it("renders empty adjustments message when no adjustments", async () => {

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -5,6 +5,7 @@ import { useEnumMetadata } from "@/hooks/useEnumMetadata";
 import { ValidationWarnings } from "@/components/ValidationWarnings";
 import { BalanceSummaryCard } from "@/components/BalanceSummaryCard";
 import { ReceiptItemsCard } from "@/components/ReceiptItemsCard";
+import { ReceiptTransactionsCard } from "@/components/ReceiptTransactionsCard";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -169,79 +170,11 @@ function ReceiptDetail() {
             </CardContent>
           </Card>
 
-          {/* Transactions Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>
-                Transactions ({trip.transactions.length})
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {trip.transactions.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  No transactions for this receipt.
-                </p>
-              ) : (
-                <div className="rounded-md border">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="text-right">Amount</TableHead>
-                        <TableHead>Date</TableHead>
-                        <TableHead>Account Code</TableHead>
-                        <TableHead>Account Name</TableHead>
-                        <TableHead>Status</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {trip.transactions.map(
-                        (ta: {
-                          transaction: {
-                            id: string;
-                            amount: number;
-                            date: string;
-                          };
-                          account: {
-                            accountCode: string;
-                            name: string;
-                            isActive: boolean;
-                          };
-                        }) => (
-                          <TableRow key={ta.transaction.id}>
-                            <TableCell className="text-right">
-                              {formatCurrency(ta.transaction.amount)}
-                            </TableCell>
-                            <TableCell>{ta.transaction.date}</TableCell>
-                            <TableCell className="font-mono">
-                              {ta.account.accountCode}
-                            </TableCell>
-                            <TableCell>{ta.account.name}</TableCell>
-                            <TableCell>
-                              <Badge
-                                variant={
-                                  ta.account.isActive ? "default" : "secondary"
-                                }
-                              >
-                                {ta.account.isActive ? "Active" : "Inactive"}
-                              </Badge>
-                            </TableCell>
-                          </TableRow>
-                        ),
-                      )}
-                    </TableBody>
-                    <TableFooter>
-                      <TableRow>
-                        <TableCell className="text-right font-bold">
-                          {formatCurrency(transactionsTotal)}
-                        </TableCell>
-                        <TableCell colSpan={4} />
-                      </TableRow>
-                    </TableFooter>
-                  </Table>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+          <ReceiptTransactionsCard
+            receiptId={id}
+            transactions={trip.transactions}
+            transactionsTotal={transactionsTotal}
+          />
 
           <Card>
             <CardHeader>


### PR DESCRIPTION
## Summary
- Add `ReceiptTransactionsCard` component following the `AdjustmentsCard` pattern with full inline CRUD (create, edit, delete with confirmation dialogs)
- Add `ReceiptTransactionForm` for create/edit dialogs with account combobox, amount, and date fields
- Replace read-only transactions table on receipt detail page with the new interactive component
- Add trips query invalidation to transaction mutations for automatic balance recalculation

## Test plan
- [x] 16 unit tests for ReceiptTransactionsCard (empty state, rows, headers, footer, buttons, badges, selection, dialogs, mutations, cancel)
- [x] 4 new hook tests verifying trips query invalidation on create/update/delete/restore
- [x] 9 ReceiptDetail page tests updated for new component
- [x] TypeScript type check passes
- [x] All 1,320 .NET tests pass
- [x] ESLint passes with no errors

Closes RECEIPTS-419

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>