### PR TITLE
feat(api): implement item similarity report

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -2820,6 +2820,104 @@ paths:
                 type: string
 
   # ──────────────────────────────────────────────
+
+  /api/reports/item-similarity:
+    get:
+      operationId: GetItemSimilarityReport
+      tags: [Reports]
+      summary: Get item similarity clusters
+      description: Returns groups of receipt items with similar descriptions using trigram matching. Items are clustered via connected-component analysis.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: threshold
+          in: query
+          required: false
+          schema:
+            type: number
+            format: double
+            minimum: 0.3
+            maximum: 0.95
+            default: 0.7
+          description: Minimum trigram similarity score (0.3 to 0.95).
+        - name: sortBy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [canonicalName, occurrences, maxSimilarity]
+            default: occurrences
+          description: Column to sort by.
+        - name: sortDirection
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort direction.
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-based).
+        - name: pageSize
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          description: Number of items per page.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ItemSimilarityResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/reports/item-similarity/rename:
+    post:
+      operationId: RenameItemSimilarityGroup
+      tags: [Reports]
+      summary: Rename all items in a similarity group
+      description: Updates the description of all specified receipt items to the given canonical name.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ItemSimilarityRenameRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ItemSimilarityRenameResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  # ──────────────────────────────────────────────
   # Dashboard
   # ──────────────────────────────────────────────
 
@@ -3127,6 +3225,70 @@ components:
         averagePerVisit:
           type: number
           format: double
+
+
+    ItemSimilarityResponse:
+      type: object
+      required: [totalCount, groups]
+      properties:
+        totalCount:
+          type: integer
+          format: int32
+          description: Total number of similarity groups.
+        groups:
+          type: array
+          items:
+            $ref: "#/components/schemas/ItemSimilarityGroup"
+
+    ItemSimilarityGroup:
+      type: object
+      required: [canonicalName, variants, itemIds, occurrences, maxSimilarity]
+      properties:
+        canonicalName:
+          type: string
+          description: Most frequent description in the cluster (ties broken by longest).
+        variants:
+          type: array
+          items:
+            type: string
+          description: All unique descriptions in the cluster.
+        itemIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: IDs of all receipt items in this cluster.
+        occurrences:
+          type: integer
+          format: int32
+          description: Number of receipt items in this cluster.
+        maxSimilarity:
+          type: number
+          format: double
+          description: Highest pairwise similarity score within this cluster.
+
+    ItemSimilarityRenameRequest:
+      type: object
+      required: [itemIds, newDescription]
+      properties:
+        itemIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: IDs of receipt items to rename.
+        newDescription:
+          type: string
+          description: The new description to apply to all items.
+
+    ItemSimilarityRenameResponse:
+      type: object
+      required: [updatedCount]
+      properties:
+        updatedCount:
+          type: integer
+          format: int32
+          description: Number of items updated.
 
     # ── Dashboard ──────────────────────────────────
 

--- a/src/Application/Commands/Reports/RenameItemSimilarityGroupCommand.cs
+++ b/src/Application/Commands/Reports/RenameItemSimilarityGroupCommand.cs
@@ -1,0 +1,7 @@
+using Application.Interfaces;
+
+namespace Application.Commands.Reports;
+
+public record RenameItemSimilarityGroupCommand(
+	List<Guid> ItemIds,
+	string NewDescription) : ICommand<int>;

--- a/src/Application/Commands/Reports/RenameItemSimilarityGroupCommandHandler.cs
+++ b/src/Application/Commands/Reports/RenameItemSimilarityGroupCommandHandler.cs
@@ -1,0 +1,16 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Commands.Reports;
+
+public class RenameItemSimilarityGroupCommandHandler(IReportService reportService)
+	: IRequestHandler<RenameItemSimilarityGroupCommand, int>
+{
+	public async Task<int> Handle(RenameItemSimilarityGroupCommand request, CancellationToken cancellationToken)
+	{
+		return await reportService.RenameItemsAsync(
+			request.ItemIds,
+			request.NewDescription,
+			cancellationToken);
+	}
+}

--- a/src/Application/Interfaces/Services/IReportService.cs
+++ b/src/Application/Interfaces/Services/IReportService.cs
@@ -19,4 +19,17 @@ public interface IReportService
 		int page,
 		int pageSize,
 		CancellationToken cancellationToken);
+
+	Task<ItemSimilarityResult> GetItemSimilarityAsync(
+		double threshold,
+		string sortBy,
+		string sortDirection,
+		int page,
+		int pageSize,
+		CancellationToken cancellationToken);
+
+	Task<int> RenameItemsAsync(
+		List<Guid> itemIds,
+		string newDescription,
+		CancellationToken cancellationToken);
 }

--- a/src/Application/Models/Reports/ItemSimilarityResult.cs
+++ b/src/Application/Models/Reports/ItemSimilarityResult.cs
@@ -1,0 +1,12 @@
+namespace Application.Models.Reports;
+
+public record ItemSimilarityGroup(
+	string CanonicalName,
+	List<string> Variants,
+	List<Guid> ItemIds,
+	int Occurrences,
+	double MaxSimilarity);
+
+public record ItemSimilarityResult(
+	List<ItemSimilarityGroup> Groups,
+	int TotalCount);

