### PR TITLE
feat(api,client): implement uncategorized items report with bulk categorization

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -3126,6 +3126,63 @@ paths:
               schema:
                 type: string
 
+  /api/reports/uncategorized-items:
+    get:
+      operationId: GetUncategorizedItemsReport
+      tags: [Reports]
+      summary: Get uncategorized items report
+      description: Returns all receipt items where the category is "Uncategorized".
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: sortBy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [description, total, itemCode]
+            default: description
+          description: Column to sort by.
+        - name: sortDirection
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: asc
+          description: Sort direction.
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-based).
+        - name: pageSize
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          description: Number of items per page.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UncategorizedItemsResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
   # ──────────────────────────────────────────────
   # Dashboard
   # ──────────────────────────────────────────────
@@ -3609,6 +3666,48 @@ components:
             type: number
             format: double
           description: Spending amounts parallel to the categories array. Zero-filled for missing data.
+
+    UncategorizedItemsResponse:
+      type: object
+      required: [totalCount, items]
+      properties:
+        totalCount:
+          type: integer
+          format: int32
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/UncategorizedItem"
+
+    UncategorizedItem:
+      type: object
+      required: [id, receiptId, description, quantity, unitPrice, totalAmount, category, pricingMode]
+      properties:
+        id:
+          type: string
+          format: uuid
+        receiptId:
+          type: string
+          format: uuid
+        receiptItemCode:
+          type: ["string", "null"]
+        description:
+          type: string
+        quantity:
+          type: number
+          format: double
+        unitPrice:
+          type: number
+          format: double
+        totalAmount:
+          type: number
+          format: double
+        category:
+          type: string
+        subcategory:
+          type: ["string", "null"]
+        pricingMode:
+          type: string
 
     # ── Dashboard ──────────────────────────────────
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-a5bea786",
+  "name": "agent-acdc0e53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/Application/Interfaces/Services/IReportService.cs
+++ b/src/Application/Interfaces/Services/IReportService.cs
@@ -59,4 +59,11 @@ public interface IReportService
 		string granularity,
 		int topN,
 		CancellationToken cancellationToken);
+
+	Task<UncategorizedItemsResult> GetUncategorizedItemsAsync(
+		string sortBy,
+		string sortDirection,
+		int page,
+		int pageSize,
+		CancellationToken cancellationToken);
 }

--- a/src/Application/Models/Reports/UncategorizedItemsResult.cs
+++ b/src/Application/Models/Reports/UncategorizedItemsResult.cs
@@ -1,0 +1,17 @@
+namespace Application.Models.Reports;
+
+public record UncategorizedItemRecord(
+	Guid Id,
+	Guid ReceiptId,
+	string? ReceiptItemCode,
+	string Description,
+	decimal Quantity,
+	decimal UnitPrice,
+	decimal TotalAmount,
+	string Category,
+	string? Subcategory,
+	string PricingMode);
+
+public record UncategorizedItemsResult(
+	List<UncategorizedItemRecord> Items,
+	int TotalCount);

