### PR TITLE
feat(api,client): implement Item Cost Over Time report

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -2917,6 +2917,111 @@ paths:
               schema:
                 type: string
 
+  /api/reports/item-descriptions:
+    get:
+      operationId: GetItemDescriptions
+      tags: [Reports]
+      summary: Search item descriptions for autocomplete
+      description: Returns distinct item descriptions with their category and occurrence count, filtered by a search term (minimum 2 characters). Results are sorted by occurrences descending.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: search
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 2
+          description: Search term to filter item descriptions (minimum 2 characters).
+        - name: categoryOnly
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: When true, search and return categories instead of item descriptions.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 20
+          description: Maximum number of results to return.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ItemDescriptionsResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/reports/item-cost-over-time:
+    get:
+      operationId: GetItemCostOverTime
+      tags: [Reports]
+      summary: Get item cost over time
+      description: Returns time-series cost data for a specific item description or category, optionally filtered by date range and bucketed by granularity.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: description
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Item description to filter by. Either description or category is required.
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Item category to filter by. Either description or category is required.
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Start date (ISO date string). Defaults to no lower bound.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: End date (ISO date string). Defaults to no upper bound.
+        - name: granularity
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [exact, monthly, yearly]
+            default: exact
+          description: Time bucket granularity. "exact" returns each purchase date.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ItemCostOverTimeResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
   # ──────────────────────────────────────────────
   # Dashboard
   # ──────────────────────────────────────────────
@@ -3289,6 +3394,46 @@ components:
           type: integer
           format: int32
           description: Number of items updated.
+
+    ItemDescriptionsResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ItemDescriptionItem"
+
+    ItemDescriptionItem:
+      type: object
+      required: [description, category, occurrences]
+      properties:
+        description:
+          type: string
+        category:
+          type: string
+        occurrences:
+          type: integer
+          format: int32
+
+    ItemCostOverTimeResponse:
+      type: object
+      required: [buckets]
+      properties:
+        buckets:
+          type: array
+          items:
+            $ref: "#/components/schemas/ItemCostBucket"
+
+    ItemCostBucket:
+      type: object
+      required: [period, amount]
+      properties:
+        period:
+          type: string
+        amount:
+          type: number
+          format: double
 
     # ── Dashboard ──────────────────────────────────
 

--- a/src/Application/Interfaces/Services/IReportService.cs
+++ b/src/Application/Interfaces/Services/IReportService.cs
@@ -32,4 +32,18 @@ public interface IReportService
 		List<Guid> itemIds,
 		string newDescription,
 		CancellationToken cancellationToken);
+
+	Task<ItemDescriptionResult> GetItemDescriptionsAsync(
+		string search,
+		bool categoryOnly,
+		int limit,
+		CancellationToken cancellationToken);
+
+	Task<ItemCostOverTimeResult> GetItemCostOverTimeAsync(
+		string? description,
+		string? category,
+		DateOnly? startDate,
+		DateOnly? endDate,
+		string granularity,
+		CancellationToken cancellationToken);
 }

--- a/src/Application/Models/Reports/ItemCostOverTimeResult.cs
+++ b/src/Application/Models/Reports/ItemCostOverTimeResult.cs
@@ -1,0 +1,8 @@
+namespace Application.Models.Reports;
+
+public record ItemCostBucket(
+	string Period,
+	decimal Amount);
+
+public record ItemCostOverTimeResult(
+	List<ItemCostBucket> Buckets);

--- a/src/Application/Models/Reports/ItemDescriptionResult.cs
+++ b/src/Application/Models/Reports/ItemDescriptionResult.cs
@@ -1,0 +1,9 @@
+namespace Application.Models.Reports;
+
+public record ItemDescriptionItem(
+	string Description,
+	string Category,
+	int Occurrences);
+
+public record ItemDescriptionResult(
+	List<ItemDescriptionItem> Items);

