### PR TITLE
feat(api): add out-of-balance receipts report

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -2688,6 +2688,67 @@ paths:
           description: Not Found
 
   # ──────────────────────────────────────────────
+  # Reports
+  # ──────────────────────────────────────────────
+
+  /api/reports/out-of-balance:
+    get:
+      operationId: GetOutOfBalanceReport
+      tags: [Reports]
+      summary: Get out-of-balance receipts report
+      description: Returns all receipts where item subtotal + tax + adjustments does not equal the transaction total.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: sortBy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [date, difference]
+            default: date
+          description: Column to sort by.
+        - name: sortDirection
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: asc
+          description: Sort direction.
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-based).
+        - name: pageSize
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          description: Number of items per page.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OutOfBalanceResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  # ──────────────────────────────────────────────
   # Dashboard
   # ──────────────────────────────────────────────
 
@@ -2879,6 +2940,54 @@ paths:
 
 components:
   schemas:
+    # ── Reports ───────────────────────────────────
+
+    OutOfBalanceResponse:
+      type: object
+      required: [totalCount, totalDiscrepancy, items]
+      properties:
+        totalCount:
+          type: integer
+          format: int32
+        totalDiscrepancy:
+          type: number
+          format: double
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/OutOfBalanceItem"
+
+    OutOfBalanceItem:
+      type: object
+      required: [receiptId, location, date, itemSubtotal, taxAmount, adjustmentTotal, expectedTotal, transactionTotal, difference]
+      properties:
+        receiptId:
+          type: string
+          format: uuid
+        location:
+          type: string
+        date:
+          type: string
+          format: date
+        itemSubtotal:
+          type: number
+          format: double
+        taxAmount:
+          type: number
+          format: double
+        adjustmentTotal:
+          type: number
+          format: double
+        expectedTotal:
+          type: number
+          format: double
+        transactionTotal:
+          type: number
+          format: double
+        difference:
+          type: number
+          format: double
+
     # ── Dashboard ──────────────────────────────────
 
     DashboardSummaryResponse:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-a2281ce0",
+  "name": "agent-a0c35c98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/Application/Interfaces/Services/IReportService.cs
+++ b/src/Application/Interfaces/Services/IReportService.cs
@@ -1,0 +1,13 @@
+using Application.Models.Reports;
+
+namespace Application.Interfaces.Services;
+
+public interface IReportService
+{
+	Task<OutOfBalanceResult> GetOutOfBalanceAsync(
+		string sortBy,
+		string sortDirection,
+		int page,
+		int pageSize,
+		CancellationToken cancellationToken);
+}

--- a/src/Application/Models/Reports/OutOfBalanceResult.cs
+++ b/src/Application/Models/Reports/OutOfBalanceResult.cs
@@ -1,0 +1,17 @@
+namespace Application.Models.Reports;
+
+public record OutOfBalanceItem(
+	Guid ReceiptId,
+	string Location,
+	DateOnly Date,
+	decimal ItemSubtotal,
+	decimal TaxAmount,
+	decimal AdjustmentTotal,
+	decimal ExpectedTotal,
+	decimal TransactionTotal,
+	decimal Difference);
+
+public record OutOfBalanceResult(
+	List<OutOfBalanceItem> Items,
+	int TotalCount,
+	decimal TotalDiscrepancy);

