### PR TITLE
feat(api,client): implement Category Trends report

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -3071,6 +3071,61 @@ paths:
               schema:
                 type: string
 
+  /api/reports/category-trends:
+    get:
+      operationId: GetCategoryTrendsReport
+      tags: [Reports]
+      summary: Get category spending trends over time
+      description: Returns time-series spending data broken down by category. Categories beyond the topN threshold are collapsed into "Other". Buckets are dense and zero-filled.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Start date (ISO date string). Defaults to all time.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: End date (ISO date string). Defaults to today.
+        - name: granularity
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [daily, monthly, quarterly, yearly]
+            default: monthly
+          description: Time bucket granularity.
+        - name: topN
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 7
+          description: Number of top categories to show. Remaining categories are collapsed into "Other".
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CategoryTrendsResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
   # ──────────────────────────────────────────────
   # Dashboard
   # ──────────────────────────────────────────────
@@ -3526,6 +3581,34 @@ components:
         transactionTotal:
           type: number
           format: double
+
+    CategoryTrendsResponse:
+      type: object
+      required: [categories, buckets]
+      properties:
+        categories:
+          type: array
+          items:
+            type: string
+          description: Ordered list of category names. The amounts array in each bucket parallels this list.
+        buckets:
+          type: array
+          items:
+            $ref: "#/components/schemas/CategoryTrendsBucket"
+
+    CategoryTrendsBucket:
+      type: object
+      required: [period, amounts]
+      properties:
+        period:
+          type: string
+          description: Time period label (e.g. "2024-01", "2024 Q1", "2024").
+        amounts:
+          type: array
+          items:
+            type: number
+            format: double
+          description: Spending amounts parallel to the categories array. Zero-filled for missing data.
 
     # ── Dashboard ──────────────────────────────────
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-ad08735e",
+  "name": "agent-a5bea786",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/Application/Interfaces/Services/IReportService.cs
+++ b/src/Application/Interfaces/Services/IReportService.cs
@@ -52,4 +52,11 @@ public interface IReportService
 		string locationTolerance,
 		decimal totalTolerance,
 		CancellationToken cancellationToken);
+
+	Task<CategoryTrendsResult> GetCategoryTrendsAsync(
+		DateOnly startDate,
+		DateOnly endDate,
+		string granularity,
+		int topN,
+		CancellationToken cancellationToken);
 }

--- a/src/Application/Models/Reports/CategoryTrendsResult.cs
+++ b/src/Application/Models/Reports/CategoryTrendsResult.cs
@@ -1,0 +1,5 @@
+namespace Application.Models.Reports;
+
+public record CategoryTrendsBucketResult(string Period, List<decimal> Amounts);
+
+public record CategoryTrendsResult(List<string> Categories, List<CategoryTrendsBucketResult> Buckets);

