### PR TITLE
feat(api,client): implement duplicate receipt detection report

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -3022,6 +3022,55 @@ paths:
               schema:
                 type: string
 
+  /api/reports/duplicates:
+    get:
+      operationId: GetDuplicateDetectionReport
+      tags: [Reports]
+      summary: Get duplicate receipt detection report
+      description: Finds receipts that share the same date+location, date+total, or all three fields and may be double entries.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: matchOn
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [DateAndLocation, DateAndTotal, DateAndLocationAndTotal]
+            default: DateAndLocation
+          description: Which fields to compare when detecting duplicates.
+        - name: locationTolerance
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [exact, normalized]
+            default: exact
+          description: "How to compare locations: exact (case-sensitive) or normalized (trimmed, lowercased, whitespace-collapsed)."
+        - name: totalTolerance
+          in: query
+          required: false
+          schema:
+            type: number
+            format: double
+            default: 0
+            minimum: 0
+          description: Maximum difference between transaction totals to still consider them matching. Default 0 (exact match).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DuplicatesResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
   # ──────────────────────────────────────────────
   # Dashboard
   # ──────────────────────────────────────────────
@@ -3432,6 +3481,49 @@ components:
         period:
           type: string
         amount:
+          type: number
+          format: double
+
+    DuplicatesResponse:
+      type: object
+      required: [groupCount, totalDuplicateReceipts, groups]
+      properties:
+        groupCount:
+          type: integer
+          format: int32
+        totalDuplicateReceipts:
+          type: integer
+          format: int32
+        groups:
+          type: array
+          items:
+            $ref: "#/components/schemas/DuplicateGroup"
+
+    DuplicateGroup:
+      type: object
+      required: [matchKey, receipts]
+      properties:
+        matchKey:
+          type: string
+          description: Human-readable description of what these receipts have in common.
+        receipts:
+          type: array
+          items:
+            $ref: "#/components/schemas/DuplicateReceipt"
+
+    DuplicateReceipt:
+      type: object
+      required: [receiptId, location, date, transactionTotal]
+      properties:
+        receiptId:
+          type: string
+          format: uuid
+        location:
+          type: string
+        date:
+          type: string
+          format: date
+        transactionTotal:
           type: number
           format: double
 

--- a/src/Application/Interfaces/Services/IReportService.cs
+++ b/src/Application/Interfaces/Services/IReportService.cs
@@ -12,13 +12,13 @@ public interface IReportService
 		CancellationToken cancellationToken);
 
 	Task<SpendingByLocationResult> GetSpendingByLocationAsync(
-		DateOnly? startDate,
-		DateOnly? endDate,
-		string sortBy,
-		string sortDirection,
-		int page,
-		int pageSize,
-		CancellationToken cancellationToken);
+			DateOnly? startDate,
+			DateOnly? endDate,
+			string sortBy,
+			string sortDirection,
+			int page,
+			int pageSize,
+			CancellationToken cancellationToken);
 
 	Task<ItemSimilarityResult> GetItemSimilarityAsync(
 		double threshold,
@@ -45,5 +45,11 @@ public interface IReportService
 		DateOnly? startDate,
 		DateOnly? endDate,
 		string granularity,
+		CancellationToken cancellationToken);
+
+	Task<DuplicateDetectionResult> GetDuplicatesAsync(
+		string matchOn,
+		string locationTolerance,
+		decimal totalTolerance,
 		CancellationToken cancellationToken);
 }

--- a/src/Application/Models/Reports/DuplicateDetectionResult.cs
+++ b/src/Application/Models/Reports/DuplicateDetectionResult.cs
@@ -1,0 +1,16 @@
+namespace Application.Models.Reports;
+
+public record DuplicateReceiptSummary(
+	Guid ReceiptId,
+	string Location,
+	DateOnly Date,
+	decimal TransactionTotal);
+
+public record DuplicateGroup(
+	string MatchKey,
+	List<DuplicateReceiptSummary> Receipts);
+
+public record DuplicateDetectionResult(
+	List<DuplicateGroup> Groups,
+	int GroupCount,
+	int TotalDuplicateReceipts);