--- a/src/Application/Queries/Aggregates/Reports/GetOutOfBalanceReportQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetOutOfBalanceReportQuery.cs
@@ -1,0 +1,10 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetOutOfBalanceReportQuery(
+	string SortBy,
+	string SortDirection,
+	int Page,
+	int PageSize) : IQuery<OutOfBalanceResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetOutOfBalanceReportQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetOutOfBalanceReportQueryHandler.cs
@@ -1,0 +1,19 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetOutOfBalanceReportQueryHandler(IReportService reportService)
+	: IRequestHandler<GetOutOfBalanceReportQuery, OutOfBalanceResult>
+{
+	public async Task<OutOfBalanceResult> Handle(GetOutOfBalanceReportQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetOutOfBalanceAsync(
+			request.SortBy,
+			request.SortDirection,
+			request.Page,
+			request.PageSize,
+			cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -137,7 +137,8 @@ public static class InfrastructureService
 			.AddScoped<IAuthAuditService, AuthAuditService>()
 			.AddScoped<IUserService, UserService>()
 			.AddScoped<ITrashService, TrashService>()
-			.AddScoped<IDashboardService, DashboardService>();
+			.AddScoped<IDashboardService, DashboardService>()
+			.AddScoped<IReportService, ReportService>();
 
 		// Embedding services (local ONNX model — always available)
 		services.AddSingleton<IEmbeddingService, OnnxEmbeddingService>();

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -1,0 +1,79 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Services;
+
+public class ReportService(IDbContextFactory<ApplicationDbContext> contextFactory) : IReportService
+{
+	public async Task<OutOfBalanceResult> GetOutOfBalanceAsync(
+		string sortBy,
+		string sortDirection,
+		int page,
+		int pageSize,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		// Build the base query: JOIN receipts with aggregated items, transactions, and adjustments.
+		// Use LEFT JOINs so receipts with no items/transactions/adjustments still appear if out of balance.
+		var baseQuery = from r in context.Receipts.AsNoTracking()
+						where r.DeletedAt == null
+						let itemSubtotal = context.ReceiptItems
+							.Where(ri => ri.ReceiptId == r.Id && ri.DeletedAt == null)
+							.Sum(ri => (decimal?)ri.TotalAmount) ?? 0m
+						let adjustmentTotal = context.Adjustments
+							.Where(a => a.ReceiptId == r.Id && a.DeletedAt == null)
+							.Sum(a => (decimal?)a.Amount) ?? 0m
+						let transactionTotal = context.Transactions
+							.Where(t => t.ReceiptId == r.Id && t.DeletedAt == null)
+							.Sum(t => (decimal?)t.Amount) ?? 0m
+						let expectedTotal = itemSubtotal + r.TaxAmount + adjustmentTotal
+						let difference = expectedTotal - transactionTotal
+						where difference != 0m
+						select new
+						{
+							r.Id,
+							r.Location,
+							r.Date,
+							ItemSubtotal = itemSubtotal,
+							TaxAmount = r.TaxAmount,
+							AdjustmentTotal = adjustmentTotal,
+							ExpectedTotal = expectedTotal,
+							TransactionTotal = transactionTotal,
+							Difference = difference
+						};
+
+		// Get total count and total discrepancy before pagination
+		// Materialize the filtered set once so both aggregations happen in a single enumeration.
+		var allItems = await baseQuery.ToListAsync(cancellationToken);
+		int totalCount = allItems.Count;
+		decimal totalDiscrepancy = allItems.Sum(x => Math.Abs(x.Difference));
+
+		// Apply sorting in memory (the data set is bounded by "out of balance" receipts, typically small)
+		var sorted = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
+		{
+			("difference", "asc") => allItems.OrderBy(x => x.Difference).AsEnumerable(),
+			("difference", "desc") => allItems.OrderByDescending(x => x.Difference).AsEnumerable(),
+			("date", "desc") => allItems.OrderByDescending(x => x.Date).AsEnumerable(),
+			_ => allItems.OrderBy(x => x.Date).AsEnumerable(), // default: date asc
+		};
+
+		List<OutOfBalanceItem> pagedItems = sorted
+			.Skip((page - 1) * pageSize)
+			.Take(pageSize)
+			.Select(x => new OutOfBalanceItem(
+				x.Id,
+				x.Location,
+				x.Date,
+				x.ItemSubtotal,
+				x.TaxAmount,
+				x.AdjustmentTotal,
+				x.ExpectedTotal,
+				x.TransactionTotal,
+				x.Difference))
+			.ToList();
+
+		return new OutOfBalanceResult(pagedItems, totalCount, totalDiscrepancy);
+	}
+}

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -1,0 +1,77 @@
+using API.Generated.Dtos;
+using Application.Queries.Aggregates.Reports;
+using Asp.Versioning;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using AppReports = Application.Models.Reports;
+
+namespace API.Controllers.Aggregates;
+
+[ApiVersion("1.0")]
+[ApiController]
+[Route("api/reports")]
+[Produces("application/json")]
+[Authorize]
+public class ReportsController(IMediator mediator) : ControllerBase
+{
+	[HttpGet("out-of-balance")]
+	[EndpointSummary("Get out-of-balance receipts report")]
+	[EndpointDescription("Returns all receipts where item subtotal + tax + adjustments does not equal the transaction total.")]
+	public async Task<Results<Ok<OutOfBalanceResponse>, BadRequest<string>>> GetOutOfBalance(
+		[FromQuery] string? sortBy,
+		[FromQuery] string? sortDirection,
+		[FromQuery] int? page,
+		[FromQuery] int? pageSize,
+		CancellationToken cancellationToken)
+	{
+		string sort = sortBy ?? "date";
+		string direction = sortDirection ?? "asc";
+		int pg = page ?? 1;
+		int ps = pageSize ?? 50;
+
+		string[] validSortColumns = ["date", "difference"];
+		if (!validSortColumns.Contains(sort.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid sortBy '{sort}'. Allowed: date, difference");
+		}
+
+		string[] validDirections = ["asc", "desc"];
+		if (!validDirections.Contains(direction.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid sortDirection '{direction}'. Allowed: asc, desc");
+		}
+
+		if (pg < 1)
+		{
+			return TypedResults.BadRequest("page must be at least 1");
+		}
+
+		if (ps < 1 || ps > 100)
+		{
+			return TypedResults.BadRequest("pageSize must be between 1 and 100");
+		}
+
+		GetOutOfBalanceReportQuery query = new(sort, direction, pg, ps);
+		AppReports.OutOfBalanceResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new OutOfBalanceResponse
+		{
+			TotalCount = result.TotalCount,
+			TotalDiscrepancy = (double)result.TotalDiscrepancy,
+			Items = result.Items.Select(i => new OutOfBalanceItem
+			{
+				ReceiptId = i.ReceiptId,
+				Location = i.Location,
+				Date = i.Date,
+				ItemSubtotal = (double)i.ItemSubtotal,
+				TaxAmount = (double)i.TaxAmount,
+				AdjustmentTotal = (double)i.AdjustmentTotal,
+				ExpectedTotal = (double)i.ExpectedTotal,
+				TransactionTotal = (double)i.TransactionTotal,
+				Difference = (double)i.Difference
+			}).ToList()
+		});
+	}
+}

--- a/src/client/src/components/reports/OutOfBalance.test.tsx
+++ b/src/client/src/components/reports/OutOfBalance.test.tsx
@@ -1,0 +1,221 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "@/test/test-utils";
+import OutOfBalance from "./OutOfBalance";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/hooks/useOutOfBalanceReport", () => ({
+  useOutOfBalanceReport: vi.fn(),
+}));
+
+import { useOutOfBalanceReport } from "@/hooks/useOutOfBalanceReport";
+const mockHook = vi.mocked(useOutOfBalanceReport);
+
+const mockItems = [
+  {
+    receiptId: "id-1",
+    location: "Store A",
+    date: "2025-03-01",
+    itemSubtotal: 10,
+    taxAmount: 1,
+    adjustmentTotal: 0,
+    expectedTotal: 11,
+    transactionTotal: 15,
+    difference: -4,
+  },
+  {
+    receiptId: "id-2",
+    location: "Store B",
+    date: "2025-03-02",
+    itemSubtotal: 20,
+    taxAmount: 2,
+    adjustmentTotal: 1,
+    expectedTotal: 23,
+    transactionTotal: 20,
+    difference: 3,
+  },
+];
+
+function setupMock(overrides: Record<string, unknown> = {}) {
+  mockHook.mockReturnValue({
+    data: {
+      totalCount: 2,
+      totalDiscrepancy: 7,
+      items: mockItems,
+    },
+    isLoading: false,
+    isError: false,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+describe("OutOfBalance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton", () => {
+    setupMock({ isLoading: true, data: undefined });
+    renderWithQueryClient(<OutOfBalance />);
+    const skeletons = document.querySelectorAll("[data-slot='skeleton']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state", () => {
+    setupMock({ isError: true, data: undefined });
+    renderWithQueryClient(<OutOfBalance />);
+    expect(
+      screen.getByText(/failed to load out-of-balance report/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no discrepancies", () => {
+    setupMock({
+      data: { totalCount: 0, totalDiscrepancy: 0, items: [] },
+    });
+    renderWithQueryClient(<OutOfBalance />);
+    expect(screen.getByText("All Balanced")).toBeInTheDocument();
+    expect(
+      screen.getByText(/all receipts are balanced/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when data is null", () => {
+    setupMock({ data: undefined });
+    renderWithQueryClient(<OutOfBalance />);
+    expect(screen.getByText("All Balanced")).toBeInTheDocument();
+  });
+
+  it("renders summary header with count and discrepancy", () => {
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("$7.00")).toBeInTheDocument();
+  });
+
+  it("renders table with all items", () => {
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+    expect(screen.getByText("Store A")).toBeInTheDocument();
+    expect(screen.getByText("Store B")).toBeInTheDocument();
+  });
+
+  it("renders table headers", () => {
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/Date/)).toBeInTheDocument();
+    expect(within(table).getByText("Location")).toBeInTheDocument();
+    expect(within(table).getByText("Item Total")).toBeInTheDocument();
+    expect(within(table).getByText("Tax")).toBeInTheDocument();
+    expect(within(table).getByText("Adjustments")).toBeInTheDocument();
+    expect(within(table).getByText("Expected Total")).toBeInTheDocument();
+    expect(within(table).getByText("Actual Total")).toBeInTheDocument();
+    expect(within(table).getByText(/Difference/)).toBeInTheDocument();
+  });
+
+  it("navigates to receipt on row click", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+
+    const row = screen.getByText("Store A").closest("tr")!;
+    await user.click(row);
+    expect(mockNavigate).toHaveBeenCalledWith("/receipts/id-1");
+  });
+
+  it("applies red color to negative difference", () => {
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+    // -$4.00 should have red styling
+    const negativeDiff = screen.getByText("-$4.00");
+    expect(negativeDiff.className).toContain("text-red-600");
+  });
+
+  it("applies amber color to positive difference", () => {
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+    // $3.00 should have amber styling
+    const positiveDiff = screen.getByText("$3.00");
+    expect(positiveDiff.className).toContain("text-amber-600");
+  });
+
+  it("toggles sort direction on clicking sortable column", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+
+    // Initially sorted by date asc
+    const dateHeader = screen
+      .getByText(/Date/)
+      .closest("th")!;
+    await user.click(dateHeader);
+
+    // Should have called hook with date desc
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sortBy: "date", sortDirection: "desc" }),
+    );
+  });
+
+  it("switches sort column when clicking a different column", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+
+    const diffHeader = screen
+      .getByText(/Difference/)
+      .closest("th")!;
+    await user.click(diffHeader);
+
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sortBy: "difference",
+        sortDirection: "asc",
+      }),
+    );
+  });
+
+  it("does not show pagination when only one page", () => {
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+    expect(screen.queryByText(/Page/)).not.toBeInTheDocument();
+  });
+
+  it("shows pagination when multiple pages", () => {
+    const manyItems = Array.from({ length: 51 }, (_, i) => ({
+      receiptId: `id-${i}`,
+      location: `Store ${i}`,
+      date: "2025-03-01",
+      itemSubtotal: 10,
+      taxAmount: 1,
+      adjustmentTotal: 0,
+      expectedTotal: 11,
+      transactionTotal: 15,
+      difference: -4,
+    }));
+    setupMock({
+      data: { totalCount: 51, totalDiscrepancy: 204, items: manyItems },
+    });
+    renderWithQueryClient(<OutOfBalance />);
+    expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Next" }),
+    ).not.toBeDisabled();
+  });
+
+  it("formats currency values correctly", () => {
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+    // $10.00 item subtotal for Store A
+    expect(screen.getByText("Store A").closest("tr")).toHaveTextContent(
+      "$10.00",
+    );
+  });
+});

