### PR TITLE
feat(client): add rolling average trendline to spending-over-time chart

### DIFF
--- a/src/client/src/components/charts/AreaTimeChart.test.tsx
+++ b/src/client/src/components/charts/AreaTimeChart.test.tsx
@@ -5,12 +5,23 @@ vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="responsive-container">{children}</div>
   ),
-  AreaChart: ({ children, data }: { children: React.ReactNode; data: unknown[] }) => (
+  AreaChart: ({
+    children,
+    data,
+  }: {
+    children: React.ReactNode;
+    data: unknown[];
+  }) => (
     <div data-testid="area-chart" data-count={data.length}>
       {children}
     </div>
   ),
-  Area: () => <div data-testid="area" />,
+  Area: ({ dataKey, strokeDasharray }: { dataKey: string; strokeDasharray?: string }) => (
+    <div
+      data-testid={dataKey === "trendline" ? "trendline-area" : "area"}
+      data-dasharray={strokeDasharray ?? ""}
+    />
+  ),
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: () => <div data-testid="y-axis" />,
   CartesianGrid: () => <div data-testid="cartesian-grid" />,
@@ -20,6 +31,12 @@ vi.mock("recharts", () => ({
 const mockData = [
   { period: "Jan", amount: 100 },
   { period: "Feb", amount: 200 },
+  { period: "Mar", amount: 150 },
+];
+
+const mockTrendline = [
+  { period: "Jan", amount: 100 },
+  { period: "Feb", amount: 150 },
   { period: "Mar", amount: 150 },
 ];
 
@@ -41,5 +58,28 @@ describe("AreaTimeChart", () => {
   it("renders with empty data", () => {
     render(<AreaTimeChart data={[]} />);
     expect(screen.getByTestId("area-chart")).toHaveAttribute("data-count", "0");
+  });
+
+  it("does not render trendline when trendlineData is not provided", () => {
+    render(<AreaTimeChart data={mockData} />);
+    expect(screen.queryByTestId("trendline-area")).not.toBeInTheDocument();
+  });
+
+  it("renders trendline area when trendlineData is provided", () => {
+    render(<AreaTimeChart data={mockData} trendlineData={mockTrendline} />);
+    expect(screen.getByTestId("trendline-area")).toBeInTheDocument();
+  });
+
+  it("renders trendline with dashed stroke", () => {
+    render(<AreaTimeChart data={mockData} trendlineData={mockTrendline} />);
+    expect(screen.getByTestId("trendline-area")).toHaveAttribute(
+      "data-dasharray",
+      "5 5",
+    );
+  });
+
+  it("does not render trendline when trendlineData is empty", () => {
+    render(<AreaTimeChart data={mockData} trendlineData={[]} />);
+    expect(screen.queryByTestId("trendline-area")).not.toBeInTheDocument();
   });
 });

--- a/src/client/src/components/charts/AreaTimeChart.tsx
+++ b/src/client/src/components/charts/AreaTimeChart.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useId, useMemo } from "react";
 import {
   ResponsiveContainer,
   AreaChart,
@@ -10,24 +10,44 @@ import {
 } from "recharts";
 import { CHART_COLORS } from "./chart-colors";
 
+interface DataPoint {
+  period: string;
+  amount: number;
+}
+
 interface AreaTimeChartProps {
-  data: Array<{ period: string; amount: number }>;
+  data: DataPoint[];
+  trendlineData?: DataPoint[];
   height?: number;
   color?: string;
+  trendlineColor?: string;
   formatValue?: (value: number) => string;
 }
 
 export function AreaTimeChart({
   data,
+  trendlineData,
   height = 300,
   color = CHART_COLORS[0],
+  trendlineColor = CHART_COLORS[1],
   formatValue = (v) => v.toLocaleString(),
 }: AreaTimeChartProps) {
   const gradientId = useId();
 
+  const mergedData = useMemo(() => {
+    if (!trendlineData || trendlineData.length === 0) return data;
+    return data.map((point, i) => ({
+      ...point,
+      trendline: trendlineData[i]?.amount,
+    }));
+  }, [data, trendlineData]);
+
   return (
     <ResponsiveContainer width="100%" height={height}>
-      <AreaChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+      <AreaChart
+        data={mergedData}
+        margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
+      >
         <defs>
           <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
             <stop offset="5%" stopColor={color} stopOpacity={0.3} />
@@ -46,7 +66,10 @@ export function AreaTimeChart({
           tickFormatter={formatValue}
         />
         <Tooltip
-          formatter={(value) => [formatValue(Number(value)), "Amount"]}
+          formatter={(value, name) => [
+            formatValue(Number(value)),
+            name === "trendline" ? "Rolling Avg" : "Amount",
+          ]}
           contentStyle={{
             backgroundColor: "hsl(var(--popover))",
             border: "1px solid hsl(var(--border))",
@@ -61,6 +84,19 @@ export function AreaTimeChart({
           fill={`url(#${gradientId})`}
           strokeWidth={2}
         />
+        {trendlineData && trendlineData.length > 0 && (
+          <Area
+            type="monotone"
+            dataKey="trendline"
+            stroke={trendlineColor}
+            fill="none"
+            strokeWidth={2}
+            strokeDasharray="5 5"
+            strokeOpacity={0.7}
+            dot={false}
+            name="trendline"
+          />
+        )}
       </AreaChart>
     </ResponsiveContainer>
   );

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.test.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.test.tsx
@@ -10,7 +10,18 @@ vi.mock("recharts", () => ({
   AreaChart: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="area-chart">{children}</div>
   ),
-  Area: () => <div data-testid="area" />,
+  Area: ({
+    dataKey,
+    strokeDasharray,
+  }: {
+    dataKey: string;
+    strokeDasharray?: string;
+  }) => (
+    <div
+      data-testid={dataKey === "trendline" ? "trendline-area" : "area"}
+      data-dasharray={strokeDasharray ?? ""}
+    />
+  ),
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: () => <div data-testid="y-axis" />,
   CartesianGrid: () => <div data-testid="cartesian-grid" />,
@@ -25,6 +36,13 @@ import { useDashboardSpendingOverTime } from "@/hooks/useDashboard";
 const mockHook = vi.mocked(useDashboardSpendingOverTime);
 
 const dateRange = { startDate: "2024-01-01", endDate: "2024-01-31" };
+
+const bucketData = [
+  { period: "2024-01", amount: 100 },
+  { period: "2024-02", amount: 200 },
+  { period: "2024-03", amount: 300 },
+  { period: "2024-04", amount: 400 },
+];
 
 describe("SpendingOverTimeWidget", () => {
   it("renders granularity toggle buttons", () => {
@@ -44,12 +62,7 @@ describe("SpendingOverTimeWidget", () => {
 
   it("renders chart with data", () => {
     mockHook.mockReturnValue({
-      data: {
-        buckets: [
-          { period: "2024-01", amount: 100 },
-          { period: "2024-02", amount: 200 },
-        ],
-      },
+      data: { buckets: bucketData },
       isLoading: false,
     } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
 
@@ -77,5 +90,85 @@ describe("SpendingOverTimeWidget", () => {
     renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
     await user.click(screen.getByRole("button", { name: "Quarter" }));
     expect(mockHook).toHaveBeenCalledWith(dateRange, "quarterly");
+  });
+
+  it("renders trendline toggle button", () => {
+    mockHook.mockReturnValue({
+      data: { buckets: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    expect(
+      screen.getByRole("button", { name: "Trendline" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show trendline by default", () => {
+    mockHook.mockReturnValue({
+      data: { buckets: bucketData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    expect(screen.queryByTestId("trendline-area")).not.toBeInTheDocument();
+  });
+
+  it("shows trendline after clicking toggle", async () => {
+    const user = userEvent.setup();
+    mockHook.mockReturnValue({
+      data: { buckets: bucketData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    await user.click(screen.getByRole("button", { name: "Trendline" }));
+    expect(screen.getByTestId("trendline-area")).toBeInTheDocument();
+  });
+
+  it("hides trendline after toggling off", async () => {
+    const user = userEvent.setup();
+    mockHook.mockReturnValue({
+      data: { buckets: bucketData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    const trendlineBtn = screen.getByRole("button", { name: "Trendline" });
+    await user.click(trendlineBtn);
+    expect(screen.getByTestId("trendline-area")).toBeInTheDocument();
+    await user.click(trendlineBtn);
+    expect(screen.queryByTestId("trendline-area")).not.toBeInTheDocument();
+  });
+
+  it("shows window size selector only when trendline is enabled", async () => {
+    const user = userEvent.setup();
+    mockHook.mockReturnValue({
+      data: { buckets: bucketData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    expect(
+      screen.queryByLabelText("Rolling average window size"),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Trendline" }));
+    expect(
+      screen.getByLabelText("Rolling average window size"),
+    ).toBeInTheDocument();
+  });
+
+  it("trendline button has aria-pressed attribute", async () => {
+    const user = userEvent.setup();
+    mockHook.mockReturnValue({
+      data: { buckets: bucketData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    const btn = screen.getByRole("button", { name: "Trendline" });
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+    await user.click(btn);
+    expect(btn).toHaveAttribute("aria-pressed", "true");
   });
 });

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
@@ -3,8 +3,17 @@ import { ChartCard, AreaTimeChart } from "@/components/charts";
 import { useDashboardSpendingOverTime } from "@/hooks/useDashboard";
 import type { DateRange } from "@/hooks/useDashboard";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { computeRollingAverage } from "@/lib/rolling-average";
 
 type Granularity = "monthly" | "quarterly" | "ytd" | "yearly";
+type WindowSize = "3" | "6" | "12";
 
 interface SpendingOverTimeWidgetProps {
   dateRange: DateRange;
@@ -16,6 +25,12 @@ const granularityOptions: { value: Granularity; label: string }[] = [
   { value: "quarterly", label: "Quarter" },
   { value: "ytd", label: "YTD" },
   { value: "yearly", label: "Year" },
+];
+
+const windowSizeOptions: { value: WindowSize; label: string }[] = [
+  { value: "3", label: "3-period" },
+  { value: "6", label: "6-period" },
+  { value: "12", label: "12-period" },
 ];
 
 function formatCurrency(value: number): string {
@@ -32,6 +47,8 @@ export function SpendingOverTimeWidget({
   className,
 }: SpendingOverTimeWidgetProps) {
   const [granularity, setGranularity] = useState<Granularity>("monthly");
+  const [showTrendline, setShowTrendline] = useState(false);
+  const [windowSize, setWindowSize] = useState<WindowSize>("3");
   const { data, isLoading } = useDashboardSpendingOverTime(
     dateRange,
     granularity,
@@ -39,6 +56,14 @@ export function SpendingOverTimeWidget({
 
   const handleGranularity = useCallback((g: Granularity) => {
     setGranularity(g);
+  }, []);
+
+  const handleToggleTrendline = useCallback(() => {
+    setShowTrendline((prev) => !prev);
+  }, []);
+
+  const handleWindowSizeChange = useCallback((value: string) => {
+    setWindowSize(value as WindowSize);
   }, []);
 
   const chartData = useMemo(
@@ -50,6 +75,14 @@ export function SpendingOverTimeWidget({
     [data?.buckets],
   );
 
+  const trendlineData = useMemo(
+    () =>
+      showTrendline
+        ? computeRollingAverage(chartData, Number(windowSize))
+        : undefined,
+    [showTrendline, chartData, windowSize],
+  );
+
   return (
     <ChartCard
       title="Spending Over Time"
@@ -57,21 +90,51 @@ export function SpendingOverTimeWidget({
       empty={chartData.length === 0 && !isLoading}
       className={className}
       action={
-        <div className="flex gap-1">
-          {granularityOptions.map(({ value, label }) => (
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1">
+            {granularityOptions.map(({ value, label }) => (
+              <Button
+                key={value}
+                variant={granularity === value ? "default" : "outline"}
+                size="sm"
+                onClick={() => handleGranularity(value)}
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+          <div className="flex items-center gap-1.5">
             <Button
-              key={value}
-              variant={granularity === value ? "default" : "outline"}
+              variant={showTrendline ? "default" : "outline"}
               size="sm"
-              onClick={() => handleGranularity(value)}
+              onClick={handleToggleTrendline}
+              aria-pressed={showTrendline}
             >
-              {label}
+              Trendline
             </Button>
-          ))}
+            {showTrendline && (
+              <Select value={windowSize} onValueChange={handleWindowSizeChange}>
+                <SelectTrigger size="sm" aria-label="Rolling average window size">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {windowSizeOptions.map(({ value, label }) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
         </div>
       }
     >
-      <AreaTimeChart data={chartData} formatValue={formatCurrency} />
+      <AreaTimeChart
+        data={chartData}
+        trendlineData={trendlineData}
+        formatValue={formatCurrency}
+      />
     </ChartCard>
   );
 }

--- a/src/client/src/lib/rolling-average.test.ts
+++ b/src/client/src/lib/rolling-average.test.ts
@@ -1,0 +1,76 @@
+import { computeRollingAverage, type TimeSeriesPoint } from "./rolling-average";
+
+const sampleData: TimeSeriesPoint[] = [
+  { period: "Jan", amount: 100 },
+  { period: "Feb", amount: 200 },
+  { period: "Mar", amount: 300 },
+  { period: "Apr", amount: 400 },
+  { period: "May", amount: 500 },
+  { period: "Jun", amount: 600 },
+];
+
+describe("computeRollingAverage", () => {
+  it("returns empty array for empty input", () => {
+    expect(computeRollingAverage([], 3)).toEqual([]);
+  });
+
+  it("returns empty array for window size < 1", () => {
+    expect(computeRollingAverage(sampleData, 0)).toEqual([]);
+    expect(computeRollingAverage(sampleData, -1)).toEqual([]);
+  });
+
+  it("computes 3-month rolling average with partial windows at start", () => {
+    const result = computeRollingAverage(sampleData, 3);
+    expect(result).toHaveLength(6);
+    // Partial windows
+    expect(result[0]).toEqual({ period: "Jan", amount: 100 }); // avg(100)
+    expect(result[1]).toEqual({ period: "Feb", amount: 150 }); // avg(100, 200)
+    // Full windows
+    expect(result[2]).toEqual({ period: "Mar", amount: 200 }); // avg(100, 200, 300)
+    expect(result[3]).toEqual({ period: "Apr", amount: 300 }); // avg(200, 300, 400)
+    expect(result[4]).toEqual({ period: "May", amount: 400 }); // avg(300, 400, 500)
+    expect(result[5]).toEqual({ period: "Jun", amount: 500 }); // avg(400, 500, 600)
+  });
+
+  it("computes 6-month rolling average", () => {
+    const result = computeRollingAverage(sampleData, 6);
+    expect(result).toHaveLength(6);
+    expect(result[5]).toEqual({ period: "Jun", amount: 350 }); // avg(100..600)
+  });
+
+  it("handles window size of 1 (returns original values)", () => {
+    const result = computeRollingAverage(sampleData, 1);
+    expect(result).toEqual(sampleData);
+  });
+
+  it("handles window size larger than data length", () => {
+    const result = computeRollingAverage(sampleData, 12);
+    expect(result).toHaveLength(6);
+    // All use partial windows; last element averages everything
+    expect(result[5]).toEqual({ period: "Jun", amount: 350 });
+  });
+
+  it("handles single data point", () => {
+    const single = [{ period: "Jan", amount: 42 }];
+    const result = computeRollingAverage(single, 3);
+    expect(result).toEqual([{ period: "Jan", amount: 42 }]);
+  });
+
+  it("preserves period strings", () => {
+    const result = computeRollingAverage(sampleData, 3);
+    expect(result.map((p) => p.period)).toEqual([
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+    ]);
+  });
+
+  it("handles fractional window size by flooring", () => {
+    const result = computeRollingAverage(sampleData, 3.7);
+    const expected = computeRollingAverage(sampleData, 3);
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/client/src/lib/rolling-average.ts
+++ b/src/client/src/lib/rolling-average.ts
@@ -1,0 +1,31 @@
+export interface TimeSeriesPoint {
+  period: string;
+  amount: number;
+}
+
+/**
+ * Compute a rolling average over a time-series dataset.
+ *
+ * Uses a trailing window: the value at index `i` is the average of
+ * points from `max(0, i - windowSize + 1)` to `i` (inclusive).
+ * When fewer than `windowSize` points are available (at the start),
+ * a partial-window average is used so there are no gaps.
+ */
+export function computeRollingAverage(
+  data: TimeSeriesPoint[],
+  windowSize: number,
+): TimeSeriesPoint[] {
+  if (data.length === 0 || windowSize < 1) return [];
+
+  const effectiveWindow = Math.max(1, Math.floor(windowSize));
+
+  return data.map((point, i) => {
+    const start = Math.max(0, i - effectiveWindow + 1);
+    const windowSlice = data.slice(start, i + 1);
+    const sum = windowSlice.reduce((acc, p) => acc + p.amount, 0);
+    return {
+      period: point.period,
+      amount: sum / windowSlice.length,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- Add configurable rolling average trendline overlay to the SpendingOverTimeWidget on the dashboard
- Trendline toggle button and window size selector (3/6/12 periods) in the chart card action area
- Trendline renders as a dashed line with different color and reduced opacity via a new `trendlineData` prop on `AreaTimeChart`
- Rolling average computed client-side using a pure utility function with partial-window support (no backend changes)

## Test plan
- [x] 9 unit tests for `computeRollingAverage` utility (empty, boundary, partial window, oversized window, single point, fractional)
- [x] 4 tests for `AreaTimeChart` trendline rendering (present, absent, dashed stroke, empty data)
- [x] 5 tests for `SpendingOverTimeWidget` toggle/selector UI (toggle on/off, window selector visibility, aria-pressed)
- [x] All 1433 client tests pass
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] 333 .NET tests pass (pre-commit hook)

Closes RECEIPTS-438

🤖 Generated with [Claude Code](https://claude.com/claude-code)