--- a/src/Application/Queries/Aggregates/Reports/GetUncategorizedItemsReportQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetUncategorizedItemsReportQuery.cs
@@ -1,0 +1,10 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetUncategorizedItemsReportQuery(
+	string SortBy,
+	string SortDirection,
+	int Page,
+	int PageSize) : IQuery<UncategorizedItemsResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetUncategorizedItemsReportQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetUncategorizedItemsReportQueryHandler.cs
@@ -1,0 +1,19 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetUncategorizedItemsReportQueryHandler(IReportService reportService)
+	: IRequestHandler<GetUncategorizedItemsReportQuery, UncategorizedItemsResult>
+{
+	public async Task<UncategorizedItemsResult> Handle(GetUncategorizedItemsReportQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetUncategorizedItemsAsync(
+			request.SortBy,
+			request.SortDirection,
+			request.Page,
+			request.PageSize,
+			cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -694,5 +694,62 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 		return periods;
 	}
 
+	public async Task<UncategorizedItemsResult> GetUncategorizedItemsAsync(
+		string sortBy,
+		string sortDirection,
+		int page,
+		int pageSize,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		var baseQuery = from ri in context.ReceiptItems.AsNoTracking()
+						where ri.DeletedAt == null && ri.Category == "Uncategorized"
+						select new
+						{
+							ri.Id,
+							ri.ReceiptId,
+							ri.ReceiptItemCode,
+							ri.Description,
+							ri.Quantity,
+							ri.UnitPrice,
+							ri.TotalAmount,
+							ri.Category,
+							ri.Subcategory,
+							ri.PricingMode
+						};
+
+		var allItems = await baseQuery.ToListAsync(cancellationToken);
+		int totalCount = allItems.Count;
+
+		var sorted = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
+		{
+			("total", "asc") => allItems.OrderBy(x => x.TotalAmount).AsEnumerable(),
+			("total", "desc") => allItems.OrderByDescending(x => x.TotalAmount).AsEnumerable(),
+			("itemcode", "asc") => allItems.OrderBy(x => x.ReceiptItemCode ?? string.Empty).AsEnumerable(),
+			("itemcode", "desc") => allItems.OrderByDescending(x => x.ReceiptItemCode ?? string.Empty).AsEnumerable(),
+			("description", "desc") => allItems.OrderByDescending(x => x.Description).AsEnumerable(),
+			_ => allItems.OrderBy(x => x.Description).AsEnumerable(),
+		};
+
+		List<UncategorizedItemRecord> pagedItems = sorted
+			.Skip((page - 1) * pageSize)
+			.Take(pageSize)
+			.Select(x => new UncategorizedItemRecord(
+				x.Id,
+				x.ReceiptId,
+				x.ReceiptItemCode,
+				x.Description,
+				x.Quantity,
+				x.UnitPrice,
+				x.TotalAmount,
+				x.Category,
+				x.Subcategory,
+				x.PricingMode.ToString().ToLowerInvariant()))
+			.ToList();
+
+		return new UncategorizedItemsResult(pagedItems, totalCount);
+	}
+
 	private record SimilarityEdge(Guid IdA, string DescA, Guid IdB, string DescB, double Score);
 }

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -394,4 +394,63 @@ public class ReportsController(IMediator mediator) : ControllerBase
 			}).ToList()
 		});
 	}
+
+	[HttpGet("uncategorized-items")]
+	[EndpointSummary("Get uncategorized items report")]
+	[EndpointDescription("Returns all receipt items where the category is \"Uncategorized\".")]
+	public async Task<Results<Ok<UncategorizedItemsResponse>, BadRequest<string>>> GetUncategorizedItems(
+		[FromQuery] string? sortBy,
+		[FromQuery] string? sortDirection,
+		[FromQuery] int? page,
+		[FromQuery] int? pageSize,
+		CancellationToken cancellationToken)
+	{
+		string sort = sortBy ?? "description";
+		string direction = sortDirection ?? "asc";
+		int pg = page ?? 1;
+		int ps = pageSize ?? 50;
+
+		string[] validSortColumns = ["description", "total", "itemcode"];
+		if (!validSortColumns.Contains(sort.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid sortBy '{sort}'. Allowed: description, total, itemCode");
+		}
+
+		string[] validDirections = ["asc", "desc"];
+		if (!validDirections.Contains(direction.ToLowerInvariant()))
+		{
+			return TypedResults.BadRequest($"Invalid sortDirection '{direction}'. Allowed: asc, desc");
+		}
+
+		if (pg < 1)
+		{
+			return TypedResults.BadRequest("page must be at least 1");
+		}
+
+		if (ps < 1 || ps > 100)
+		{
+			return TypedResults.BadRequest("pageSize must be between 1 and 100");
+		}
+
+		GetUncategorizedItemsReportQuery query = new(sort, direction, pg, ps);
+		AppReports.UncategorizedItemsResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new UncategorizedItemsResponse
+		{
+			TotalCount = result.TotalCount,
+			Items = result.Items.Select(i => new UncategorizedItem
+			{
+				Id = i.Id,
+				ReceiptId = i.ReceiptId,
+				ReceiptItemCode = i.ReceiptItemCode,
+				Description = i.Description,
+				Quantity = (double)i.Quantity,
+				UnitPrice = (double)i.UnitPrice,
+				TotalAmount = (double)i.TotalAmount,
+				Category = i.Category,
+				Subcategory = i.Subcategory,
+				PricingMode = i.PricingMode
+			}).ToList()
+		});
+	}
 }

