### PR TITLE
feat(client): redesign dashboard with unified date selector and spending by store

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -2921,6 +2921,44 @@ paths:
               schema:
                 type: string
 
+  /api/dashboard/spending-by-store:
+    get:
+      operationId: GetSpendingByStore
+      tags: [Dashboard]
+      summary: Get spending grouped by store
+      description: Returns spending amounts grouped by receipt location (store), including visit count and average per visit.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Start date (ISO date string). Defaults to 30 days ago.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: End date (ISO date string). Defaults to today.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpendingByStoreResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
   /api/dashboard/earliest-receipt-year:
     get:
       operationId: GetEarliestReceiptYear
@@ -3083,6 +3121,31 @@ components:
           type: number
           format: double
         percentage:
+          type: number
+          format: double
+
+    SpendingByStoreResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SpendingByStoreItem"
+
+    SpendingByStoreItem:
+      type: object
+      required: [location, visitCount, totalAmount, averagePerVisit]
+      properties:
+        location:
+          type: string
+        visitCount:
+          type: integer
+          format: int32
+        totalAmount:
+          type: number
+          format: double
+        averagePerVisit:
           type: number
           format: double
 

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -2819,7 +2819,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [monthly, quarterly, ytd, yearly]
+            enum: [daily, monthly, quarterly, yearly]
             default: monthly
           description: Time bucket granularity.
       responses:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-a0c35c98",
+  "name": "agent-a82f3894",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/Application/Interfaces/Services/IDashboardService.cs
+++ b/src/Application/Interfaces/Services/IDashboardService.cs
@@ -8,5 +8,6 @@ public interface IDashboardService
 	Task<SpendingOverTimeResult> GetSpendingOverTimeAsync(DateOnly startDate, DateOnly endDate, string granularity, CancellationToken cancellationToken);
 	Task<SpendingByCategoryResult> GetSpendingByCategoryAsync(DateOnly startDate, DateOnly endDate, int limit, CancellationToken cancellationToken);
 	Task<SpendingByAccountResult> GetSpendingByAccountAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken);
+	Task<SpendingByStoreResult> GetSpendingByStoreAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken);
 	Task<int> GetEarliestReceiptYearAsync(CancellationToken cancellationToken);
 }

--- a/src/Application/Models/Dashboard/SpendingByStoreResult.cs
+++ b/src/Application/Models/Dashboard/SpendingByStoreResult.cs
@@ -1,0 +1,5 @@
+namespace Application.Models.Dashboard;
+
+public record SpendingByStoreResult(List<SpendingByStoreItemResult> Items);
+
+public record SpendingByStoreItemResult(string Location, int VisitCount, decimal TotalAmount, decimal AveragePerVisit);

--- a/src/Application/Queries/Aggregates/Dashboard/GetSpendingByStoreQuery.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetSpendingByStoreQuery.cs
@@ -1,0 +1,6 @@
+using Application.Interfaces;
+using Application.Models.Dashboard;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public record GetSpendingByStoreQuery(DateOnly StartDate, DateOnly EndDate) : IQuery<SpendingByStoreResult>;

--- a/src/Application/Queries/Aggregates/Dashboard/GetSpendingByStoreQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Dashboard/GetSpendingByStoreQueryHandler.cs
@@ -1,0 +1,14 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Dashboard;
+
+public class GetSpendingByStoreQueryHandler(IDashboardService dashboardService)
+	: IRequestHandler<GetSpendingByStoreQuery, SpendingByStoreResult>
+{
+	public async Task<SpendingByStoreResult> Handle(GetSpendingByStoreQuery request, CancellationToken cancellationToken)
+	{
+		return await dashboardService.GetSpendingByStoreAsync(request.StartDate, request.EndDate, cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/DashboardService.cs
+++ b/src/Infrastructure/Services/DashboardService.cs
@@ -217,8 +217,6 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 			.AsNoTracking()
 			.Where(r => r.Date >= startDate && r.Date <= endDate);
 
-		IQueryable<Guid> receiptIds = receiptsInRange.Select(r => r.Id);
-
 		// Get per-receipt totals (sum of transactions per receipt) with location
 		var receiptTotals = await receiptsInRange
 			.Select(r => new

--- a/src/Infrastructure/Services/DashboardService.cs
+++ b/src/Infrastructure/Services/DashboardService.cs
@@ -86,6 +86,15 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 
 		switch (granularity.ToLowerInvariant())
 		{
+			case "daily":
+				var dailyMaterialized = await transactionsWithDate.ToListAsync(cancellationToken);
+				buckets = dailyMaterialized
+					.GroupBy(x => x.Date)
+					.OrderBy(g => g.Key)
+					.Select(g => new SpendingBucketResult(g.Key.ToString("yyyy-MM-dd"), g.Sum(x => x.Amount)))
+					.ToList();
+				break;
+
 			case "quarterly":
 				var quarterlyRaw = await transactionsWithDate
 					.GroupBy(x => new { x.Date.Year, Quarter = (x.Date.Month - 1) / 3 + 1 })
@@ -95,18 +104,6 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 					.ToListAsync(cancellationToken);
 				buckets = quarterlyRaw
 					.Select(q => new SpendingBucketResult($"{q.Year} Q{q.Quarter}", q.Amount))
-					.ToList();
-				break;
-
-			case "ytd":
-				var ytdRaw = await transactionsWithDate
-					.GroupBy(x => new { x.Date.Year, x.Date.Month })
-					.Select(g => new { g.Key.Year, g.Key.Month, Amount = g.Sum(x => x.Amount) })
-					.OrderBy(g => g.Year)
-					.ThenBy(g => g.Month)
-					.ToListAsync(cancellationToken);
-				buckets = ytdRaw
-					.Select(m => new SpendingBucketResult($"{m.Year}-{m.Month:D2}", m.Amount))
 					.ToList();
 				break;
 

--- a/src/Infrastructure/Services/DashboardService.cs
+++ b/src/Infrastructure/Services/DashboardService.cs
@@ -209,6 +209,44 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 		return new SpendingByAccountResult(items);
 	}
 
+	public async Task<SpendingByStoreResult> GetSpendingByStoreAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		IQueryable<ReceiptEntity> receiptsInRange = context.Receipts
+			.AsNoTracking()
+			.Where(r => r.Date >= startDate && r.Date <= endDate);
+
+		IQueryable<Guid> receiptIds = receiptsInRange.Select(r => r.Id);
+
+		// Get per-receipt totals (sum of transactions per receipt) with location
+		var receiptTotals = await receiptsInRange
+			.Select(r => new
+			{
+				r.Id,
+				Location = r.Location ?? "Unknown",
+				TransactionTotal = context.Transactions
+					.AsNoTracking()
+					.Where(t => t.ReceiptId == r.Id)
+					.Sum(t => t.Amount)
+			})
+			.ToListAsync(cancellationToken);
+
+		List<SpendingByStoreItemResult> items = receiptTotals
+			.GroupBy(r => r.Location)
+			.Select(g =>
+			{
+				int visitCount = g.Count();
+				decimal totalAmount = g.Sum(r => r.TransactionTotal);
+				decimal averagePerVisit = visitCount > 0 ? Math.Round(totalAmount / visitCount, 2) : 0;
+				return new SpendingByStoreItemResult(g.Key, visitCount, totalAmount, averagePerVisit);
+			})
+			.OrderByDescending(i => i.TotalAmount)
+			.ToList();
+
+		return new SpendingByStoreResult(items);
+	}
+
 	public async Task<int> GetEarliestReceiptYearAsync(CancellationToken cancellationToken)
 	{
 		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);

--- a/src/Presentation/API/Controllers/Aggregates/DashboardController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/DashboardController.cs
@@ -141,6 +141,37 @@ public class DashboardController(IMediator mediator) : ControllerBase
 		});
 	}
 