--- a/src/Application/Queries/Aggregates/Reports/GetItemSimilarityReportQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetItemSimilarityReportQuery.cs
@@ -1,0 +1,11 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetItemSimilarityReportQuery(
+	double Threshold,
+	string SortBy,
+	string SortDirection,
+	int Page,
+	int PageSize) : IQuery<ItemSimilarityResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetItemSimilarityReportQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetItemSimilarityReportQueryHandler.cs
@@ -1,0 +1,20 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetItemSimilarityReportQueryHandler(IReportService reportService)
+	: IRequestHandler<GetItemSimilarityReportQuery, ItemSimilarityResult>
+{
+	public async Task<ItemSimilarityResult> Handle(GetItemSimilarityReportQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetItemSimilarityAsync(
+			request.Threshold,
+			request.SortBy,
+			request.SortDirection,
+			request.Page,
+			request.PageSize,
+			cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -141,4 +141,216 @@ public class ReportService(IDbContextFactory<ApplicationDbContext> contextFactor
 
 		return new SpendingByLocationResult(pagedItems, totalCount, grandTotal);
 	}
+
+	public async Task<ItemSimilarityResult> GetItemSimilarityAsync(
+		double threshold,
+		string sortBy,
+		string sortDirection,
+		int page,
+		int pageSize,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		// Step 1: Find all similar pairs using pg_trgm similarity self-join.
+		// The GIN index on "Description" accelerates this query.
+		const string sql = """
+			SELECT
+				a."Id" AS "IdA",
+				a."Description" AS "DescA",
+				b."Id" AS "IdB",
+				b."Description" AS "DescB",
+				similarity(a."Description", b."Description") AS "Score"
+			FROM "ReceiptItems" a
+			JOIN "ReceiptItems" b
+				ON a."Id" < b."Id"
+				AND a."DeletedAt" IS NULL
+				AND b."DeletedAt" IS NULL
+				AND similarity(a."Description", b."Description") >= @threshold
+			WHERE a."DeletedAt" IS NULL
+			""";
+
+		List<SimilarityEdge> edges = [];
+
+		await using (NpgsqlConnection connection = (NpgsqlConnection)context.Database.GetDbConnection())
+		{
+			await connection.OpenAsync(cancellationToken);
+
+			await using NpgsqlCommand command = new(sql, connection);
+			command.Parameters.AddWithValue("@threshold", threshold);
+
+			await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+			while (await reader.ReadAsync(cancellationToken))
+			{
+				edges.Add(new SimilarityEdge(
+					reader.GetGuid(0),
+					reader.GetString(1),
+					reader.GetGuid(2),
+					reader.GetString(3),
+					reader.GetDouble(4)));
+			}
+		}
+
+		if (edges.Count == 0)
+		{
+			return new ItemSimilarityResult([], 0);
+		}
+
+		// Step 2: Build connected components via union-find.
+		// Collect all unique item IDs and their descriptions.
+		Dictionary<Guid, string> itemDescriptions = [];
+		foreach (SimilarityEdge edge in edges)
+		{
+			itemDescriptions.TryAdd(edge.IdA, edge.DescA);
+			itemDescriptions.TryAdd(edge.IdB, edge.DescB);
+		}
+
+		Dictionary<Guid, Guid> parent = [];
+		Dictionary<Guid, int> rank = [];
+
+		foreach (Guid id in itemDescriptions.Keys)
+		{
+			parent[id] = id;
+			rank[id] = 0;
+		}
+
+		Guid Find(Guid x)
+		{
+			while (parent[x] != x)
+			{
+				parent[x] = parent[parent[x]]; // path compression
+				x = parent[x];
+			}
+			return x;
+		}
+
+		void Union(Guid x, Guid y)
+		{
+			Guid rx = Find(x);
+			Guid ry = Find(y);
+			if (rx == ry)
+			{
+				return;
+			}
+
+			if (rank[rx] < rank[ry])
+			{
+				parent[rx] = ry;
+			}
+			else if (rank[rx] > rank[ry])
+			{
+				parent[ry] = rx;
+			}
+			else
+			{
+				parent[ry] = rx;
+				rank[rx]++;
+			}
+		}
+
+		// Track max similarity per pair of roots for each cluster
+		Dictionary<Guid, double> clusterMaxSimilarity = [];
+
+		foreach (SimilarityEdge edge in edges)
+		{
+			Union(edge.IdA, edge.IdB);
+		}
+
+		// Step 3: Build clusters from the union-find structure.
+		Dictionary<Guid, List<Guid>> clusters = [];
+		foreach (Guid id in itemDescriptions.Keys)
+		{
+			Guid root = Find(id);
+			if (!clusters.TryGetValue(root, out List<Guid>? members))
+			{
+				members = [];
+				clusters[root] = members;
+			}
+			members.Add(id);
+		}
+
+		// Compute max similarity per cluster
+		foreach (SimilarityEdge edge in edges)
+		{
+			Guid root = Find(edge.IdA);
+			if (!clusterMaxSimilarity.TryGetValue(root, out double current) || edge.Score > current)
+			{
+				clusterMaxSimilarity[root] = edge.Score;
+			}
+		}
+
+		// Step 4: Build result groups.
+		List<ItemSimilarityGroup> groups = [];
+		foreach ((Guid root, List<Guid> members) in clusters)
+		{
+			if (members.Count < 2)
+			{
+				continue; // single items are not "similar" clusters
+			}
+
+			// Count frequency of each description
+			Dictionary<string, int> descFrequency = [];
+			foreach (Guid id in members)
+			{
+				string desc = itemDescriptions[id];
+				descFrequency[desc] = descFrequency.GetValueOrDefault(desc) + 1;
+			}
+
+			// Canonical = most frequent, ties broken by longest string
+			string canonical = descFrequency
+				.OrderByDescending(kv => kv.Value)
+				.ThenByDescending(kv => kv.Key.Length)
+				.First()
+				.Key;
+
+			List<string> variants = descFrequency.Keys.OrderBy(d => d).ToList();
+			double maxSim = clusterMaxSimilarity.GetValueOrDefault(root, 0.0);
+
+			groups.Add(new ItemSimilarityGroup(
+				canonical,
+				variants,
+				members,
+				members.Count,
+				maxSim));
+		}
+
+		// Step 5: Sort
+		IEnumerable<ItemSimilarityGroup> sorted = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
+		{
+			("canonicalname", "asc") => groups.OrderBy(g => g.CanonicalName),
+			("canonicalname", "desc") => groups.OrderByDescending(g => g.CanonicalName),
+			("occurrences", "asc") => groups.OrderBy(g => g.Occurrences),
+			("maxsimilarity", "asc") => groups.OrderBy(g => g.MaxSimilarity),
+			("maxsimilarity", "desc") => groups.OrderByDescending(g => g.MaxSimilarity),
+			_ => groups.OrderByDescending(g => g.Occurrences), // default: occurrences desc
+		};
+
+		int totalCount = groups.Count;
+
+		// Step 6: Paginate
+		List<ItemSimilarityGroup> pagedGroups = sorted
+			.Skip((page - 1) * pageSize)
+			.Take(pageSize)
+			.ToList();
+
+		return new ItemSimilarityResult(pagedGroups, totalCount);
+	}
+
+	public async Task<int> RenameItemsAsync(
+		List<Guid> itemIds,
+		string newDescription,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		int updated = await context.ReceiptItems
+			.Where(ri => itemIds.Contains(ri.Id) && ri.DeletedAt == null)
+			.ExecuteUpdateAsync(
+				s => s.SetProperty(ri => ri.Description, newDescription),
+				cancellationToken);
+
+		return updated;
+	}
+
+	private record SimilarityEdge(Guid IdA, string DescA, Guid IdB, string DescB, double Score);
 }

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -1,6 +1,7 @@
 using Application.Interfaces.Services;
 using Application.Models.Reports;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace Infrastructure.Services;
 

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -1,4 +1,5 @@
 using API.Generated.Dtos;
+using Application.Commands.Reports;
 using Application.Queries.Aggregates.Reports;
 using Asp.Versioning;
 using MediatR;

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -135,4 +135,91 @@ public class ReportsController(IMediator mediator) : ControllerBase
 			}).ToList()
 		});
 	}