--- a/src/Application/Queries/Aggregates/Reports/GetItemCostOverTimeQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetItemCostOverTimeQuery.cs
@@ -1,0 +1,11 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetItemCostOverTimeQuery(
+	string? Description,
+	string? Category,
+	DateOnly? StartDate,
+	DateOnly? EndDate,
+	string Granularity) : IQuery<ItemCostOverTimeResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetItemCostOverTimeQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetItemCostOverTimeQueryHandler.cs
@@ -1,0 +1,20 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetItemCostOverTimeQueryHandler(IReportService reportService)
+	: IRequestHandler<GetItemCostOverTimeQuery, ItemCostOverTimeResult>
+{
+	public async Task<ItemCostOverTimeResult> Handle(GetItemCostOverTimeQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetItemCostOverTimeAsync(
+			request.Description,
+			request.Category,
+			request.StartDate,
+			request.EndDate,
+			request.Granularity,
+			cancellationToken);
+	}
+}

--- a/src/Application/Queries/Aggregates/Reports/GetItemDescriptionsQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetItemDescriptionsQuery.cs
@@ -1,0 +1,9 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetItemDescriptionsQuery(
+	string Search,
+	bool CategoryOnly,
+	int Limit) : IQuery<ItemDescriptionResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetItemDescriptionsQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetItemDescriptionsQueryHandler.cs
@@ -1,0 +1,18 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetItemDescriptionsQueryHandler(IReportService reportService)
+	: IRequestHandler<GetItemDescriptionsQuery, ItemDescriptionResult>
+{
+	public async Task<ItemDescriptionResult> Handle(GetItemDescriptionsQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetItemDescriptionsAsync(
+			request.Search,
+			request.CategoryOnly,
+			request.Limit,
+			cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -353,5 +353,124 @@ public class ReportService(IDbContextFactory<ApplicationDbContext> contextFactor
 		return updated;
 	}
 
+	public async Task<ItemDescriptionResult> GetItemDescriptionsAsync(
+		string search,
+		bool categoryOnly,
+		int limit,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		string searchLower = search.ToLower();
+
+		if (categoryOnly)
+		{
+			List<ItemDescriptionItem> categories = await context.ReceiptItems
+				.AsNoTracking()
+				.Where(ri => ri.DeletedAt == null && ri.Category.ToLower().Contains(searchLower))
+				.GroupBy(ri => ri.Category)
+				.Select(g => new ItemDescriptionItem(g.Key, g.Key, g.Count()))
+				.OrderByDescending(x => x.Occurrences)
+				.Take(limit)
+				.ToListAsync(cancellationToken);
+
+			return new ItemDescriptionResult(categories);
+		}
+
+		List<ItemDescriptionItem> items = await context.ReceiptItems
+			.AsNoTracking()
+			.Where(ri => ri.DeletedAt == null && ri.Description.ToLower().Contains(searchLower))
+			.GroupBy(ri => new { ri.Description, ri.Category })
+			.Select(g => new ItemDescriptionItem(g.Key.Description, g.Key.Category, g.Count()))
+			.OrderByDescending(x => x.Occurrences)
+			.Take(limit)
+			.ToListAsync(cancellationToken);
+
+		return new ItemDescriptionResult(items);
+	}
+
+	public async Task<ItemCostOverTimeResult> GetItemCostOverTimeAsync(
+		string? description,
+		string? category,
+		DateOnly? startDate,
+		DateOnly? endDate,
+		string granularity,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		var query = context.ReceiptItems
+			.AsNoTracking()
+			.Where(ri => ri.DeletedAt == null)
+			.Join(
+				context.Receipts.AsNoTracking().Where(r => r.DeletedAt == null),
+				ri => ri.ReceiptId,
+				r => r.Id,
+				(ri, r) => new { ri.Description, ri.Category, ri.TotalAmount, ri.Quantity, ri.UnitPrice, r.Date });
+
+		if (!string.IsNullOrEmpty(description))
+		{
+			string descLower = description.ToLower();
+			query = query.Where(x => x.Description.ToLower() == descLower);
+		}
+		else if (!string.IsNullOrEmpty(category))
+		{
+			string catLower = category.ToLower();
+			query = query.Where(x => x.Category.ToLower() == catLower);
+		}
+
+		if (startDate.HasValue)
+		{
+			query = query.Where(x => x.Date >= startDate.Value);
+		}
+
+		if (endDate.HasValue)
+		{
+			query = query.Where(x => x.Date <= endDate.Value);
+		}
+
+		List<ItemCostBucket> buckets;
+
+		switch (granularity.ToLowerInvariant())
+		{
+			case "monthly":
+				var monthlyData = await query
+					.GroupBy(x => new { x.Date.Year, x.Date.Month })
+					.Select(g => new { g.Key.Year, g.Key.Month, Amount = g.Average(x => x.UnitPrice) })
+					.OrderBy(x => x.Year).ThenBy(x => x.Month)
+					.ToListAsync(cancellationToken);
+
+				buckets = monthlyData
+					.Select(x => new ItemCostBucket($"{x.Year}-{x.Month:D2}", x.Amount))
+					.ToList();
+				break;
+
+			case "yearly":
+				var yearlyData = await query
+					.GroupBy(x => x.Date.Year)
+					.Select(g => new { Year = g.Key, Amount = g.Average(x => x.UnitPrice) })
+					.OrderBy(x => x.Year)
+					.ToListAsync(cancellationToken);
+
+				buckets = yearlyData
+					.Select(x => new ItemCostBucket(x.Year.ToString(), x.Amount))
+					.ToList();
+				break;
+
+			default: // "exact"
+				var exactData = await query
+					.Select(x => new { x.Date, x.UnitPrice })
+					.OrderBy(x => x.Date)
+					.ToListAsync(cancellationToken);
+
+				buckets = exactData
+					.Select(x => new ItemCostBucket(x.Date.ToString("yyyy-MM-dd"), x.UnitPrice))
+					.ToList();
+				break;
+		}
+
+		return new ItemCostOverTimeResult(buckets);
+	}
+
 	private record SimilarityEdge(Guid IdA, string DescA, Guid IdB, string DescB, double Score);
 }

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -223,4 +223,79 @@ public class ReportsController(IMediator mediator) : ControllerBase
 			UpdatedCount = updatedCount
 		});
 	}