--- a/src/client/src/components/reports/OutOfBalance.tsx
+++ b/src/client/src/components/reports/OutOfBalance.tsx
@@ -1,8 +1,194 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import {
+  useOutOfBalanceReport,
+  type OutOfBalanceParams,
+} from "@/hooks/useOutOfBalanceReport";
+import { formatCurrency } from "@/lib/format";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+type SortColumn = "date" | "difference";
+type SortDirection = "asc" | "desc";
+
 export default function OutOfBalance() {
+  const navigate = useNavigate();
+  const [sortBy, setSortBy] = useState<SortColumn>("date");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  const [page, setPage] = useState(1);
+  const pageSize = 50;
+
+  const params: OutOfBalanceParams = {
+    sortBy,
+    sortDirection,
+    page,
+    pageSize,
+  };
+
+  const { data, isLoading, isError } = useOutOfBalanceReport(params);
+
+  function handleSort(column: SortColumn) {
+    if (sortBy === column) {
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(column);
+      setSortDirection("asc");
+    }
+    setPage(1);
+  }
+
+  function sortIndicator(column: SortColumn) {
+    if (sortBy !== column) return null;
+    return sortDirection === "asc" ? " \u2191" : " \u2193";
+  }
+
+  function handleRowClick(receiptId: string) {
+    navigate(`/receipts/${receiptId}`);
+  }
+
+  const totalPages = data ? Math.ceil(data.totalCount / pageSize) : 0;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-20 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">
+          Failed to load out-of-balance report.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data || data.totalCount === 0) {
+    return (
+      <div className="rounded-lg border p-6 text-center">
+        <h2 className="text-lg font-semibold">All Balanced</h2>
+        <p className="mt-2 text-muted-foreground">
+          All receipts are balanced. No discrepancies found.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-lg border p-6 text-center">
-      <h2 className="text-lg font-semibold">Out of Balance</h2>
-      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    <div className="space-y-4">
+      <div className="flex gap-6 rounded-lg border p-4">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Out-of-Balance Receipts
+          </p>
+          <p className="text-2xl font-bold">{data.totalCount}</p>
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">Total Discrepancy</p>
+          <p className="text-2xl font-bold">
+            {formatCurrency(data.totalDiscrepancy)}
+          </p>
+        </div>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead
+              className="cursor-pointer select-none"
+              onClick={() => handleSort("date")}
+            >
+              Date{sortIndicator("date")}
+            </TableHead>
+            <TableHead>Location</TableHead>
+            <TableHead className="text-right">Item Total</TableHead>
+            <TableHead className="text-right">Tax</TableHead>
+            <TableHead className="text-right">Adjustments</TableHead>
+            <TableHead className="text-right">Expected Total</TableHead>
+            <TableHead className="text-right">Actual Total</TableHead>
+            <TableHead
+              className="cursor-pointer select-none text-right"
+              onClick={() => handleSort("difference")}
+            >
+              Difference{sortIndicator("difference")}
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.items.map((item) => (
+            <TableRow
+              key={item.receiptId}
+              className="cursor-pointer"
+              onClick={() => handleRowClick(item.receiptId)}
+            >
+              <TableCell>{item.date}</TableCell>
+              <TableCell>{item.location}</TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(item.itemSubtotal)}
+              </TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(item.taxAmount)}
+              </TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(item.adjustmentTotal)}
+              </TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(item.expectedTotal)}
+              </TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(item.transactionTotal)}
+              </TableCell>
+              <TableCell
+                className={`text-right font-medium ${
+                  item.difference < 0
+                    ? "text-red-600 dark:text-red-400"
+                    : "text-amber-600 dark:text-amber-400"
+                }`}
+              >
+                {formatCurrency(item.difference)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/client/src/hooks/useOutOfBalanceReport.test.ts
+++ b/src/client/src/hooks/useOutOfBalanceReport.test.ts
@@ -1,0 +1,117 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import { useOutOfBalanceReport } from "./useOutOfBalanceReport";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useOutOfBalanceReport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches report data with default parameters", async () => {
+    const mockData = {
+      totalCount: 2,
+      totalDiscrepancy: 10.5,
+      items: [
+        {
+          receiptId: "abc",
+          location: "Store A",
+          date: "2025-03-01",
+          itemSubtotal: 10,
+          taxAmount: 1,
+          adjustmentTotal: 0,
+          expectedTotal: 11,
+          transactionTotal: 15,
+          difference: -4,
+        },
+      ],
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useOutOfBalanceReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/out-of-balance",
+      {
+        params: {
+          query: {
+            sortBy: undefined,
+            sortDirection: undefined,
+            page: undefined,
+            pageSize: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("passes custom parameters", async () => {
+    const mockData = { totalCount: 0, totalDiscrepancy: 0, items: [] };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useOutOfBalanceReport({
+          sortBy: "difference",
+          sortDirection: "desc",
+          page: 2,
+          pageSize: 25,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/out-of-balance",
+      {
+        params: {
+          query: {
+            sortBy: "difference",
+            sortDirection: "desc",
+            page: 2,
+            pageSize: 25,
+          },
+        },
+      },
+    );
+  });
+
+  it("throws when API returns an error", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useOutOfBalanceReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/src/client/src/hooks/useOutOfBalanceReport.ts
+++ b/src/client/src/hooks/useOutOfBalanceReport.ts
@@ -1,0 +1,40 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export interface OutOfBalanceParams {
+  sortBy?: "date" | "difference";
+  sortDirection?: "asc" | "desc";
+  page?: number;
+  pageSize?: number;
+}
+
+export function useOutOfBalanceReport(params: OutOfBalanceParams = {}) {
+  return useQuery({
+    queryKey: [
+      "reports",
+      "out-of-balance",
+      params.sortBy,
+      params.sortDirection,
+      params.page,
+      params.pageSize,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/reports/out-of-balance",
+        {
+          params: {
+            query: {
+              sortBy: params.sortBy,
+              sortDirection: params.sortDirection,
+              page: params.page,
+              pageSize: params.pageSize,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/tests/Application.Tests/Queries/Aggregates/Reports/GetOutOfBalanceReportQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Reports/GetOutOfBalanceReportQueryHandlerTests.cs
@@ -1,0 +1,83 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Reports;
+
+public class GetOutOfBalanceReportQueryHandlerTests
+{
+	private readonly Mock<IReportService> _reportServiceMock;
+	private readonly GetOutOfBalanceReportQueryHandler _handler;
+
+	public GetOutOfBalanceReportQueryHandlerTests()
+	{
+		_reportServiceMock = new Mock<IReportService>();
+		_handler = new GetOutOfBalanceReportQueryHandler(_reportServiceMock.Object);
+	}
+
+	[Fact]
+	public async Task Handle_DelegatesToReportService()
+	{
+		// Arrange
+		GetOutOfBalanceReportQuery query = new("date", "asc", 1, 50);
+		OutOfBalanceResult expectedResult = new([], 0, 0m);
+
+		_reportServiceMock.Setup(s => s.GetOutOfBalanceAsync(
+			"date", "asc", 1, 50, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		OutOfBalanceResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+		_reportServiceMock.Verify(s => s.GetOutOfBalanceAsync(
+			"date", "asc", 1, 50, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PassesAllParametersToService()
+	{
+		// Arrange
+		GetOutOfBalanceReportQuery query = new("difference", "desc", 3, 25);
+		OutOfBalanceResult expectedResult = new([], 0, 0m);
+
+		_reportServiceMock.Setup(s => s.GetOutOfBalanceAsync(
+			"difference", "desc", 3, 25, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		_reportServiceMock.Verify(s => s.GetOutOfBalanceAsync(
+			"difference", "desc", 3, 25, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsServiceResult()
+	{
+		// Arrange
+		GetOutOfBalanceReportQuery query = new("date", "asc", 1, 50);
+		OutOfBalanceResult expectedResult = new(
+		[
+			new OutOfBalanceItem(Guid.NewGuid(), "Store", new DateOnly(2025, 1, 1),
+				10m, 1m, 0m, 11m, 15m, -4m),
+		], 1, 4m);
+
+		_reportServiceMock.Setup(s => s.GetOutOfBalanceAsync(
+			It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		OutOfBalanceResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.TotalCount.Should().Be(1);
+		result.TotalDiscrepancy.Should().Be(4m);
+		result.Items.Should().ContainSingle();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
@@ -1,0 +1,454 @@
+using Application.Models.Reports;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Services;
+using Infrastructure.Tests.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Tests.Services;
+
+public class ReportServiceTests
+{
+	[Fact]
+	public async Task GetOutOfBalanceAsync_ReturnsEmptyWhenAllBalanced()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "Store A", Date = date, TaxAmount = 1.00m });
+
+			context.ReceiptItems.Add(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Item 1", Quantity = 1, UnitPrice = 10.00m, TotalAmount = 10.00m, Category = "Food" });
+
+			context.Transactions.Add(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, AccountId = accountId, Amount = 11.00m, Date = date });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("date", "asc", 1, 50, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().BeEmpty();
+		result.TotalCount.Should().Be(0);
+		result.TotalDiscrepancy.Should().Be(0m);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_ReturnsReceiptsWhereExpectedDoesNotMatchTransaction()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			// Receipt: items=10, tax=1, adjustments=0, expected=11, transaction=15
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "Store A", Date = date, TaxAmount = 1.00m });
+
+			context.ReceiptItems.Add(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Item 1", Quantity = 1, UnitPrice = 10.00m, TotalAmount = 10.00m, Category = "Food" });
+
+			context.Transactions.Add(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, AccountId = accountId, Amount = 15.00m, Date = date });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("date", "asc", 1, 50, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		result.TotalCount.Should().Be(1);
+
+		OutOfBalanceItem item = result.Items[0];
+		item.ReceiptId.Should().Be(receiptId);
+		item.Location.Should().Be("Store A");
+		item.Date.Should().Be(date);
+		item.ItemSubtotal.Should().Be(10.00m);
+		item.TaxAmount.Should().Be(1.00m);
+		item.AdjustmentTotal.Should().Be(0m);
+		item.ExpectedTotal.Should().Be(11.00m);
+		item.TransactionTotal.Should().Be(15.00m);
+		item.Difference.Should().Be(-4.00m);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_IncludesAdjustmentsInExpectedTotal()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			// items=10, tax=1, adjustment=2, expected=13, transaction=10 => diff=3
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "Store B", Date = date, TaxAmount = 1.00m });
+
+			context.ReceiptItems.Add(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Item 1", Quantity = 1, UnitPrice = 10.00m, TotalAmount = 10.00m, Category = "Food" });
+
+			context.Adjustments.Add(
+				new AdjustmentEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Type = Common.AdjustmentType.Discount, Amount = 2.00m });
+
+			context.Transactions.Add(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, AccountId = accountId, Amount = 10.00m, Date = date });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("date", "asc", 1, 50, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		OutOfBalanceItem item = result.Items[0];
+		item.AdjustmentTotal.Should().Be(2.00m);
+		item.ExpectedTotal.Should().Be(13.00m);
+		item.Difference.Should().Be(3.00m);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_ExcludesSoftDeletedRecords()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			// Soft-deleted receipt should not appear
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "Deleted Store", Date = date, TaxAmount = 1.00m, DeletedAt = DateTimeOffset.UtcNow });
+
+			context.ReceiptItems.Add(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Item 1", Quantity = 1, UnitPrice = 10.00m, TotalAmount = 10.00m, Category = "Food" });
+
+			// No transaction — would normally be out of balance
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("date", "asc", 1, 50, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().BeEmpty();
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_SortsByDateAscByDefault()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid accountId = Guid.NewGuid();
+
+		Guid receiptId1 = Guid.NewGuid();
+		Guid receiptId2 = Guid.NewGuid();
+		DateOnly day1 = new(2025, 3, 1);
+		DateOnly day2 = new(2025, 3, 2);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			// Insert in reverse order
+			context.Receipts.AddRange(
+				new ReceiptEntity { Id = receiptId2, Location = "B", Date = day2, TaxAmount = 0m },
+				new ReceiptEntity { Id = receiptId1, Location = "A", Date = day1, TaxAmount = 0m });
+
+			context.Transactions.AddRange(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId1, AccountId = accountId, Amount = 99.00m, Date = day1 },
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId2, AccountId = accountId, Amount = 99.00m, Date = day2 });
+
+			// No items — so expected=0, transaction=99 => diff=-99 for both
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("date", "asc", 1, 50, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().HaveCount(2);
+		result.Items[0].Date.Should().Be(day1);
+		result.Items[1].Date.Should().Be(day2);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_SortsByDifferenceDesc()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid accountId = Guid.NewGuid();
+
+		Guid receiptId1 = Guid.NewGuid();
+		Guid receiptId2 = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Receipts.AddRange(
+				new ReceiptEntity { Id = receiptId1, Location = "A", Date = date, TaxAmount = 0m },
+				new ReceiptEntity { Id = receiptId2, Location = "B", Date = date, TaxAmount = 0m });
+
+			// Receipt 1: items=10, transaction=5 => diff=5
+			context.ReceiptItems.Add(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId1, Description = "Item", Quantity = 1, UnitPrice = 10.00m, TotalAmount = 10.00m, Category = "Food" });
+			context.Transactions.Add(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId1, AccountId = accountId, Amount = 5.00m, Date = date });
+
+			// Receipt 2: items=20, transaction=5 => diff=15
+			context.ReceiptItems.Add(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId2, Description = "Item", Quantity = 1, UnitPrice = 20.00m, TotalAmount = 20.00m, Category = "Food" });
+			context.Transactions.Add(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId2, AccountId = accountId, Amount = 5.00m, Date = date });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("difference", "desc", 1, 50, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().HaveCount(2);
+		result.Items[0].Difference.Should().Be(15.00m);
+		result.Items[1].Difference.Should().Be(5.00m);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_PaginatesCorrectly()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid accountId = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			// Create 3 out-of-balance receipts
+			for (int i = 0; i < 3; i++)
+			{
+				Guid receiptId = Guid.NewGuid();
+				DateOnly date = new(2025, 3, i + 1);
+
+				context.Receipts.Add(
+					new ReceiptEntity { Id = receiptId, Location = $"Store {i}", Date = date, TaxAmount = 0m });
+
+				context.Transactions.Add(
+					new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, AccountId = accountId, Amount = 99.00m, Date = date });
+			}
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act - page 1, size 2
+		OutOfBalanceResult page1 = await service.GetOutOfBalanceAsync("date", "asc", 1, 2, CancellationToken.None);
+
+		// Assert
+		page1.Items.Should().HaveCount(2);
+		page1.TotalCount.Should().Be(3);
+
+		// Act - page 2, size 2
+		OutOfBalanceResult page2 = await service.GetOutOfBalanceAsync("date", "asc", 2, 2, CancellationToken.None);
+
+		// Assert
+		page2.Items.Should().ContainSingle();
+		page2.TotalCount.Should().Be(3);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_CalculatesTotalDiscrepancyAsAbsoluteSum()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid accountId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		Guid receiptId1 = Guid.NewGuid();
+		Guid receiptId2 = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Receipts.AddRange(
+				new ReceiptEntity { Id = receiptId1, Location = "A", Date = date, TaxAmount = 0m },
+				new ReceiptEntity { Id = receiptId2, Location = "B", Date = date, TaxAmount = 0m });
+
+			// Receipt 1: items=10, transaction=5 => diff=5 (positive)
+			context.ReceiptItems.Add(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId1, Description = "Item", Quantity = 1, UnitPrice = 10.00m, TotalAmount = 10.00m, Category = "Food" });
+			context.Transactions.Add(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId1, AccountId = accountId, Amount = 5.00m, Date = date });
+
+			// Receipt 2: items=5, transaction=10 => diff=-5 (negative)
+			context.ReceiptItems.Add(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId2, Description = "Item", Quantity = 1, UnitPrice = 5.00m, TotalAmount = 5.00m, Category = "Food" });
+			context.Transactions.Add(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId2, AccountId = accountId, Amount = 10.00m, Date = date });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("date", "asc", 1, 50, CancellationToken.None);
+
+		// Assert
+		result.TotalDiscrepancy.Should().Be(10.00m); // |5| + |-5| = 10
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_ExcludesSoftDeletedItemsFromCalculation()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			// Receipt with items=10 (active) + 5 (deleted), tax=1, transaction=11
+			// Expected with active only: 10+1=11 => balanced
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "Store", Date = date, TaxAmount = 1.00m });
+
+			context.ReceiptItems.AddRange(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Active", Quantity = 1, UnitPrice = 10.00m, TotalAmount = 10.00m, Category = "Food" },
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Deleted", Quantity = 1, UnitPrice = 5.00m, TotalAmount = 5.00m, Category = "Food", DeletedAt = DateTimeOffset.UtcNow });
+
+			context.Transactions.Add(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, AccountId = accountId, Amount = 11.00m, Date = date });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("date", "asc", 1, 50, CancellationToken.None);
+
+		// Assert - should be balanced since deleted items are excluded
+		result.Items.Should().BeEmpty();
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_HandlesReceiptWithNoItems()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			// Receipt with no items, tax=0, transaction=5 => expected=0, diff=-5
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "Empty Store", Date = date, TaxAmount = 0m });
+
+			context.Transactions.Add(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, AccountId = accountId, Amount = 5.00m, Date = date });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("date", "asc", 1, 50, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		result.Items[0].ItemSubtotal.Should().Be(0m);
+		result.Items[0].TransactionTotal.Should().Be(5.00m);
+		result.Items[0].Difference.Should().Be(-5.00m);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_HandlesReceiptWithNoTransactions()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			// Receipt with items=10, tax=1, no transaction => expected=11, transaction=0, diff=11
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "No Payment", Date = date, TaxAmount = 1.00m });
+
+			context.ReceiptItems.Add(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Item 1", Quantity = 1, UnitPrice = 10.00m, TotalAmount = 10.00m, Category = "Food" });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync("date", "asc", 1, 50, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		result.Items[0].TransactionTotal.Should().Be(0m);
+		result.Items[0].ExpectedTotal.Should().Be(11.00m);
+		result.Items[0].Difference.Should().Be(11.00m);
+
+		contextFactory.ResetDatabase();
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
@@ -1,0 +1,202 @@
+using API.Controllers.Aggregates;
+using API.Generated.Dtos;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using AppReports = Application.Models.Reports;
+
+namespace Presentation.API.Tests.Controllers.Aggregates;
+
+public class ReportsControllerTests
+{
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly ReportsController _controller;
+
+	public ReportsControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_controller = new ReportsController(_mediatorMock.Object);
+	}
+
+	[Fact]
+	public async Task GetOutOfBalance_ReturnsOkResult_WithDefaultParameters()
+	{
+		// Arrange
+		AppReports.OutOfBalanceResult reportResult = new(
+		[
+			new AppReports.OutOfBalanceItem(
+				Guid.NewGuid(), "Store A", new DateOnly(2025, 3, 1),
+				10.00m, 1.00m, 0m, 11.00m, 15.00m, -4.00m),
+		], 1, 4.00m);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetOutOfBalanceReportQuery>(q =>
+				q.SortBy == "date" && q.SortDirection == "asc" && q.Page == 1 && q.PageSize == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<OutOfBalanceResponse>, BadRequest<string>> result =
+			await _controller.GetOutOfBalance(null, null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<OutOfBalanceResponse> okResult = Assert.IsType<Ok<OutOfBalanceResponse>>(result.Result);
+		OutOfBalanceResponse response = okResult.Value!;
+		response.TotalCount.Should().Be(1);
+		response.TotalDiscrepancy.Should().Be(4.00);
+		response.Items.Should().ContainSingle();
+		response.Items.First().Location.Should().Be("Store A");
+		response.Items.First().Difference.Should().Be(-4.00);
+	}
+
+	[Fact]
+	public async Task GetOutOfBalance_PassesCustomParameters()
+	{
+		// Arrange
+		AppReports.OutOfBalanceResult reportResult = new([], 0, 0m);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetOutOfBalanceReportQuery>(q =>
+				q.SortBy == "difference" && q.SortDirection == "desc" && q.Page == 2 && q.PageSize == 25),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<OutOfBalanceResponse>, BadRequest<string>> result =
+			await _controller.GetOutOfBalance("difference", "desc", 2, 25, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<OutOfBalanceResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetOutOfBalanceReportQuery>(q =>
+				q.SortBy == "difference" && q.SortDirection == "desc" && q.Page == 2 && q.PageSize == 25),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetOutOfBalance_ReturnsBadRequest_WhenInvalidSortBy()
+	{
+		// Act
+		Results<Ok<OutOfBalanceResponse>, BadRequest<string>> result =
+			await _controller.GetOutOfBalance("invalid", null, null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid sortBy");
+	}
+
+	[Fact]
+	public async Task GetOutOfBalance_ReturnsBadRequest_WhenInvalidSortDirection()
+	{
+		// Act
+		Results<Ok<OutOfBalanceResponse>, BadRequest<string>> result =
+			await _controller.GetOutOfBalance(null, "invalid", null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid sortDirection");
+	}
+
+	[Fact]
+	public async Task GetOutOfBalance_ReturnsBadRequest_WhenPageLessThanOne()
+	{
+		// Act
+		Results<Ok<OutOfBalanceResponse>, BadRequest<string>> result =
+			await _controller.GetOutOfBalance(null, null, 0, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("page must be at least 1");
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	[InlineData(101)]
+	public async Task GetOutOfBalance_ReturnsBadRequest_WhenPageSizeOutOfRange(int pageSize)
+	{
+		// Act
+		Results<Ok<OutOfBalanceResponse>, BadRequest<string>> result =
+			await _controller.GetOutOfBalance(null, null, null, pageSize, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("pageSize must be between 1 and 100");
+	}
+
+	[Theory]
+	[InlineData("date")]
+	[InlineData("difference")]
+	public async Task GetOutOfBalance_AcceptsValidSortColumns(string sortBy)
+	{
+		// Arrange
+		AppReports.OutOfBalanceResult reportResult = new([], 0, 0m);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetOutOfBalanceReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<OutOfBalanceResponse>, BadRequest<string>> result =
+			await _controller.GetOutOfBalance(sortBy, null, null, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<OutOfBalanceResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetOutOfBalance_ThrowsException_WhenMediatorFails()
+	{
+		// Arrange
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetOutOfBalanceReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		// Act
+		Func<Task> act = () => _controller.GetOutOfBalance(null, null, null, null, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalance_MapsResponseFieldsCorrectly()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		DateOnly date = new(2025, 6, 15);
+
+		AppReports.OutOfBalanceResult reportResult = new(
+		[
+			new AppReports.OutOfBalanceItem(
+				receiptId, "Test Location", date,
+				25.50m, 2.25m, 1.00m, 28.75m, 30.00m, -1.25m),
+		], 1, 1.25m);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetOutOfBalanceReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<OutOfBalanceResponse>, BadRequest<string>> result =
+			await _controller.GetOutOfBalance(null, null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<OutOfBalanceResponse> okResult = Assert.IsType<Ok<OutOfBalanceResponse>>(result.Result);
+		OutOfBalanceItem item = okResult.Value!.Items.First();
+		item.ReceiptId.Should().Be(receiptId);
+		item.Location.Should().Be("Test Location");
+		item.Date.Should().Be(date);
+		item.ItemSubtotal.Should().Be(25.50);
+		item.TaxAmount.Should().Be(2.25);
+		item.AdjustmentTotal.Should().Be(1.00);
+		item.ExpectedTotal.Should().Be(28.75);
+		item.TransactionTotal.Should().Be(30.00);
+		item.Difference.Should().Be(-1.25);
+	}
+}


### PR DESCRIPTION
## Summary
- Add GET `/api/reports/out-of-balance` endpoint that identifies receipts where item subtotal + tax + adjustments does not equal the transaction total, with sorting (date, difference) and pagination support
- Replace the `OutOfBalance.tsx` stub with a full implementation: summary header (count + total discrepancy), sortable data table, row-click navigation to `/receipts/:id`, and color-coded difference column (red for negative, amber for positive)
- Add `useOutOfBalanceReport` React Query hook and update OpenAPI spec with new path and schemas

## Test plan
- [x] ReportService: 10 unit tests (balanced, imbalanced, adjustments, soft-deletes, sorting, pagination, discrepancy totals, no-items, no-transactions)
- [x] ReportsController: 8 unit tests (defaults, custom params, validation, field mapping, error propagation)
- [x] GetOutOfBalanceReportQueryHandler: 3 unit tests (delegation, params, results)
- [x] useOutOfBalanceReport hook: 3 unit tests (defaults, custom params, error handling)
- [x] OutOfBalance component: 15 unit tests (loading, error, empty, summary, table headers, navigation, color-coding, sorting, pagination)
- [x] All 1373 .NET tests pass
- [x] All 1412 client tests pass

Closes RECEIPTS-436

🤖 Generated with [Claude Code](https://claude.com/claude-code)