+	[HttpGet("spending-by-store")]
+	[EndpointSummary("Get spending grouped by store")]
+	[EndpointDescription("Returns spending amounts grouped by receipt location (store), including visit count and average per visit.")]
+	public async Task<Results<Ok<SpendingByStoreResponse>, BadRequest<string>>> GetSpendingByStore(
+		[FromQuery] DateOnly? startDate,
+		[FromQuery] DateOnly? endDate,
+		CancellationToken cancellationToken)
+	{
+		DateOnly start = startDate ?? DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly end = endDate ?? DateOnly.FromDateTime(DateTime.Today);
+
+		if (start > end)
+		{
+			return TypedResults.BadRequest("startDate must be before or equal to endDate");
+		}
+
+		GetSpendingByStoreQuery query = new(start, end);
+		SpendingByStoreResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new SpendingByStoreResponse
+		{
+			Items = result.Items.Select(i => new SpendingByStoreItem
+			{
+				Location = i.Location,
+				VisitCount = i.VisitCount,
+				TotalAmount = (double)i.TotalAmount,
+				AveragePerVisit = (double)i.AveragePerVisit
+			}).ToList()
+		});
+	}
+
 	[HttpGet("spending-by-account")]
 	[EndpointSummary("Get spending grouped by account")]
 	[EndpointDescription("Returns spending amounts grouped by payment account.")]

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",

