### PR TITLE
fix(infrastructure): move Select before Skip/Take in GetDeletedAsync queries

### DIFF
--- a/src/Infrastructure/Repositories/AdjustmentRepository.cs
+++ b/src/Infrastructure/Repositories/AdjustmentRepository.cs
@@ -82,8 +82,6 @@ public class AdjustmentRepository(IDbContextFactory<ApplicationDbContext> contex
 			.IgnoreAutoIncludes()
 			.AsNoTracking()
 			.ApplySort(sort, AllowedSortColumns, e => e.Type)
-			.Skip(offset)
-			.Take(limit)
 			.Select(a => new AdjustmentEntity
 			{
 				Id = a.Id,
@@ -94,6 +92,8 @@ public class AdjustmentRepository(IDbContextFactory<ApplicationDbContext> contex
 				Description = a.Description,
 				DeletedAt = a.DeletedAt
 			})
+			.Skip(offset)
+			.Take(limit)
 			.ToListAsync(cancellationToken);
 	}
 

--- a/src/Infrastructure/Repositories/CategoryRepository.cs
+++ b/src/Infrastructure/Repositories/CategoryRepository.cs
@@ -38,8 +38,6 @@ public class CategoryRepository(IDbContextFactory<ApplicationDbContext> contextF
 			.OnlyDeleted()
 			.AsNoTracking()
 			.ApplySort(sort, AllowedSortColumns, e => e.Name)
-			.Skip(offset)
-			.Take(limit)
 			.Select(c => new CategoryEntity
 			{
 				Id = c.Id,
@@ -48,6 +46,8 @@ public class CategoryRepository(IDbContextFactory<ApplicationDbContext> contextF
 				IsActive = c.IsActive,
 				DeletedAt = c.DeletedAt
 			})
+			.Skip(offset)
+			.Take(limit)
 			.ToListAsync(cancellationToken);
 	}
 

--- a/src/Infrastructure/Repositories/ReceiptItemRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptItemRepository.cs
@@ -96,8 +96,6 @@ public class ReceiptItemRepository(IDbContextFactory<ApplicationDbContext> conte
 			.IgnoreAutoIncludes()
 			.AsNoTracking()
 			.ApplySort(sort, AllowedSortColumns, e => e.Description)
-			.Skip(offset)
-			.Take(limit)
 			.Select(ri => new ReceiptItemEntity
 			{
 				Id = ri.Id,
@@ -114,6 +112,8 @@ public class ReceiptItemRepository(IDbContextFactory<ApplicationDbContext> conte
 				PricingMode = ri.PricingMode,
 				DeletedAt = ri.DeletedAt
 			})
+			.Skip(offset)
+			.Take(limit)
 			.ToListAsync(cancellationToken);
 	}
 

--- a/src/Infrastructure/Repositories/ReceiptRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptRepository.cs
@@ -48,8 +48,6 @@ public class ReceiptRepository(IDbContextFactory<ApplicationDbContext> contextFa
 			.OnlyDeleted()
 			.AsNoTracking()
 			.ApplySort(sort, AllowedSortColumns, e => e.Date, defaultDescending: true)
-			.Skip(offset)
-			.Take(limit)
 			.Select(r => new ReceiptEntity
 			{
 				Id = r.Id,
@@ -59,6 +57,8 @@ public class ReceiptRepository(IDbContextFactory<ApplicationDbContext> contextFa
 				TaxAmountCurrency = r.TaxAmountCurrency,
 				DeletedAt = r.DeletedAt
 			})
+			.Skip(offset)
+			.Take(limit)
 			.ToListAsync(cancellationToken);
 	}
 

--- a/src/Infrastructure/Repositories/SubcategoryRepository.cs
+++ b/src/Infrastructure/Repositories/SubcategoryRepository.cs
@@ -38,8 +38,6 @@ public class SubcategoryRepository(IDbContextFactory<ApplicationDbContext> conte
 			.OnlyDeleted()
 			.AsNoTracking()
 			.ApplySort(sort, AllowedSortColumns, e => e.Name)
-			.Skip(offset)
-			.Take(limit)
 			.Select(s => new SubcategoryEntity
 			{
 				Id = s.Id,
@@ -49,6 +47,8 @@ public class SubcategoryRepository(IDbContextFactory<ApplicationDbContext> conte
 				IsActive = s.IsActive,
 				DeletedAt = s.DeletedAt
 			})
+			.Skip(offset)
+			.Take(limit)
 			.ToListAsync(cancellationToken);
 	}
 

--- a/src/Infrastructure/Repositories/TransactionRepository.cs
+++ b/src/Infrastructure/Repositories/TransactionRepository.cs
@@ -93,8 +93,6 @@ public class TransactionRepository(IDbContextFactory<ApplicationDbContext> conte
 			.IgnoreAutoIncludes()
 			.AsNoTracking()
 			.ApplySort(sort, AllowedSortColumns, e => e.Date, defaultDescending: true)
-			.Skip(offset)
-			.Take(limit)
 			.Select(t => new TransactionEntity
 			{
 				Id = t.Id,
@@ -105,6 +103,8 @@ public class TransactionRepository(IDbContextFactory<ApplicationDbContext> conte
 				Date = t.Date,
 				DeletedAt = t.DeletedAt
 			})
+			.Skip(offset)
+			.Take(limit)
 			.ToListAsync(cancellationToken);
 	}
 


### PR DESCRIPTION
## Summary
- Fixes EF Core warning "The query uses a row limiting operator ('Skip'/'Take') without an 'OrderBy' operator" in all `GetDeletedAsync` repository methods
- Moves `.Select()` projection before `.Skip().Take()` in 6 repositories (Category, Subcategory, Receipt, Transaction, ReceiptItem, Adjustment) so the ORDER BY from `ApplySort()` stays in the same query scope as OFFSET/FETCH
- Functionally equivalent transformation — projection does not alter row count or order

## Test plan
- [x] Build passes (0 errors)
- [x] All 1341 unit tests pass (117 Domain + 246 Application + 660 API + 318 Infrastructure)
- [x] No new test files needed — mechanical LINQ reorder verified by existing test coverage

Closes RECEIPTS-429

🤖 Generated with [Claude Code](https://claude.com/claude-code)