+
+	[HttpGet("item-descriptions")]
+	[EndpointSummary("Search item descriptions for autocomplete")]
+	[EndpointDescription("Returns distinct item descriptions with their category and occurrence count, filtered by a search term (minimum 2 characters).")]
+	public async Task<Results<Ok<ItemDescriptionsResponse>, BadRequest<string>>> GetItemDescriptions(
+		[FromQuery] string? search,
+		[FromQuery] bool? categoryOnly,
+		[FromQuery] int? limit,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(search) || search.Length < 2)
+		{
+			return TypedResults.BadRequest("search must be at least 2 characters");
+		}
+
+		int lim = limit ?? 20;
+		if (lim < 1 || lim > 50)
+		{
+			return TypedResults.BadRequest("limit must be between 1 and 50");
+		}
+
+		GetItemDescriptionsQuery query = new(search, categoryOnly ?? false, lim);
+		AppReports.ItemDescriptionResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new ItemDescriptionsResponse
+		{
+			Items = result.Items.Select(i => new ItemDescriptionItem
+			{
+				Description = i.Description,
+				Category = i.Category,
+				Occurrences = i.Occurrences
+			}).ToList()
+		});
+	}
+
+	[HttpGet("item-cost-over-time")]
+	[EndpointSummary("Get item cost over time")]
+	[EndpointDescription("Returns time-series cost data for a specific item description or category.")]
+	public async Task<Results<Ok<ItemCostOverTimeResponse>, BadRequest<string>>> GetItemCostOverTime(
+		[FromQuery] string? description,
+		[FromQuery] string? category,
+		[FromQuery] DateOnly? startDate,
+		[FromQuery] DateOnly? endDate,
+		[FromQuery] string? granularity,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrEmpty(description) && string.IsNullOrEmpty(category))
+		{
+			return TypedResults.BadRequest("Either description or category is required");
+		}
+
+		string gran = granularity ?? "exact";
+		string[] validGranularities = ["exact", "monthly", "yearly"];
+		if (!validGranularities.Contains(gran.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid granularity '{gran}'. Allowed: exact, monthly, yearly");
+		}
+
+		if (startDate.HasValue && endDate.HasValue && startDate.Value > endDate.Value)
+		{
+			return TypedResults.BadRequest("startDate must be before or equal to endDate");
+		}
+
+		GetItemCostOverTimeQuery query = new(description, category, startDate, endDate, gran);
+		AppReports.ItemCostOverTimeResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new ItemCostOverTimeResponse
+		{
+			Buckets = result.Buckets.Select(b => new ItemCostBucket
+			{
+				Period = b.Period,
+				Amount = (double)b.Amount
+			}).ToList()
+		});
+	}
 }

