### PR TITLE
feat(api): implement spending by location report

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -2748,6 +2748,77 @@ paths:
               schema:
                 type: string
 
+  /api/reports/spending-by-location:
+    get:
+      operationId: GetSpendingByLocationReport
+      tags: [Reports]
+      summary: Get spending by location report
+      description: Returns spending aggregated by store location with visit count, total, and average per visit.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Start date (ISO date string). Defaults to all time when omitted.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: End date (ISO date string). Defaults to all time when omitted.
+        - name: sortBy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [location, visits, total, averagePerVisit]
+            default: total
+          description: Column to sort by.
+        - name: sortDirection
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort direction.
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-based).
+        - name: pageSize
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          description: Number of items per page.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpendingByLocationResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
   # ──────────────────────────────────────────────
   # Dashboard
   # ──────────────────────────────────────────────
@@ -3023,6 +3094,37 @@ components:
           type: number
           format: double
         difference:
+          type: number
+          format: double
+
+    SpendingByLocationResponse:
+      type: object
+      required: [totalCount, grandTotal, items]
+      properties:
+        totalCount:
+          type: integer
+          format: int32
+        grandTotal:
+          type: number
+          format: double
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SpendingByLocationItem"
+
+    SpendingByLocationItem:
+      type: object
+      required: [location, visits, total, averagePerVisit]
+      properties:
+        location:
+          type: string
+        visits:
+          type: integer
+          format: int32
+        total:
+          type: number
+          format: double
+        averagePerVisit:
           type: number
           format: double
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-a82f3894",
+  "name": "agent-ad08735e",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/Application/Interfaces/Services/IReportService.cs
+++ b/src/Application/Interfaces/Services/IReportService.cs
@@ -10,4 +10,13 @@ public interface IReportService
 		int page,
 		int pageSize,
 		CancellationToken cancellationToken);
+
+	Task<SpendingByLocationResult> GetSpendingByLocationAsync(
+		DateOnly? startDate,
+		DateOnly? endDate,
+		string sortBy,
+		string sortDirection,
+		int page,
+		int pageSize,
+		CancellationToken cancellationToken);
 }

--- a/src/Application/Models/Reports/SpendingByLocationResult.cs
+++ b/src/Application/Models/Reports/SpendingByLocationResult.cs
@@ -1,0 +1,12 @@
+namespace Application.Models.Reports;
+
+public record SpendingByLocationItem(
+	string Location,
+	int Visits,
+	decimal Total,
+	decimal AveragePerVisit);
+
+public record SpendingByLocationResult(
+	List<SpendingByLocationItem> Items,
+	int TotalCount,
+	decimal GrandTotal);