--- a/src/Application/Queries/Aggregates/Reports/GetCategoryTrendsReportQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetCategoryTrendsReportQuery.cs
@@ -1,0 +1,10 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetCategoryTrendsReportQuery(
+	DateOnly StartDate,
+	DateOnly EndDate,
+	string Granularity,
+	int TopN) : IQuery<CategoryTrendsResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetCategoryTrendsReportQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetCategoryTrendsReportQueryHandler.cs
@@ -1,0 +1,19 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetCategoryTrendsReportQueryHandler(IReportService reportService)
+	: IRequestHandler<GetCategoryTrendsReportQuery, CategoryTrendsResult>
+{
+	public async Task<CategoryTrendsResult> Handle(GetCategoryTrendsReportQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetCategoryTrendsAsync(
+			request.StartDate,
+			request.EndDate,
+			request.Granularity,
+			request.TopN,
+			cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -577,5 +577,122 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 
 	private sealed record ReceiptSnapshot(Guid Id, string Location, DateOnly Date, decimal TransactionTotal);
 
+	public async Task<CategoryTrendsResult> GetCategoryTrendsAsync(
+		DateOnly startDate,
+		DateOnly endDate,
+		string granularity,
+		int topN,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		// Join receipt items with receipts for date filtering
+		var itemsInRange = context.ReceiptItems
+			.AsNoTracking()
+			.Where(ri => ri.DeletedAt == null)
+			.Join(
+				context.Receipts.AsNoTracking().Where(r => r.DeletedAt == null && r.Date >= startDate && r.Date <= endDate),
+				ri => ri.ReceiptId,
+				r => r.Id,
+				(ri, r) => new { ri.Category, ri.TotalAmount, r.Date });
+
+		// Materialize for in-memory grouping (bounded by item count in date range)
+		var materialized = await itemsInRange.ToListAsync(cancellationToken);
+
+		if (materialized.Count == 0)
+		{
+			return new CategoryTrendsResult([], []);
+		}
+
+		// Find top-N categories by total spending
+		var categoryTotals = materialized
+			.GroupBy(x => x.Category)
+			.Select(g => new { Category = g.Key, Total = g.Sum(x => x.TotalAmount) })
+			.OrderByDescending(x => x.Total)
+			.ToList();
+
+		HashSet<string> topCategories = categoryTotals
+			.Take(topN)
+			.Select(x => x.Category)
+			.ToHashSet();
+
+		bool hasOther = categoryTotals.Count > topN;
+
+		// Build ordered category list
+		List<string> categories = categoryTotals
+			.Take(topN)
+			.Select(x => x.Category)
+			.ToList();
+
+		if (hasOther)
+		{
+			categories.Add("Other");
+		}
+
+		// Map items to resolved category (top-N or "Other")
+		var resolvedItems = materialized.Select(x => new
+		{
+			Category = topCategories.Contains(x.Category) ? x.Category : "Other",
+			x.TotalAmount,
+			x.Date
+		});
+
+		// Generate all periods in range
+		List<string> allPeriods = GeneratePeriods(startDate, endDate, granularity);
+
+		// Group by period and category
+		var grouped = resolvedItems
+			.GroupBy(x => new { Period = FormatPeriod(x.Date, granularity), x.Category })
+			.ToDictionary(g => (g.Key.Period, g.Key.Category), g => g.Sum(x => x.TotalAmount));
+
+		// Build dense zero-filled buckets
+		List<CategoryTrendsBucketResult> buckets = allPeriods.Select(period =>
+		{
+			List<decimal> amounts = categories.Select(cat =>
+				grouped.TryGetValue((period, cat), out decimal amount) ? amount : 0m
+			).ToList();
+			return new CategoryTrendsBucketResult(period, amounts);
+		}).ToList();
+
+		return new CategoryTrendsResult(categories, buckets);
+	}
+
+	private static string FormatPeriod(DateOnly date, string granularity)
+	{
+		return granularity.ToLowerInvariant() switch
+		{
+			"daily" => date.ToString("yyyy-MM-dd"),
+			"quarterly" => $"{date.Year} Q{(date.Month - 1) / 3 + 1}",
+			"yearly" => date.Year.ToString(),
+			_ => $"{date.Year}-{date.Month:D2}" // monthly
+		};
+	}
+
+	private static List<string> GeneratePeriods(DateOnly start, DateOnly end, string granularity)
+	{
+		List<string> periods = [];
+		DateOnly current = granularity.ToLowerInvariant() switch
+		{
+			"daily" => start,
+			"quarterly" => new DateOnly(start.Year, ((start.Month - 1) / 3) * 3 + 1, 1),
+			"yearly" => new DateOnly(start.Year, 1, 1),
+			_ => new DateOnly(start.Year, start.Month, 1) // monthly
+		};
+
+		while (current <= end)
+		{
+			periods.Add(FormatPeriod(current, granularity));
+			current = granularity.ToLowerInvariant() switch
+			{
+				"daily" => current.AddDays(1),
+				"quarterly" => current.AddMonths(3),
+				"yearly" => current.AddYears(1),
+				_ => current.AddMonths(1) // monthly
+			};
+		}
+
+		return periods;
+	}
+
 	private record SimilarityEdge(Guid IdA, string DescA, Guid IdB, string DescB, double Score);
 }

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -349,4 +349,49 @@ public class ReportsController(IMediator mediator) : ControllerBase
 			}).ToList()
 		});
 	}
