### PR TITLE
feat(api,client): add delete button to category edit modal

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -291,6 +291,41 @@ paths:
               $ref: "#/components/headers/X-Resource-Id"
         "404":
           description: Not Found
+    delete:
+      operationId: DeleteCategory
+      tags: [Categories]
+      summary: Hard-delete a category
+      description: >
+        Permanently deletes a category. Requires the Admin role. Returns 409
+        Conflict if subcategories or receipt items reference this category.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+        "409":
+          description: Conflict — subcategories or receipt items reference this category
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  subcategoryCount:
+                    type: integer
+                  receiptItemCount:
+                    type: integer
 
   /api/categories:
     get:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-a5151c1d",
+  "name": "agent-a03790d4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/Application/Commands/Category/Delete/DeleteCategoryCommand.cs
+++ b/src/Application/Commands/Category/Delete/DeleteCategoryCommand.cs
@@ -1,0 +1,20 @@
+using Application.Interfaces;
+
+namespace Application.Commands.Category.Delete;
+
+public record DeleteCategoryCommand : ICommand<bool>
+{
+	public Guid Id { get; }
+
+	public const string IdCannotBeEmpty = "Id cannot be empty.";
+
+	public DeleteCategoryCommand(Guid id)
+	{
+		if (id == Guid.Empty)
+		{
+			throw new ArgumentException(IdCannotBeEmpty, nameof(id));
+		}
+
+		Id = id;
+	}
+}

--- a/src/Application/Commands/Category/Delete/DeleteCategoryCommandHandler.cs
+++ b/src/Application/Commands/Category/Delete/DeleteCategoryCommandHandler.cs
@@ -1,0 +1,19 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Commands.Category.Delete;
+
+public class DeleteCategoryCommandHandler(ICategoryService categoryService) : IRequestHandler<DeleteCategoryCommand, bool>
+{
+	public async Task<bool> Handle(DeleteCategoryCommand request, CancellationToken cancellationToken)
+	{
+		bool exists = await categoryService.ExistsAsync(request.Id, cancellationToken);
+		if (!exists)
+		{
+			return false;
+		}
+
+		await categoryService.DeleteAsync(request.Id, cancellationToken);
+		return true;
+	}
+}

--- a/src/Application/Interfaces/Services/ICategoryService.cs
+++ b/src/Application/Interfaces/Services/ICategoryService.cs
@@ -6,4 +6,7 @@ public interface ICategoryService : IService<Category>
 {
 	Task<List<Category>> CreateAsync(List<Category> models, CancellationToken cancellationToken);
 	Task UpdateAsync(List<Category> models, CancellationToken cancellationToken);
+	Task DeleteAsync(Guid id, CancellationToken cancellationToken);
+	Task<int> GetSubcategoryCountAsync(Guid categoryId, CancellationToken cancellationToken);
+	Task<int> GetReceiptItemCountByCategoryNameAsync(string categoryName, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Interfaces/Repositories/ICategoryRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/ICategoryRepository.cs
@@ -11,4 +11,7 @@ public interface ICategoryRepository
 	Task UpdateAsync(List<CategoryEntity> entities, CancellationToken cancellationToken);
 	Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken);
 	Task<int> GetCountAsync(CancellationToken cancellationToken);
+	Task DeleteAsync(Guid id, CancellationToken cancellationToken);
+	Task<int> GetSubcategoryCountAsync(Guid categoryId, CancellationToken cancellationToken);
+	Task<int> GetReceiptItemCountByCategoryNameAsync(string categoryName, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Repositories/CategoryRepository.cs
+++ b/src/Infrastructure/Repositories/CategoryRepository.cs
@@ -67,4 +67,30 @@ public class CategoryRepository(IDbContextFactory<ApplicationDbContext> contextF
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
 		return await context.Categories.CountAsync(cancellationToken);
 	}
+
+	public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		CategoryEntity? entity = await context.Categories.FindAsync([id], cancellationToken);
+		if (entity != null)
+		{
+			context.Categories.Remove(entity);
+			await context.SaveChangesAsync(cancellationToken);
+		}
+	}
+
+	public async Task<int> GetSubcategoryCountAsync(Guid categoryId, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		return await context.Subcategories
+			.CountAsync(s => s.CategoryId == categoryId, cancellationToken);
+	}
+
+	public async Task<int> GetReceiptItemCountByCategoryNameAsync(string categoryName, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		return await context.ReceiptItems
+			.IgnoreQueryFilters()
+			.CountAsync(ri => ri.Category == categoryName, cancellationToken);
+	}
 }