--- a/src/client/src/components/reports/ItemCostOverTime.tsx
+++ b/src/client/src/components/reports/ItemCostOverTime.tsx
@@ -1,8 +1,317 @@
+import { useState, useCallback, useMemo } from "react";
+import { ChartCard, AreaTimeChart } from "@/components/charts";
+import {
+  useItemDescriptions,
+  useItemCostOverTime,
+} from "@/hooks/useItemCostOverTime";
+import type { DateRange } from "@/hooks/useDashboard";
+import { DateRangeSelector } from "@/components/dashboard/DateRangeSelector";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { computeRollingAverage } from "@/lib/rolling-average";
+import { ChevronsUpDown } from "lucide-react";
+
+type Granularity = "exact" | "monthly" | "yearly";
+type WindowSize = "3" | "6" | "12";
+
+const granularityOptions: { value: Granularity; label: string }[] = [
+  { value: "exact", label: "Each purchase" },
+  { value: "monthly", label: "Monthly" },
+  { value: "yearly", label: "Yearly" },
+];
+
+const windowSizeOptions: { value: WindowSize; label: string }[] = [
+  { value: "3", label: "3-period" },
+  { value: "6", label: "6-period" },
+  { value: "12", label: "12-period" },
+];
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+interface SelectedItem {
+  description: string;
+  category: string;
+}
+
 export default function ItemCostOverTime() {
+  const [open, setOpen] = useState(false);
+  const [searchInput, setSearchInput] = useState("");
+  const [categoryOnly, setCategoryOnly] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<SelectedItem | null>(null);
+  const [dateRange, setDateRange] = useState<DateRange>({
+    startDate: undefined,
+    endDate: undefined,
+  });
+  const [granularity, setGranularity] = useState<Granularity>("exact");
+  const [showTrendline, setShowTrendline] = useState(false);
+  const [windowSize, setWindowSize] = useState<WindowSize>("3");
+
+  const debouncedSearch = useDebouncedValue(searchInput, 300);
+
+  const { data: descriptionsData, isLoading: isSearching } =
+    useItemDescriptions({
+      search: debouncedSearch,
+      categoryOnly,
+    });
+
+  const costParams = useMemo(
+    () => ({
+      description: categoryOnly ? undefined : selectedItem?.description,
+      category: categoryOnly
+        ? selectedItem?.category
+        : undefined,
+      startDate: dateRange.startDate,
+      endDate: dateRange.endDate,
+      granularity,
+    }),
+    [categoryOnly, selectedItem, dateRange, granularity],
+  );
+
+  const { data: costData, isLoading: isCostLoading } =
+    useItemCostOverTime(costParams);
+
+  const chartData = useMemo(
+    () =>
+      (costData?.buckets ?? []).map((b) => ({
+        period: b.period,
+        amount: Number(b.amount ?? 0),
+      })),
+    [costData?.buckets],
+  );
+
+  const trendlineData = useMemo(
+    () =>
+      showTrendline
+        ? computeRollingAverage(chartData, Number(windowSize))
+        : undefined,
+    [showTrendline, chartData, windowSize],
+  );
+
+  const handleSelect = useCallback(
+    (description: string, category: string) => {
+      setSelectedItem({ description, category });
+      setOpen(false);
+      setSearchInput("");
+    },
+    [],
+  );
+
+  const handleCategoryToggle = useCallback(() => {
+    setCategoryOnly((prev) => !prev);
+    setSelectedItem(null);
+    setSearchInput("");
+  }, []);
+
+  const handleGranularity = useCallback((g: Granularity) => {
+    setGranularity(g);
+  }, []);
+
+  const handleToggleTrendline = useCallback(() => {
+    setShowTrendline((prev) => !prev);
+  }, []);
+
+  const handleWindowSizeChange = useCallback((value: string) => {
+    setWindowSize(value as WindowSize);
+  }, []);
+
+  const handleDateRangeChange = useCallback((range: DateRange) => {
+    setDateRange(range);
+  }, []);
+
+  const displayLabel = selectedItem
+    ? categoryOnly
+      ? selectedItem.category
+      : selectedItem.description
+    : categoryOnly
+      ? "Search categories..."
+      : "Search items...";
+
   return (
-    <div className="rounded-lg border p-6 text-center">
-      <h2 className="text-lg font-semibold">Item Cost Over Time</h2>
-      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2">
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                role="combobox"
+                aria-expanded={open}
+                className="w-[300px] justify-between"
+              >
+                <span className="truncate">{displayLabel}</span>
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[300px] p-0">
+              <Command shouldFilter={false}>
+                <CommandInput
+                  placeholder={
+                    categoryOnly
+                      ? "Type to search categories..."
+                      : "Type to search items..."
+                  }
+                  value={searchInput}
+                  onValueChange={setSearchInput}
+                />
+                <CommandList>
+                  {debouncedSearch.length < 2 ? (
+                    <CommandEmpty>Type at least 2 characters</CommandEmpty>
+                  ) : isSearching ? (
+                    <CommandEmpty>Searching...</CommandEmpty>
+                  ) : !descriptionsData?.items?.length ? (
+                    <CommandEmpty>No results found</CommandEmpty>
+                  ) : (
+                    <CommandGroup>
+                      {descriptionsData.items.map((item) => (
+                        <CommandItem
+                          key={`${item.description}-${item.category}`}
+                          value={`${item.description}-${item.category}`}
+                          onSelect={() =>
+                            handleSelect(item.description, item.category)
+                          }
+                        >
+                          <div className="flex w-full items-center justify-between">
+                            <div className="flex flex-col">
+                              <span className="text-sm">
+                                {item.description}
+                              </span>
+                              {!categoryOnly && (
+                                <span className="text-xs text-muted-foreground">
+                                  {item.category}
+                                </span>
+                              )}
+                            </div>
+                            <span className="text-xs text-muted-foreground">
+                              {item.occurrences}x
+                            </span>
+                          </div>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+
+          <Button
+            variant={categoryOnly ? "default" : "outline"}
+            size="sm"
+            onClick={handleCategoryToggle}
+            aria-pressed={categoryOnly}
+          >
+            Category
+          </Button>
+        </div>
+
+        <DateRangeSelector value={dateRange} onChange={handleDateRangeChange} />
+      </div>
+
+      {selectedItem && (
+        <ChartCard
+          title={
+            categoryOnly
+              ? `Category: ${selectedItem.category}`
+              : selectedItem.description
+          }
+          subtitle={
+            categoryOnly
+              ? "Average unit price over time"
+              : `${selectedItem.category} — Unit price over time`
+          }
+          loading={isCostLoading}
+          empty={chartData.length === 0 && !isCostLoading}
+          emptyMessage="No purchase history found for the selected item"
+          action={
+            <div className="flex items-center gap-2">
+              <div className="flex gap-1">
+                {granularityOptions.map(({ value, label }) => (
+                  <Button
+                    key={value}
+                    variant={granularity === value ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => handleGranularity(value)}
+                  >
+                    {label}
+                  </Button>
+                ))}
+              </div>
+              <div className="flex items-center gap-1.5">
+                <Button
+                  variant={showTrendline ? "default" : "outline"}
+                  size="sm"
+                  onClick={handleToggleTrendline}
+                  aria-pressed={showTrendline}
+                >
+                  Trendline
+                </Button>
+                {showTrendline && (
+                  <Select
+                    value={windowSize}
+                    onValueChange={handleWindowSizeChange}
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      aria-label="Rolling average window size"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {windowSizeOptions.map(({ value, label }) => (
+                        <SelectItem key={value} value={value}>
+                          {label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+            </div>
+          }
+        >
+          <AreaTimeChart
+            data={chartData}
+            trendlineData={trendlineData}
+            formatValue={formatCurrency}
+          />
+        </ChartCard>
+      )}
+
+      {!selectedItem && (
+        <div className="rounded-lg border p-6 text-center">
+          <h2 className="text-lg font-semibold">Item Cost Over Time</h2>
+          <p className="mt-2 text-muted-foreground">
+            Search for an item above to see its price history
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/client/src/hooks/useItemCostOverTime.test.ts
+++ b/src/client/src/hooks/useItemCostOverTime.test.ts
@@ -1,0 +1,253 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import {
+  useItemDescriptions,
+  useItemCostOverTime,
+} from "./useItemCostOverTime";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useItemDescriptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches descriptions when search is at least 2 characters", async () => {
+    const mockData = {
+      items: [
+        { description: "Milk", category: "Dairy", occurrences: 10 },
+        { description: "Milk Chocolate", category: "Candy", occurrences: 3 },
+      ],
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () => useItemDescriptions({ search: "mi" }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/item-descriptions",
+      {
+        params: {
+          query: {
+            search: "mi",
+            categoryOnly: undefined,
+            limit: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("does not fetch when search is less than 2 characters", () => {
+    renderHook(() => useItemDescriptions({ search: "m" }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(mockClient.GET).not.toHaveBeenCalled();
+  });
+
+  it("passes categoryOnly and limit parameters", async () => {
+    const mockData = { items: [] };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useItemDescriptions({
+          search: "da",
+          categoryOnly: true,
+          limit: 10,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/item-descriptions",
+      {
+        params: {
+          query: {
+            search: "da",
+            categoryOnly: true,
+            limit: 10,
+          },
+        },
+      },
+    );
+  });
+
+  it("throws when API returns an error", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () => useItemDescriptions({ search: "milk" }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});
+
+describe("useItemCostOverTime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches cost data when description is provided", async () => {
+    const mockData = {
+      buckets: [
+        { period: "2025-01-15", amount: 3.99 },
+        { period: "2025-02-20", amount: 4.29 },
+      ],
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () => useItemCostOverTime({ description: "Milk" }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/item-cost-over-time",
+      {
+        params: {
+          query: {
+            description: "Milk",
+            category: undefined,
+            startDate: undefined,
+            endDate: undefined,
+            granularity: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("fetches cost data when category is provided", async () => {
+    const mockData = { buckets: [] };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () => useItemCostOverTime({ category: "Dairy" }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/item-cost-over-time",
+      {
+        params: {
+          query: {
+            description: undefined,
+            category: "Dairy",
+            startDate: undefined,
+            endDate: undefined,
+            granularity: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("does not fetch when neither description nor category is provided", () => {
+    renderHook(() => useItemCostOverTime({}), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(mockClient.GET).not.toHaveBeenCalled();
+  });
+
+  it("passes all parameters including date range and granularity", async () => {
+    const mockData = { buckets: [{ period: "2025-01", amount: 4.15 }] };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useItemCostOverTime({
+          description: "Milk",
+          startDate: "2025-01-01",
+          endDate: "2025-12-31",
+          granularity: "monthly",
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/item-cost-over-time",
+      {
+        params: {
+          query: {
+            description: "Milk",
+            category: undefined,
+            startDate: "2025-01-01",
+            endDate: "2025-12-31",
+            granularity: "monthly",
+          },
+        },
+      },
+    );
+  });
+
+  it("throws when API returns an error", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () => useItemCostOverTime({ description: "Milk" }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/src/client/src/hooks/useItemCostOverTime.ts
+++ b/src/client/src/hooks/useItemCostOverTime.ts
@@ -1,0 +1,84 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export interface ItemDescriptionsParams {
+  search: string;
+  categoryOnly?: boolean;
+  limit?: number;
+}
+
+export function useItemDescriptions(params: ItemDescriptionsParams) {
+  const enabled = params.search.length >= 2;
+
+  return useQuery({
+    queryKey: [
+      "reports",
+      "item-descriptions",
+      params.search,
+      params.categoryOnly,
+      params.limit,
+    ],
+    enabled,
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/reports/item-descriptions",
+        {
+          params: {
+            query: {
+              search: params.search,
+              categoryOnly: params.categoryOnly,
+              limit: params.limit,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export interface ItemCostOverTimeParams {
+  description?: string;
+  category?: string;
+  startDate?: string;
+  endDate?: string;
+  granularity?: "exact" | "monthly" | "yearly";
+}
+
+export function useItemCostOverTime(params: ItemCostOverTimeParams) {
+  const enabled = Boolean(params.description || params.category);
+
+  return useQuery({
+    queryKey: [
+      "reports",
+      "item-cost-over-time",
+      params.description,
+      params.category,
+      params.startDate,
+      params.endDate,
+      params.granularity,
+    ],
+    enabled,
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/reports/item-cost-over-time",
+        {
+          params: {
+            query: {
+              description: params.description,
+              category: params.category,
+              startDate: params.startDate,
+              endDate: params.endDate,
+              granularity: params.granularity,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
@@ -199,4 +199,225 @@ public class ReportsControllerTests
 		item.TransactionTotal.Should().Be(30.00);
 		item.Difference.Should().Be(-1.25);
 	}
+
+	// ── GetItemDescriptions ──────────────────────────────
+
+	[Fact]
+	public async Task GetItemDescriptions_ReturnsOkResult_WithValidSearch()
+	{
+		// Arrange
+		AppReports.ItemDescriptionResult descResult = new(
+		[
+			new AppReports.ItemDescriptionItem("Milk", "Dairy", 10),
+			new AppReports.ItemDescriptionItem("Milk Chocolate", "Candy", 3),
+		]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemDescriptionsQuery>(q =>
+				q.Search == "mi" && !q.CategoryOnly && q.Limit == 20),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(descResult);
+
+		// Act
+		Results<Ok<ItemDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.GetItemDescriptions("mi", null, null, CancellationToken.None);
+
+		// Assert
+		Ok<ItemDescriptionsResponse> okResult = Assert.IsType<Ok<ItemDescriptionsResponse>>(result.Result);
+		okResult.Value!.Items.Should().HaveCount(2);
+		okResult.Value!.Items.First().Description.Should().Be("Milk");
+		okResult.Value!.Items.First().Category.Should().Be("Dairy");
+		okResult.Value!.Items.First().Occurrences.Should().Be(10);
+	}
+
+	[Fact]
+	public async Task GetItemDescriptions_PassesCategoryOnlyAndLimit()
+	{
+		// Arrange
+		AppReports.ItemDescriptionResult descResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemDescriptionsQuery>(q =>
+				q.Search == "da" && q.CategoryOnly && q.Limit == 10),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(descResult);
+
+		// Act
+		Results<Ok<ItemDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.GetItemDescriptions("da", true, 10, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<ItemDescriptionsResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetItemDescriptionsQuery>(q =>
+				q.Search == "da" && q.CategoryOnly && q.Limit == 10),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("a")]
+	public async Task GetItemDescriptions_ReturnsBadRequest_WhenSearchTooShort(string? search)
+	{
+		// Act
+		Results<Ok<ItemDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.GetItemDescriptions(search, null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("search must be at least 2 characters");
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	[InlineData(51)]
+	public async Task GetItemDescriptions_ReturnsBadRequest_WhenLimitOutOfRange(int limit)
+	{
+		// Act
+		Results<Ok<ItemDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.GetItemDescriptions("milk", null, limit, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("limit must be between 1 and 50");
+	}
+
+	// ── GetItemCostOverTime ──────────────────────────────
+
+	[Fact]
+	public async Task GetItemCostOverTime_ReturnsOkResult_WithDescription()
+	{
+		// Arrange
+		AppReports.ItemCostOverTimeResult costResult = new(
+		[
+			new AppReports.ItemCostBucket("2025-01-15", 3.99m),
+			new AppReports.ItemCostBucket("2025-02-20", 4.29m),
+		]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemCostOverTimeQuery>(q =>
+				q.Description == "Milk" && q.Category == null && q.Granularity == "exact"),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(costResult);
+
+		// Act
+		Results<Ok<ItemCostOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetItemCostOverTime("Milk", null, null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<ItemCostOverTimeResponse> okResult = Assert.IsType<Ok<ItemCostOverTimeResponse>>(result.Result);
+		okResult.Value!.Buckets.Should().HaveCount(2);
+		okResult.Value!.Buckets.First().Period.Should().Be("2025-01-15");
+		okResult.Value!.Buckets.First().Amount.Should().Be(3.99);
+	}
+
+	[Fact]
+	public async Task GetItemCostOverTime_ReturnsOkResult_WithCategory()
+	{
+		// Arrange
+		AppReports.ItemCostOverTimeResult costResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemCostOverTimeQuery>(q =>
+				q.Description == null && q.Category == "Dairy" && q.Granularity == "monthly"),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(costResult);
+
+		// Act
+		Results<Ok<ItemCostOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetItemCostOverTime(null, "Dairy", null, null, "monthly", CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<ItemCostOverTimeResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetItemCostOverTimeQuery>(q =>
+				q.Category == "Dairy" && q.Granularity == "monthly"),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetItemCostOverTime_ReturnsBadRequest_WhenNoDescriptionOrCategory()
+	{
+		// Act
+		Results<Ok<ItemCostOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetItemCostOverTime(null, null, null, null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Either description or category is required");
+	}
+
+	[Fact]
+	public async Task GetItemCostOverTime_ReturnsBadRequest_WhenInvalidGranularity()
+	{
+		// Act
+		Results<Ok<ItemCostOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetItemCostOverTime("Milk", null, null, null, "invalid", CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid granularity");
+	}
+
+	[Theory]
+	[InlineData("exact")]
+	[InlineData("monthly")]
+	[InlineData("yearly")]
+	public async Task GetItemCostOverTime_AcceptsValidGranularities(string granularity)
+	{
+		// Arrange
+		AppReports.ItemCostOverTimeResult costResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetItemCostOverTimeQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(costResult);
+
+		// Act
+		Results<Ok<ItemCostOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetItemCostOverTime("Milk", null, null, null, granularity, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<ItemCostOverTimeResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetItemCostOverTime_ReturnsBadRequest_WhenStartDateAfterEndDate()
+	{
+		// Act
+		Results<Ok<ItemCostOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetItemCostOverTime("Milk", null, new DateOnly(2025, 12, 31), new DateOnly(2025, 1, 1), null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("startDate must be before or equal to endDate");
+	}
+
+	[Fact]
+	public async Task GetItemCostOverTime_PassesDateRange()
+	{
+		// Arrange
+		DateOnly start = new(2025, 1, 1);
+		DateOnly end = new(2025, 12, 31);
+		AppReports.ItemCostOverTimeResult costResult = new([]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemCostOverTimeQuery>(q =>
+				q.StartDate == start && q.EndDate == end),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(costResult);
+
+		// Act
+		Results<Ok<ItemCostOverTimeResponse>, BadRequest<string>> result =
+			await _controller.GetItemCostOverTime("Milk", null, start, end, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<ItemCostOverTimeResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetItemCostOverTimeQuery>(q =>
+				q.StartDate == start && q.EndDate == end),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
 }


### PR DESCRIPTION
## Summary
- Add two new API endpoints: `GET /api/reports/item-descriptions` (autocomplete search) and `GET /api/reports/item-cost-over-time` (time-series cost data with granularity/date range filtering)
- Replace the Coming Soon placeholder in `ItemCostOverTime.tsx` with a full interactive report: combobox with debounced autocomplete, category-only mode, DateRangeSelector, granularity toggle, and AreaTimeChart with optional trendline
- Add 19 new tests (10 backend controller tests + 9 frontend hook tests)

Resolves RECEIPTS-445

## Test plan
- [x] All 1411 .NET unit tests pass
- [x] All 1452 client-side tests pass
- [x] OpenAPI spec lint passes, no spec drift
- [x] Pre-commit hooks pass (format, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)