--- a/src/client/src/components/dashboard/DateRangeSelector.test.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.test.tsx
@@ -28,7 +28,8 @@ describe("DateRangeSelector", () => {
     );
     expect(screen.getByRole("button", { name: "1M" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "3M" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "12M" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "1Y" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "5Y" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "MTD" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "QTD" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "YTD" })).toBeInTheDocument();

--- a/src/client/src/components/dashboard/DateRangeSelector.test.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.test.tsx
@@ -26,16 +26,13 @@ describe("DateRangeSelector", () => {
     renderWithProviders(
       <DateRangeSelector value={defaultRange} onChange={onChange} />,
     );
-    expect(
-      screen.getByRole("button", { name: "30 days" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "90 days" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "1M" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "3M" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "12M" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "MTD" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "QTD" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "YTD" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "All time" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
   });
 
   it("renders a year dropdown", () => {
@@ -53,7 +50,7 @@ describe("DateRangeSelector", () => {
       <DateRangeSelector value={defaultRange} onChange={onChange} />,
     );
 
-    await user.click(screen.getByRole("button", { name: "30 days" }));
+    await user.click(screen.getByRole("button", { name: "1M" }));
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         startDate: expect.any(String),
@@ -62,14 +59,14 @@ describe("DateRangeSelector", () => {
     );
   });
 
-  it("calls onChange with undefined dates for All time", async () => {
+  it("calls onChange with undefined dates for All", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     renderWithProviders(
       <DateRangeSelector value={defaultRange} onChange={onChange} />,
     );
 
-    await user.click(screen.getByRole("button", { name: "All time" }));
+    await user.click(screen.getByRole("button", { name: "All" }));
     expect(onChange).toHaveBeenCalledWith({
       startDate: undefined,
       endDate: undefined,
@@ -84,5 +81,21 @@ describe("DateRangeSelector", () => {
     // There should be at least one combobox (the narrow screen dropdown or the year dropdown)
     const comboboxes = screen.getAllByRole("combobox");
     expect(comboboxes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("calls onChange when 3M is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <DateRangeSelector value={defaultRange} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "3M" }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: expect.any(String),
+        endDate: expect.any(String),
+      }),
+    );
   });
 });

--- a/src/client/src/components/dashboard/DateRangeSelector.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.tsx
@@ -1,5 +1,11 @@
 import { useState, useCallback, useMemo } from "react";
-import { format, subDays, startOfYear } from "date-fns";
+import {
+  format,
+  subMonths,
+  startOfMonth,
+  startOfQuarter,
+  startOfYear,
+} from "date-fns";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -11,7 +17,16 @@ import {
 import type { DateRange } from "@/hooks/useDashboard";
 import { useDashboardEarliestReceiptYear } from "@/hooks/useDashboard";
 
-type PresetKey = "30d" | "90d" | "ytd" | "year" | "all";
+export type PresetKey =
+  | "1M"
+  | "3M"
+  | "12M"
+  | "60M"
+  | "MTD"
+  | "QTD"
+  | "YTD"
+  | "all"
+  | "year";
 
 interface Preset {
   label: string;
@@ -19,25 +34,60 @@ interface Preset {
 }
 
 const presets: Record<PresetKey, Preset> = {
-  "30d": {
-    label: "30 days",
+  "1M": {
+    label: "1M",
     getRange: () => ({
-      startDate: format(subDays(new Date(), 30), "yyyy-MM-dd"),
+      startDate: format(subMonths(new Date(), 1), "yyyy-MM-dd"),
       endDate: format(new Date(), "yyyy-MM-dd"),
     }),
   },
-  "90d": {
-    label: "90 days",
+  "3M": {
+    label: "3M",
     getRange: () => ({
-      startDate: format(subDays(new Date(), 90), "yyyy-MM-dd"),
+      startDate: format(subMonths(new Date(), 3), "yyyy-MM-dd"),
       endDate: format(new Date(), "yyyy-MM-dd"),
     }),
   },
-  ytd: {
+  "12M": {
+    label: "12M",
+    getRange: () => ({
+      startDate: format(subMonths(new Date(), 12), "yyyy-MM-dd"),
+      endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
+  },
+  "60M": {
+    label: "5Y",
+    getRange: () => ({
+      startDate: format(subMonths(new Date(), 60), "yyyy-MM-dd"),
+      endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
+  },
+  MTD: {
+    label: "MTD",
+    getRange: () => ({
+      startDate: format(startOfMonth(new Date()), "yyyy-MM-dd"),
+      endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
+  },
+  QTD: {
+    label: "QTD",
+    getRange: () => ({
+      startDate: format(startOfQuarter(new Date()), "yyyy-MM-dd"),
+      endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
+  },
+  YTD: {
     label: "YTD",
     getRange: () => ({
       startDate: format(startOfYear(new Date()), "yyyy-MM-dd"),
       endDate: format(new Date(), "yyyy-MM-dd"),
+    }),
+  },
+  all: {
+    label: "All",
+    getRange: () => ({
+      startDate: undefined,
+      endDate: undefined,
     }),
   },
   year: {
@@ -50,14 +100,17 @@ const presets: Record<PresetKey, Preset> = {
       };
     },
   },
-  all: {
-    label: "All time",
-    getRange: () => ({
-      startDate: undefined,
-      endDate: undefined,
-    }),
-  },
 };
+
+const segmentedPresets: PresetKey[] = [
+  "1M",
+  "3M",
+  "12M",
+  "MTD",
+  "QTD",
+  "YTD",
+  "all",
+];
 
 interface DateRangeSelectorProps {
   value: DateRange;
@@ -65,7 +118,7 @@ interface DateRangeSelectorProps {
 }
 
 export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
-  const [activePreset, setActivePreset] = useState<PresetKey>("30d");
+  const [activePreset, setActivePreset] = useState<PresetKey>("1M");
   const [selectedYear, setSelectedYear] = useState<number>(
     new Date().getFullYear(),
   );
@@ -123,10 +176,6 @@ export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
     [handlePreset],
   );
 
-  const nonYearPresets = (
-    Object.keys(presets) as PresetKey[]
-  ).filter((k) => k !== "year");
-
   return (
     <div className="flex items-center gap-2">
       {/* Dropdown for narrow screens */}
@@ -136,19 +185,18 @@ export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
             <SelectValue>{displayLabel}</SelectValue>
           </SelectTrigger>
           <SelectContent>
-            {nonYearPresets.map((key) => (
+            {segmentedPresets.map((key) => (
               <SelectItem key={key} value={key}>
                 {presets[key].label}
               </SelectItem>
             ))}
-            <SelectItem value="year">Year</SelectItem>
           </SelectContent>
         </Select>
       </div>
 
       {/* Button row for wider screens */}
-      <div className="hidden sm:flex items-center gap-2">
-        {nonYearPresets.map((key) => (
+      <div className="hidden sm:flex items-center gap-1">
+        {segmentedPresets.map((key) => (
           <Button
             key={key}
             variant={activePreset === key ? "default" : "outline"}

--- a/src/client/src/components/dashboard/DateRangeSelector.tsx
+++ b/src/client/src/components/dashboard/DateRangeSelector.tsx
@@ -49,7 +49,7 @@ const presets: Record<PresetKey, Preset> = {
     }),
   },
   "12M": {
-    label: "12M",
+    label: "1Y",
     getRange: () => ({
       startDate: format(subMonths(new Date(), 12), "yyyy-MM-dd"),
       endDate: format(new Date(), "yyyy-MM-dd"),
@@ -102,14 +102,10 @@ const presets: Record<PresetKey, Preset> = {
   },
 };
 
-const segmentedPresets: PresetKey[] = [
-  "1M",
-  "3M",
-  "12M",
-  "MTD",
-  "QTD",
-  "YTD",
-  "all",
+const presetGroups: { label: string; keys: PresetKey[] }[] = [
+  { label: "Trailing", keys: ["1M", "3M", "12M", "60M"] },
+  { label: "To Date", keys: ["MTD", "QTD", "YTD"] },
+  { label: "", keys: ["all"] },
 ];
 
 interface DateRangeSelectorProps {
@@ -185,26 +181,35 @@ export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
             <SelectValue>{displayLabel}</SelectValue>
           </SelectTrigger>
           <SelectContent>
-            {segmentedPresets.map((key) => (
-              <SelectItem key={key} value={key}>
-                {presets[key].label}
-              </SelectItem>
-            ))}
+            {presetGroups.map((group) =>
+              group.keys.map((key) => (
+                <SelectItem key={key} value={key}>
+                  {group.label ? `${group.label}: ${presets[key].label}` : presets[key].label}
+                </SelectItem>
+              )),
+            )}
           </SelectContent>
         </Select>
       </div>
 
-      {/* Button row for wider screens */}
+      {/* Button row for wider screens — grouped with separators */}
       <div className="hidden sm:flex items-center gap-1">
-        {segmentedPresets.map((key) => (
-          <Button
-            key={key}
-            variant={activePreset === key ? "default" : "outline"}
-            size="sm"
-            onClick={() => handlePreset(key)}
-          >
-            {presets[key].label}
-          </Button>
+        {presetGroups.map((group, i) => (
+          <div key={group.label || "misc"} className="flex items-center gap-1">
+            {i > 0 && (
+              <div className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
+            )}
+            {group.keys.map((key) => (
+              <Button
+                key={key}
+                variant={activePreset === key ? "default" : "outline"}
+                size="sm"
+                onClick={() => handlePreset(key)}
+              >
+                {presets[key].label}
+              </Button>
+            ))}
+          </div>
         ))}
       </div>
 

--- a/src/client/src/components/dashboard/SpendingByStoreWidget.test.tsx
+++ b/src/client/src/components/dashboard/SpendingByStoreWidget.test.tsx
@@ -1,0 +1,99 @@
+import { screen } from "@testing-library/react";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { SpendingByStoreWidget } from "./SpendingByStoreWidget";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: () => <div data-testid="bar" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+}));
+
+vi.mock("@/hooks/useDashboard", () => ({
+  useDashboardSpendingByStore: vi.fn(),
+}));
+
+import { useDashboardSpendingByStore } from "@/hooks/useDashboard";
+const mockHook = vi.mocked(useDashboardSpendingByStore);
+
+const dateRange = { startDate: "2024-01-01", endDate: "2024-01-31" };
+
+const storeData = [
+  { location: "Walmart", visitCount: 5, totalAmount: 500, averagePerVisit: 100 },
+  { location: "Target", visitCount: 3, totalAmount: 300, averagePerVisit: 100 },
+];
+
+describe("SpendingByStoreWidget", () => {
+  it("renders chart and table with data", () => {
+    mockHook.mockReturnValue({
+      data: { items: storeData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByStore>);
+
+    renderWithQueryClient(<SpendingByStoreWidget dateRange={dateRange} />);
+    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+    expect(screen.getByText("Walmart")).toBeInTheDocument();
+    expect(screen.getByText("Target")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockHook.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useDashboardSpendingByStore>);
+
+    renderWithQueryClient(<SpendingByStoreWidget dateRange={dateRange} />);
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no data", () => {
+    mockHook.mockReturnValue({
+      data: { items: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByStore>);
+
+    renderWithQueryClient(<SpendingByStoreWidget dateRange={dateRange} />);
+    expect(screen.getByText("No store data")).toBeInTheDocument();
+  });
+
+  it("renders table headers", () => {
+    mockHook.mockReturnValue({
+      data: { items: storeData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByStore>);
+
+    renderWithQueryClient(<SpendingByStoreWidget dateRange={dateRange} />);
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByText("Visits")).toBeInTheDocument();
+    expect(screen.getByText("Total")).toBeInTheDocument();
+    expect(screen.getByText("Avg/Visit")).toBeInTheDocument();
+  });
+
+  it("displays visit counts in table", () => {
+    mockHook.mockReturnValue({
+      data: { items: storeData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByStore>);
+
+    renderWithQueryClient(<SpendingByStoreWidget dateRange={dateRange} />);
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("has correct title", () => {
+    mockHook.mockReturnValue({
+      data: { items: storeData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingByStore>);
+
+    renderWithQueryClient(<SpendingByStoreWidget dateRange={dateRange} />);
+    expect(screen.getByText("Spending by Store")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/dashboard/SpendingByStoreWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingByStoreWidget.tsx
@@ -1,0 +1,91 @@
+import { useMemo } from "react";
+import { ChartCard, BarChart } from "@/components/charts";
+import { useDashboardSpendingByStore } from "@/hooks/useDashboard";
+import type { DateRange } from "@/hooks/useDashboard";
+
+interface SpendingByStoreWidgetProps {
+  dateRange: DateRange;
+  className?: string;
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function SpendingByStoreWidget({
+  dateRange,
+  className,
+}: SpendingByStoreWidgetProps) {
+  const { data, isLoading } = useDashboardSpendingByStore(dateRange);
+
+  const items = useMemo(() => data?.items ?? [], [data?.items]);
+
+  const chartData = useMemo(
+    () =>
+      items
+        .slice(0, 10)
+        .map((item) => ({
+          name: item.location,
+          value: Number(item.totalAmount ?? 0),
+        })),
+    [items],
+  );
+
+  return (
+    <ChartCard
+      title="Spending by Store"
+      loading={isLoading}
+      empty={items.length === 0 && !isLoading}
+      emptyMessage="No store data"
+      className={className}
+    >
+      <div className="space-y-4">
+        <BarChart
+          data={chartData}
+          layout="horizontal"
+          formatValue={formatCurrency}
+        />
+        {items.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="pb-2 pr-4 font-medium">Location</th>
+                  <th className="pb-2 pr-4 font-medium text-right">Visits</th>
+                  <th className="pb-2 pr-4 font-medium text-right">Total</th>
+                  <th className="pb-2 font-medium text-right">Avg/Visit</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((item) => (
+                  <tr
+                    key={item.location}
+                    className="border-b border-border/50 last:border-0"
+                  >
+                    <td className="py-2 pr-4 truncate max-w-[200px]">
+                      {item.location}
+                    </td>
+                    <td className="py-2 pr-4 text-right tabular-nums">
+                      {item.visitCount}
+                    </td>
+                    <td className="py-2 pr-4 text-right tabular-nums">
+                      {formatCurrency(Number(item.totalAmount ?? 0))}
+                    </td>
+                    <td className="py-2 text-right tabular-nums">
+                      {formatCurrency(Number(item.averagePerVisit ?? 0))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </ChartCard>
+  );
+}

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.test.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.test.tsx
@@ -104,17 +104,17 @@ describe("SpendingOverTimeWidget", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not show trendline by default", () => {
+  it("shows trendline by default", () => {
     mockHook.mockReturnValue({
       data: { buckets: bucketData },
       isLoading: false,
     } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
 
     renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
-    expect(screen.queryByTestId("trendline-area")).not.toBeInTheDocument();
+    expect(screen.getByTestId("trendline-area")).toBeInTheDocument();
   });
 
-  it("shows trendline after clicking toggle", async () => {
+  it("hides trendline after clicking toggle", async () => {
     const user = userEvent.setup();
     mockHook.mockReturnValue({
       data: { buckets: bucketData },
@@ -123,10 +123,10 @@ describe("SpendingOverTimeWidget", () => {
 
     renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
     await user.click(screen.getByRole("button", { name: "Trendline" }));
-    expect(screen.getByTestId("trendline-area")).toBeInTheDocument();
+    expect(screen.queryByTestId("trendline-area")).not.toBeInTheDocument();
   });
 
-  it("hides trendline after toggling off", async () => {
+  it("shows trendline again after toggling on", async () => {
     const user = userEvent.setup();
     mockHook.mockReturnValue({
       data: { buckets: bucketData },
@@ -136,13 +136,12 @@ describe("SpendingOverTimeWidget", () => {
     renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
     const trendlineBtn = screen.getByRole("button", { name: "Trendline" });
     await user.click(trendlineBtn);
-    expect(screen.getByTestId("trendline-area")).toBeInTheDocument();
-    await user.click(trendlineBtn);
     expect(screen.queryByTestId("trendline-area")).not.toBeInTheDocument();
+    await user.click(trendlineBtn);
+    expect(screen.getByTestId("trendline-area")).toBeInTheDocument();
   });
 
-  it("shows window size selector only when trendline is enabled", async () => {
-    const user = userEvent.setup();
+  it("shows window size selector when trendline is enabled (default)", () => {
     mockHook.mockReturnValue({
       data: { buckets: bucketData },
       isLoading: false,
@@ -150,16 +149,25 @@ describe("SpendingOverTimeWidget", () => {
 
     renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
     expect(
-      screen.queryByLabelText("Rolling average window size"),
-    ).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Trendline" }));
-    expect(
       screen.getByLabelText("Rolling average window size"),
     ).toBeInTheDocument();
   });
 
-  it("trendline button has aria-pressed attribute", async () => {
+  it("hides window size selector when trendline is off", async () => {
     const user = userEvent.setup();
+    mockHook.mockReturnValue({
+      data: { buckets: bucketData },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    await user.click(screen.getByRole("button", { name: "Trendline" }));
+    expect(
+      screen.queryByLabelText("Rolling average window size"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("trendline button has aria-pressed attribute defaulting to true", () => {
     mockHook.mockReturnValue({
       data: { buckets: bucketData },
       isLoading: false,
@@ -167,8 +175,27 @@ describe("SpendingOverTimeWidget", () => {
 
     renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
     const btn = screen.getByRole("button", { name: "Trendline" });
-    expect(btn).toHaveAttribute("aria-pressed", "false");
-    await user.click(btn);
     expect(btn).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("auto-selects monthly granularity for short ranges", () => {
+    mockHook.mockReturnValue({
+      data: { buckets: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    expect(mockHook).toHaveBeenCalledWith(dateRange, "monthly");
+  });
+
+  it("auto-selects quarterly granularity for ranges over 2 years", () => {
+    mockHook.mockReturnValue({
+      data: { buckets: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
+
+    const longRange = { startDate: "2020-01-01", endDate: "2024-01-01" };
+    renderWithQueryClient(<SpendingOverTimeWidget dateRange={longRange} />);
+    expect(mockHook).toHaveBeenCalledWith(longRange, "quarterly");
   });
 });

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.test.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.test.tsx
@@ -52,11 +52,11 @@ describe("SpendingOverTimeWidget", () => {
     } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
 
     renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
+    expect(screen.getByRole("button", { name: "Day" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Month" })).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Quarter" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "YTD" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Year" })).toBeInTheDocument();
   });
 
@@ -178,17 +178,17 @@ describe("SpendingOverTimeWidget", () => {
     expect(btn).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("auto-selects monthly granularity for short ranges", () => {
+  it("auto-selects daily granularity for short ranges", () => {
     mockHook.mockReturnValue({
       data: { buckets: [] },
       isLoading: false,
     } as unknown as ReturnType<typeof useDashboardSpendingOverTime>);
 
     renderWithQueryClient(<SpendingOverTimeWidget dateRange={dateRange} />);
-    expect(mockHook).toHaveBeenCalledWith(dateRange, "monthly");
+    expect(mockHook).toHaveBeenCalledWith(dateRange, "daily");
   });
 
-  it("auto-selects quarterly granularity for ranges over 2 years", () => {
+  it("auto-selects yearly granularity for ranges over 2 years", () => {
     mockHook.mockReturnValue({
       data: { buckets: [] },
       isLoading: false,
@@ -196,6 +196,6 @@ describe("SpendingOverTimeWidget", () => {
 
     const longRange = { startDate: "2020-01-01", endDate: "2024-01-01" };
     renderWithQueryClient(<SpendingOverTimeWidget dateRange={longRange} />);
-    expect(mockHook).toHaveBeenCalledWith(longRange, "quarterly");
+    expect(mockHook).toHaveBeenCalledWith(longRange, "yearly");
   });
 });

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
+import { differenceInDays, parseISO } from "date-fns";
 import { ChartCard, AreaTimeChart } from "@/components/charts";
 import { useDashboardSpendingOverTime } from "@/hooks/useDashboard";
 import type { DateRange } from "@/hooks/useDashboard";
@@ -42,20 +43,40 @@ function formatCurrency(value: number): string {
   }).format(value);
 }
 
+function getAutoGranularity(dateRange: DateRange): Granularity {
+  if (!dateRange.startDate || !dateRange.endDate) {
+    return "quarterly";
+  }
+  const days = differenceInDays(
+    parseISO(dateRange.endDate),
+    parseISO(dateRange.startDate),
+  );
+  if (days > 730) return "quarterly";
+  return "monthly";
+}
+
 export function SpendingOverTimeWidget({
   dateRange,
   className,
 }: SpendingOverTimeWidgetProps) {
-  const [granularity, setGranularity] = useState<Granularity>("monthly");
-  const [showTrendline, setShowTrendline] = useState(false);
+  const [granularityOverride, setGranularityOverride] =
+    useState<Granularity | null>(null);
+  const [showTrendline, setShowTrendline] = useState(true);
   const [windowSize, setWindowSize] = useState<WindowSize>("3");
+
+  const autoGranularity = useMemo(
+    () => getAutoGranularity(dateRange),
+    [dateRange],
+  );
+  const granularity = granularityOverride ?? autoGranularity;
+
   const { data, isLoading } = useDashboardSpendingOverTime(
     dateRange,
     granularity,
   );
 
   const handleGranularity = useCallback((g: Granularity) => {
-    setGranularity(g);
+    setGranularityOverride(g);
   }, []);
 
   const handleToggleTrendline = useCallback(() => {

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/select";
 import { computeRollingAverage } from "@/lib/rolling-average";
 
-type Granularity = "monthly" | "quarterly" | "ytd" | "yearly";
+type Granularity = "daily" | "monthly" | "quarterly" | "yearly";
 type WindowSize = "3" | "6" | "12";
 
 interface SpendingOverTimeWidgetProps {
@@ -22,9 +22,9 @@ interface SpendingOverTimeWidgetProps {
 }
 
 const granularityOptions: { value: Granularity; label: string }[] = [
+  { value: "daily", label: "Day" },
   { value: "monthly", label: "Month" },
   { value: "quarterly", label: "Quarter" },
-  { value: "ytd", label: "YTD" },
   { value: "yearly", label: "Year" },
 ];
 
@@ -45,14 +45,15 @@ function formatCurrency(value: number): string {
 
 function getAutoGranularity(dateRange: DateRange): Granularity {
   if (!dateRange.startDate || !dateRange.endDate) {
-    return "quarterly";
+    return "yearly";
   }
   const days = differenceInDays(
     parseISO(dateRange.endDate),
     parseISO(dateRange.startDate),
   );
-  if (days > 730) return "quarterly";
-  return "monthly";
+  if (days <= 93) return "daily";
+  if (days <= 730) return "monthly";
+  return "yearly";
 }
 
 export function SpendingOverTimeWidget({

--- a/src/client/src/hooks/useDashboard.ts
+++ b/src/client/src/hooks/useDashboard.ts
@@ -27,7 +27,7 @@ export function useDashboardSummary(dateRange: DateRange) {
 
 export function useDashboardSpendingOverTime(
   dateRange: DateRange,
-  granularity?: "monthly" | "quarterly" | "ytd" | "yearly",
+  granularity?: "daily" | "monthly" | "quarterly" | "yearly",
 ) {
   return useQuery({
     queryKey: [

--- a/src/client/src/hooks/useDashboard.ts
+++ b/src/client/src/hooks/useDashboard.ts
@@ -103,6 +103,33 @@ export function useDashboardSpendingByCategory(
   });
 }
 
+export function useDashboardSpendingByStore(dateRange: DateRange) {
+  return useQuery({
+    queryKey: [
+      "dashboard",
+      "spending-by-store",
+      dateRange.startDate,
+      dateRange.endDate,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/dashboard/spending-by-store",
+        {
+          params: {
+            query: {
+              startDate: dateRange.startDate,
+              endDate: dateRange.endDate,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
 export function useDashboardSpendingByAccount(dateRange: DateRange) {
   return useQuery({
     queryKey: [

--- a/src/client/src/pages/Dashboard.test.tsx
+++ b/src/client/src/pages/Dashboard.test.tsx
@@ -26,8 +26,8 @@ vi.mock("@/components/dashboard/SpendingByAccountWidget", () => ({
   SpendingByAccountWidget: () => <div data-testid="spending-by-account" />,
 }));
 
-vi.mock("@/components/dashboard/RecentReceiptsWidget", () => ({
-  RecentReceiptsWidget: () => <div data-testid="recent-receipts" />,
+vi.mock("@/components/dashboard/SpendingByStoreWidget", () => ({
+  SpendingByStoreWidget: () => <div data-testid="spending-by-store" />,
 }));
 
 describe("Dashboard", () => {
@@ -49,7 +49,7 @@ describe("Dashboard", () => {
     expect(screen.getByTestId("spending-over-time")).toBeInTheDocument();
     expect(screen.getByTestId("spending-by-category")).toBeInTheDocument();
     expect(screen.getByTestId("spending-by-account")).toBeInTheDocument();
-    expect(screen.getByTestId("recent-receipts")).toBeInTheDocument();
+    expect(screen.getByTestId("spending-by-store")).toBeInTheDocument();
   });
 
   it("calls usePageTitle with Dashboard", async () => {

--- a/src/client/src/pages/Dashboard.tsx
+++ b/src/client/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { Link } from "react-router";
-import { format, subDays } from "date-fns";
+import { format, subMonths } from "date-fns";
 import { Plus } from "lucide-react";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { DateRange } from "@/hooks/useDashboard";
@@ -10,12 +10,12 @@ import { SummaryStats } from "@/components/dashboard/SummaryStats";
 import { SpendingOverTimeWidget } from "@/components/dashboard/SpendingOverTimeWidget";
 import { SpendingByCategoryWidget } from "@/components/dashboard/SpendingByCategoryWidget";
 import { SpendingByAccountWidget } from "@/components/dashboard/SpendingByAccountWidget";
-import { RecentReceiptsWidget } from "@/components/dashboard/RecentReceiptsWidget";
+import { SpendingByStoreWidget } from "@/components/dashboard/SpendingByStoreWidget";
 
 function getDefaultRange(): DateRange {
   const now = new Date();
   return {
-    startDate: format(subDays(now, 30), "yyyy-MM-dd"),
+    startDate: format(subMonths(now, 1), "yyyy-MM-dd"),
     endDate: format(now, "yyyy-MM-dd"),
   };
 }
@@ -55,7 +55,7 @@ function Dashboard() {
 
       <div className="grid gap-6 md:grid-cols-2">
         <SpendingByAccountWidget dateRange={dateRange} />
-        <RecentReceiptsWidget />
+        <SpendingByStoreWidget dateRange={dateRange} />
       </div>
     </div>
   );

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByStoreQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByStoreQueryHandlerTests.cs
@@ -1,0 +1,61 @@
+using Application.Interfaces.Services;
+using Application.Models.Dashboard;
+using Application.Queries.Aggregates.Dashboard;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetSpendingByStoreQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ShouldReturnStoreSpending()
+	{
+		// Arrange
+		DateOnly startDate = DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
+		DateOnly endDate = DateOnly.FromDateTime(DateTime.Today);
+
+		SpendingByStoreResult expected = new(
+		[
+			new SpendingByStoreItemResult("Walmart", 5, 250m, 50m),
+			new SpendingByStoreItemResult("Target", 3, 150m, 50m),
+		]);
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSpendingByStoreAsync(startDate, endDate, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetSpendingByStoreQueryHandler handler = new(mockService.Object);
+		GetSpendingByStoreQuery query = new(startDate, endDate);
+
+		// Act
+		SpendingByStoreResult result = await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetSpendingByStoreAsync(startDate, endDate, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ShouldPassDatesToService()
+	{
+		// Arrange
+		DateOnly startDate = new(2025, 1, 1);
+		DateOnly endDate = new(2025, 6, 30);
+
+		SpendingByStoreResult expected = new([]);
+
+		Mock<IDashboardService> mockService = new();
+		mockService.Setup(s => s.GetSpendingByStoreAsync(startDate, endDate, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetSpendingByStoreQueryHandler handler = new(mockService.Object);
+		GetSpendingByStoreQuery query = new(startDate, endDate);
+
+		// Act
+		await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		mockService.Verify(s => s.GetSpendingByStoreAsync(startDate, endDate, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByStoreQueryTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Dashboard/GetSpendingByStoreQueryTests.cs
@@ -1,0 +1,13 @@
+using Application.Queries.Aggregates.Dashboard;
+
+namespace Application.Tests.Queries.Aggregates.Dashboard;
+
+public class GetSpendingByStoreQueryTests : IQueryTests
+{
+	[Fact]
+	public void Query_CanBeCreated()
+	{
+		GetSpendingByStoreQuery query = new(DateOnly.FromDateTime(DateTime.Today.AddDays(-30)), DateOnly.FromDateTime(DateTime.Today));
+		Assert.NotNull(query);
+	}
+}

--- a/tests/Infrastructure.Tests/Services/DashboardServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/DashboardServiceTests.cs
@@ -290,4 +290,113 @@ public class DashboardServiceTests
 
 		contextFactory.ResetDatabase();
 	}
+
+	[Fact]
+	public async Task GetSpendingByStoreAsync_GroupsByLocation_ReturnsCorrectResults()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId1 = Guid.NewGuid();
+		Guid receiptId2 = Guid.NewGuid();
+		Guid receiptId3 = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Receipts.AddRange(
+				new ReceiptEntity { Id = receiptId1, Location = "Walmart", Date = new DateOnly(2025, 3, 1), TaxAmount = 0 },
+				new ReceiptEntity { Id = receiptId2, Location = "Walmart", Date = new DateOnly(2025, 3, 15), TaxAmount = 0 },
+				new ReceiptEntity { Id = receiptId3, Location = "Target", Date = new DateOnly(2025, 3, 10), TaxAmount = 0 });
+
+			context.Transactions.AddRange(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId1, AccountId = accountId, Amount = 50.00m, Date = new DateOnly(2025, 3, 1) },
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId2, AccountId = accountId, Amount = 75.00m, Date = new DateOnly(2025, 3, 15) },
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId3, AccountId = accountId, Amount = 100.00m, Date = new DateOnly(2025, 3, 10) });
+
+			await context.SaveChangesAsync();
+		}
+
+		DashboardService service = new(contextFactory);
+
+		// Act
+		SpendingByStoreResult result = await service.GetSpendingByStoreAsync(
+			new DateOnly(2025, 3, 1),
+			new DateOnly(2025, 3, 31),
+			CancellationToken.None);
+
+		// Assert
+		result.Items.Should().HaveCount(2);
+		result.Items[0].Location.Should().Be("Walmart");
+		result.Items[0].VisitCount.Should().Be(2);
+		result.Items[0].TotalAmount.Should().Be(125.00m);
+		result.Items[0].AveragePerVisit.Should().Be(62.50m);
+		result.Items[1].Location.Should().Be("Target");
+		result.Items[1].VisitCount.Should().Be(1);
+		result.Items[1].TotalAmount.Should().Be(100.00m);
+		result.Items[1].AveragePerVisit.Should().Be(100.00m);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByStoreAsync_EmptyRange_ReturnsEmptyItems()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		DashboardService service = new(contextFactory);
+
+		// Act
+		SpendingByStoreResult result = await service.GetSpendingByStoreAsync(
+			new DateOnly(2025, 1, 1),
+			new DateOnly(2025, 1, 31),
+			CancellationToken.None);
+
+		// Assert
+		result.Items.Should().BeEmpty();
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByStoreAsync_OrdersByTotalAmountDescending()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId1 = Guid.NewGuid();
+		Guid receiptId2 = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Receipts.AddRange(
+				new ReceiptEntity { Id = receiptId1, Location = "Small Store", Date = new DateOnly(2025, 3, 1), TaxAmount = 0 },
+				new ReceiptEntity { Id = receiptId2, Location = "Big Store", Date = new DateOnly(2025, 3, 10), TaxAmount = 0 });
+
+			context.Transactions.AddRange(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId1, AccountId = accountId, Amount = 10.00m, Date = new DateOnly(2025, 3, 1) },
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId2, AccountId = accountId, Amount = 500.00m, Date = new DateOnly(2025, 3, 10) });
+
+			await context.SaveChangesAsync();
+		}
+
+		DashboardService service = new(contextFactory);
+
+		// Act
+		SpendingByStoreResult result = await service.GetSpendingByStoreAsync(
+			new DateOnly(2025, 3, 1),
+			new DateOnly(2025, 3, 31),
+			CancellationToken.None);
+
+		// Assert
+		result.Items.Should().HaveCount(2);
+		result.Items[0].Location.Should().Be("Big Store");
+		result.Items[0].TotalAmount.Should().Be(500.00m);
+		result.Items[1].Location.Should().Be("Small Store");
+		result.Items[1].TotalAmount.Should().Be(10.00m);
+
+		contextFactory.ResetDatabase();
+	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/DashboardControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/DashboardControllerTests.cs
@@ -556,4 +556,101 @@ public class DashboardControllerTests
 	}
 
 	#endregion
+
+	#region GetSpendingByStore
+
+	[Fact]
+	public async Task GetSpendingByStore_ReturnsOkResult_WithValidDates()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+		SpendingByStoreResult storeResult = new(
+		[
+			new SpendingByStoreItemResult("Walmart", 5, 250m, 50m),
+			new SpendingByStoreItemResult("Target", 3, 150m, 50m),
+		]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByStoreQuery>(q => q.StartDate == start && q.EndDate == end),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(storeResult);
+
+		// Act
+		Results<Ok<SpendingByStoreResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByStore(start, end, CancellationToken.None);
+
+		// Assert
+		Ok<SpendingByStoreResponse> okResult = Assert.IsType<Ok<SpendingByStoreResponse>>(result.Result);
+		SpendingByStoreResponse response = okResult.Value!;
+		response.Items.Should().HaveCount(2);
+		response.Items.First().Location.Should().Be("Walmart");
+		response.Items.First().VisitCount.Should().Be(5);
+		response.Items.First().TotalAmount.Should().Be(250);
+		response.Items.First().AveragePerVisit.Should().Be(50);
+	}
+
+	[Fact]
+	public async Task GetSpendingByStore_ReturnsBadRequest_WhenInvalidDates()
+	{
+		// Arrange
+		DateOnly start = new(2024, 2, 1);
+		DateOnly end = new(2024, 1, 1);
+
+		// Act
+		Results<Ok<SpendingByStoreResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByStore(start, end, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("startDate must be before or equal to endDate");
+	}
+
+	[Fact]
+	public async Task GetSpendingByStore_UsesDefaultDates_WhenNullDatesProvided()
+	{
+		// Arrange
+		DateOnly today = DateOnly.FromDateTime(DateTime.Today);
+		DateOnly expectedStart = today.AddDays(-30);
+
+		SpendingByStoreResult storeResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingByStoreQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(storeResult);
+
+		// Act
+		Results<Ok<SpendingByStoreResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByStore(null, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingByStoreResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetSpendingByStoreQuery>(q =>
+				q.StartDate == expectedStart
+				&& q.EndDate == today),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetSpendingByStore_ThrowsException_WhenMediatorFails()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 1, 31);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingByStoreQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		// Act
+		Func<Task> act = () => _controller.GetSpendingByStore(start, end, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	#endregion
 }


### PR DESCRIPTION
## Summary
- Add unified date range selector (1M, 3M, 12M, 5Y, MTD, QTD, YTD, All, year dropdown) that governs all dashboard widgets
- Add new `GET /api/dashboard/spending-by-store` endpoint with CQRS query, service, and OpenAPI spec
- Create `SpendingByStoreWidget` with horizontal bar chart and summary table (location, visits, total, avg/visit)
- Replace `RecentReceiptsWidget` with `SpendingByStoreWidget` in dashboard layout
- Update `SpendingOverTimeWidget`: auto-granularity based on date range, trendline defaults ON, window size dropdown (3/6/12)

Closes RECEIPTS-439

## Test plan
- [x] Backend unit tests: controller (4 new), service (3 new), query handler (2 new), query (1 new)
- [x] Frontend component tests: DateRangeSelector (6), SpendingOverTimeWidget (11), SpendingByStoreWidget (6), Dashboard (4)
- [x] All 1394 backend tests pass
- [x] All 1443 client tests pass
- [x] OpenAPI spec lint passes, no drift detected
- [x] Pre-commit hooks pass (formatting, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)