--- a/src/Application/Queries/Aggregates/Reports/GetDuplicateDetectionReportQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetDuplicateDetectionReportQuery.cs
@@ -1,0 +1,9 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetDuplicateDetectionReportQuery(
+	string MatchOn,
+	string LocationTolerance,
+	decimal TotalTolerance) : IQuery<DuplicateDetectionResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetDuplicateDetectionReportQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetDuplicateDetectionReportQueryHandler.cs
@@ -1,0 +1,18 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetDuplicateDetectionReportQueryHandler(IReportService reportService)
+	: IRequestHandler<GetDuplicateDetectionReportQuery, DuplicateDetectionResult>
+{
+	public async Task<DuplicateDetectionResult> Handle(GetDuplicateDetectionReportQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetDuplicatesAsync(
+			request.MatchOn,
+			request.LocationTolerance,
+			request.TotalTolerance,
+			cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Application.Interfaces.Services;
 using Application.Models.Reports;
 using Microsoft.EntityFrameworkCore;
@@ -5,8 +6,10 @@ using Npgsql;
 
 namespace Infrastructure.Services;
 
-public class ReportService(IDbContextFactory<ApplicationDbContext> contextFactory) : IReportService
+public partial class ReportService(IDbContextFactory<ApplicationDbContext> contextFactory) : IReportService
 {
+	[GeneratedRegex(@"\s+")]
+	private static partial Regex WhitespaceRegex();
 	public async Task<OutOfBalanceResult> GetOutOfBalanceAsync(
 		string sortBy,
 		string sortDirection,
@@ -471,6 +474,108 @@ public class ReportService(IDbContextFactory<ApplicationDbContext> contextFactor
 
 		return new ItemCostOverTimeResult(buckets);
 	}
+
+	public async Task<DuplicateDetectionResult> GetDuplicatesAsync(
+		string matchOn,
+		string locationTolerance,
+		decimal totalTolerance,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		List<ReceiptSnapshot> receipts = await (from r in context.Receipts.AsNoTracking()
+												where r.DeletedAt == null
+												let transactionTotal = context.Transactions
+													.Where(t => t.ReceiptId == r.Id && t.DeletedAt == null)
+													.Sum(t => (decimal?)t.Amount) ?? 0m
+												select new ReceiptSnapshot(
+													r.Id,
+													r.Location,
+													r.Date,
+													transactionTotal
+												)).ToListAsync(cancellationToken);
+
+		bool normalized = locationTolerance.Equals("normalized", StringComparison.OrdinalIgnoreCase);
+
+		string NormalizeLocation(string location)
+		{
+			string trimmed = location.Trim().ToLowerInvariant();
+			return WhitespaceRegex().Replace(trimmed, " ");
+		}
+
+		bool TotalsMatch(decimal a, decimal b) => Math.Abs(a - b) <= totalTolerance;
+
+		List<DuplicateGroup> groups = matchOn.ToLowerInvariant() switch
+		{
+			"dateandlocation" => receipts
+				.GroupBy(r => (r.Date, Location: normalized ? NormalizeLocation(r.Location) : r.Location))
+				.Where(g => g.Count() > 1)
+				.Select(g => new DuplicateGroup(
+					$"{g.Key.Date:yyyy-MM-dd} @ {g.First().Location}",
+					g.Select(ToSummary).ToList()))
+				.ToList(),
+
+			"dateandtotal" => ClusterByTotal(
+				receipts.GroupBy(r => r.Date),
+				TotalsMatch,
+				dateGroup => dateGroup.Key,
+				(date, seed) => $"{date:yyyy-MM-dd} — ${seed.TransactionTotal:F2}"),
+
+			_ => ClusterByTotal(
+				receipts.GroupBy(r => (r.Date, Location: normalized ? NormalizeLocation(r.Location) : r.Location)),
+				TotalsMatch,
+				locDateGroup => locDateGroup.Key,
+				(key, seed) => $"{key.Date:yyyy-MM-dd} @ {seed.Location} — ${seed.TransactionTotal:F2}")
+		};
+
+		int totalDuplicateReceipts = groups.Sum(g => g.Receipts.Count);
+		return new DuplicateDetectionResult(groups, groups.Count, totalDuplicateReceipts);
+	}
+
+	private static List<DuplicateGroup> ClusterByTotal<TKey>(
+		IEnumerable<IGrouping<TKey, ReceiptSnapshot>> groupedReceipts,
+		Func<decimal, decimal, bool> totalsMatch,
+		Func<IGrouping<TKey, ReceiptSnapshot>, TKey> keySelector,
+		Func<TKey, ReceiptSnapshot, string> formatMatchKey)
+	{
+		List<DuplicateGroup> result = [];
+
+		foreach (IGrouping<TKey, ReceiptSnapshot> group in groupedReceipts)
+		{
+			List<ReceiptSnapshot> remaining = [.. group];
+			TKey key = keySelector(group);
+
+			while (remaining.Count > 0)
+			{
+				ReceiptSnapshot seed = remaining[0];
+				List<ReceiptSnapshot> cluster = [seed];
+				remaining.RemoveAt(0);
+
+				for (int i = remaining.Count - 1; i >= 0; i--)
+				{
+					if (totalsMatch(seed.TransactionTotal, remaining[i].TransactionTotal))
+					{
+						cluster.Add(remaining[i]);
+						remaining.RemoveAt(i);
+					}
+				}
+
+				if (cluster.Count > 1)
+				{
+					result.Add(new DuplicateGroup(
+						formatMatchKey(key, seed),
+						cluster.Select(ToSummary).ToList()));
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private static DuplicateReceiptSummary ToSummary(ReceiptSnapshot r) =>
+		new(r.Id, r.Location, r.Date, r.TransactionTotal);
+
+	private sealed record ReceiptSnapshot(Guid Id, string Location, DateOnly Date, decimal TransactionTotal);
 
 	private record SimilarityEdge(Guid IdA, string DescA, Guid IdB, string DescB, double Score);
 }

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -298,4 +298,55 @@ public class ReportsController(IMediator mediator) : ControllerBase
 			}).ToList()
 		});
 	}
+
+	[HttpGet("duplicates")]
+	[EndpointSummary("Get duplicate receipt detection report")]
+	[EndpointDescription("Finds receipts that share the same date+location, date+total, or all three fields and may be double entries.")]
+	public async Task<Results<Ok<DuplicatesResponse>, BadRequest<string>>> GetDuplicates(
+		[FromQuery] string? matchOn,
+		[FromQuery] string? locationTolerance,
+		[FromQuery] double? totalTolerance,
+		CancellationToken cancellationToken)
+	{
+		string match = matchOn ?? "DateAndLocation";
+		string locTol = locationTolerance ?? "exact";
+		decimal totTol = (decimal)(totalTolerance ?? 0);
+
+		string[] validMatchOn = ["DateAndLocation", "DateAndTotal", "DateAndLocationAndTotal"];
+		if (!validMatchOn.Contains(match))
+		{
+			return TypedResults.BadRequest($"Invalid matchOn '{match}'. Allowed: DateAndLocation, DateAndTotal, DateAndLocationAndTotal");
+		}
+
+		string[] validLocTolerance = ["exact", "normalized"];
+		if (!validLocTolerance.Contains(locTol.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid locationTolerance '{locTol}'. Allowed: exact, normalized");
+		}
+
+		if (totTol < 0)
+		{
+			return TypedResults.BadRequest("totalTolerance must be >= 0");
+		}
+
+		GetDuplicateDetectionReportQuery query = new(match, locTol, totTol);
+		AppReports.DuplicateDetectionResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new DuplicatesResponse
+		{
+			GroupCount = result.GroupCount,
+			TotalDuplicateReceipts = result.TotalDuplicateReceipts,
+			Groups = result.Groups.Select(g => new DuplicateGroup
+			{
+				MatchKey = g.MatchKey,
+				Receipts = g.Receipts.Select(r => new DuplicateReceipt
+				{
+					ReceiptId = r.ReceiptId,
+					Location = r.Location,
+					Date = r.Date,
+					TransactionTotal = (double)r.TransactionTotal
+				}).ToList()
+			}).ToList()
+		});
+	}
 }

--- a/src/client/src/components/reports/DuplicateDetection.test.tsx
+++ b/src/client/src/components/reports/DuplicateDetection.test.tsx
@@ -1,0 +1,212 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { mockMutationResult } from "@/test/mock-hooks";
+import DuplicateDetection from "./DuplicateDetection";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/hooks/useDuplicateDetectionReport", () => ({
+  useDuplicateDetectionReport: vi.fn(),
+}));
+
+vi.mock("@/hooks/useReceipts", () => ({
+  useDeleteReceipts: vi.fn(() => mockMutationResult()),
+}));
+
+import { useDuplicateDetectionReport } from "@/hooks/useDuplicateDetectionReport";
+const mockHook = vi.mocked(useDuplicateDetectionReport);
+
+const mockGroups = [
+  {
+    matchKey: "2025-03-01 @ Store A",
+    receipts: [
+      {
+        receiptId: "id-1",
+        location: "Store A",
+        date: "2025-03-01",
+        transactionTotal: 25.5,
+      },
+      {
+        receiptId: "id-2",
+        location: "Store A",
+        date: "2025-03-01",
+        transactionTotal: 30.0,
+      },
+    ],
+  },
+];
+
+function setupMock(overrides: Record<string, unknown> = {}) {
+  mockHook.mockReturnValue({
+    data: {
+      groupCount: 1,
+      totalDuplicateReceipts: 2,
+      groups: mockGroups,
+    },
+    isLoading: false,
+    isError: false,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+describe("DuplicateDetection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton", () => {
+    setupMock({ isLoading: true, data: undefined });
+    renderWithQueryClient(<DuplicateDetection />);
+    const skeletons = document.querySelectorAll("[data-slot='skeleton']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state", () => {
+    setupMock({ isError: true, data: undefined });
+    renderWithQueryClient(<DuplicateDetection />);
+    expect(
+      screen.getByText(/failed to load duplicate detection report/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no duplicates found", () => {
+    setupMock({
+      data: { groupCount: 0, totalDuplicateReceipts: 0, groups: [] },
+    });
+    renderWithQueryClient(<DuplicateDetection />);
+    expect(screen.getByText("No Duplicates Found")).toBeInTheDocument();
+    expect(
+      screen.getByText(/no potential duplicate receipts/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when data is null", () => {
+    setupMock({ data: undefined });
+    renderWithQueryClient(<DuplicateDetection />);
+    expect(screen.getByText("No Duplicates Found")).toBeInTheDocument();
+  });
+
+  it("renders summary header with counts", () => {
+    setupMock();
+    renderWithQueryClient(<DuplicateDetection />);
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("renders duplicate group card with match key", () => {
+    setupMock();
+    renderWithQueryClient(<DuplicateDetection />);
+    expect(screen.getByText("2025-03-01 @ Store A")).toBeInTheDocument();
+    expect(
+      screen.getByText("2 receipts in this group"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders receipt cards with location, date, and total", () => {
+    setupMock();
+    renderWithQueryClient(<DuplicateDetection />);
+    const storeAs = screen.getAllByText("Store A");
+    expect(storeAs.length).toBe(2);
+    expect(screen.getByText("$25.50")).toBeInTheDocument();
+    expect(screen.getByText("$30.00")).toBeInTheDocument();
+  });
+
+  it("highlights differing total fields", () => {
+    setupMock();
+    renderWithQueryClient(<DuplicateDetection />);
+    const total25 = screen.getByText("$25.50");
+    expect(total25.className).toContain("text-amber-600");
+    const total30 = screen.getByText("$30.00");
+    expect(total30.className).toContain("text-amber-600");
+  });
+
+  it("shows 'Total differs' badges when totals differ", () => {
+    setupMock();
+    renderWithQueryClient(<DuplicateDetection />);
+    const badges = screen.getAllByText("Total differs");
+    expect(badges.length).toBe(2);
+  });
+
+  it("navigates to receipt on View click", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<DuplicateDetection />);
+
+    const viewButtons = screen.getAllByRole("button", { name: "View" });
+    await user.click(viewButtons[0]);
+    expect(mockNavigate).toHaveBeenCalledWith("/receipts/id-1");
+  });
+
+  it("opens delete confirmation dialog on Delete click", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<DuplicateDetection />);
+
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    await user.click(deleteButtons[0]);
+
+    expect(screen.getByText("Delete Receipt")).toBeInTheDocument();
+    expect(
+      screen.getByText(/are you sure you want to delete/i),
+    ).toBeInTheDocument();
+  });
+
+  it("calls deleteReceipts on confirm", async () => {
+    const user = userEvent.setup();
+    const mockMutate = vi.fn();
+    const { useDeleteReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeleteReceipts).mockReturnValue(
+      mockMutationResult({ mutate: mockMutate }),
+    );
+    setupMock();
+    renderWithQueryClient(<DuplicateDetection />);
+
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    await user.click(deleteButtons[0]);
+
+    const dialog = screen.getByRole("alertdialog");
+    const confirmButton = within(dialog).getByRole("button", {
+      name: "Delete",
+    });
+    await user.click(confirmButton);
+
+    expect(mockMutate).toHaveBeenCalledWith(["id-1"], expect.any(Object));
+  });
+
+  it("renders parameter controls", () => {
+    setupMock();
+    renderWithQueryClient(<DuplicateDetection />);
+    expect(screen.getByText("Match On")).toBeInTheDocument();
+    expect(screen.getByText("Location Matching")).toBeInTheDocument();
+  });
+
+  it("does not show location tolerance for DateAndTotal", () => {
+    mockHook.mockImplementation(() => {
+      return {
+        data: { groupCount: 0, totalDuplicateReceipts: 0, groups: [] },
+        isLoading: false,
+        isError: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+    });
+    renderWithQueryClient(<DuplicateDetection />);
+    // Default is DateAndLocation, so Location Matching should be visible
+    expect(screen.getByText("Location Matching")).toBeInTheDocument();
+  });
+
+  it("does not show total tolerance in DateAndLocation match mode", () => {
+    setupMock({
+      data: { groupCount: 0, totalDuplicateReceipts: 0, groups: [] },
+    });
+    renderWithQueryClient(<DuplicateDetection />);
+
+    // Initially DateAndLocation mode, no Total Tolerance control
+    expect(screen.queryByText("Total Tolerance")).not.toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/reports/DuplicateDetection.tsx
+++ b/src/client/src/components/reports/DuplicateDetection.tsx
@@ -1,8 +1,304 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import {
+  useDuplicateDetectionReport,
+  type MatchOn,
+  type LocationTolerance,
+  type TotalTolerance,
+  type DuplicateDetectionParams,
+} from "@/hooks/useDuplicateDetectionReport";
+import { useDeleteReceipts } from "@/hooks/useReceipts";
+import { formatCurrency } from "@/lib/format";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+
 export default function DuplicateDetection() {
+  const navigate = useNavigate();
+  const [matchOn, setMatchOn] = useState<MatchOn>("DateAndLocation");
+  const [locationTolerance, setLocationTolerance] =
+    useState<LocationTolerance>("exact");
+  const [totalTolerance, setTotalTolerance] = useState<TotalTolerance>(0);
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: string;
+    location: string;
+  } | null>(null);
+
+  const params: DuplicateDetectionParams = {
+    matchOn,
+    locationTolerance,
+    totalTolerance,
+  };
+
+  const { data, isLoading, isError } = useDuplicateDetectionReport(params);
+  const deleteReceipts = useDeleteReceipts();
+
+  const showLocationTolerance =
+    matchOn === "DateAndLocation" || matchOn === "DateAndLocationAndTotal";
+  const showTotalTolerance =
+    matchOn === "DateAndTotal" || matchOn === "DateAndLocationAndTotal";
+
+  function handleDelete() {
+    if (!deleteTarget) return;
+    deleteReceipts.mutate([deleteTarget.id], {
+      onSuccess: () => setDeleteTarget(null),
+    });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">
+          Failed to load duplicate detection report.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-lg border p-6 text-center">
-      <h2 className="text-lg font-semibold">Duplicate Detection</h2>
-      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-4 rounded-lg border p-4">
+        <div className="space-y-1">
+          <Label htmlFor="match-on-select">Match On</Label>
+          <Select
+            value={matchOn}
+            onValueChange={(v) => setMatchOn(v as MatchOn)}
+          >
+            <SelectTrigger id="match-on-select" className="w-[200px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="DateAndLocation">Date & Location</SelectItem>
+              <SelectItem value="DateAndTotal">Date & Total</SelectItem>
+              <SelectItem value="DateAndLocationAndTotal">
+                Date, Location & Total
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {showLocationTolerance && (
+          <div className="space-y-1">
+            <Label htmlFor="location-tolerance-select">Location Matching</Label>
+            <Select
+              value={locationTolerance}
+              onValueChange={(v) =>
+                setLocationTolerance(v as LocationTolerance)
+              }
+            >
+              <SelectTrigger id="location-tolerance-select" className="w-[160px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="exact">Exact</SelectItem>
+                <SelectItem value="normalized">Normalized</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {showTotalTolerance && (
+          <div className="space-y-1">
+            <Label htmlFor="total-tolerance-select">Total Tolerance</Label>
+            <Select
+              value={String(totalTolerance)}
+              onValueChange={(v) =>
+                setTotalTolerance(Number(v) as TotalTolerance)
+              }
+            >
+              <SelectTrigger id="total-tolerance-select" className="w-[140px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">Exact ($0.00)</SelectItem>
+                <SelectItem value="0.01">$0.01</SelectItem>
+                <SelectItem value="0.05">$0.05</SelectItem>
+                <SelectItem value="0.1">$0.10</SelectItem>
+                <SelectItem value="0.5">$0.50</SelectItem>
+                <SelectItem value="1">$1.00</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+
+      {!data || data.groupCount === 0 ? (
+        <div className="rounded-lg border p-6 text-center">
+          <h2 className="text-lg font-semibold">No Duplicates Found</h2>
+          <p className="mt-2 text-muted-foreground">
+            No potential duplicate receipts were detected with the current
+            settings.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="flex gap-6 rounded-lg border p-4">
+            <div>
+              <p className="text-sm text-muted-foreground">Duplicate Groups</p>
+              <p className="text-2xl font-bold">{data.groupCount}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">
+                Total Duplicate Receipts
+              </p>
+              <p className="text-2xl font-bold">
+                {data.totalDuplicateReceipts}
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            {data.groups.map((group) => (
+              <Card key={group.matchKey}>
+                <CardHeader>
+                  <CardTitle className="text-base">{group.matchKey}</CardTitle>
+                  <CardDescription>
+                    {group.receipts.length} receipts in this group
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {group.receipts.map((receipt, index) => {
+                      const others = group.receipts.filter(
+                        (_, i) => i !== index,
+                      );
+                      const locationDiffers = others.some(
+                        (o) => o.location !== receipt.location,
+                      );
+                      const totalDiffers = others.some(
+                        (o) => o.transactionTotal !== receipt.transactionTotal,
+                      );
+
+                      return (
+                        <div
+                          key={receipt.receiptId}
+                          className="rounded-md border p-3 space-y-2"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="space-y-1 min-w-0">
+                              <p
+                                className={`text-sm font-medium truncate ${
+                                  locationDiffers
+                                    ? "text-amber-600 dark:text-amber-400"
+                                    : ""
+                                }`}
+                              >
+                                {receipt.location}
+                              </p>
+                              <p className="text-sm text-muted-foreground">
+                                {receipt.date}
+                              </p>
+                              <p
+                                className={`text-sm font-medium ${
+                                  totalDiffers
+                                    ? "text-amber-600 dark:text-amber-400"
+                                    : ""
+                                }`}
+                              >
+                                {formatCurrency(receipt.transactionTotal)}
+                              </p>
+                            </div>
+                            <div className="flex flex-col gap-1">
+                              {locationDiffers && (
+                                <Badge variant="outline" className="text-xs">
+                                  Location differs
+                                </Badge>
+                              )}
+                              {totalDiffers && (
+                                <Badge variant="outline" className="text-xs">
+                                  Total differs
+                                </Badge>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex gap-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() =>
+                                navigate(`/receipts/${receipt.receiptId}`)
+                              }
+                            >
+                              View
+                            </Button>
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() =>
+                                setDeleteTarget({
+                                  id: receipt.receiptId,
+                                  location: receipt.location,
+                                })
+                              }
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </>
+      )}
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Receipt</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete the receipt from &quot;
+              {deleteTarget?.location}&quot;? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/client/src/hooks/useDuplicateDetectionReport.test.ts
+++ b/src/client/src/hooks/useDuplicateDetectionReport.test.ts
@@ -1,0 +1,118 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import { useDuplicateDetectionReport } from "./useDuplicateDetectionReport";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useDuplicateDetectionReport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches report data with default parameters", async () => {
+    const mockData = {
+      groupCount: 1,
+      totalDuplicateReceipts: 2,
+      groups: [
+        {
+          matchKey: "2025-03-01 @ Store A",
+          receipts: [
+            {
+              receiptId: "id-1",
+              location: "Store A",
+              date: "2025-03-01",
+              transactionTotal: 25.5,
+            },
+            {
+              receiptId: "id-2",
+              location: "Store A",
+              date: "2025-03-01",
+              transactionTotal: 30.0,
+            },
+          ],
+        },
+      ],
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useDuplicateDetectionReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith("/api/reports/duplicates", {
+      params: {
+        query: {
+          matchOn: undefined,
+          locationTolerance: undefined,
+          totalTolerance: undefined,
+        },
+      },
+    });
+  });
+
+  it("passes custom parameters", async () => {
+    const mockData = {
+      groupCount: 0,
+      totalDuplicateReceipts: 0,
+      groups: [],
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useDuplicateDetectionReport({
+          matchOn: "DateAndTotal",
+          locationTolerance: "normalized",
+          totalTolerance: 0.05,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith("/api/reports/duplicates", {
+      params: {
+        query: {
+          matchOn: "DateAndTotal",
+          locationTolerance: "normalized",
+          totalTolerance: 0.05,
+        },
+      },
+    });
+  });
+
+  it("throws when API returns an error", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useDuplicateDetectionReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/src/client/src/hooks/useDuplicateDetectionReport.ts
+++ b/src/client/src/hooks/useDuplicateDetectionReport.ts
@@ -1,0 +1,45 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export type MatchOn =
+  | "DateAndLocation"
+  | "DateAndTotal"
+  | "DateAndLocationAndTotal";
+
+export type LocationTolerance = "exact" | "normalized";
+
+export type TotalTolerance = 0 | 0.01 | 0.05 | 0.1 | 0.5 | 1;
+
+export interface DuplicateDetectionParams {
+  matchOn?: MatchOn;
+  locationTolerance?: LocationTolerance;
+  totalTolerance?: TotalTolerance;
+}
+
+export function useDuplicateDetectionReport(
+  params: DuplicateDetectionParams = {},
+) {
+  return useQuery({
+    queryKey: [
+      "reports",
+      "duplicates",
+      params.matchOn,
+      params.locationTolerance,
+      params.totalTolerance,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/reports/duplicates", {
+        params: {
+          query: {
+            matchOn: params.matchOn,
+            locationTolerance: params.locationTolerance,
+            totalTolerance: params.totalTolerance,
+          },
+        },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/reports/duplicates` endpoint for detecting potential duplicate receipts
- Implement React UI with configurable match-on strategy (date+location, date+total, or all three), location normalization, and total tolerance
- Include View/Delete actions per receipt within each duplicate group, with visual diff highlighting for differing fields

## Implementation
- **Backend:** `GetDuplicateDetectionReportQuery` + handler, `IReportService.GetDuplicatesAsync`, `DuplicateDetectionResult` model
- **Frontend:** `DuplicateDetection` component with `useDuplicateDetectionReport` hook, wired into Reports page
- **OpenAPI:** New `/api/reports/duplicates` endpoint with `DuplicatesResponse`, `DuplicateGroup`, and `DuplicateReceipt` schemas
- **Tests:** 14 component tests + 3 hook tests (client), full backend test suite passes (1462 tests)

## Test plan
- [x] `dotnet test` -- all 1462 unit tests pass
- [x] `vitest run` -- all 1494 client tests pass
- [x] `spectral lint` -- no errors
- [x] `check:drift` -- no spec drift
- [x] Pre-commit hook passes (format, build, lint, types, tests)

Closes RECEIPTS-444

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>