+
+	[HttpGet("category-trends")]
+	[EndpointSummary("Get category spending trends over time")]
+	[EndpointDescription("Returns time-series spending data broken down by category. Categories beyond the topN threshold are collapsed into \"Other\". Buckets are dense and zero-filled.")]
+	public async Task<Results<Ok<CategoryTrendsResponse>, BadRequest<string>>> GetCategoryTrends(
+		[FromQuery] DateOnly? startDate,
+		[FromQuery] DateOnly? endDate,
+		[FromQuery] string? granularity,
+		[FromQuery] int? topN,
+		CancellationToken cancellationToken)
+	{
+		DateOnly start = startDate ?? DateOnly.MinValue;
+		DateOnly end = endDate ?? DateOnly.FromDateTime(DateTime.Today);
+		string gran = granularity ?? "monthly";
+		int top = topN ?? 7;
+
+		if (start > end)
+		{
+			return TypedResults.BadRequest("startDate must be before or equal to endDate");
+		}
+
+		string[] validGranularities = ["daily", "monthly", "quarterly", "yearly"];
+		if (!validGranularities.Contains(gran.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid granularity '{gran}'. Allowed: daily, monthly, quarterly, yearly");
+		}
+
+		if (top < 1 || top > 50)
+		{
+			return TypedResults.BadRequest("topN must be between 1 and 50");
+		}
+
+		GetCategoryTrendsReportQuery query = new(start, end, gran, top);
+		AppReports.CategoryTrendsResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new CategoryTrendsResponse
+		{
+			Categories = result.Categories,
+			Buckets = result.Buckets.Select(b => new CategoryTrendsBucket
+			{
+				Period = b.Period,
+				Amounts = b.Amounts.Select(a => (double)a).ToList()
+			}).ToList()
+		});
+	}
 }