--- a/src/Application/Queries/Aggregates/Reports/GetSpendingByLocationReportQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetSpendingByLocationReportQuery.cs
@@ -1,0 +1,12 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetSpendingByLocationReportQuery(
+	DateOnly? StartDate,
+	DateOnly? EndDate,
+	string SortBy,
+	string SortDirection,
+	int Page,
+	int PageSize) : IQuery<SpendingByLocationResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetSpendingByLocationReportQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetSpendingByLocationReportQueryHandler.cs
@@ -1,0 +1,21 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetSpendingByLocationReportQueryHandler(IReportService reportService)
+	: IRequestHandler<GetSpendingByLocationReportQuery, SpendingByLocationResult>
+{
+	public async Task<SpendingByLocationResult> Handle(GetSpendingByLocationReportQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetSpendingByLocationAsync(
+			request.StartDate,
+			request.EndDate,
+			request.SortBy,
+			request.SortDirection,
+			request.Page,
+			request.PageSize,
+			cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -76,4 +76,69 @@ public class ReportService(IDbContextFactory<ApplicationDbContext> contextFactor
 
 		return new OutOfBalanceResult(pagedItems, totalCount, totalDiscrepancy);
 	}
+
+	public async Task<SpendingByLocationResult> GetSpendingByLocationAsync(
+		DateOnly? startDate,
+		DateOnly? endDate,
+		string sortBy,
+		string sortDirection,
+		int page,
+		int pageSize,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		var receiptsQuery = context.Receipts.AsNoTracking()
+			.Where(r => r.DeletedAt == null);
+
+		if (startDate.HasValue)
+		{
+			receiptsQuery = receiptsQuery.Where(r => r.Date >= startDate.Value);
+		}
+
+		if (endDate.HasValue)
+		{
+			receiptsQuery = receiptsQuery.Where(r => r.Date <= endDate.Value);
+		}
+
+		var baseQuery = from r in receiptsQuery
+						let transactionTotal = context.Transactions
+							.Where(t => t.ReceiptId == r.Id && t.DeletedAt == null)
+							.Sum(t => (decimal?)t.Amount) ?? 0m
+						group new { TransactionTotal = transactionTotal } by (r.Location ?? "") into g
+						select new
+						{
+							Location = g.Key == "" ? "(No Location)" : g.Key,
+							Visits = g.Count(),
+							Total = g.Sum(x => x.TransactionTotal),
+						};
+
+		var allItems = await baseQuery.ToListAsync(cancellationToken);
+		int totalCount = allItems.Count;
+		decimal grandTotal = allItems.Sum(x => x.Total);
+
+		var sorted = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
+		{
+			("location", "asc") => allItems.OrderBy(x => x.Location).AsEnumerable(),
+			("location", "desc") => allItems.OrderByDescending(x => x.Location).AsEnumerable(),
+			("visits", "asc") => allItems.OrderBy(x => x.Visits).AsEnumerable(),
+			("visits", "desc") => allItems.OrderByDescending(x => x.Visits).AsEnumerable(),
+			("averagepervisit", "asc") => allItems.OrderBy(x => x.Visits > 0 ? x.Total / x.Visits : 0).AsEnumerable(),
+			("averagepervisit", "desc") => allItems.OrderByDescending(x => x.Visits > 0 ? x.Total / x.Visits : 0).AsEnumerable(),
+			("total", "asc") => allItems.OrderBy(x => x.Total).AsEnumerable(),
+			_ => allItems.OrderByDescending(x => x.Total).AsEnumerable(), // default: total desc
+		};
+
+		List<SpendingByLocationItem> pagedItems = sorted
+			.Skip((page - 1) * pageSize)
+			.Take(pageSize)
+			.Select(x => new SpendingByLocationItem(
+				x.Location,
+				x.Visits,
+				x.Total,
+				x.Visits > 0 ? Math.Round(x.Total / x.Visits, 2) : 0m))
+			.ToList();
+
+		return new SpendingByLocationResult(pagedItems, totalCount, grandTotal);
+	}
 }

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -74,4 +74,65 @@ public class ReportsController(IMediator mediator) : ControllerBase
 			}).ToList()
 		});
 	}
+
+	[HttpGet("spending-by-location")]
+	[EndpointSummary("Get spending by location report")]
+	[EndpointDescription("Returns spending aggregated by store location with visit count, total, and average per visit.")]
+	public async Task<Results<Ok<SpendingByLocationResponse>, BadRequest<string>>> GetSpendingByLocation(
+		[FromQuery] DateOnly? startDate,
+		[FromQuery] DateOnly? endDate,
+		[FromQuery] string? sortBy,
+		[FromQuery] string? sortDirection,
+		[FromQuery] int? page,
+		[FromQuery] int? pageSize,
+		CancellationToken cancellationToken)
+	{
+		string sort = sortBy ?? "total";
+		string direction = sortDirection ?? "desc";
+		int pg = page ?? 1;
+		int ps = pageSize ?? 50;
+
+		string[] validSortColumns = ["location", "visits", "total", "averagepervisit"];
+		if (!validSortColumns.Contains(sort.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid sortBy '{sort}'. Allowed: location, visits, total, averagePerVisit");
+		}
+
+		string[] validDirections = ["asc", "desc"];
+		if (!validDirections.Contains(direction.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid sortDirection '{direction}'. Allowed: asc, desc");
+		}
+
+		if (pg < 1)
+		{
+			return TypedResults.BadRequest("page must be at least 1");
+		}
+
+		if (ps < 1 || ps > 100)
+		{
+			return TypedResults.BadRequest("pageSize must be between 1 and 100");
+		}
+
+		if (startDate.HasValue && endDate.HasValue && startDate > endDate)
+		{
+			return TypedResults.BadRequest("startDate must be before or equal to endDate");
+		}
+
+		GetSpendingByLocationReportQuery query = new(startDate, endDate, sort, direction, pg, ps);
+		AppReports.SpendingByLocationResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new SpendingByLocationResponse
+		{
+			TotalCount = result.TotalCount,
+			GrandTotal = (double)result.GrandTotal,
+			Items = result.Items.Select(i => new SpendingByLocationItem
+			{
+				Location = i.Location,
+				Visits = i.Visits,
+				Total = (double)i.Total,
+				AveragePerVisit = (double)i.AveragePerVisit
+			}).ToList()
+		});
+	}
 }

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.26",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.26",
+      "version": "0.1.28",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",

