### PR TITLE
fix(client): add bottom padding to clear Sentry feedback button

### DIFF
--- a/src/client/src/components/Layout.test.tsx
+++ b/src/client/src/components/Layout.test.tsx
@@ -231,4 +231,11 @@ describe("Layout", () => {
     renderLayout();
     expect(screen.queryByText(/dev/)).not.toBeInTheDocument();
   });
+
+  it("applies bottom padding to main content to clear the Sentry feedback button", () => {
+    renderLayout();
+    const main = document.getElementById("main-content");
+    expect(main).not.toBeNull();
+    expect(main!.className).toContain("pb-16");
+  });
 });

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -381,7 +381,7 @@ export function Layout() {
       <main
         id="main-content"
         tabIndex={-1}
-        className="flex-1 container mx-auto px-4 py-6 focus:outline-none"
+        className="flex-1 container mx-auto px-4 pt-6 pb-16 focus:outline-none"
       >
         <Breadcrumbs />
         <div


### PR DESCRIPTION
## Summary
- The Sentry feedback widget renders a fixed-position "Report a Bug" button at the bottom of the viewport that overlays pagination controls and table action buttons
- Adds `pb-16` (64px) bottom padding to the `<main>` content area in `Layout.tsx` to push all page content above the Sentry button
- Adds a unit test verifying the padding class is applied

## Test plan
- [x] TypeScript type-check passes
- [x] Vite build succeeds
- [x] All 17 Layout tests pass (including 1 new test)
- [x] Pre-commit hook passes (build, lint, format, tests)

Closes RECEIPTS-450

🤖 Generated with [Claude Code](https://claude.com/claude-code)