--- a/src/client/src/components/charts/StackedAreaChart.tsx
+++ b/src/client/src/components/charts/StackedAreaChart.tsx
@@ -1,0 +1,115 @@
+import { useId, useMemo } from "react";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { CHART_COLORS } from "./chart-colors";
+
+interface StackedAreaChartProps {
+  categories: string[];
+  buckets: Array<{ period: string; amounts: number[] }>;
+  height?: number;
+  formatValue?: (value: number) => string;
+}
+
+export function StackedAreaChart({
+  categories,
+  buckets,
+  height = 350,
+  formatValue = (v) => v.toLocaleString(),
+}: StackedAreaChartProps) {
+  const baseId = useId();
+
+  const chartData = useMemo(
+    () =>
+      buckets.map((bucket) => {
+        const point: Record<string, string | number> = {
+          period: bucket.period,
+        };
+        categories.forEach((cat, i) => {
+          point[cat] = bucket.amounts[i] ?? 0;
+        });
+        return point;
+      }),
+    [buckets, categories],
+  );
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <AreaChart
+        data={chartData}
+        margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
+      >
+        <defs>
+          {categories.map((cat, i) => (
+            <linearGradient
+              key={cat}
+              id={`${baseId}-gradient-${i}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <stop
+                offset="5%"
+                stopColor={CHART_COLORS[i % CHART_COLORS.length]}
+                stopOpacity={0.4}
+              />
+              <stop
+                offset="95%"
+                stopColor={CHART_COLORS[i % CHART_COLORS.length]}
+                stopOpacity={0.05}
+              />
+            </linearGradient>
+          ))}
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+        <XAxis
+          dataKey="period"
+          tick={{ fontSize: 12 }}
+          className="fill-muted-foreground"
+        />
+        <YAxis
+          tick={{ fontSize: 12 }}
+          className="fill-muted-foreground"
+          tickFormatter={formatValue}
+        />
+        <Tooltip
+          formatter={(value, name) => [
+            formatValue(Number(value)),
+            String(name),
+          ]}
+          contentStyle={{
+            backgroundColor: "hsl(var(--popover))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: "var(--radius)",
+            color: "hsl(var(--popover-foreground))",
+          }}
+        />
+        <Legend
+          verticalAlign="bottom"
+          iconType="circle"
+          iconSize={8}
+          wrapperStyle={{ fontSize: "12px" }}
+        />
+        {categories.map((cat, i) => (
+          <Area
+            key={cat}
+            type="monotone"
+            dataKey={cat}
+            stackId="1"
+            stroke={CHART_COLORS[i % CHART_COLORS.length]}
+            fill={`url(#${baseId}-gradient-${i})`}
+            strokeWidth={1.5}
+          />
+        ))}
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/client/src/components/charts/index.ts
+++ b/src/client/src/components/charts/index.ts
@@ -1,5 +1,6 @@
 export { ChartCard } from "./ChartCard";
 export { AreaTimeChart } from "./AreaTimeChart";
+export { StackedAreaChart } from "./StackedAreaChart";
 export { DonutChart } from "./DonutChart";
 export { BarChart } from "./BarChart";
 export { CHART_COLORS } from "./chart-colors";

--- a/src/client/src/components/reports/CategoryTrends.tsx
+++ b/src/client/src/components/reports/CategoryTrends.tsx
@@ -1,8 +1,146 @@
+import { useState, useCallback, useMemo } from "react";
+import { differenceInDays, parseISO } from "date-fns";
+import { ChartCard, StackedAreaChart } from "@/components/charts";
+import { DateRangeSelector } from "@/components/dashboard/DateRangeSelector";
+import type { DateRange } from "@/hooks/useDashboard";
+import { useCategoryTrendsReport } from "@/hooks/useCategoryTrendsReport";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type Granularity = "daily" | "monthly" | "quarterly" | "yearly";
+
+const granularityOptions: { value: Granularity; label: string }[] = [
+  { value: "daily", label: "Day" },
+  { value: "monthly", label: "Month" },
+  { value: "quarterly", label: "Quarter" },
+  { value: "yearly", label: "Year" },
+];
+
+const topNOptions = [3, 5, 7, 10, 15];
+
+function getAutoGranularity(dateRange: DateRange): Granularity {
+  if (!dateRange.startDate || !dateRange.endDate) {
+    return "yearly";
+  }
+  const days = differenceInDays(
+    parseISO(dateRange.endDate),
+    parseISO(dateRange.startDate),
+  );
+  if (days <= 93) return "daily";
+  if (days <= 730) return "monthly";
+  return "yearly";
+}
+
+function formatCompactCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
 export default function CategoryTrends() {
+  const [dateRange, setDateRange] = useState<DateRange>(() => ({
+    startDate: undefined,
+    endDate: undefined,
+  }));
+  const [granularityOverride, setGranularityOverride] =
+    useState<Granularity | null>(null);
+  const [topN, setTopN] = useState(7);
+
+  const autoGranularity = useMemo(
+    () => getAutoGranularity(dateRange),
+    [dateRange],
+  );
+  const granularity = granularityOverride ?? autoGranularity;
+
+  const { data, isLoading } = useCategoryTrendsReport({
+    startDate: dateRange.startDate,
+    endDate: dateRange.endDate,
+    granularity,
+    topN,
+  });
+
+  const handleGranularity = useCallback((g: Granularity) => {
+    setGranularityOverride(g);
+  }, []);
+
+  const handleTopNChange = useCallback((value: string) => {
+    setTopN(Number(value));
+  }, []);
+
+  const handleDateRangeChange = useCallback((range: DateRange) => {
+    setDateRange(range);
+    setGranularityOverride(null);
+  }, []);
+
+  const categories = useMemo(() => data?.categories ?? [], [data?.categories]);
+  const buckets = useMemo(
+    () =>
+      (data?.buckets ?? []).map((b) => ({
+        period: b.period,
+        amounts: (b.amounts ?? []).map(Number),
+      })),
+    [data?.buckets],
+  );
+
   return (
-    <div className="rounded-lg border p-6 text-center">
-      <h2 className="text-lg font-semibold">Category Trends</h2>
-      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <DateRangeSelector
+          value={dateRange}
+          onChange={handleDateRangeChange}
+        />
+      </div>
+
+      <ChartCard
+        title="Category Trends"
+        subtitle="Spending by category over time"
+        loading={isLoading}
+        empty={categories.length === 0 && !isLoading}
+        emptyMessage="No category spending data for this date range"
+        action={
+          <div className="flex items-center gap-2">
+            <div className="flex gap-1">
+              {granularityOptions.map(({ value, label }) => (
+                <Button
+                  key={value}
+                  variant={granularity === value ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => handleGranularity(value)}
+                >
+                  {label}
+                </Button>
+              ))}
+            </div>
+            <Select value={String(topN)} onValueChange={handleTopNChange}>
+              <SelectTrigger size="sm" className="w-[100px]" aria-label="Top N categories">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {topNOptions.map((n) => (
+                  <SelectItem key={n} value={String(n)}>
+                    Top {n}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        }
+      >
+        <StackedAreaChart
+          categories={categories}
+          buckets={buckets}
+          formatValue={formatCompactCurrency}
+        />
+      </ChartCard>
     </div>
   );
 }

--- a/src/client/src/hooks/useCategoryTrendsReport.ts
+++ b/src/client/src/hooks/useCategoryTrendsReport.ts
@@ -1,0 +1,40 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export interface CategoryTrendsParams {
+  startDate?: string;
+  endDate?: string;
+  granularity?: "daily" | "monthly" | "quarterly" | "yearly";
+  topN?: number;
+}
+
+export function useCategoryTrendsReport(params: CategoryTrendsParams) {
+  return useQuery({
+    queryKey: [
+      "reports",
+      "category-trends",
+      params.startDate,
+      params.endDate,
+      params.granularity,
+      params.topN,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/reports/category-trends",
+        {
+          params: {
+            query: {
+              startDate: params.startDate,
+              endDate: params.endDate,
+              granularity: params.granularity,
+              topN: params.topN,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/tests/Application.Tests/Queries/Aggregates/Reports/GetCategoryTrendsReportQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Reports/GetCategoryTrendsReportQueryHandlerTests.cs
@@ -1,0 +1,95 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Reports;
+
+public class GetCategoryTrendsReportQueryHandlerTests
+{
+	private readonly Mock<IReportService> _reportServiceMock;
+	private readonly GetCategoryTrendsReportQueryHandler _handler;
+
+	public GetCategoryTrendsReportQueryHandlerTests()
+	{
+		_reportServiceMock = new Mock<IReportService>();
+		_handler = new GetCategoryTrendsReportQueryHandler(_reportServiceMock.Object);
+	}
+
+	[Fact]
+	public async Task Handle_DelegatesToReportService()
+	{
+		// Arrange
+		DateOnly start = new(2025, 1, 1);
+		DateOnly end = new(2025, 12, 31);
+		GetCategoryTrendsReportQuery query = new(start, end, "monthly", 7);
+		CategoryTrendsResult expectedResult = new([], []);
+
+		_reportServiceMock.Setup(s => s.GetCategoryTrendsAsync(
+			start, end, "monthly", 7, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		CategoryTrendsResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+		_reportServiceMock.Verify(s => s.GetCategoryTrendsAsync(
+			start, end, "monthly", 7, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PassesAllParametersToService()
+	{
+		// Arrange
+		DateOnly start = new(2024, 6, 1);
+		DateOnly end = new(2024, 12, 31);
+		GetCategoryTrendsReportQuery query = new(start, end, "quarterly", 5);
+		CategoryTrendsResult expectedResult = new([], []);
+
+		_reportServiceMock.Setup(s => s.GetCategoryTrendsAsync(
+			start, end, "quarterly", 5, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		_reportServiceMock.Verify(s => s.GetCategoryTrendsAsync(
+			start, end, "quarterly", 5, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsServiceResult()
+	{
+		// Arrange
+		DateOnly start = new(2025, 1, 1);
+		DateOnly end = new(2025, 3, 31);
+		GetCategoryTrendsReportQuery query = new(start, end, "monthly", 3);
+		CategoryTrendsResult expectedResult = new(
+			["Groceries", "Dining", "Other"],
+			[
+				new CategoryTrendsBucketResult("2025-01", [150.00m, 75.50m, 20.00m]),
+				new CategoryTrendsBucketResult("2025-02", [200.00m, 60.00m, 15.00m]),
+				new CategoryTrendsBucketResult("2025-03", [180.00m, 90.00m, 25.00m]),
+			]);
+
+		_reportServiceMock.Setup(s => s.GetCategoryTrendsAsync(
+			It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
+			It.IsAny<string>(), It.IsAny<int>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		CategoryTrendsResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Categories.Should().HaveCount(3);
+		result.Categories.Should().ContainInOrder("Groceries", "Dining", "Other");
+		result.Buckets.Should().HaveCount(3);
+		result.Buckets[0].Period.Should().Be("2025-01");
+		result.Buckets[0].Amounts.Should().Equal(150.00m, 75.50m, 20.00m);
+		result.Buckets[2].Amounts.Should().Equal(180.00m, 90.00m, 25.00m);
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
@@ -420,4 +420,130 @@ public class ReportsControllerTests
 				q.StartDate == start && q.EndDate == end),
 			It.IsAny<CancellationToken>()), Times.Once);
 	}
+
+	// ── CategoryTrends ─────────────────────────────
+
+	[Fact]
+	public async Task GetCategoryTrends_ReturnsOkResult_WithDefaultParameters()
+	{
+		// Arrange
+		AppReports.CategoryTrendsResult trendsResult = new(
+			["Groceries", "Dining"],
+			[new AppReports.CategoryTrendsBucketResult("2025-01", [100.00m, 50.00m])]);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryTrendsReportQuery>(q =>
+				q.Granularity == "monthly" && q.TopN == 7),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(trendsResult);
+
+		// Act
+		Results<Ok<CategoryTrendsResponse>, BadRequest<string>> result =
+			await _controller.GetCategoryTrends(null, null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<CategoryTrendsResponse> okResult = Assert.IsType<Ok<CategoryTrendsResponse>>(result.Result);
+		CategoryTrendsResponse response = okResult.Value!;
+		response.Categories.Should().ContainInOrder("Groceries", "Dining");
+		response.Buckets.Should().ContainSingle();
+		response.Buckets.First().Period.Should().Be("2025-01");
+		response.Buckets.First().Amounts.Should().Equal(100.00, 50.00);
+	}
+
+	[Fact]
+	public async Task GetCategoryTrends_ReturnsBadRequest_WhenStartDateAfterEndDate()
+	{
+		// Act
+		Results<Ok<CategoryTrendsResponse>, BadRequest<string>> result =
+			await _controller.GetCategoryTrends(new DateOnly(2025, 12, 31), new DateOnly(2025, 1, 1), null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("startDate must be before or equal to endDate");
+	}
+
+	[Fact]
+	public async Task GetCategoryTrends_ReturnsBadRequest_WhenInvalidGranularity()
+	{
+		// Act
+		Results<Ok<CategoryTrendsResponse>, BadRequest<string>> result =
+			await _controller.GetCategoryTrends(null, null, "invalid", null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid granularity");
+	}
+
+	[Theory]
+	[InlineData("daily")]
+	[InlineData("monthly")]
+	[InlineData("quarterly")]
+	[InlineData("yearly")]
+	public async Task GetCategoryTrends_AcceptsValidGranularities(string granularity)
+	{
+		// Arrange
+		AppReports.CategoryTrendsResult trendsResult = new([], []);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetCategoryTrendsReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(trendsResult);
+
+		// Act
+		Results<Ok<CategoryTrendsResponse>, BadRequest<string>> result =
+			await _controller.GetCategoryTrends(null, null, granularity, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<CategoryTrendsResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetCategoryTrends_ReturnsBadRequest_WhenTopNTooLow()
+	{
+		// Act
+		Results<Ok<CategoryTrendsResponse>, BadRequest<string>> result =
+			await _controller.GetCategoryTrends(null, null, null, 0, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("topN must be between 1 and 50");
+	}
+
+	[Fact]
+	public async Task GetCategoryTrends_ReturnsBadRequest_WhenTopNTooHigh()
+	{
+		// Act
+		Results<Ok<CategoryTrendsResponse>, BadRequest<string>> result =
+			await _controller.GetCategoryTrends(null, null, null, 51, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("topN must be between 1 and 50");
+	}
+
+	[Fact]
+	public async Task GetCategoryTrends_PassesCustomParameters()
+	{
+		// Arrange
+		DateOnly start = new(2024, 1, 1);
+		DateOnly end = new(2024, 12, 31);
+		AppReports.CategoryTrendsResult trendsResult = new([], []);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetCategoryTrendsReportQuery>(q =>
+				q.StartDate == start && q.EndDate == end && q.Granularity == "quarterly" && q.TopN == 5),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(trendsResult);
+
+		// Act
+		Results<Ok<CategoryTrendsResponse>, BadRequest<string>> result =
+			await _controller.GetCategoryTrends(start, end, "quarterly", 5, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<CategoryTrendsResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetCategoryTrendsReportQuery>(q =>
+				q.StartDate == start && q.EndDate == end && q.Granularity == "quarterly" && q.TopN == 5),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
 }


### PR DESCRIPTION
## Summary
- Add `/api/reports/category-trends` endpoint returning time-series spending data broken down by top-N categories with "Other" rollup and dense zero-filled buckets
- Add `StackedAreaChart` Recharts component with gradient fills, tooltips, and legends
- Add `CategoryTrends` page with date range selector, granularity toggle (daily/monthly/quarterly/yearly), and top-N category selector
- Add 13 new unit tests (3 query handler + 10 controller) -- all 1,475 tests pass

## Test plan
- [x] .NET build succeeds with warnings-as-errors
- [x] OpenAPI spec lint clean, no drift
- [x] TypeScript type check passes
- [x] All 1,475 unit tests pass (266 Application + 738 Presentation + 336 Infrastructure + 18 Common + 117 Domain)
- [x] ESLint passes

Closes RECEIPTS-442

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>