--- a/src/client/src/components/reports/SpendingByLocation.test.tsx
+++ b/src/client/src/components/reports/SpendingByLocation.test.tsx
@@ -1,0 +1,265 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "@/test/test-utils";
+import SpendingByLocation from "./SpendingByLocation";
+
+vi.mock("@/hooks/useSpendingByLocationReport", () => ({
+  useSpendingByLocationReport: vi.fn(),
+}));
+
+vi.mock("@/components/dashboard/DateRangeSelector", () => ({
+  DateRangeSelector: ({
+    onChange,
+  }: {
+    value: { startDate?: string; endDate?: string };
+    onChange: (range: { startDate?: string; endDate?: string }) => void;
+  }) => (
+    <button
+      data-testid="date-range-selector"
+      onClick={() =>
+        onChange({ startDate: "2025-01-01", endDate: "2025-12-31" })
+      }
+    >
+      DateRangeSelector
+    </button>
+  ),
+}));
+
+vi.mock("@/components/charts", () => ({
+  ChartCard: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="chart-card">
+      <h3>{title}</h3>
+      {children}
+    </div>
+  ),
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+import { useSpendingByLocationReport } from "@/hooks/useSpendingByLocationReport";
+const mockHook = vi.mocked(useSpendingByLocationReport);
+
+const mockItems = [
+  {
+    location: "Store A",
+    visits: 5,
+    total: 100.5,
+    averagePerVisit: 20.1,
+  },
+  {
+    location: "Store B",
+    visits: 3,
+    total: 60.0,
+    averagePerVisit: 20.0,
+  },
+];
+
+function setupMock(overrides: Record<string, unknown> = {}) {
+  mockHook.mockReturnValue({
+    data: {
+      totalCount: 2,
+      grandTotal: 160.5,
+      items: mockItems,
+    },
+    isLoading: false,
+    isError: false,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+describe("SpendingByLocation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton", () => {
+    setupMock({ isLoading: true, data: undefined });
+    renderWithQueryClient(<SpendingByLocation />);
+    const skeletons = document.querySelectorAll("[data-slot='skeleton']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state", () => {
+    setupMock({ isError: true, data: undefined });
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(
+      screen.getByText(/failed to load spending by location report/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no data", () => {
+    setupMock({
+      data: { totalCount: 0, grandTotal: 0, items: [] },
+    });
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(screen.getByText("No Data")).toBeInTheDocument();
+    expect(
+      screen.getByText(/no spending data found/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when data is null", () => {
+    setupMock({ data: undefined });
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(screen.getByText("No Data")).toBeInTheDocument();
+  });
+
+  it("renders summary header with count and total", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("$160.50")).toBeInTheDocument();
+  });
+
+  it("renders bar chart", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+    expect(
+      screen.getByText("Top Locations by Spending"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders table with all items", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(screen.getByText("Store A")).toBeInTheDocument();
+    expect(screen.getByText("Store B")).toBeInTheDocument();
+  });
+
+  it("renders table headers", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/Location/)).toBeInTheDocument();
+    expect(within(table).getByText(/Visits/)).toBeInTheDocument();
+    expect(within(table).getByText(/Total/)).toBeInTheDocument();
+    expect(within(table).getByText(/Avg\/Visit/)).toBeInTheDocument();
+  });
+
+  it("toggles sort direction on clicking sortable column", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+
+    // Initially sorted by total desc — find it within the table
+    const table = screen.getByRole("table");
+    const totalHeader = within(table)
+      .getByText(/^Total/)
+      .closest("th")!;
+    await user.click(totalHeader);
+
+    // Should have called hook with total asc (toggled from desc)
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sortBy: "total", sortDirection: "asc" }),
+    );
+  });
+
+  it("switches sort column when clicking a different column", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+
+    const visitsHeader = screen
+      .getByText(/Visits/)
+      .closest("th")!;
+    await user.click(visitsHeader);
+
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sortBy: "visits",
+        sortDirection: "desc",
+      }),
+    );
+  });
+
+  it("sorts location column ascending by default", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+
+    const table = screen.getByRole("table");
+    const locationHeader = within(table)
+      .getByText(/^Location$/)
+      .closest("th")!;
+    await user.click(locationHeader);
+
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sortBy: "location",
+        sortDirection: "asc",
+      }),
+    );
+  });
+
+  it("does not show pagination when only one page", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(screen.queryByText(/Page/)).not.toBeInTheDocument();
+  });
+
+  it("shows pagination when multiple pages", () => {
+    const manyItems = Array.from({ length: 51 }, (_, i) => ({
+      location: `Store ${i}`,
+      visits: 1,
+      total: 10,
+      averagePerVisit: 10,
+    }));
+    setupMock({
+      data: { totalCount: 51, grandTotal: 510, items: manyItems },
+    });
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Next" }),
+    ).not.toBeDisabled();
+  });
+
+  it("formats currency values correctly", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(screen.getByText("Store A").closest("tr")).toHaveTextContent(
+      "$100.50",
+    );
+  });
+
+  it("renders date range selector", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByLocation />);
+    expect(screen.getByTestId("date-range-selector")).toBeInTheDocument();
+  });
+
+  it("resets page on date range change", async () => {
+    const user = userEvent.setup();
+    const manyItems = Array.from({ length: 51 }, (_, i) => ({
+      location: `Store ${i}`,
+      visits: 1,
+      total: 10,
+      averagePerVisit: 10,
+    }));
+    setupMock({
+      data: { totalCount: 51, grandTotal: 510, items: manyItems },
+    });
+    renderWithQueryClient(<SpendingByLocation />);
+
+    // Go to page 2
+    const nextBtn = screen.getByRole("button", { name: "Next" });
+    await user.click(nextBtn);
+
+    // Change date range
+    const dateSelector = screen.getByTestId("date-range-selector");
+    await user.click(dateSelector);
+
+    // Should reset to page 1
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 1 }),
+    );
+  });
+});