--- a/src/client/src/components/reports/UncategorizedItems.test.tsx
+++ b/src/client/src/components/reports/UncategorizedItems.test.tsx
@@ -1,0 +1,276 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "@/test/test-utils";
+import UncategorizedItems from "./UncategorizedItems";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/hooks/useUncategorizedItemsReport", () => ({
+  useUncategorizedItemsReport: vi.fn(),
+}));
+
+vi.mock("@/hooks/useCategories", () => ({
+  useCategories: vi.fn().mockReturnValue({
+    data: [
+      { id: "cat-1", name: "Groceries" },
+      { id: "cat-2", name: "Uncategorized" },
+    ],
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useSubcategories", () => ({
+  useSubcategoriesByCategoryId: vi.fn().mockReturnValue({
+    data: [{ id: "sub-1", name: "Produce" }],
+    isLoading: false,
+  }),
+}));
+
+import { useUncategorizedItemsReport } from "@/hooks/useUncategorizedItemsReport";
+const mockHook = vi.mocked(useUncategorizedItemsReport);
+
+const mockItems = [
+  {
+    id: "item-1",
+    receiptId: "receipt-1",
+    receiptItemCode: "ABC",
+    description: "Apples",
+    quantity: 2,
+    unitPrice: 1.5,
+    totalAmount: 3.0,
+    category: "Uncategorized",
+    subcategory: null,
+    pricingMode: "quantity",
+  },
+  {
+    id: "item-2",
+    receiptId: "receipt-2",
+    receiptItemCode: null,
+    description: "Bananas",
+    quantity: 1,
+    unitPrice: 2.0,
+    totalAmount: 2.0,
+    category: "Uncategorized",
+    subcategory: "Fruit",
+    pricingMode: "quantity",
+  },
+];
+
+function setupMock(overrides: Record<string, unknown> = {}) {
+  mockHook.mockReturnValue({
+    data: {
+      totalCount: 2,
+      items: mockItems,
+    },
+    isLoading: false,
+    isError: false,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+describe("UncategorizedItems", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton", () => {
+    setupMock({ isLoading: true, data: undefined });
+    renderWithQueryClient(<UncategorizedItems />);
+    const skeletons = document.querySelectorAll("[data-slot='skeleton']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state", () => {
+    setupMock({ isError: true, data: undefined });
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(
+      screen.getByText(/failed to load uncategorized items report/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no uncategorized items", () => {
+    setupMock({
+      data: { totalCount: 0, items: [] },
+    });
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(screen.getByText("All Categorized")).toBeInTheDocument();
+    expect(
+      screen.getByText(/all receipt items have been categorized/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when data is null", () => {
+    setupMock({ data: undefined });
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(screen.getByText("All Categorized")).toBeInTheDocument();
+  });
+
+  it("renders summary header with count", () => {
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Uncategorized Items")).toBeInTheDocument();
+  });
+
+  it("renders table with all items", () => {
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(screen.getByText("Apples")).toBeInTheDocument();
+    expect(screen.getByText("Bananas")).toBeInTheDocument();
+  });
+
+  it("renders table headers", () => {
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/Description/)).toBeInTheDocument();
+    expect(within(table).getByText(/Item Code/)).toBeInTheDocument();
+    expect(within(table).getByText("Receipt")).toBeInTheDocument();
+    expect(within(table).getByText(/Total/)).toBeInTheDocument();
+    expect(within(table).getByText("Subcategory")).toBeInTheDocument();
+  });
+
+  it("displays item code or dash when missing", () => {
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(screen.getByText("ABC")).toBeInTheDocument();
+    // Bananas has null item code, should show "-"
+    const bananaRow = screen.getByText("Bananas").closest("tr")!;
+    expect(within(bananaRow).getAllByText("-").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("displays subcategory or dash when missing", () => {
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(screen.getByText("Fruit")).toBeInTheDocument();
+  });
+
+  it("navigates to receipt on View click", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+
+    const viewLinks = screen.getAllByText("View");
+    await user.click(viewLinks[0]);
+    expect(mockNavigate).toHaveBeenCalledWith("/receipts/receipt-1");
+  });
+
+  it("toggles sort direction on clicking sortable column", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+
+    const descHeader = screen
+      .getByText(/Description/)
+      .closest("th")!;
+    await user.click(descHeader);
+
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sortBy: "description", sortDirection: "desc" }),
+    );
+  });
+
+  it("switches sort column when clicking a different column", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+
+    const totalHeader = screen
+      .getByText(/Total/)
+      .closest("th")!;
+    await user.click(totalHeader);
+
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sortBy: "total",
+        sortDirection: "asc",
+      }),
+    );
+  });
+
+  it("shows checkboxes for selection", () => {
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Select-all + 2 item checkboxes
+    expect(checkboxes.length).toBe(3);
+  });
+
+  it("shows bulk action toolbar when items are selected", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]); // Select first item
+
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    expect(screen.getByText("Apply to Selected")).toBeInTheDocument();
+  });
+
+  it("does not show pagination when only one page", () => {
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(screen.queryByText(/Page/)).not.toBeInTheDocument();
+  });
+
+  it("shows pagination when multiple pages", () => {
+    const manyItems = Array.from({ length: 51 }, (_, i) => ({
+      id: `id-${i}`,
+      receiptId: `receipt-${i}`,
+      receiptItemCode: null,
+      description: `Item ${i}`,
+      quantity: 1,
+      unitPrice: 1.0,
+      totalAmount: 1.0,
+      category: "Uncategorized",
+      subcategory: null,
+      pricingMode: "quantity",
+    }));
+    setupMock({
+      data: { totalCount: 51, items: manyItems },
+    });
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Next" }),
+    ).not.toBeDisabled();
+  });
+
+  it("formats currency values correctly", () => {
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+    expect(screen.getByText("$3.00")).toBeInTheDocument();
+    expect(screen.getByText("$2.00")).toBeInTheDocument();
+  });
+
+  it("selects all items when select-all checkbox is clicked", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+
+    const selectAll = screen.getAllByRole("checkbox")[0];
+    await user.click(selectAll);
+
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+  });
+
+  it("filters Uncategorized from category options", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<UncategorizedItems />);
+
+    // Select an item to show toolbar
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+
+    // The category combobox should be present but "Uncategorized" should not be an option
+    expect(screen.getByText("Select category...")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/reports/UncategorizedItems.tsx
+++ b/src/client/src/components/reports/UncategorizedItems.tsx
@@ -1,8 +1,391 @@
+import { useState, useMemo } from "react";
+import { useNavigate } from "react-router";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useUncategorizedItemsReport,
+  type UncategorizedItemsParams,
+} from "@/hooks/useUncategorizedItemsReport";
+import { useCategories } from "@/hooks/useCategories";
+import { useSubcategoriesByCategoryId } from "@/hooks/useSubcategories";
+import { formatCurrency } from "@/lib/format";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
+import client from "@/lib/api-client";
+import { toast } from "sonner";
+
+type SortColumn = "description" | "total" | "itemCode";
+type SortDirection = "asc" | "desc";
+
+interface UncategorizedItemData {
+  id: string;
+  receiptId: string;
+  receiptItemCode?: string | null;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  totalAmount: number;
+  category: string;
+  subcategory?: string | null;
+  pricingMode: string;
+}
+
 export default function UncategorizedItems() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [sortBy, setSortBy] = useState<SortColumn>("description");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  const [page, setPage] = useState(1);