+
+	[HttpGet("item-similarity")]
+	[EndpointSummary("Get item similarity clusters")]
+	[EndpointDescription("Returns groups of receipt items with similar descriptions using trigram matching.")]
+	public async Task<Results<Ok<ItemSimilarityResponse>, BadRequest<string>>> GetItemSimilarity(
+		[FromQuery] double? threshold,
+		[FromQuery] string? sortBy,
+		[FromQuery] string? sortDirection,
+		[FromQuery] int? page,
+		[FromQuery] int? pageSize,
+		CancellationToken cancellationToken)
+	{
+		double th = threshold ?? 0.7;
+		string sort = sortBy ?? "occurrences";
+		string direction = sortDirection ?? "desc";
+		int pg = page ?? 1;
+		int ps = pageSize ?? 50;
+
+		if (th < 0.3 || th > 0.95)
+		{
+			return TypedResults.BadRequest("threshold must be between 0.3 and 0.95");
+		}
+
+		string[] validSortColumns = ["canonicalName", "occurrences", "maxSimilarity"];
+		if (!validSortColumns.Contains(sort, StringComparer.OrdinalIgnoreCase))
+		{
+			return TypedResults.BadRequest($"Invalid sortBy '{sort}'. Allowed: canonicalName, occurrences, maxSimilarity");
+		}
+
+		string[] validDirections = ["asc", "desc"];
+		if (!validDirections.Contains(direction.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid sortDirection '{direction}'. Allowed: asc, desc");
+		}
+
+		if (pg < 1)
+		{
+			return TypedResults.BadRequest("page must be at least 1");
+		}
+
+		if (ps < 1 || ps > 100)
+		{
+			return TypedResults.BadRequest("pageSize must be between 1 and 100");
+		}
+
+		GetItemSimilarityReportQuery query = new(th, sort, direction, pg, ps);
+		AppReports.ItemSimilarityResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new ItemSimilarityResponse
+		{
+			TotalCount = result.TotalCount,
+			Groups = result.Groups.Select(g => new ItemSimilarityGroup
+			{
+				CanonicalName = g.CanonicalName,
+				Variants = g.Variants,
+				ItemIds = g.ItemIds,
+				Occurrences = g.Occurrences,
+				MaxSimilarity = g.MaxSimilarity
+			}).ToList()
+		});
+	}
+
+	[HttpPost("item-similarity/rename")]
+	[EndpointSummary("Rename all items in a similarity group")]
+	[EndpointDescription("Updates the description of all specified receipt items to the given canonical name.")]
+	public async Task<Results<Ok<ItemSimilarityRenameResponse>, BadRequest<string>>> RenameItemSimilarityGroup(
+		[FromBody] ItemSimilarityRenameRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (request.ItemIds.Count == 0)
+		{
+			return TypedResults.BadRequest("itemIds must not be empty");
+		}
+
+		if (string.IsNullOrWhiteSpace(request.NewDescription))
+		{
+			return TypedResults.BadRequest("newDescription must not be empty");
+		}
+
+		RenameItemSimilarityGroupCommand command = new(request.ItemIds.ToList(), request.NewDescription);
+		int updatedCount = await mediator.Send(command, cancellationToken);
+
+		return TypedResults.Ok(new ItemSimilarityRenameResponse
+		{
+			UpdatedCount = updatedCount
+		});
+	}
 }

