### PR TITLE
fix(api): persist DataProtection keys to /data volume

### DIFF
--- a/src/Presentation/API/Program.cs
+++ b/src/Presentation/API/Program.cs
@@ -5,12 +5,17 @@ using API.Middleware;
 using API.Services;
 using Application.Services;
 using Infrastructure.Services;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HttpOverrides;
 
 // Create builder
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 builder.AddApplicationConfiguration();
+
+// Persist DataProtection keys to the /data volume so they survive container restarts
+builder.Services.AddDataProtection()
+	.PersistKeysToFileSystem(new DirectoryInfo("/data/DataProtection-Keys"));
 
 // Register services
 builder.Services


### PR DESCRIPTION
## Summary
- Configure `PersistKeysToFileSystem` in `Program.cs` so ASP.NET DataProtection keys survive container restarts by writing them to `/data/DataProtection-Keys` on the already-mounted `app-data` volume
- No new NuGet packages needed — `Microsoft.AspNetCore.DataProtection` is part of the shared framework
- Closes RECEIPTS-431

## Test plan
- [x] Solution builds with 0 errors
- [x] All 1359 unit tests pass
- [x] Code review: no critical or warning findings
- [x] Security review: low-risk infrastructure change, no vulnerabilities
- [x] Verified `/data` volume is mounted in docker-compose.yml and owned by app user via entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)