### PR TITLE
fix(client): disable browser autofill on financial input fields

### DIFF
--- a/src/client/src/components/ui/currency-input.test.tsx
+++ b/src/client/src/components/ui/currency-input.test.tsx
@@ -129,6 +129,13 @@ describe("CurrencyInput", () => {
     expect(screen.getByText("EUR")).toBeInTheDocument();
   });
 
+  it("disables browser autofill with autoComplete='off'", () => {
+    render(<CurrencyInput {...defaultProps} />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveAttribute("autocomplete", "off");
+  });
+
   it("keeps text empty (not '0.00') when focusing a zero-value field", async () => {
     const user = userEvent.setup();
 

--- a/src/client/src/components/ui/currency-input.tsx
+++ b/src/client/src/components/ui/currency-input.tsx
@@ -80,6 +80,7 @@ export function CurrencyInput({
         ref={inputRef}
         type="text"
         inputMode="decimal"
+        autoComplete="off"
         value={displayValue}
         placeholder="0.00"
         onChange={handleChange}

--- a/src/client/src/components/ui/date-input.test.tsx
+++ b/src/client/src/components/ui/date-input.test.tsx
@@ -153,6 +153,13 @@ describe("DateInput", () => {
     expect(input).toHaveAttribute("aria-required", "true");
   });
 
+  it("disables browser autofill with autoComplete='off'", () => {
+    render(<DateInput {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("MM/DD/YYYY");
+    expect(input).toHaveAttribute("autocomplete", "off");
+  });
+
   it("updates display when controlled value changes externally", () => {
     const { rerender } = render(
       <DateInput value="2024-01-01" onChange={vi.fn()} />,
@@ -467,6 +474,13 @@ describe("DateInput", () => {
 
       const input = screen.getByDisplayValue("");
       expect(input).toHaveAttribute("type", "date");
+    });
+
+    it("disables browser autofill with autoComplete='off' on touch devices", () => {
+      render(<DateInput {...defaultProps} />);
+
+      const input = document.querySelector('input[type="date"]')!;
+      expect(input).toHaveAttribute("autocomplete", "off");
     });
 
     it("does not render the Popover/Calendar button on touch devices", () => {

--- a/src/client/src/components/ui/date-input.tsx
+++ b/src/client/src/components/ui/date-input.tsx
@@ -214,6 +214,7 @@ export function DateInput({
         ref={mergedRef}
         type="date"
         data-slot="input"
+        autoComplete="off"
         value={value || ""}
         min={min}
         max={max}
@@ -238,6 +239,7 @@ export function DateInput({
         type="text"
         inputMode="text"
         data-slot="input"
+        autoComplete="off"
         value={displayValue}
         onFocus={handleFocus}
         onChange={handleTextChange}


### PR DESCRIPTION
## Summary
- Add `autoComplete="off"` to `CurrencyInput` and `DateInput` components to prevent browsers from suggesting irrelevant autofill values on financial input fields
- Covers receipt date, tax amount, transaction amount, transaction date, and unit price fields across all form surfaces (ReceiptHeaderForm, ReceiptForm, ReceiptTransactionForm, ReceiptItemForm, NewReceiptPage, wizard steps, and filter/API key pages)
- Add 3 unit tests verifying the autocomplete attribute on both components (desktop and touch paths)

## SDLC Pipeline

| Phase | Status | Notes |
|-------|--------|-------|
| Plan | Pass | Component-level fix covers all 15+ usage sites |
| Implement | Pass | 2 files changed, 2 commits |
| Review | Pass | No findings |
| Security | Pass | No attack surfaces; marginally improves security |
| QA | Pass | 1517/1517 client tests pass |
| Accept | Pass | 5/5 field types covered |

## Test plan
- [x] `autoComplete="off"` rendered on CurrencyInput
- [x] `autoComplete="off"` rendered on DateInput (desktop)
- [x] `autoComplete="off"` rendered on DateInput (touch/mobile)
- [x] All 148 test files pass (1517 tests)
- [x] Build succeeds

Resolves RECEIPTS-448

Generated with [Claude Code](https://claude.com/claude-code)