--- a/src/Infrastructure/Services/CategoryService.cs
+++ b/src/Infrastructure/Services/CategoryService.cs
@@ -55,4 +55,19 @@ public class CategoryService(ICategoryRepository repository, CategoryMapper mapp
 		List<CategoryEntity> categoryEntities = [.. models.Select(mapper.ToEntity)];
 		await repository.UpdateAsync(categoryEntities, cancellationToken);
 	}
+
+	public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)
+	{
+		await repository.DeleteAsync(id, cancellationToken);
+	}
+
+	public async Task<int> GetSubcategoryCountAsync(Guid categoryId, CancellationToken cancellationToken)
+	{
+		return await repository.GetSubcategoryCountAsync(categoryId, cancellationToken);
+	}
+
+	public async Task<int> GetReceiptItemCountByCategoryNameAsync(string categoryName, CancellationToken cancellationToken)
+	{
+		return await repository.GetReceiptItemCountByCategoryNameAsync(categoryName, cancellationToken);
+	}
 }

--- a/src/Presentation/API/Controllers/Core/CategoriesController.cs
+++ b/src/Presentation/API/Controllers/Core/CategoriesController.cs
@@ -146,7 +146,7 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	[EndpointDescription("Permanently deletes a category. Requires the Admin role. Returns 409 Conflict if subcategories or receipt items reference this category.")]
 	public async Task<Results<NoContent, NotFound, Conflict<object>>> DeleteCategory([FromRoute] Guid id)
 	{
-		Category? category = await mediator.Send(new Application.Queries.Core.Category.GetCategoryByIdQuery(id));
+		Category? category = await mediator.Send(new GetCategoryByIdQuery(id));
 		if (category == null)
 		{
 			logger.LogWarning("Category {Id} not found for deletion", id);
@@ -157,7 +157,7 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 		if (subcategoryCount > 0)
 		{
 			logger.LogWarning("Category {Id} cannot be deleted — {Count} subcategories reference it", id, subcategoryCount);
-			return TypedResults.Conflict<object>(new { message = $"Cannot delete — {subcategoryCount} subcategorie(s) belong to this category. Delete them first.", subcategoryCount });
+			return TypedResults.Conflict<object>(new { message = $"Cannot delete — {subcategoryCount} subcategories belong to this category. Delete them first.", subcategoryCount });
 		}
 
 		int receiptItemCount = await categoryService.GetReceiptItemCountByCategoryNameAsync(category.Name, HttpContext.RequestAborted);

--- a/src/Presentation/API/Controllers/Core/CategoriesController.cs
+++ b/src/Presentation/API/Controllers/Core/CategoriesController.cs
@@ -2,7 +2,9 @@ using API.Generated.Dtos;
 using API.Mapping.Core;
 using API.Services;
 using Application.Commands.Category.Create;
+using Application.Commands.Category.Delete;
 using Application.Commands.Category.Update;
+using Application.Interfaces.Services;
 using Application.Models;
 using Application.Queries.Core.Category;
 using Asp.Versioning;
@@ -19,7 +21,7 @@ namespace API.Controllers.Core;
 [Route("api/categories")]
 [Produces("application/json")]
 [Authorize]
-public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILogger<CategoriesController> logger, IEntityChangeNotifier notifier) : ControllerBase
+public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILogger<CategoriesController> logger, IEntityChangeNotifier notifier, ICategoryService categoryService) : ControllerBase
 {
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
@@ -27,6 +29,7 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	public const string RouteCreateBatch = "batch";
 	public const string RouteUpdate = "{id}";
 	public const string RouteUpdateBatch = "batch";
+	public const string RouteDelete = "{id}";
 
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get a category by ID")]
@@ -134,6 +137,46 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 		}
 
 		await notifier.NotifyBulkChanged("category", "updated", models.Select(m => m.Id));