+  const pageSize = 50;
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [selectedCategory, setSelectedCategory] = useState("");
+  const [selectedSubcategory, setSelectedSubcategory] = useState("");
+
+  const params: UncategorizedItemsParams = {
+    sortBy,
+    sortDirection,
+    page,
+    pageSize,
+  };
+
+  const { data, isLoading, isError } = useUncategorizedItemsReport(params);
+  const { data: categories, isLoading: categoriesLoading } = useCategories(
+    0,
+    200,
+    "name",
+    "asc",
+    true,
+  );
+
+  const categoryOptions: ComboboxOption[] = useMemo(
+    () =>
+      (categories ?? [])
+        .filter((c) => c.name !== "Uncategorized")
+        .map((c) => ({ value: c.name, label: c.name })),
+    [categories],
+  );
+
+  const selectedCategoryId = useMemo(() => {
+    const found = (categories ?? []).find((c) => c.name === selectedCategory);
+    return found?.id ?? null;
+  }, [categories, selectedCategory]);
+
+  const { data: subcategories, isLoading: subcategoriesLoading } =
+    useSubcategoriesByCategoryId(selectedCategoryId, 0, 200, "name", "asc", true);
+
+  const subcategoryOptions: ComboboxOption[] = useMemo(
+    () =>
+      (subcategories ?? []).map((s) => ({
+        value: s.name,
+        label: s.name,
+      })),
+    [subcategories],
+  );
+
+  const bulkUpdateMutation = useMutation({
+    mutationFn: async ({
+      items,
+      category,
+      subcategory,
+    }: {
+      items: UncategorizedItemData[];
+      category: string;
+      subcategory: string | null;
+    }) => {
+      const grouped = new Map<string, UncategorizedItemData[]>();
+      for (const item of items) {
+        const group = grouped.get(item.receiptId) ?? [];
+        group.push(item);
+        grouped.set(item.receiptId, group);
+      }
+
+      const promises = Array.from(grouped.values()).map((groupItems) =>
+        client.PUT("/api/receipt-items/batch", {
+          body: groupItems.map((item) => ({
+            id: item.id,
+            receiptItemCode: item.receiptItemCode ?? null,
+            description: item.description,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            category,
+            subcategory: subcategory || null,
+            pricingMode: item.pricingMode as "quantity" | "flat",
+          })),
+        }),
+      );
+
+      const results = await Promise.all(promises);
+      for (const result of results) {
+        if (result.error) throw result.error;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["reports", "uncategorized-items"],
+      });
+      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
+      setSelectedIds(new Set());
+      setSelectedCategory("");
+      setSelectedSubcategory("");
+      toast.success("Items categorized successfully");
+    },
+    onError: () => {
+      toast.error("Failed to update items");
+    },
+  });
+
+  function handleSort(column: SortColumn) {
+    if (sortBy === column) {
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(column);
+      setSortDirection("asc");
+    }
+    setPage(1);
+  }
+
+  function sortIndicator(column: SortColumn) {
+    if (sortBy !== column) return null;
+    return sortDirection === "asc" ? " \u2191" : " \u2193";
+  }
+
+  function handleReceiptClick(e: React.MouseEvent, receiptId: string) {
+    e.stopPropagation();
+    navigate(`/receipts/${receiptId}`);
+  }
+
+  function handleToggleItem(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function handleToggleAll() {
+    if (!data?.items) return;
+    setSelectedIds((prev) => {
+      const allOnPage = data.items.map((item) => item.id);
+      const allSelected = allOnPage.every((id) => prev.has(id));
+      if (allSelected) {
+        const next = new Set(prev);
+        for (const id of allOnPage) next.delete(id);
+        return next;
+      } else {
+        const next = new Set(prev);
+        for (const id of allOnPage) next.add(id);
+        return next;
+      }
+    });
+  }
+
+  function handleApply() {
+    if (!data?.items || selectedIds.size === 0 || !selectedCategory) return;
+
+    const itemsToUpdate = data.items.filter((item) =>
+      selectedIds.has(item.id),
+    ) as UncategorizedItemData[];
+
+    bulkUpdateMutation.mutate({
+      items: itemsToUpdate,
+      category: selectedCategory,
+      subcategory: selectedSubcategory || null,
+    });
+  }
+
+  function handleCategoryChange(value: string) {
+    setSelectedCategory(value);
+    setSelectedSubcategory("");
+  }
+
+  const totalPages = data ? Math.ceil(data.totalCount / pageSize) : 0;
+  const allOnPageSelected =
+    data?.items &&
+    data.items.length > 0 &&
+    data.items.every((item) => selectedIds.has(item.id));
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-20 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">
+          Failed to load uncategorized items report.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data || data.totalCount === 0) {
+    return (
+      <div className="rounded-lg border p-6 text-center">
+        <h2 className="text-lg font-semibold">All Categorized</h2>
+        <p className="mt-2 text-muted-foreground">
+          All receipt items have been categorized. No uncategorized items found.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-lg border p-6 text-center">
-      <h2 className="text-lg font-semibold">Uncategorized Items</h2>
-      <p className="mt-2 text-muted-foreground">Coming soon</p>
+    <div className="space-y-4">
+      <div className="flex gap-6 rounded-lg border p-4">
+        <div>
+          <p className="text-sm text-muted-foreground">Uncategorized Items</p>
+          <p className="text-2xl font-bold">{data.totalCount}</p>
+        </div>
+      </div>
+
+      {selectedIds.size > 0 && (
+        <div className="flex items-center gap-3 rounded-lg border bg-muted/50 p-3">
+          <span className="text-sm font-medium">
+            {selectedIds.size} selected
+          </span>
+          <Combobox
+            options={categoryOptions}
+            value={selectedCategory}
+            onValueChange={handleCategoryChange}
+            placeholder="Select category..."
+            searchPlaceholder="Search categories..."
+            loading={categoriesLoading}
+            className="w-48"
+          />
+          <Combobox
+            options={subcategoryOptions}
+            value={selectedSubcategory}
+            onValueChange={setSelectedSubcategory}
+            placeholder="Subcategory (optional)"
+            searchPlaceholder="Search subcategories..."
+            disabled={!selectedCategory}
+            loading={subcategoriesLoading}
+            className="w-48"
+          />
+          <Button
+            size="sm"
+            disabled={
+              !selectedCategory ||
+              selectedIds.size === 0 ||
+              bulkUpdateMutation.isPending
+            }
+            onClick={handleApply}
+          >
+            {bulkUpdateMutation.isPending ? "Applying..." : "Apply to Selected"}
+          </Button>
+        </div>
+      )}
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-10">
+              <input
+                type="checkbox"
+                checked={!!allOnPageSelected}
+                onChange={handleToggleAll}
+                aria-label="Select all items on this page"
+                className="h-4 w-4 rounded border-gray-300"
+              />
+            </TableHead>
+            <TableHead
+              className="cursor-pointer select-none"
+              onClick={() => handleSort("description")}
+            >
+              Description{sortIndicator("description")}
+            </TableHead>
+            <TableHead
+              className="cursor-pointer select-none"
+              onClick={() => handleSort("itemCode")}
+            >
+              Item Code{sortIndicator("itemCode")}
+            </TableHead>
+            <TableHead>Receipt</TableHead>
+            <TableHead
+              className="cursor-pointer select-none text-right"
+              onClick={() => handleSort("total")}
+            >
+              Total{sortIndicator("total")}
+            </TableHead>
+            <TableHead>Subcategory</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.items.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell>
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(item.id)}
+                  onChange={() => handleToggleItem(item.id)}
+                  aria-label={`Select ${item.description}`}
+                  className="h-4 w-4 rounded border-gray-300"
+                />
+              </TableCell>
+              <TableCell>{item.description}</TableCell>
+              <TableCell>{item.receiptItemCode ?? "-"}</TableCell>
+              <TableCell>
+                <button
+                  type="button"
+                  className="text-primary underline-offset-4 hover:underline"
+                  onClick={(e) => handleReceiptClick(e, item.receiptId)}
+                >
+                  View
+                </button>
+              </TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(item.totalAmount)}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {item.subcategory ?? "-"}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/client/src/hooks/useUncategorizedItemsReport.test.ts
+++ b/src/client/src/hooks/useUncategorizedItemsReport.test.ts
@@ -1,0 +1,117 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import { useUncategorizedItemsReport } from "./useUncategorizedItemsReport";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useUncategorizedItemsReport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches report data with default parameters", async () => {
+    const mockData = {
+      totalCount: 2,
+      items: [
+        {
+          id: "item-1",
+          receiptId: "receipt-1",
+          receiptItemCode: "ABC",
+          description: "Test Item",
+          quantity: 1,
+          unitPrice: 5.0,
+          totalAmount: 5.0,
+          category: "Uncategorized",
+          subcategory: null,
+          pricingMode: "quantity",
+        },
+      ],
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useUncategorizedItemsReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/uncategorized-items",
+      {
+        params: {
+          query: {
+            sortBy: undefined,
+            sortDirection: undefined,
+            page: undefined,
+            pageSize: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("passes custom parameters", async () => {
+    const mockData = { totalCount: 0, items: [] };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useUncategorizedItemsReport({
+          sortBy: "total",
+          sortDirection: "desc",
+          page: 2,
+          pageSize: 25,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/uncategorized-items",
+      {
+        params: {
+          query: {
+            sortBy: "total",
+            sortDirection: "desc",
+            page: 2,
+            pageSize: 25,
+          },
+        },
+      },
+    );
+  });
+
+  it("throws when API returns an error", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useUncategorizedItemsReport(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/src/client/src/hooks/useUncategorizedItemsReport.ts
+++ b/src/client/src/hooks/useUncategorizedItemsReport.ts
@@ -1,0 +1,42 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export interface UncategorizedItemsParams {
+  sortBy?: "description" | "total" | "itemCode";
+  sortDirection?: "asc" | "desc";
+  page?: number;
+  pageSize?: number;
+}
+
+export function useUncategorizedItemsReport(
+  params: UncategorizedItemsParams = {},
+) {
+  return useQuery({
+    queryKey: [
+      "reports",
+      "uncategorized-items",
+      params.sortBy,
+      params.sortDirection,
+      params.page,
+      params.pageSize,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/reports/uncategorized-items",
+        {
+          params: {
+            query: {
+              sortBy: params.sortBy,
+              sortDirection: params.sortDirection,
+              page: params.page,
+              pageSize: params.pageSize,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/tests/Application.Tests/Queries/Aggregates/Reports/GetUncategorizedItemsReportQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Reports/GetUncategorizedItemsReportQueryHandlerTests.cs
@@ -1,0 +1,82 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Reports;
+
+public class GetUncategorizedItemsReportQueryHandlerTests
+{
+	private readonly Mock<IReportService> _reportServiceMock;
+	private readonly GetUncategorizedItemsReportQueryHandler _handler;
+
+	public GetUncategorizedItemsReportQueryHandlerTests()
+	{
+		_reportServiceMock = new Mock<IReportService>();
+		_handler = new GetUncategorizedItemsReportQueryHandler(_reportServiceMock.Object);
+	}
+
+	[Fact]
+	public async Task Handle_DelegatesToReportService()
+	{
+		// Arrange
+		GetUncategorizedItemsReportQuery query = new("description", "asc", 1, 50);
+		UncategorizedItemsResult expectedResult = new([], 0);
+
+		_reportServiceMock.Setup(s => s.GetUncategorizedItemsAsync(
+			"description", "asc", 1, 50, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		UncategorizedItemsResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+		_reportServiceMock.Verify(s => s.GetUncategorizedItemsAsync(
+			"description", "asc", 1, 50, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PassesAllParametersToService()
+	{
+		// Arrange
+		GetUncategorizedItemsReportQuery query = new("total", "desc", 3, 25);
+		UncategorizedItemsResult expectedResult = new([], 0);
+
+		_reportServiceMock.Setup(s => s.GetUncategorizedItemsAsync(
+			"total", "desc", 3, 25, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		_reportServiceMock.Verify(s => s.GetUncategorizedItemsAsync(
+			"total", "desc", 3, 25, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsServiceResult()
+	{
+		// Arrange
+		GetUncategorizedItemsReportQuery query = new("description", "asc", 1, 50);
+		UncategorizedItemsResult expectedResult = new(
+		[
+			new UncategorizedItemRecord(Guid.NewGuid(), Guid.NewGuid(), "ABC",
+				"Test Item", 1m, 5.00m, 5.00m, "Uncategorized", null, "quantity"),
+		], 1);
+
+		_reportServiceMock.Setup(s => s.GetUncategorizedItemsAsync(
+			It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		UncategorizedItemsResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.TotalCount.Should().Be(1);
+		result.Items.Should().ContainSingle();
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/UncategorizedItemsReportsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/UncategorizedItemsReportsControllerTests.cs
@@ -1,0 +1,202 @@
+using API.Controllers.Aggregates;
+using API.Generated.Dtos;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using AppReports = Application.Models.Reports;
+
+namespace Presentation.API.Tests.Controllers.Aggregates;
+
+public class UncategorizedItemsReportsControllerTests
+{
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly ReportsController _controller;
+
+	public UncategorizedItemsReportsControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_controller = new ReportsController(_mediatorMock.Object);
+	}
+
+	[Fact]
+	public async Task GetUncategorizedItems_ReturnsOkResult_WithDefaultParameters()
+	{
+		// Arrange
+		AppReports.UncategorizedItemsResult reportResult = new(
+		[
+			new AppReports.UncategorizedItemRecord(
+				Guid.NewGuid(), Guid.NewGuid(), "ABC",
+				"Test Item", 1m, 5.00m, 5.00m, "Uncategorized", null, "quantity"),
+		], 1);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetUncategorizedItemsReportQuery>(q =>
+				q.SortBy == "description" && q.SortDirection == "asc" && q.Page == 1 && q.PageSize == 50),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<UncategorizedItemsResponse>, BadRequest<string>> result =
+			await _controller.GetUncategorizedItems(null, null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<UncategorizedItemsResponse> okResult = Assert.IsType<Ok<UncategorizedItemsResponse>>(result.Result);
+		UncategorizedItemsResponse response = okResult.Value!;
+		response.TotalCount.Should().Be(1);
+		response.Items.Should().ContainSingle();
+		response.Items.First().Description.Should().Be("Test Item");
+	}
+
+	[Fact]
+	public async Task GetUncategorizedItems_PassesCustomParameters()
+	{
+		// Arrange
+		AppReports.UncategorizedItemsResult reportResult = new([], 0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetUncategorizedItemsReportQuery>(q =>
+				q.SortBy == "total" && q.SortDirection == "desc" && q.Page == 2 && q.PageSize == 25),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<UncategorizedItemsResponse>, BadRequest<string>> result =
+			await _controller.GetUncategorizedItems("total", "desc", 2, 25, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<UncategorizedItemsResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetUncategorizedItemsReportQuery>(q =>
+				q.SortBy == "total" && q.SortDirection == "desc" && q.Page == 2 && q.PageSize == 25),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetUncategorizedItems_ReturnsBadRequest_WhenInvalidSortBy()
+	{
+		// Act
+		Results<Ok<UncategorizedItemsResponse>, BadRequest<string>> result =
+			await _controller.GetUncategorizedItems("invalid", null, null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid sortBy");
+	}
+
+	[Fact]
+	public async Task GetUncategorizedItems_ReturnsBadRequest_WhenInvalidSortDirection()
+	{
+		// Act
+		Results<Ok<UncategorizedItemsResponse>, BadRequest<string>> result =
+			await _controller.GetUncategorizedItems(null, "invalid", null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid sortDirection");
+	}
+
+	[Fact]
+	public async Task GetUncategorizedItems_ReturnsBadRequest_WhenPageLessThanOne()
+	{
+		// Act
+		Results<Ok<UncategorizedItemsResponse>, BadRequest<string>> result =
+			await _controller.GetUncategorizedItems(null, null, 0, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("page must be at least 1");
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	[InlineData(101)]
+	public async Task GetUncategorizedItems_ReturnsBadRequest_WhenPageSizeOutOfRange(int pageSize)
+	{
+		// Act
+		Results<Ok<UncategorizedItemsResponse>, BadRequest<string>> result =
+			await _controller.GetUncategorizedItems(null, null, null, pageSize, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("pageSize must be between 1 and 100");
+	}
+
+	[Theory]
+	[InlineData("description")]
+	[InlineData("total")]
+	[InlineData("itemCode")]
+	public async Task GetUncategorizedItems_AcceptsValidSortColumns(string sortBy)
+	{
+		// Arrange
+		AppReports.UncategorizedItemsResult reportResult = new([], 0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetUncategorizedItemsReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<UncategorizedItemsResponse>, BadRequest<string>> result =
+			await _controller.GetUncategorizedItems(sortBy, null, null, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<UncategorizedItemsResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetUncategorizedItems_ThrowsException_WhenMediatorFails()
+	{
+		// Arrange
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetUncategorizedItemsReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception());
+
+		// Act
+		Func<Task> act = () => _controller.GetUncategorizedItems(null, null, null, null, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	[Fact]
+	public async Task GetUncategorizedItems_MapsResponseFieldsCorrectly()
+	{
+		// Arrange
+		Guid itemId = Guid.NewGuid();
+		Guid receiptId = Guid.NewGuid();
+
+		AppReports.UncategorizedItemsResult reportResult = new(
+		[
+			new AppReports.UncategorizedItemRecord(
+				itemId, receiptId, "ITM-001",
+				"Test Description", 2m, 3.50m, 7.00m, "Uncategorized", "SomeSub", "flat"),
+		], 1);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetUncategorizedItemsReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<UncategorizedItemsResponse>, BadRequest<string>> result =
+			await _controller.GetUncategorizedItems(null, null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<UncategorizedItemsResponse> okResult = Assert.IsType<Ok<UncategorizedItemsResponse>>(result.Result);
+		UncategorizedItem item = okResult.Value!.Items.First();
+		item.Id.Should().Be(itemId);
+		item.ReceiptId.Should().Be(receiptId);
+		item.ReceiptItemCode.Should().Be("ITM-001");
+		item.Description.Should().Be("Test Description");
+		item.Quantity.Should().Be(2.0);
+		item.UnitPrice.Should().Be(3.50);
+		item.TotalAmount.Should().Be(7.00);
+		item.Category.Should().Be("Uncategorized");
+		item.Subcategory.Should().Be("SomeSub");
+		item.PricingMode.Should().Be("flat");
+	}
+}


### PR DESCRIPTION
## Summary
- Add `/api/reports/uncategorized-items` API endpoint returning receipt items with "Uncategorized" category, with server-side sorting (description, total, itemCode) and pagination
- Add `UncategorizedItems` React component with table display, checkbox selection, and bulk category/subcategory assignment via existing batch update endpoint
- Include OpenAPI spec definitions, CQRS query handler, report service implementation, and comprehensive tests (Application + API controller + React hook + component)

## Test plan
- [x] All 1478 .NET unit tests pass
- [x] OpenAPI spec lints clean (no warnings/errors)
- [x] No spec drift between hand-authored and generated spec
- [x] TypeScript compilation passes
- [x] ESLint passes (0 errors)
- [x] Pre-commit hook passes all 9 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)