--- a/src/client/src/components/reports/SpendingByLocation.tsx
+++ b/src/client/src/components/reports/SpendingByLocation.tsx
@@ -1,8 +1,226 @@
+import { useState, useCallback, useMemo } from "react";
+import { format, subMonths } from "date-fns";
+import {
+  useSpendingByLocationReport,
+  type SpendingByLocationParams,
+} from "@/hooks/useSpendingByLocationReport";
+import { formatCurrency } from "@/lib/format";
+import { ChartCard, BarChart } from "@/components/charts";
+import { DateRangeSelector } from "@/components/dashboard/DateRangeSelector";
+import type { DateRange } from "@/hooks/useDashboard";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+type SortColumn = "location" | "visits" | "total" | "averagePerVisit";
+type SortDirection = "asc" | "desc";
+
+function getDefaultRange(): DateRange {
+  const now = new Date();
+  return {
+    startDate: format(subMonths(now, 1), "yyyy-MM-dd"),
+    endDate: format(now, "yyyy-MM-dd"),
+  };
+}
+
 export default function SpendingByLocation() {
+  const [dateRange, setDateRange] = useState<DateRange>(getDefaultRange);
+  const [sortBy, setSortBy] = useState<SortColumn>("total");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [page, setPage] = useState(1);
+  const pageSize = 50;
+
+  const params: SpendingByLocationParams = {
+    startDate: dateRange.startDate,
+    endDate: dateRange.endDate,
+    sortBy,
+    sortDirection,
+    page,
+    pageSize,
+  };
+
+  const { data, isLoading, isError } = useSpendingByLocationReport(params);
+
+  const handleDateRangeChange = useCallback((range: DateRange) => {
+    setDateRange(range);
+    setPage(1);
+  }, []);
+
+  function handleSort(column: SortColumn) {
+    if (sortBy === column) {
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(column);
+      setSortDirection(column === "location" ? "asc" : "desc");
+    }
+    setPage(1);
+  }
+
+  function sortIndicator(column: SortColumn) {
+    if (sortBy !== column) return null;
+    return sortDirection === "asc" ? " \u2191" : " \u2193";
+  }
+
+  const chartData = useMemo(
+    () =>
+      (data?.items ?? []).slice(0, 10).map((item) => ({
+        name: item.location,
+        value: Number(item.total ?? 0),
+      })),
+    [data?.items],
+  );
+
+  const totalPages = data ? Math.ceil(data.totalCount / pageSize) : 0;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-full rounded-lg" />
+        <Skeleton className="h-20 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">
+          Failed to load spending by location report.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data || data.totalCount === 0) {
+    return (
+      <div className="space-y-4">
+        <div className="flex justify-end">
+          <DateRangeSelector
+            value={dateRange}
+            onChange={handleDateRangeChange}
+          />
+        </div>
+        <div className="rounded-lg border p-6 text-center">
+          <h2 className="text-lg font-semibold">No Data</h2>
+          <p className="mt-2 text-muted-foreground">
+            No spending data found for the selected date range.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-lg border p-6 text-center">
-      <h2 className="text-lg font-semibold">Spending by Location</h2>
-      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex gap-6">
+          <div>
+            <p className="text-sm text-muted-foreground">Locations</p>
+            <p className="text-2xl font-bold">{data.totalCount}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Total Spending</p>
+            <p className="text-2xl font-bold">
+              {formatCurrency(data.grandTotal)}
+            </p>
+          </div>
+        </div>
+        <DateRangeSelector
+          value={dateRange}
+          onChange={handleDateRangeChange}
+        />
+      </div>
+
+      <ChartCard
+        title="Top Locations by Spending"
+        empty={chartData.length === 0}
+      >
+        <BarChart
+          data={chartData}
+          layout="horizontal"
+          height={Math.max(200, chartData.length * 40)}
+          formatValue={formatCurrency}
+        />
+      </ChartCard>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead
+              className="cursor-pointer select-none"
+              onClick={() => handleSort("location")}
+            >
+              Location{sortIndicator("location")}
+            </TableHead>
+            <TableHead
+              className="cursor-pointer select-none text-right"
+              onClick={() => handleSort("visits")}
+            >
+              Visits{sortIndicator("visits")}
+            </TableHead>
+            <TableHead
+              className="cursor-pointer select-none text-right"
+              onClick={() => handleSort("total")}
+            >
+              Total{sortIndicator("total")}
+            </TableHead>
+            <TableHead
+              className="cursor-pointer select-none text-right"
+              onClick={() => handleSort("averagePerVisit")}
+            >
+              Avg/Visit{sortIndicator("averagePerVisit")}
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.items.map((item) => (
+            <TableRow key={item.location}>
+              <TableCell>{item.location}</TableCell>
+              <TableCell className="text-right">{item.visits}</TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(item.total)}
+              </TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(item.averagePerVisit)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/client/src/hooks/useSpendingByLocationReport.test.ts
+++ b/src/client/src/hooks/useSpendingByLocationReport.test.ts
@@ -1,0 +1,118 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import { useSpendingByLocationReport } from "./useSpendingByLocationReport";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useSpendingByLocationReport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches report data with default parameters", async () => {
+    const mockData = {
+      totalCount: 2,
+      grandTotal: 150.5,
+      items: [
+        {
+          location: "Store A",
+          visits: 5,
+          total: 100.5,
+          averagePerVisit: 20.1,
+        },
+      ],
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSpendingByLocationReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/spending-by-location",
+      {
+        params: {
+          query: {
+            startDate: undefined,
+            endDate: undefined,
+            sortBy: undefined,
+            sortDirection: undefined,
+            page: undefined,
+            pageSize: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("passes custom parameters", async () => {
+    const mockData = { totalCount: 0, grandTotal: 0, items: [] };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useSpendingByLocationReport({
+          startDate: "2025-01-01",
+          endDate: "2025-12-31",
+          sortBy: "visits",
+          sortDirection: "asc",
+          page: 2,
+          pageSize: 25,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/spending-by-location",
+      {
+        params: {
+          query: {
+            startDate: "2025-01-01",
+            endDate: "2025-12-31",
+            sortBy: "visits",
+            sortDirection: "asc",
+            page: 2,
+            pageSize: 25,
+          },
+        },
+      },
+    );
+  });
+
+  it("throws when API returns an error", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSpendingByLocationReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/src/client/src/hooks/useSpendingByLocationReport.ts
+++ b/src/client/src/hooks/useSpendingByLocationReport.ts
@@ -1,0 +1,48 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export interface SpendingByLocationParams {
+  startDate?: string;
+  endDate?: string;
+  sortBy?: "location" | "visits" | "total" | "averagePerVisit";
+  sortDirection?: "asc" | "desc";
+  page?: number;
+  pageSize?: number;
+}
+
+export function useSpendingByLocationReport(
+  params: SpendingByLocationParams = {},
+) {
+  return useQuery({
+    queryKey: [
+      "reports",
+      "spending-by-location",
+      params.startDate,
+      params.endDate,
+      params.sortBy,
+      params.sortDirection,
+      params.page,
+      params.pageSize,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/reports/spending-by-location",
+        {
+          params: {
+            query: {
+              startDate: params.startDate,
+              endDate: params.endDate,
+              sortBy: params.sortBy,
+              sortDirection: params.sortDirection,
+              page: params.page,
+              pageSize: params.pageSize,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/tests/Application.Tests/Queries/Aggregates/Reports/GetSpendingByLocationReportQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Reports/GetSpendingByLocationReportQueryHandlerTests.cs
@@ -1,0 +1,89 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Reports;
+
+public class GetSpendingByLocationReportQueryHandlerTests
+{
+	private readonly Mock<IReportService> _reportServiceMock;
+	private readonly GetSpendingByLocationReportQueryHandler _handler;
+
+	public GetSpendingByLocationReportQueryHandlerTests()
+	{
+		_reportServiceMock = new Mock<IReportService>();
+		_handler = new GetSpendingByLocationReportQueryHandler(_reportServiceMock.Object);
+	}
+
+	[Fact]
+	public async Task Handle_DelegatesToReportService()
+	{
+		// Arrange
+		GetSpendingByLocationReportQuery query = new(null, null, "total", "desc", 1, 50);
+		SpendingByLocationResult expectedResult = new([], 0, 0m);
+
+		_reportServiceMock.Setup(s => s.GetSpendingByLocationAsync(
+			null, null, "total", "desc", 1, 50, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		SpendingByLocationResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+		_reportServiceMock.Verify(s => s.GetSpendingByLocationAsync(
+			null, null, "total", "desc", 1, 50, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PassesAllParametersToService()
+	{
+		// Arrange
+		DateOnly start = new(2025, 1, 1);
+		DateOnly end = new(2025, 12, 31);
+		GetSpendingByLocationReportQuery query = new(start, end, "visits", "asc", 3, 25);
+		SpendingByLocationResult expectedResult = new([], 0, 0m);
+
+		_reportServiceMock.Setup(s => s.GetSpendingByLocationAsync(
+			start, end, "visits", "asc", 3, 25, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		_reportServiceMock.Verify(s => s.GetSpendingByLocationAsync(
+			start, end, "visits", "asc", 3, 25, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsServiceResult()
+	{
+		// Arrange
+		GetSpendingByLocationReportQuery query = new(null, null, "total", "desc", 1, 50);
+		SpendingByLocationResult expectedResult = new(
+		[
+			new SpendingByLocationItem("Store A", 5, 100.50m, 20.10m),
+		], 1, 100.50m);
+
+		_reportServiceMock.Setup(s => s.GetSpendingByLocationAsync(
+			It.IsAny<DateOnly?>(), It.IsAny<DateOnly?>(),
+			It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		SpendingByLocationResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.TotalCount.Should().Be(1);
+		result.GrandTotal.Should().Be(100.50m);
+		result.Items.Should().ContainSingle();
+		result.Items[0].Location.Should().Be("Store A");
+		result.Items[0].Visits.Should().Be(5);
+		result.Items[0].Total.Should().Be(100.50m);
+		result.Items[0].AveragePerVisit.Should().Be(20.10m);
+	}
+}


### PR DESCRIPTION
## Summary
- Implements the Spending by Location report (RECEIPTS-440), adding a new `GET /api/reports/spending-by-location` endpoint with sorting, pagination, and date filtering
- Adds full React UI with date range selector, horizontal bar chart (top 10 locations), sortable table (Location, Visits, Total, Avg/Visit), and pagination
- Follows the OutOfBalance report pattern across all layers: OpenAPI spec, application models, MediatR query/handler, ReportService, controller, React hook, and React component

## Test plan
- [x] All 1397 .NET unit tests pass (including 3 new handler tests)
- [x] All 1462 frontend tests pass (including 16 new component tests + 3 new hook tests)
- [x] Build succeeds with 0 errors
- [x] OpenAPI spec updated with new endpoint, request params, and response schemas
- [x] SDLC pipeline passed all 6 phases (Plan, Implement, Review, Security, QA, Accept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)