+		return TypedResults.NoContent();
+	}
+
+	[HttpDelete(RouteDelete)]
+	[Authorize(Policy = "RequireAdmin")]
+	[EndpointSummary("Hard-delete a category")]
+	[EndpointDescription("Permanently deletes a category. Requires the Admin role. Returns 409 Conflict if subcategories or receipt items reference this category.")]
+	public async Task<Results<NoContent, NotFound, Conflict<object>>> DeleteCategory([FromRoute] Guid id)
+	{
+		Category? category = await mediator.Send(new Application.Queries.Core.Category.GetCategoryByIdQuery(id));
+		if (category == null)
+		{
+			logger.LogWarning("Category {Id} not found for deletion", id);
+			return TypedResults.NotFound();
+		}
+
+		int subcategoryCount = await categoryService.GetSubcategoryCountAsync(id, HttpContext.RequestAborted);
+		if (subcategoryCount > 0)
+		{
+			logger.LogWarning("Category {Id} cannot be deleted — {Count} subcategories reference it", id, subcategoryCount);
+			return TypedResults.Conflict<object>(new { message = $"Cannot delete — {subcategoryCount} subcategorie(s) belong to this category. Delete them first.", subcategoryCount });
+		}
+
+		int receiptItemCount = await categoryService.GetReceiptItemCountByCategoryNameAsync(category.Name, HttpContext.RequestAborted);
+		if (receiptItemCount > 0)
+		{
+			logger.LogWarning("Category {Id} cannot be deleted — {Count} receipt items reference it", id, receiptItemCount);
+			return TypedResults.Conflict<object>(new { message = $"Cannot delete — {receiptItemCount} receipt item(s) use this category", receiptItemCount });
+		}
+
+		DeleteCategoryCommand command = new(id);
+		bool result = await mediator.Send(command);
+
+		if (!result)
+		{
+			logger.LogWarning("Category {Id} not found for deletion", id);
+			return TypedResults.NotFound();
+		}
+
+		await notifier.NotifyDeleted("category", id);
 		return TypedResults.NoContent();
 	}
 }

--- a/src/client/src/components/CategoryForm.test.tsx
+++ b/src/client/src/components/CategoryForm.test.tsx
@@ -98,4 +98,104 @@ describe("CategoryForm", () => {
       );
     });
   });
