### PR TITLE
feat(client): add Reports view with report switcher

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -13,6 +13,7 @@ import Categories from "@/pages/Categories";
 import Subcategories from "@/pages/Subcategories";
 import Receipts from "@/pages/Receipts";
 import ItemTemplates from "@/pages/ItemTemplates";
+import Reports from "@/pages/Reports";
 import ReceiptDetail from "@/pages/ReceiptDetail";
 import ReceiptDetailRedirect from "@/pages/ReceiptDetailRedirect";
 import AdminUsers from "@/pages/AdminUsers";
@@ -50,6 +51,7 @@ export const routeConfig = [
           { path: "/transactions", element: <Navigate to="/receipts" replace /> },
           { path: "/trips", element: <Navigate to="/receipts" replace /> },
           { path: "/item-templates", element: <ItemTemplates /> },
+          { path: "/reports", element: <Reports /> },
           { path: "/receipts/:id", element: <ReceiptDetail /> },
           { path: "/receipt-detail", element: <ReceiptDetailRedirect /> },
           { path: "/transaction-detail", element: <Navigate to="/receipts" replace /> },

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -81,6 +81,11 @@ const navGroups: NavGroup[] = [
         label: "Receipts",
         description: "View and manage receipts",
       },
+      {
+        to: "/reports",
+        label: "Reports",
+        description: "View analytical reports",
+      },
     ],
   },
   {
@@ -198,6 +203,7 @@ export function Layout() {
     { to: "/categories", label: "Categories" },
     { to: "/subcategories", label: "Subcategories" },
     { to: "/receipts", label: "Receipts" },
+    { to: "/reports", label: "Reports" },
     { to: "/item-templates", label: "Item Templates" },
     { to: "/security", label: "Security" },
   ];

--- a/src/client/src/components/reports/CategoryTrends.tsx
+++ b/src/client/src/components/reports/CategoryTrends.tsx
@@ -1,0 +1,8 @@
+export default function CategoryTrends() {
+  return (
+    <div className="rounded-lg border p-6 text-center">
+      <h2 className="text-lg font-semibold">Category Trends</h2>
+      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    </div>
+  );
+}

--- a/src/client/src/components/reports/DuplicateDetection.tsx
+++ b/src/client/src/components/reports/DuplicateDetection.tsx
@@ -1,0 +1,8 @@
+export default function DuplicateDetection() {
+  return (
+    <div className="rounded-lg border p-6 text-center">
+      <h2 className="text-lg font-semibold">Duplicate Detection</h2>
+      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    </div>
+  );
+}

--- a/src/client/src/components/reports/ItemCostOverTime.tsx
+++ b/src/client/src/components/reports/ItemCostOverTime.tsx
@@ -1,0 +1,8 @@
+export default function ItemCostOverTime() {
+  return (
+    <div className="rounded-lg border p-6 text-center">
+      <h2 className="text-lg font-semibold">Item Cost Over Time</h2>
+      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    </div>
+  );
+}

--- a/src/client/src/components/reports/ItemSimilarity.tsx
+++ b/src/client/src/components/reports/ItemSimilarity.tsx
@@ -1,0 +1,8 @@
+export default function ItemSimilarity() {
+  return (
+    <div className="rounded-lg border p-6 text-center">
+      <h2 className="text-lg font-semibold">Item Similarity</h2>
+      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    </div>
+  );
+}

--- a/src/client/src/components/reports/OutOfBalance.tsx
+++ b/src/client/src/components/reports/OutOfBalance.tsx
@@ -1,0 +1,8 @@
+export default function OutOfBalance() {
+  return (
+    <div className="rounded-lg border p-6 text-center">
+      <h2 className="text-lg font-semibold">Out of Balance</h2>
+      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    </div>
+  );
+}

--- a/src/client/src/components/reports/SpendingByLocation.tsx
+++ b/src/client/src/components/reports/SpendingByLocation.tsx
@@ -1,0 +1,8 @@
+export default function SpendingByLocation() {
+  return (
+    <div className="rounded-lg border p-6 text-center">
+      <h2 className="text-lg font-semibold">Spending by Location</h2>
+      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    </div>
+  );
+}

--- a/src/client/src/components/reports/UncategorizedItems.tsx
+++ b/src/client/src/components/reports/UncategorizedItems.tsx
@@ -1,0 +1,8 @@
+export default function UncategorizedItems() {
+  return (
+    <div className="rounded-lg border p-6 text-center">
+      <h2 className="text-lg font-semibold">Uncategorized Items</h2>
+      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    </div>
+  );
+}

--- a/src/client/src/hooks/useBreadcrumbs.test.tsx
+++ b/src/client/src/hooks/useBreadcrumbs.test.tsx
@@ -144,8 +144,8 @@ describe("useBreadcrumbs", () => {
 
   // useLocation().pathname does not include query strings or hash fragments.
   // For example, navigating to "/accounts?sort=name" yields pathname "/accounts",
-  // so breadcrumbs are never affected by query parameters. This test documents
-  // that behavior.
+  // so breadcrumbs are never affected by query parameters (unless the route has
+  // explicit query-param breadcrumb configuration).
   it("is unaffected by query strings (pathname excludes them)", () => {
     const { result } = renderHook(() => useBreadcrumbs(), {
       wrapper: createWrapper("/accounts?sort=name&order=asc"),
@@ -154,5 +154,39 @@ describe("useBreadcrumbs", () => {
       { label: "Home", path: "/" },
       { label: "Accounts", path: "/accounts" },
     ]);
+  });
+
+  it("appends report name breadcrumb from query param on /reports", () => {
+    const { result } = renderHook(() => useBreadcrumbs(), {
+      wrapper: createWrapper("/reports?report=out-of-balance"),
+    });
+    expect(result.current).toEqual([
+      { label: "Home", path: "/" },
+      { label: "Reports", path: "/reports" },
+      {
+        label: "Out Of Balance",
+        path: "/reports?report=out-of-balance",
+      },
+    ]);
+  });
+
+  it("shows only Home > Reports when no report query param", () => {
+    const { result } = renderHook(() => useBreadcrumbs(), {
+      wrapper: createWrapper("/reports"),
+    });
+    expect(result.current).toEqual([
+      { label: "Home", path: "/" },
+      { label: "Reports", path: "/reports" },
+    ]);
+  });
+
+  it("title-cases multi-word report slugs in breadcrumb", () => {
+    const { result } = renderHook(() => useBreadcrumbs(), {
+      wrapper: createWrapper("/reports?report=item-cost-over-time"),
+    });
+    expect(result.current[2]).toEqual({
+      label: "Item Cost Over Time",
+      path: "/reports?report=item-cost-over-time",
+    });
   });
 });

--- a/src/client/src/hooks/useBreadcrumbs.ts
+++ b/src/client/src/hooks/useBreadcrumbs.ts
@@ -18,6 +18,21 @@ const routeLabels: Record<string, string> = {
   "/change-password": "Change Password",
 };
 
+/** Maps query param keys to breadcrumb label resolvers for specific routes. */
+const queryParamBreadcrumbs: Record<
+  string,
+  { param: string; resolve: (value: string) => string }
+> = {
+  "/reports": {
+    param: "report",
+    resolve: (slug) =>
+      slug
+        .split("-")
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(" "),
+  },
+};
+
 function toTitleCase(slug: string): string {
   return slug
     .split("-")
@@ -33,7 +48,7 @@ export interface BreadcrumbSegment {
 const EMPTY: BreadcrumbSegment[] = [];
 
 export function useBreadcrumbs(): BreadcrumbSegment[] {
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
 
   return useMemo(() => {
     if (pathname === "/") return EMPTY;
@@ -55,6 +70,19 @@ export function useBreadcrumbs(): BreadcrumbSegment[] {
       }
     }
 
+    // Append query-param-based breadcrumb segment if configured for this route
+    const qpConfig = queryParamBreadcrumbs[pathname];
+    if (qpConfig) {
+      const params = new URLSearchParams(search);
+      const value = params.get(qpConfig.param);
+      if (value) {
+        crumbs.push({
+          label: qpConfig.resolve(value),
+          path: `${pathname}?${qpConfig.param}=${value}`,
+        });
+      }
+    }
+
     return crumbs;
-  }, [pathname]);
+  }, [pathname, search]);
 }

--- a/src/client/src/hooks/useBreadcrumbs.ts
+++ b/src/client/src/hooks/useBreadcrumbs.ts
@@ -8,6 +8,7 @@ const routeLabels: Record<string, string> = {
   "/subcategories": "Subcategories",
   "/item-templates": "Item Templates",
   "/receipts": "Receipts",
+  "/reports": "Reports",
   "/api-keys": "API Keys",
   "/security": "Security",
   "/audit": "Audit Log",

--- a/src/client/src/pages/Reports.test.tsx
+++ b/src/client/src/pages/Reports.test.tsx
@@ -1,0 +1,135 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import Reports, { REPORTS, DEFAULT_REPORT } from "./Reports";
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@/components/reports/OutOfBalance", () => ({
+  default: () => <div data-testid="report-out-of-balance">Out of Balance</div>,
+}));
+
+vi.mock("@/components/reports/ItemSimilarity", () => ({
+  default: () => (
+    <div data-testid="report-item-similarity">Item Similarity</div>
+  ),
+}));
+
+vi.mock("@/components/reports/ItemCostOverTime", () => ({
+  default: () => (
+    <div data-testid="report-item-cost-over-time">Item Cost Over Time</div>
+  ),
+}));
+
+vi.mock("@/components/reports/SpendingByLocation", () => ({
+  default: () => (
+    <div data-testid="report-spending-by-location">Spending by Location</div>
+  ),
+}));
+
+vi.mock("@/components/reports/CategoryTrends", () => ({
+  default: () => (
+    <div data-testid="report-category-trends">Category Trends</div>
+  ),
+}));
+
+vi.mock("@/components/reports/DuplicateDetection", () => ({
+  default: () => (
+    <div data-testid="report-duplicate-detection">Duplicate Detection</div>
+  ),
+}));
+
+vi.mock("@/components/reports/UncategorizedItems", () => ({
+  default: () => (
+    <div data-testid="report-uncategorized-items">Uncategorized Items</div>
+  ),
+}));
+
+describe("Reports", () => {
+  it("renders the page heading", () => {
+    renderWithProviders(<Reports />, { route: "/reports" });
+    expect(
+      screen.getByRole("heading", { name: /reports/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all report tabs", () => {
+    renderWithProviders(<Reports />, { route: "/reports" });
+    const tablist = screen.getByRole("tablist");
+    for (const report of REPORTS) {
+      expect(
+        within(tablist).getByRole("tab", { name: report.name }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("defaults to the first report when no query param", async () => {
+    renderWithProviders(<Reports />, { route: "/reports" });
+    expect(
+      await screen.findByTestId("report-out-of-balance"),
+    ).toBeInTheDocument();
+  });
+
+  it("selects the report specified by query param", async () => {
+    renderWithProviders(<Reports />, {
+      route: "/reports?report=item-similarity",
+    });
+    expect(
+      await screen.findByTestId("report-item-similarity"),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to default report for invalid query param", async () => {
+    renderWithProviders(<Reports />, {
+      route: "/reports?report=nonexistent",
+    });
+    expect(
+      await screen.findByTestId("report-out-of-balance"),
+    ).toBeInTheDocument();
+  });
+
+  it("switches report when a tab is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Reports />, { route: "/reports" });
+
+    await user.click(screen.getByRole("tab", { name: "Category Trends" }));
+
+    expect(
+      await screen.findByTestId("report-category-trends"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls usePageTitle with the active report name", async () => {
+    const { usePageTitle } = await import("@/hooks/usePageTitle");
+    renderWithProviders(<Reports />, {
+      route: "/reports?report=duplicate-detection",
+    });
+    expect(usePageTitle).toHaveBeenCalledWith(
+      "Reports - Duplicate Detection",
+    );
+  });
+
+  it("exports REPORTS config with correct number of reports", () => {
+    expect(REPORTS).toHaveLength(7);
+  });
+
+  it("exports DEFAULT_REPORT as out-of-balance", () => {
+    expect(DEFAULT_REPORT).toBe("out-of-balance");
+  });
+
+  it("has the default tab marked as selected", () => {
+    renderWithProviders(<Reports />, { route: "/reports" });
+    const tab = screen.getByRole("tab", { name: "Out of Balance" });
+    expect(tab).toHaveAttribute("data-state", "active");
+  });
+
+  it("marks the correct tab as selected from query param", () => {
+    renderWithProviders(<Reports />, {
+      route: "/reports?report=spending-by-location",
+    });
+    const tab = screen.getByRole("tab", { name: "Spending by Location" });
+    expect(tab).toHaveAttribute("data-state", "active");
+  });
+});

--- a/src/client/src/pages/Reports.tsx
+++ b/src/client/src/pages/Reports.tsx
@@ -1,0 +1,99 @@
+import { lazy, Suspense, useMemo } from "react";
+import { useSearchParams } from "react-router";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface ReportConfig {
+  slug: string;
+  name: string;
+  component: React.LazyExoticComponent<React.ComponentType>;
+}
+
+const REPORTS: ReportConfig[] = [
+  {
+    slug: "out-of-balance",
+    name: "Out of Balance",
+    component: lazy(() => import("@/components/reports/OutOfBalance")),
+  },
+  {
+    slug: "item-similarity",
+    name: "Item Similarity",
+    component: lazy(() => import("@/components/reports/ItemSimilarity")),
+  },
+  {
+    slug: "item-cost-over-time",
+    name: "Item Cost Over Time",
+    component: lazy(() => import("@/components/reports/ItemCostOverTime")),
+  },
+  {
+    slug: "spending-by-location",
+    name: "Spending by Location",
+    component: lazy(() => import("@/components/reports/SpendingByLocation")),
+  },
+  {
+    slug: "category-trends",
+    name: "Category Trends",
+    component: lazy(() => import("@/components/reports/CategoryTrends")),
+  },
+  {
+    slug: "duplicate-detection",
+    name: "Duplicate Detection",
+    component: lazy(() => import("@/components/reports/DuplicateDetection")),
+  },
+  {
+    slug: "uncategorized-items",
+    name: "Uncategorized Items",
+    component: lazy(() => import("@/components/reports/UncategorizedItems")),
+  },
+];
+
+const DEFAULT_REPORT = REPORTS[0].slug;
+const VALID_SLUGS = new Set(REPORTS.map((r) => r.slug));
+
+function ReportFallback() {
+  return <Skeleton className="h-32 w-full rounded-lg" />;
+}
+
+function Reports() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawReport = searchParams.get("report");
+  const activeSlug =
+    rawReport && VALID_SLUGS.has(rawReport) ? rawReport : DEFAULT_REPORT;
+
+  const activeReport = useMemo(
+    () => REPORTS.find((r) => r.slug === activeSlug)!,
+    [activeSlug],
+  );
+
+  usePageTitle(`Reports - ${activeReport.name}`);
+
+  function handleTabChange(slug: string) {
+    setSearchParams({ report: slug }, { replace: true });
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold tracking-tight">Reports</h1>
+      <Tabs value={activeSlug} onValueChange={handleTabChange}>
+        <TabsList className="flex-wrap">
+          {REPORTS.map((report) => (
+            <TabsTrigger key={report.slug} value={report.slug}>
+              {report.name}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {REPORTS.map((report) => (
+          <TabsContent key={report.slug} value={report.slug}>
+            <Suspense fallback={<ReportFallback />}>
+              <report.component />
+            </Suspense>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+}
+
+export default Reports;
+export { REPORTS, DEFAULT_REPORT };


### PR DESCRIPTION
## Summary
- Add Reports page with tab-based report switcher under the Data navigation group
- 7 placeholder report tabs (Out of Balance, Item Similarity, Item Cost Over Time, Spending by Location, Category Trends, Duplicate Detection, Uncategorized Items) with lazy-loaded components
- Selected report persists in URL query param (`?report=out-of-balance`) for shareability
- Breadcrumbs extended to show `Home > Reports > [Report Name]` via query-param-based breadcrumb support

## Test plan
- [x] 11 unit tests for Reports page shell (heading, tabs, default selection, query param, tab switching, page title, exports, active state)
- [x] 3 unit tests for query-param breadcrumbs on /reports
- [x] Full client test suite passes (1391 tests, 0 failures)
- [x] Full .NET test suite passes (pre-commit hook)
- [x] TypeScript type check clean

Closes RECEIPTS-437

🤖 Generated with [Claude Code](https://claude.com/claude-code)