--- a/src/client/src/components/reports/ItemSimilarity.tsx
+++ b/src/client/src/components/reports/ItemSimilarity.tsx
@@ -1,8 +1,352 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  useItemSimilarityReport,
+  useRenameItemSimilarityGroup,
+  type ItemSimilarityParams,
+} from "@/hooks/useItemSimilarityReport";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { formatDecimal } from "@/lib/format";
+
+type SortColumn = "canonicalName" | "occurrences" | "maxSimilarity";
+type SortDirection = "asc" | "desc";
+
+interface RenameTarget {
+  canonicalName: string;
+  itemIds: string[];
+  variants: string[];
+}
+
 export default function ItemSimilarity() {
+  const [sortBy, setSortBy] = useState<SortColumn>("occurrences");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [page, setPage] = useState(1);
+  const [threshold, setThreshold] = useState(0.7);
+  const [renameTarget, setRenameTarget] = useState<RenameTarget | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const pageSize = 50;
+
+  // Debounce threshold changes
+  const [debouncedThreshold, setDebouncedThreshold] = useState(0.7);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleThresholdChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = parseFloat(e.target.value);
+      setThreshold(value);
+
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+      debounceTimerRef.current = setTimeout(() => {
+        setDebouncedThreshold(value);
+        setPage(1);
+      }, 400);
+    },
+    [],
+  );
+
+  const params: ItemSimilarityParams = useMemo(
+    () => ({
+      threshold: debouncedThreshold,
+      sortBy,
+      sortDirection,
+      page,
+      pageSize,
+    }),
+    [debouncedThreshold, sortBy, sortDirection, page, pageSize],
+  );
+
+  const { data, isLoading, isError } = useItemSimilarityReport(params);
+  const renameMutation = useRenameItemSimilarityGroup();
+
+  function handleSort(column: SortColumn) {
+    if (sortBy === column) {
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(column);
+      setSortDirection(column === "canonicalName" ? "asc" : "desc");
+    }
+    setPage(1);
+  }
+
+  function sortIndicator(column: SortColumn) {
+    if (sortBy !== column) return null;
+    return sortDirection === "asc" ? " \u2191" : " \u2193";
+  }
+
+  function handleRenameClick(group: {
+    canonicalName: string;
+    itemIds: string[];
+    variants: string[];
+  }) {
+    setRenameTarget({
+      canonicalName: group.canonicalName,
+      itemIds: group.itemIds,
+      variants: group.variants,
+    });
+    setRenameValue(group.canonicalName);
+  }
+
+  function handleRenameConfirm() {
+    if (!renameTarget || !renameValue.trim()) return;
+    renameMutation.mutate(
+      {
+        itemIds: renameTarget.itemIds,
+        newDescription: renameValue.trim(),
+      },
+      {
+        onSuccess: () => {
+          setRenameTarget(null);
+          setRenameValue("");
+        },
+      },
+    );
+  }
+
+  const totalPages = data ? Math.ceil(data.totalCount / pageSize) : 0;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-20 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">
+          Failed to load item similarity report.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-lg border p-6 text-center">
-      <h2 className="text-lg font-semibold">Item Similarity</h2>
-      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    <div className="space-y-4">
+      <div className="flex items-end gap-6 rounded-lg border p-4">
+        <div className="flex-1">
+          <Label htmlFor="threshold-slider">
+            Similarity Threshold: {formatDecimal(threshold)}
+          </Label>
+          <input
+            id="threshold-slider"
+            type="range"
+            min={0.3}
+            max={0.95}
+            step={0.05}
+            value={threshold}
+            onChange={handleThresholdChange}
+            className="mt-2 w-full accent-primary"
+          />
+          <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+            <span>0.30 (loose)</span>
+            <span>0.95 (strict)</span>
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-muted-foreground">Groups Found</p>
+          <p className="text-2xl font-bold">{data?.totalCount ?? 0}</p>
+        </div>
+      </div>
+
+      {!data || data.totalCount === 0 ? (
+        <div className="rounded-lg border p-6 text-center">
+          <h2 className="text-lg font-semibold">No Similar Items</h2>
+          <p className="mt-2 text-muted-foreground">
+            No similar item descriptions found at this threshold. Try lowering
+            the similarity threshold.
+          </p>
+        </div>
+      ) : (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead
+                  className="cursor-pointer select-none"
+                  onClick={() => handleSort("canonicalName")}
+                >
+                  Canonical Name{sortIndicator("canonicalName")}
+                </TableHead>
+                <TableHead>Variants</TableHead>
+                <TableHead
+                  className="cursor-pointer select-none text-right"
+                  onClick={() => handleSort("occurrences")}
+                >
+                  Occurrences{sortIndicator("occurrences")}
+                </TableHead>
+                <TableHead
+                  className="cursor-pointer select-none text-right"
+                  onClick={() => handleSort("maxSimilarity")}
+                >
+                  Max Similarity{sortIndicator("maxSimilarity")}
+                </TableHead>
+                <TableHead className="text-right">Action</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.groups.map((group) => (
+                <TableRow key={group.canonicalName}>
+                  <TableCell className="font-medium">
+                    {group.canonicalName}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {group.variants.map((variant) => (
+                        <Badge
+                          key={variant}
+                          variant={
+                            variant === group.canonicalName
+                              ? "default"
+                              : "secondary"
+                          }
+                        >
+                          {variant}
+                        </Badge>
+                      ))}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {group.occurrences}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {formatDecimal(group.maxSimilarity)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        handleRenameClick({
+                          canonicalName: group.canonicalName,
+                          itemIds: group.itemIds,
+                          variants: group.variants,
+                        })
+                      }
+                    >
+                      Rename All
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Page {page} of {totalPages}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      <Dialog
+        open={renameTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRenameTarget(null);
+            setRenameValue("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename Items</DialogTitle>
+            <DialogDescription>
+              Update the description for {renameTarget?.itemIds.length ?? 0}{" "}
+              items in this group.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="rename-input">New Description</Label>
+              <Input
+                id="rename-input"
+                value={renameValue}
+                onChange={(e) => setRenameValue(e.target.value)}
+                placeholder="Enter new description"
+                className="mt-1"
+              />
+            </div>
+            {renameTarget && (
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Current variants:
+                </p>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {renameTarget.variants.map((v) => (
+                    <Badge key={v} variant="secondary">
+                      {v}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setRenameTarget(null);
+                setRenameValue("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleRenameConfirm}
+              disabled={
+                !renameValue.trim() || renameMutation.isPending
+              }
+            >
+              {renameMutation.isPending ? "Renaming..." : "Rename All"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/client/src/hooks/useItemSimilarityReport.test.ts
+++ b/src/client/src/hooks/useItemSimilarityReport.test.ts
@@ -1,0 +1,175 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import {
+  useItemSimilarityReport,
+  useRenameItemSimilarityGroup,
+} from "./useItemSimilarityReport";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useItemSimilarityReport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches report data with default parameters", async () => {
+    const mockData = {
+      totalCount: 1,
+      groups: [
+        {
+          canonicalName: "Milk",
+          variants: ["Milk", "MILK"],
+          itemIds: ["id-1", "id-2"],
+          occurrences: 2,
+          maxSimilarity: 0.85,
+        },
+      ],
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useItemSimilarityReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/item-similarity",
+      {
+        params: {
+          query: {
+            threshold: undefined,
+            sortBy: undefined,
+            sortDirection: undefined,
+            page: undefined,
+            pageSize: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("passes custom parameters", async () => {
+    const mockData = { totalCount: 0, groups: [] };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useItemSimilarityReport({
+          threshold: 0.5,
+          sortBy: "canonicalName",
+          sortDirection: "asc",
+          page: 2,
+          pageSize: 25,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/item-similarity",
+      {
+        params: {
+          query: {
+            threshold: 0.5,
+            sortBy: "canonicalName",
+            sortDirection: "asc",
+            page: 2,
+            pageSize: 25,
+          },
+        },
+      },
+    );
+  });
+
+  it("throws when API returns an error", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useItemSimilarityReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});
+
+describe("useRenameItemSimilarityGroup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls POST with correct parameters", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: { updatedCount: 3 },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useRenameItemSimilarityGroup(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({
+      itemIds: ["id-1", "id-2", "id-3"],
+      newDescription: "Milk",
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/reports/item-similarity/rename",
+      {
+        body: {
+          itemIds: ["id-1", "id-2", "id-3"],
+          newDescription: "Milk",
+        },
+      },
+    );
+  });
+
+  it("throws when API returns an error", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.POST.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useRenameItemSimilarityGroup(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({
+      itemIds: ["id-1"],
+      newDescription: "Test",
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/client/src/hooks/useItemSimilarityReport.ts
+++ b/src/client/src/hooks/useItemSimilarityReport.ts
@@ -1,0 +1,78 @@
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+import { toast } from "sonner";
+
+export interface ItemSimilarityParams {
+  threshold?: number;
+  sortBy?: "canonicalName" | "occurrences" | "maxSimilarity";
+  sortDirection?: "asc" | "desc";
+  page?: number;
+  pageSize?: number;
+}
+
+export function useItemSimilarityReport(params: ItemSimilarityParams = {}) {
+  return useQuery({
+    queryKey: [
+      "reports",
+      "item-similarity",
+      params.threshold,
+      params.sortBy,
+      params.sortDirection,
+      params.page,
+      params.pageSize,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/reports/item-similarity",
+        {
+          params: {
+            query: {
+              threshold: params.threshold,
+              sortBy: params.sortBy,
+              sortDirection: params.sortDirection,
+              page: params.page,
+              pageSize: params.pageSize,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useRenameItemSimilarityGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      itemIds,
+      newDescription,
+    }: {
+      itemIds: string[];
+      newDescription: string;
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/reports/item-similarity/rename",
+        {
+          body: { itemIds, newDescription },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["reports", "item-similarity"],
+      });
+      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
+      toast.success(
+        `Renamed ${variables.itemIds.length} items to "${variables.newDescription}"`,
+      );
+    },
+    onError: () => {
+      toast.error("Failed to rename items");
+    },
+  });
+}

--- a/tests/Application.Tests/Commands/Reports/RenameItemSimilarityGroupCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Reports/RenameItemSimilarityGroupCommandHandlerTests.cs
@@ -1,0 +1,56 @@
+using Application.Commands.Reports;
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.Reports;
+
+public class RenameItemSimilarityGroupCommandHandlerTests
+{
+	private readonly Mock<IReportService> _reportServiceMock;
+	private readonly RenameItemSimilarityGroupCommandHandler _handler;
+
+	public RenameItemSimilarityGroupCommandHandlerTests()
+	{
+		_reportServiceMock = new Mock<IReportService>();
+		_handler = new RenameItemSimilarityGroupCommandHandler(_reportServiceMock.Object);
+	}
+
+	[Fact]
+	public async Task Handle_DelegatesToReportService()
+	{
+		// Arrange
+		List<Guid> itemIds = [Guid.NewGuid(), Guid.NewGuid()];
+		RenameItemSimilarityGroupCommand command = new(itemIds, "New Description");
+
+		_reportServiceMock.Setup(s => s.RenameItemsAsync(
+			itemIds, "New Description", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(2);
+
+		// Act
+		int result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().Be(2);
+		_reportServiceMock.Verify(s => s.RenameItemsAsync(
+			itemIds, "New Description", It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsUpdatedCount()
+	{
+		// Arrange
+		List<Guid> itemIds = [Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()];
+		RenameItemSimilarityGroupCommand command = new(itemIds, "Unified Name");
+
+		_reportServiceMock.Setup(s => s.RenameItemsAsync(
+			It.IsAny<List<Guid>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(3);
+
+		// Act
+		int result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().Be(3);
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Reports/GetItemSimilarityReportQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Reports/GetItemSimilarityReportQueryHandlerTests.cs
@@ -1,0 +1,88 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Reports;
+
+public class GetItemSimilarityReportQueryHandlerTests
+{
+	private readonly Mock<IReportService> _reportServiceMock;
+	private readonly GetItemSimilarityReportQueryHandler _handler;
+
+	public GetItemSimilarityReportQueryHandlerTests()
+	{
+		_reportServiceMock = new Mock<IReportService>();
+		_handler = new GetItemSimilarityReportQueryHandler(_reportServiceMock.Object);
+	}
+
+	[Fact]
+	public async Task Handle_DelegatesToReportService()
+	{
+		// Arrange
+		GetItemSimilarityReportQuery query = new(0.7, "occurrences", "desc", 1, 50);
+		ItemSimilarityResult expectedResult = new([], 0);
+
+		_reportServiceMock.Setup(s => s.GetItemSimilarityAsync(
+			0.7, "occurrences", "desc", 1, 50, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		ItemSimilarityResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+		_reportServiceMock.Verify(s => s.GetItemSimilarityAsync(
+			0.7, "occurrences", "desc", 1, 50, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PassesAllParametersToService()
+	{
+		// Arrange
+		GetItemSimilarityReportQuery query = new(0.5, "canonicalName", "asc", 3, 25);
+		ItemSimilarityResult expectedResult = new([], 0);
+
+		_reportServiceMock.Setup(s => s.GetItemSimilarityAsync(
+			0.5, "canonicalName", "asc", 3, 25, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		_reportServiceMock.Verify(s => s.GetItemSimilarityAsync(
+			0.5, "canonicalName", "asc", 3, 25, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsServiceResult()
+	{
+		// Arrange
+		GetItemSimilarityReportQuery query = new(0.7, "occurrences", "desc", 1, 50);
+		ItemSimilarityResult expectedResult = new(
+		[
+			new ItemSimilarityGroup(
+				"Milk",
+				["Milk", "MILK", "milk 2%"],
+				[Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()],
+				3,
+				0.85),
+		], 1);
+
+		_reportServiceMock.Setup(s => s.GetItemSimilarityAsync(
+			It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string>(),
+			It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		ItemSimilarityResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.TotalCount.Should().Be(1);
+		result.Groups.Should().ContainSingle();
+		result.Groups[0].CanonicalName.Should().Be("Milk");
+		result.Groups[0].Occurrences.Should().Be(3);
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/ItemSimilarityReportsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/ItemSimilarityReportsControllerTests.cs
@@ -1,0 +1,297 @@
+using API.Controllers.Aggregates;
+using API.Generated.Dtos;
+using Application.Commands.Reports;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using AppReports = Application.Models.Reports;
+
+namespace Presentation.API.Tests.Controllers.Aggregates;
+
+public class ItemSimilarityReportsControllerTests
+{
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly ReportsController _controller;
+
+	public ItemSimilarityReportsControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_controller = new ReportsController(_mediatorMock.Object);
+	}
+
+	[Fact]
+	public async Task GetItemSimilarity_ReturnsOkResult_WithDefaultParameters()
+	{
+		// Arrange
+		AppReports.ItemSimilarityResult reportResult = new(
+		[
+			new AppReports.ItemSimilarityGroup(
+				"Milk", ["MILK", "Milk"], [Guid.NewGuid(), Guid.NewGuid()], 2, 0.85),
+		], 1);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemSimilarityReportQuery>(q =>
+				q.Threshold == 0.7 && q.SortBy == "occurrences" && q.SortDirection == "desc" &&
+				q.Page == 1 && q.PageSize == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(null, null, null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<ItemSimilarityResponse> okResult = Assert.IsType<Ok<ItemSimilarityResponse>>(result.Result);
+		ItemSimilarityResponse response = okResult.Value!;
+		response.TotalCount.Should().Be(1);
+		response.Groups.Should().ContainSingle();
+		response.Groups.First().CanonicalName.Should().Be("Milk");
+		response.Groups.First().Occurrences.Should().Be(2);
+		response.Groups.First().MaxSimilarity.Should().Be(0.85);
+	}
+
+	[Fact]
+	public async Task GetItemSimilarity_PassesCustomParameters()
+	{
+		// Arrange
+		AppReports.ItemSimilarityResult reportResult = new([], 0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetItemSimilarityReportQuery>(q =>
+				q.Threshold == 0.5 && q.SortBy == "canonicalName" && q.SortDirection == "asc" &&
+				q.Page == 2 && q.PageSize == 25),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(0.5, "canonicalName", "asc", 2, 25, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<ItemSimilarityResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetItemSimilarityReportQuery>(q =>
+				q.Threshold == 0.5 && q.SortBy == "canonicalName" && q.SortDirection == "asc" &&
+				q.Page == 2 && q.PageSize == 25),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Theory]
+	[InlineData(0.2)]
+	[InlineData(0.96)]
+	[InlineData(-1.0)]
+	[InlineData(1.0)]
+	public async Task GetItemSimilarity_ReturnsBadRequest_WhenThresholdOutOfRange(double threshold)
+	{
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(threshold, null, null, null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("threshold must be between 0.3 and 0.95");
+	}
+
+	[Fact]
+	public async Task GetItemSimilarity_ReturnsBadRequest_WhenInvalidSortBy()
+	{
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(null, "invalid", null, null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid sortBy");
+	}
+
+	[Fact]
+	public async Task GetItemSimilarity_ReturnsBadRequest_WhenInvalidSortDirection()
+	{
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(null, null, "invalid", null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid sortDirection");
+	}
+
+	[Fact]
+	public async Task GetItemSimilarity_ReturnsBadRequest_WhenPageLessThanOne()
+	{
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(null, null, null, 0, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("page must be at least 1");
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	[InlineData(101)]
+	public async Task GetItemSimilarity_ReturnsBadRequest_WhenPageSizeOutOfRange(int pageSize)
+	{
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(null, null, null, null, pageSize, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("pageSize must be between 1 and 100");
+	}
+
+	[Theory]
+	[InlineData("canonicalName")]
+	[InlineData("occurrences")]
+	[InlineData("maxSimilarity")]
+	public async Task GetItemSimilarity_AcceptsValidSortColumns(string sortBy)
+	{
+		// Arrange
+		AppReports.ItemSimilarityResult reportResult = new([], 0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetItemSimilarityReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(null, sortBy, null, null, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<ItemSimilarityResponse>>(result.Result);
+	}
+
+	[Theory]
+	[InlineData(0.3)]
+	[InlineData(0.5)]
+	[InlineData(0.7)]
+	[InlineData(0.95)]
+	public async Task GetItemSimilarity_AcceptsValidThresholds(double threshold)
+	{
+		// Arrange
+		AppReports.ItemSimilarityResult reportResult = new([], 0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetItemSimilarityReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(threshold, null, null, null, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<ItemSimilarityResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetItemSimilarity_MapsResponseFieldsCorrectly()
+	{
+		// Arrange
+		Guid itemId1 = Guid.NewGuid();
+		Guid itemId2 = Guid.NewGuid();
+
+		AppReports.ItemSimilarityResult reportResult = new(
+		[
+			new AppReports.ItemSimilarityGroup(
+				"Coffee",
+				["Coffee", "COFFEE", "Coffe"],
+				[itemId1, itemId2],
+				2,
+				0.92),
+		], 1);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetItemSimilarityReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<ItemSimilarityResponse>, BadRequest<string>> result =
+			await _controller.GetItemSimilarity(null, null, null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<ItemSimilarityResponse> okResult = Assert.IsType<Ok<ItemSimilarityResponse>>(result.Result);
+		ItemSimilarityGroup group = okResult.Value!.Groups.First();
+		group.CanonicalName.Should().Be("Coffee");
+		group.Variants.Should().HaveCount(3);
+		group.ItemIds.Should().HaveCount(2);
+		group.Occurrences.Should().Be(2);
+		group.MaxSimilarity.Should().Be(0.92);
+	}
+
+	[Fact]
+	public async Task RenameItemSimilarityGroup_ReturnsOkResult()
+	{
+		// Arrange
+		Guid id1 = Guid.NewGuid();
+		Guid id2 = Guid.NewGuid();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<RenameItemSimilarityGroupCommand>(c =>
+				c.ItemIds.Count == 2 && c.NewDescription == "Milk"),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(2);
+
+		ItemSimilarityRenameRequest request = new()
+		{
+			ItemIds = [id1, id2],
+			NewDescription = "Milk"
+		};
+
+		// Act
+		Results<Ok<ItemSimilarityRenameResponse>, BadRequest<string>> result =
+			await _controller.RenameItemSimilarityGroup(request, CancellationToken.None);
+
+		// Assert
+		Ok<ItemSimilarityRenameResponse> okResult = Assert.IsType<Ok<ItemSimilarityRenameResponse>>(result.Result);
+		okResult.Value!.UpdatedCount.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task RenameItemSimilarityGroup_ReturnsBadRequest_WhenItemIdsEmpty()
+	{
+		// Arrange
+		ItemSimilarityRenameRequest request = new()
+		{
+			ItemIds = [],
+			NewDescription = "Milk"
+		};
+
+		// Act
+		Results<Ok<ItemSimilarityRenameResponse>, BadRequest<string>> result =
+			await _controller.RenameItemSimilarityGroup(request, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("itemIds must not be empty");
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData(null)]
+	public async Task RenameItemSimilarityGroup_ReturnsBadRequest_WhenDescriptionEmpty(string? description)
+	{
+		// Arrange
+		ItemSimilarityRenameRequest request = new()
+		{
+			ItemIds = [Guid.NewGuid()],
+			NewDescription = description!
+		};
+
+		// Act
+		Results<Ok<ItemSimilarityRenameResponse>, BadRequest<string>> result =
+			await _controller.RenameItemSimilarityGroup(request, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("newDescription must not be empty");
+	}
+}


### PR DESCRIPTION
## Summary
- Add item similarity report endpoint (`GET /api/reports/item-similarity`) using PostgreSQL pg_trgm trigram matching with union-find clustering for connected components
- Add rename endpoint (`POST /api/reports/item-similarity/rename`) to bulk-update item descriptions
- Replace Coming Soon placeholder in `ItemSimilarity.tsx` with full UI: threshold slider (0.3-0.95, debounced 400ms), sortable table with variant badges, rename dialog with toast confirmation, and pagination
- Add 30 new unit tests across 4 test files (controller validation, MediatR handlers, React hooks)

Closes RECEIPTS-441

## Test plan
- [x] All 1424 .NET unit tests pass (0 failures)
- [x] Build succeeds with zero errors
- [x] OpenAPI spec lints clean (Spectral)
- [x] Code review: no critical or warning findings
- [x] Security review: no critical or high findings, all inputs validated and queries parameterized
- [x] Acceptance criteria: 12/12 met

Generated with [Claude Code](https://claude.com/claude-code)