+
+  it("does not show delete button in create mode", () => {
+    render(
+      <CategoryForm
+        {...defaultProps}
+        isAdmin={true}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("does not show delete button in edit mode for non-admin users", () => {
+    render(
+      <CategoryForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Groceries", description: "Food items", isActive: true }}
+        isAdmin={false}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("shows delete button in edit mode for admin users", () => {
+    render(
+      <CategoryForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Groceries", description: "Food items", isActive: true }}
+        isAdmin={true}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it("shows confirmation dialog when delete button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <CategoryForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Groceries", description: "Food items", isActive: true }}
+        isAdmin={true}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete Category?")).toBeInTheDocument();
+      expect(screen.getByText(/permanently delete/i)).toBeInTheDocument();
+    });
+  });
+
+  it("calls onDelete when delete is confirmed", async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CategoryForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Groceries", description: "Food items", isActive: true }}
+        isAdmin={true}
+        onDelete={onDelete}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete Category?")).toBeInTheDocument();
+    });
+
+    // Click the "Delete" action in the confirmation dialog
+    const confirmButtons = screen.getAllByRole("button", { name: /delete/i });
+    const confirmButton = confirmButtons[confirmButtons.length - 1];
+    await user.click(confirmButton);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show delete button when onDelete is not provided", () => {
+    render(
+      <CategoryForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Groceries", description: "Food items", isActive: true }}
+        isAdmin={true}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
 });

--- a/src/client/src/components/CategoryForm.tsx
+++ b/src/client/src/components/CategoryForm.tsx
@@ -7,6 +7,17 @@ import { Button } from "@/components/ui/button";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
   Form,
   FormControl,
   FormField,
@@ -14,6 +25,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { Trash2 } from "lucide-react";
 
 const categorySchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -29,6 +41,9 @@ interface CategoryFormProps {
   onSubmit: (values: CategoryFormValues) => void;
   onCancel: () => void;
   isSubmitting?: boolean;
+  onDelete?: () => void;
+  isDeleting?: boolean;
+  isAdmin?: boolean;
 }
 
 export function CategoryForm({
@@ -37,6 +52,9 @@ export function CategoryForm({
   onSubmit,
   onCancel,
   isSubmitting,
+  onDelete,
+  isDeleting,
+  isAdmin,
 }: CategoryFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
   useFormShortcuts({ formRef });
@@ -102,15 +120,50 @@ export function CategoryForm({
           )}
         />
 
-        <div className="flex justify-end gap-2 pt-4">
-          <Button type="button" variant="outline" onClick={onCancel}>
-            Cancel
-          </Button>
-          <SubmitButton
-            isSubmitting={isSubmitting ?? false}
-            label={mode === "create" ? "Create Category" : "Update Category"}
-            loadingLabel="Saving..."
-          />
+        <div className="flex items-center pt-4">
+          {mode === "edit" && isAdmin && onDelete && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  disabled={isDeleting}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  {isDeleting ? "Deleting..." : "Delete"}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete Category?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently delete this category. This action
+                    cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    variant="destructive"
+                    onClick={onDelete}
+                  >
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+            <SubmitButton
+              isSubmitting={isSubmitting ?? false}
+              label={mode === "create" ? "Create Category" : "Update Category"}
+              loadingLabel="Saving..."
+            />
+          </div>
         </div>
       </form>
     </Form>

--- a/src/client/src/hooks/useCategories.ts
+++ b/src/client/src/hooks/useCategories.ts
@@ -3,6 +3,8 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
 
+// Note: Categories are hard-delete entities (no soft-delete/restore).
+
 export function useCategories(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
   const query = useQuery({
     queryKey: ["categories", "list", offset, limit, sortBy, sortDirection],
@@ -74,6 +76,42 @@ export function useUpdateCategory() {
     },
     onError: () => {
       toast.error("Failed to update category");
+    },
+  });
+}
+
+export interface DeleteCategoryConflict {
+  message: string;
+  subcategoryCount?: number;
+  receiptItemCount?: number;
+}
+
+export function useDeleteCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error, response } = await client.DELETE("/api/categories/{id}", {
+        params: { path: { id } },
+      });
+      if (error) {
+        if (response.status === 409) {
+          const body = error as unknown as DeleteCategoryConflict;
+          throw { conflict: true, ...body };
+        }
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+      toast.success("Category deleted");
+    },
+    onError: (error: unknown) => {
+      const err = error as { conflict?: boolean; message?: string };
+      if (err.conflict) {
+        toast.error(err.message ?? "Cannot delete — dependencies reference this category");
+      } else {
+        toast.error("Failed to delete category");
+      }
     },
   });
 }

--- a/src/client/src/pages/Categories.test.tsx
+++ b/src/client/src/pages/Categories.test.tsx
@@ -11,6 +11,15 @@ vi.mock("@/hooks/useCategories", () => ({
   useCategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
   useCreateCategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateCategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDeleteCategory: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/hooks/usePermission", () => ({
+  usePermission: vi.fn(() => ({
+    roles: ["Admin"],
+    hasRole: (role: string) => role === "Admin",
+    isAdmin: () => true,
+  })),
 }));
 
 vi.mock("@/hooks/useFuzzySearch", () => ({

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -4,7 +4,9 @@ import {
   useCategories,
   useCreateCategory,
   useUpdateCategory,
+  useDeleteCategory,
 } from "@/hooks/useCategories";
+import { usePermission } from "@/hooks/usePermission";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useEntityLinkParams } from "@/hooks/useEntityLinkParams";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
@@ -68,6 +70,8 @@ function Categories() {
   const { data: categoriesData, total: serverTotal, isLoading } = useCategories(offset, limit, sortBy, sortDirection);
   const createCategory = useCreateCategory();
   const updateCategory = useUpdateCategory();
+  const deleteCategory = useDeleteCategory();
+  const { isAdmin } = usePermission();
   const [createOpen, setCreateOpen] = useState(false);
   const [editCategory, setEditCategory] = useState<CategoryResponse | null>(
     null,
@@ -314,6 +318,13 @@ function Categories() {
                   { id: editCategory.id, ...values },
                   { onSuccess: () => setEditCategory(null) },
                 );
+              }}
+              isAdmin={isAdmin()}
+              isDeleting={deleteCategory.isPending}
+              onDelete={() => {
+                deleteCategory.mutate(editCategory.id, {
+                  onSuccess: () => setEditCategory(null),
+                });
               }}
             />
           )}

--- a/tests/Application.Tests/Commands/Category/DeleteCategoryCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Category/DeleteCategoryCommandHandlerTests.cs
@@ -1,0 +1,52 @@
+using Application.Commands.Category.Delete;
+using Application.Interfaces.Services;
+using Moq;
+
+namespace Application.Tests.Commands.Category;
+
+public class DeleteCategoryCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_WhenCategoryExists_ReturnsTrueAndCallsDelete()
+	{
+		// Arrange
+		Mock<ICategoryService> mockService = new();
+		DeleteCategoryCommandHandler handler = new(mockService.Object);
+		Guid id = Guid.NewGuid();
+
+		mockService.Setup(s => s.ExistsAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+		mockService.Setup(s => s.DeleteAsync(id, It.IsAny<CancellationToken>()))
+			.Returns(Task.CompletedTask);
+
+		DeleteCategoryCommand command = new(id);
+
+		// Act
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		Assert.True(result);
+		mockService.Verify(s => s.DeleteAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_WhenCategoryDoesNotExist_ReturnsFalse()
+	{
+		// Arrange
+		Mock<ICategoryService> mockService = new();
+		DeleteCategoryCommandHandler handler = new(mockService.Object);
+		Guid id = Guid.NewGuid();
+
+		mockService.Setup(s => s.ExistsAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		DeleteCategoryCommand command = new(id);
+
+		// Act
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		Assert.False(result);
+		mockService.Verify(s => s.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+}

--- a/tests/Application.Tests/Commands/Category/DeleteCategoryCommandTests.cs
+++ b/tests/Application.Tests/Commands/Category/DeleteCategoryCommandTests.cs
@@ -1,0 +1,21 @@
+using Application.Commands.Category.Delete;
+using FluentAssertions;
+
+namespace Application.Tests.Commands.Category;
+
+public class DeleteCategoryCommandTests
+{
+	[Fact]
+	public void Command_WithEmptyId_ThrowsArgumentException()
+	{
+		Assert.Throws<ArgumentException>(() => new DeleteCategoryCommand(Guid.Empty));
+	}
+
+	[Fact]
+	public void Command_WithValidId_ReturnsValidCommand()
+	{
+		Guid id = Guid.NewGuid();
+		DeleteCategoryCommand command = new(id);
+		command.Id.Should().Be(id);
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Core/CategoriesControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/CategoriesControllerTests.cs
@@ -3,13 +3,17 @@ using API.Generated.Dtos;
 using API.Mapping.Core;
 using API.Services;
 using Application.Commands.Category.Create;
+using Application.Commands.Category.Delete;
 using Application.Commands.Category.Update;
+using Application.Interfaces.Services;
 using Application.Models;
 using Application.Queries.Core.Category;
 using Domain.Core;
 using FluentAssertions;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using SampleData.Domain.Core;
@@ -23,6 +27,7 @@ public class CategoriesControllerTests
 	private readonly Mock<IMediator> _mediatorMock;
 	private readonly Mock<ILogger<CategoriesController>> _loggerMock;
 	private readonly Mock<IEntityChangeNotifier> _notifierMock;
+	private readonly Mock<ICategoryService> _categoryServiceMock;
 	private readonly CategoriesController _controller;
 
 	public CategoriesControllerTests()
@@ -31,7 +36,12 @@ public class CategoriesControllerTests
 		_mapper = new CategoryMapper();
 		_loggerMock = ControllerTestHelpers.GetLoggerMock<CategoriesController>();
 		_notifierMock = new Mock<IEntityChangeNotifier>();
-		_controller = new CategoriesController(_mediatorMock.Object, _mapper, _loggerMock.Object, _notifierMock.Object);
+		_categoryServiceMock = new Mock<ICategoryService>();
+		_controller = new CategoriesController(_mediatorMock.Object, _mapper, _loggerMock.Object, _notifierMock.Object, _categoryServiceMock.Object);
+		_controller.ControllerContext = new ControllerContext
+		{
+			HttpContext = new DefaultHttpContext()
+		};
 	}
 
 	// ── GetCategoryById ─────────────────────────────────────
@@ -304,6 +314,114 @@ public class CategoriesControllerTests
 			.ThrowsAsync(new Exception());
 
 		Func<Task> act = () => _controller.UpdateCategories(controllerInput);
+
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	// ── DeleteCategory ──────────────────────────────────────
+
+	[Fact]
+	public async Task DeleteCategory_ReturnsNoContent_WhenDeleteSucceeds()
+	{
+		Category category = CategoryGenerator.Generate();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryByIdQuery>(q => q.Id == category.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(category);
+
+		_categoryServiceMock.Setup(s => s.GetSubcategoryCountAsync(category.Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(0);
+
+		_categoryServiceMock.Setup(s => s.GetReceiptItemCountByCategoryNameAsync(category.Name, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteCategoryCommand>(c => c.Id == category.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound, Conflict<object>> result = await _controller.DeleteCategory(category.Id);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteCategory_ReturnsNotFound_WhenCategoryDoesNotExist()
+	{
+		Guid id = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryByIdQuery>(q => q.Id == id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Category?)null);
+
+		Results<NoContent, NotFound, Conflict<object>> result = await _controller.DeleteCategory(id);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteCategory_ReturnsConflict_WhenSubcategoriesExist()
+	{
+		Category category = CategoryGenerator.Generate();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryByIdQuery>(q => q.Id == category.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(category);
+
+		_categoryServiceMock.Setup(s => s.GetSubcategoryCountAsync(category.Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(3);
+
+		Results<NoContent, NotFound, Conflict<object>> result = await _controller.DeleteCategory(category.Id);
+
+		Assert.IsType<Conflict<object>>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteCategory_ReturnsConflict_WhenReceiptItemsExist()
+	{
+		Category category = CategoryGenerator.Generate();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryByIdQuery>(q => q.Id == category.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(category);
+
+		_categoryServiceMock.Setup(s => s.GetSubcategoryCountAsync(category.Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(0);
+
+		_categoryServiceMock.Setup(s => s.GetReceiptItemCountByCategoryNameAsync(category.Name, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(5);
+
+		Results<NoContent, NotFound, Conflict<object>> result = await _controller.DeleteCategory(category.Id);
+
+		Assert.IsType<Conflict<object>>(result.Result);
+	}
+
+	[Fact]
+	public async Task DeleteCategory_ThrowsException_WhenMediatorFails()
+	{
+		Category category = CategoryGenerator.Generate();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryByIdQuery>(q => q.Id == category.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(category);
+
+		_categoryServiceMock.Setup(s => s.GetSubcategoryCountAsync(category.Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(0);
+
+		_categoryServiceMock.Setup(s => s.GetReceiptItemCountByCategoryNameAsync(category.Name, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<DeleteCategoryCommand>(c => c.Id == category.Id),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		Func<Task> act = () => _controller.DeleteCategory(category.Id);
 
 		await act.Should().ThrowAsync<Exception>();
 	}


### PR DESCRIPTION
## Summary
- Add hard-delete functionality for categories with two-tier dependency checking (subcategories first, then receipt items)
- Backend: DELETE `/api/categories/{id}` endpoint requiring Admin role, returns 409 Conflict if dependencies exist
- Frontend: admin-only delete button with confirmation dialog in the category edit modal, with cache invalidation and toast on success

## Changes
- **Backend:** `DeleteCategoryCommand` + handler, `ICategoryRepository.DeleteAsync` / `GetSubcategoryCountAsync` / `GetReceiptItemCountByCategoryNameAsync`, `CategoriesController.DeleteCategory`, OpenAPI spec
- **Frontend:** `CategoryForm.tsx` delete button + AlertDialog, `useDeleteCategory` hook, `Categories.tsx` wiring
- **Tests:** 15 new tests (2 command, 2 handler, 5 controller, 6 form component)

## Test plan
- [x] All 1329 .NET unit tests pass
- [x] All 1410 client tests pass (138 test files)
- [x] OpenAPI spec lints clean, no drift
- [x] Build succeeds

Closes RECEIPTS-411

Generated with [Claude Code](https://claude.com/claude-code)