### PR TITLE
fix(api): add isActive filter to accounts endpoint

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -146,6 +146,11 @@ paths:
         - BearerAuth: []
         - ApiKey: []
       parameters:
+        - name: isActive
+          in: query
+          required: false
+          schema:
+            type: boolean
         - $ref: "#/components/parameters/Offset"
         - $ref: "#/components/parameters/Limit"
         - $ref: "#/components/parameters/SortBy"

--- a/src/Application/Interfaces/Services/IAccountService.cs
+++ b/src/Application/Interfaces/Services/IAccountService.cs
@@ -1,9 +1,11 @@
+using Application.Models;
 using Domain.Core;
 
 namespace Application.Interfaces.Services;
 
 public interface IAccountService : IService<Account>
 {
+	Task<PagedResult<Account>> GetAllAsync(int offset, int limit, SortParams sort, bool? isActive, CancellationToken cancellationToken);
 	Task<Account?> GetByTransactionIdAsync(Guid transactionId, CancellationToken cancellationToken);
 	Task<List<Account>> CreateAsync(List<Account> models, CancellationToken cancellationToken);
 	Task UpdateAsync(List<Account> models, CancellationToken cancellationToken);

--- a/src/Application/Queries/Core/Account/GetAllAccountsQuery.cs
+++ b/src/Application/Queries/Core/Account/GetAllAccountsQuery.cs
@@ -3,4 +3,4 @@ using Application.Models;
 
 namespace Application.Queries.Core.Account;
 
-public record GetAllAccountsQuery(int Offset, int Limit, SortParams Sort) : IQuery<PagedResult<Domain.Core.Account>>;
+public record GetAllAccountsQuery(int Offset, int Limit, SortParams Sort, bool? IsActive = null) : IQuery<PagedResult<Domain.Core.Account>>;

--- a/src/Application/Queries/Core/Account/GetAllAccountsQueryHandler.cs
+++ b/src/Application/Queries/Core/Account/GetAllAccountsQueryHandler.cs
@@ -8,6 +8,6 @@ public class GetAllAccountsQueryHandler(IAccountService accountService) : IReque
 {
 	public async Task<PagedResult<Domain.Core.Account>> Handle(GetAllAccountsQuery request, CancellationToken cancellationToken)
 	{
-		return await accountService.GetAllAsync(request.Offset, request.Limit, request.Sort, cancellationToken);
+		return await accountService.GetAllAsync(request.Offset, request.Limit, request.Sort, request.IsActive, cancellationToken);
 	}
 }

--- a/src/Infrastructure/Interfaces/Repositories/IAccountRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/IAccountRepository.cs
@@ -7,11 +7,11 @@ public interface IAccountRepository
 {
 	Task<AccountEntity?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 	Task<AccountEntity?> GetByTransactionIdAsync(Guid transactionId, CancellationToken cancellationToken);
-	Task<List<AccountEntity>> GetAllAsync(int offset, int limit, SortParams sort, CancellationToken cancellationToken);
+	Task<List<AccountEntity>> GetAllAsync(int offset, int limit, SortParams sort, CancellationToken cancellationToken, bool? isActive = null);
 	Task<List<AccountEntity>> CreateAsync(List<AccountEntity> entities, CancellationToken cancellationToken);
 	Task UpdateAsync(List<AccountEntity> entities, CancellationToken cancellationToken);
 	Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken);
-	Task<int> GetCountAsync(CancellationToken cancellationToken);
+	Task<int> GetCountAsync(CancellationToken cancellationToken, bool? isActive = null);
 	Task DeleteAsync(Guid id, CancellationToken cancellationToken);
 	Task<int> GetTransactionCountByAccountIdAsync(Guid accountId, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Repositories/AccountRepository.cs
+++ b/src/Infrastructure/Repositories/AccountRepository.cs
@@ -31,11 +31,16 @@ public class AccountRepository(IDbContextFactory<ApplicationDbContext> contextFa
 			.FirstOrDefaultAsync(cancellationToken);
 	}
 
-	public async Task<List<AccountEntity>> GetAllAsync(int offset, int limit, SortParams sort, CancellationToken cancellationToken)
+	public async Task<List<AccountEntity>> GetAllAsync(int offset, int limit, SortParams sort, CancellationToken cancellationToken, bool? isActive = null)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		return await context.Accounts
-			.AsNoTracking()
+		IQueryable<AccountEntity> query = context.Accounts.AsNoTracking();
+		if (isActive.HasValue)
+		{
+			query = query.Where(e => e.IsActive == isActive.Value);
+		}
+
+		return await query
 			.ApplySort(sort, AllowedSortColumns, e => e.Name)
 			.Skip(offset)
 			.Take(limit)
@@ -80,10 +85,16 @@ public class AccountRepository(IDbContextFactory<ApplicationDbContext> contextFa
 		return await context.Accounts.AnyAsync(e => e.Id == id, cancellationToken);
 	}
 
-	public async Task<int> GetCountAsync(CancellationToken cancellationToken)
+	public async Task<int> GetCountAsync(CancellationToken cancellationToken, bool? isActive = null)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
-		return await context.Accounts.CountAsync(cancellationToken);
+		IQueryable<AccountEntity> query = context.Accounts;
+		if (isActive.HasValue)
+		{
+			query = query.Where(e => e.IsActive == isActive.Value);
+		}
+
+		return await query.CountAsync(cancellationToken);
 	}
 
 	public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)

--- a/src/Infrastructure/Services/AccountService.cs
+++ b/src/Infrastructure/Services/AccountService.cs
@@ -29,6 +29,14 @@ public class AccountService(IAccountRepository repository, AccountMapper mapper)
 		return new PagedResult<Account>(data, total, offset, limit);
 	}
 
+	public async Task<PagedResult<Account>> GetAllAsync(int offset, int limit, SortParams sort, bool? isActive, CancellationToken cancellationToken)
+	{
+		int total = await repository.GetCountAsync(cancellationToken, isActive);
+		List<AccountEntity> entities = await repository.GetAllAsync(offset, limit, sort, cancellationToken, isActive);
+		List<Account> data = [.. entities.Select(mapper.ToDomain)];
+		return new PagedResult<Account>(data, total, offset, limit);
+	}
+
 	public async Task<Account?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
 	{
 		AccountEntity? accountEntity = await repository.GetByIdAsync(id, cancellationToken);

--- a/src/Presentation/API/Controllers/Core/AccountsController.cs
+++ b/src/Presentation/API/Controllers/Core/AccountsController.cs
@@ -51,7 +51,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, ILogge
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all accounts")]
-	public async Task<Results<Ok<AccountListResponse>, BadRequest<string>>> GetAllAccounts([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<AccountListResponse>, BadRequest<string>>> GetAllAccounts([FromQuery] bool? isActive = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
 	{
 		if (offset < 0)
 		{
@@ -74,7 +74,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, ILogge
 		}
 
 		SortParams sort = new(sortBy, sortDirection);
-		GetAllAccountsQuery query = new(offset, limit, sort);
+		GetAllAccountsQuery query = new(offset, limit, sort, isActive);
 		PagedResult<Account> result = await mediator.Send(query);
 
 		return TypedResults.Ok(new AccountListResponse

--- a/src/client/src/hooks/useAccounts.test.ts
+++ b/src/client/src/hooks/useAccounts.test.ts
@@ -57,6 +57,38 @@ describe("useAccounts", () => {
     });
   });
 
+  it("list query passes isActive filter to API", async () => {
+    const accounts = [
+      { id: "1", accountCode: "ACC1", name: "Checking", isActive: true },
+    ];
+    (client.GET as Mock).mockResolvedValue({ data: { data: accounts, total: 1, offset: 0, limit: 50 }, error: undefined });
+
+    const { result } = renderHook(() => useAccounts(0, 50, null, null, true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/accounts", {
+      params: { query: { offset: 0, limit: 50, isActive: true } },
+    });
+  });
+
+  it("list query omits isActive when null", async () => {
+    const accounts = [
+      { id: "1", accountCode: "ACC1", name: "Checking", isActive: true },
+    ];
+    (client.GET as Mock).mockResolvedValue({ data: { data: accounts, total: 1, offset: 0, limit: 50 }, error: undefined });
+
+    const { result } = renderHook(() => useAccounts(0, 50, null, null, null), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/accounts", {
+      params: { query: { offset: 0, limit: 50 } },
+    });
+  });
+
   it("single query is disabled when id is null", () => {
     const { result } = renderHook(() => useAccount(null), {
       wrapper: createWrapper(),

--- a/src/client/src/hooks/useAccounts.ts
+++ b/src/client/src/hooks/useAccounts.ts
@@ -5,12 +5,12 @@ import { toast } from "sonner";
 
 // Note: Accounts are hard-delete entities (no soft-delete/restore).
 
-export function useAccounts(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
+export function useAccounts(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, isActive?: boolean | null) {
   const query = useQuery({
-    queryKey: ["accounts", "list", offset, limit, sortBy, sortDirection],
+    queryKey: ["accounts", "list", offset, limit, sortBy, sortDirection, isActive],
     queryFn: async () => {
       const { data, error } = await client.GET("/api/accounts", {
-        params: { query: { offset, limit, sortBy: sortBy ?? undefined, sortDirection: (sortDirection ?? undefined) as "asc" | "desc" | undefined } },
+        params: { query: { offset, limit, sortBy: sortBy ?? undefined, sortDirection: (sortDirection ?? undefined) as "asc" | "desc" | undefined, isActive: isActive ?? undefined } },
       });
       if (error) throw error;
       return data;

--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -349,36 +349,41 @@ describe("Accounts", () => {
     expect(screen.getByText(/try fewer keywords/i)).toBeInTheDocument();
   });
 
-  it("defaults to showing only active accounts", async () => {
-    const items = [
+  it("defaults to showing only active accounts (server-side filtered)", async () => {
+    // Server-side filtering: useAccounts is called with isActive=true by default,
+    // so mock data only contains active accounts (the server already filtered).
+    const activeItems = [
       mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }),
-      mockAccountResponse({ id: "2", accountCode: "ACC-002", name: "Savings", isActive: false }),
     ];
 
     const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
     vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
-      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
-      totalCount: items.length,
+      results: activeItems.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: activeItems.length,
       isSearching: false,
       clearSearch: vi.fn(),
     }));
 
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: items,
-      total: items.length,
+      data: activeItems,
+      total: activeItems.length,
       isLoading: false,
     }));
 
     renderWithProviders(<Accounts />);
     expect(screen.getByText("Checking")).toBeInTheDocument();
-    expect(screen.queryByText("Savings")).not.toBeInTheDocument();
 
     // Active tab should be selected
     const activeTab = screen.getByRole("tab", { name: "Active" });
     expect(activeTab).toHaveAttribute("data-state", "active");
+
+    // Verify useAccounts was called with isActive=true (5th argument)
+    expect(useAccounts).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), expect.anything(), true,
+    );
   });
 
   it("persists status filter in localStorage", async () => {
@@ -398,10 +403,9 @@ describe("Accounts", () => {
     expect(localStorage.getItem("accounts-status-filter")).toBe("all");
   });
 
-  it("shows inactive accounts when Inactive tab is selected", async () => {
+  it("passes isActive=false to useAccounts when Inactive tab is selected", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
-    const items = [
-      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }),
+    const inactiveItems = [
       mockAccountResponse({ id: "2", accountCode: "ACC-002", name: "Savings", isActive: false }),
     ];
 
@@ -409,24 +413,26 @@ describe("Accounts", () => {
     vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
       search: "",
       setSearch: vi.fn(),
-      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
-      totalCount: items.length,
+      results: inactiveItems.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: inactiveItems.length,
       isSearching: false,
       clearSearch: vi.fn(),
     }));
 
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
-      data: items,
-      total: items.length,
+      data: inactiveItems,
+      total: inactiveItems.length,
       isLoading: false,
     }));
 
     renderWithProviders(<Accounts />);
     await user.click(screen.getByRole("tab", { name: "Inactive" }));
 
-    expect(screen.queryByText("Checking")).not.toBeInTheDocument();
-    expect(screen.getByText("Savings")).toBeInTheDocument();
+    // Verify useAccounts was called with isActive=false after tab switch
+    expect(useAccounts).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), expect.anything(), false,
+    );
   });
 
 });

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -66,17 +66,18 @@ function Accounts() {
   const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
   const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
   const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ sortBy, sortDirection });
-  const { data: accountsData, total: serverTotal, isLoading } = useAccounts(offset, limit, sortBy, sortDirection);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => {
+    const saved = localStorage.getItem(STATUS_STORAGE_KEY);
+    return saved === "all" || saved === "true" || saved === "false" ? saved : "true";
+  });
+  const isActiveParam = statusFilter === "all" ? undefined : statusFilter === "true";
+  const { data: accountsData, total: serverTotal, isLoading } = useAccounts(offset, limit, sortBy, sortDirection, isActiveParam);
   const createAccount = useCreateAccount();
   const updateAccount = useUpdateAccount();
   const deleteAccount = useDeleteAccount();
   const { isAdmin } = usePermission();
   const [createOpen, setCreateOpen] = useState(false);
   const [editAccount, setEditAccount] = useState<AccountResponse | null>(null);
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => {
-    const saved = localStorage.getItem(STATUS_STORAGE_KEY);
-    return saved === "all" || saved === "true" || saved === "false" ? saved : "true";
-  });
 
   const anyDialogOpen = createOpen || editAccount !== null;
 
@@ -102,14 +103,12 @@ function Accounts() {
     const v = value as StatusFilter;
     setStatusFilter(v);
     localStorage.setItem(STATUS_STORAGE_KEY, v);
+    resetPage();
   }
 
   const filteredResults = useMemo(() => {
-    const items = results.map((r) => r.item);
-    if (statusFilter === "all") return items;
-    const expected = statusFilter === "true";
-    return items.filter((a) => a.isActive === expected);
-  }, [results, statusFilter]);
+    return results.map((r) => r.item);
+  }, [results]);
 
   const matchMap = useMemo(() => {
     const map = new Map<string, (typeof results)[number]>();

--- a/tests/Application.Tests/Queries/Core/Account/GetAllAccountsQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Core/Account/GetAllAccountsQueryHandlerTests.cs
@@ -15,7 +15,7 @@ public class GetAllAccountsQueryHandlerTests
 		List<Domain.Core.Account> expected = AccountGenerator.GenerateList(2);
 
 		Mock<IAccountService> mockService = new();
-		mockService.Setup(r => r.GetAllAsync(0, 50, It.IsAny<SortParams>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PagedResult<Domain.Core.Account>(expected, expected.Count, 0, 50));
+		mockService.Setup(r => r.GetAllAsync(0, 50, It.IsAny<SortParams>(), It.IsAny<bool?>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PagedResult<Domain.Core.Account>(expected, expected.Count, 0, 50));
 
 		GetAllAccountsQueryHandler handler = new(mockService.Object);
 		GetAllAccountsQuery query = new(0, 50, SortParams.Default);

--- a/tests/Infrastructure.Tests/Repositories/AccountRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Repositories/AccountRepositoryTests.cs
@@ -106,6 +106,106 @@ public class AccountRepositoryTests
 	}
 
 	[Fact]
+	public async Task GetAllAsync_WithIsActiveTrue_ReturnsOnlyActiveAccounts()
+	{
+		// Arrange
+		using ApplicationDbContext context = _contextFactory.CreateDbContext();
+		AccountEntity activeAccount = AccountEntityGenerator.Generate();
+		activeAccount.IsActive = true;
+		AccountEntity inactiveAccount = AccountEntityGenerator.Generate();
+		inactiveAccount.IsActive = false;
+		await context.Accounts.AddRangeAsync([activeAccount, inactiveAccount]);
+		await context.SaveChangesAsync(CancellationToken.None);
+
+		AccountRepository repository = new(_contextFactory);
+
+		// Act
+		List<AccountEntity> actual = await repository.GetAllAsync(0, 50, SortParams.Default, CancellationToken.None, isActive: true);
+
+		// Assert
+		actual.Should().HaveCount(1);
+		actual[0].Id.Should().Be(activeAccount.Id);
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetAllAsync_WithIsActiveFalse_ReturnsOnlyInactiveAccounts()
+	{
+		// Arrange
+		using ApplicationDbContext context = _contextFactory.CreateDbContext();
+		AccountEntity activeAccount = AccountEntityGenerator.Generate();
+		activeAccount.IsActive = true;
+		AccountEntity inactiveAccount = AccountEntityGenerator.Generate();
+		inactiveAccount.IsActive = false;
+		await context.Accounts.AddRangeAsync([activeAccount, inactiveAccount]);
+		await context.SaveChangesAsync(CancellationToken.None);
+
+		AccountRepository repository = new(_contextFactory);
+
+		// Act
+		List<AccountEntity> actual = await repository.GetAllAsync(0, 50, SortParams.Default, CancellationToken.None, isActive: false);
+
+		// Assert
+		actual.Should().HaveCount(1);
+		actual[0].Id.Should().Be(inactiveAccount.Id);
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetAllAsync_WithIsActiveNull_ReturnsAllAccounts()
+	{
+		// Arrange
+		using ApplicationDbContext context = _contextFactory.CreateDbContext();
+		AccountEntity activeAccount = AccountEntityGenerator.Generate();
+		activeAccount.IsActive = true;
+		AccountEntity inactiveAccount = AccountEntityGenerator.Generate();
+		inactiveAccount.IsActive = false;
+		await context.Accounts.AddRangeAsync([activeAccount, inactiveAccount]);
+		await context.SaveChangesAsync(CancellationToken.None);
+
+		AccountRepository repository = new(_contextFactory);
+
+		// Act
+		List<AccountEntity> actual = await repository.GetAllAsync(0, 50, SortParams.Default, CancellationToken.None, isActive: null);
+
+		// Assert
+		actual.Should().HaveCount(2);
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetCountAsync_WithIsActive_ReturnsFilteredCount()
+	{
+		// Arrange
+		using ApplicationDbContext context = _contextFactory.CreateDbContext();
+		AccountEntity activeAccount1 = AccountEntityGenerator.Generate();
+		activeAccount1.IsActive = true;
+		AccountEntity activeAccount2 = AccountEntityGenerator.Generate();
+		activeAccount2.IsActive = true;
+		AccountEntity inactiveAccount = AccountEntityGenerator.Generate();
+		inactiveAccount.IsActive = false;
+		await context.Accounts.AddRangeAsync([activeAccount1, activeAccount2, inactiveAccount]);
+		await context.SaveChangesAsync(CancellationToken.None);
+
+		AccountRepository repository = new(_contextFactory);
+
+		// Act
+		int activeCount = await repository.GetCountAsync(CancellationToken.None, isActive: true);
+		int inactiveCount = await repository.GetCountAsync(CancellationToken.None, isActive: false);
+		int allCount = await repository.GetCountAsync(CancellationToken.None, isActive: null);
+
+		// Assert
+		activeCount.Should().Be(2);
+		inactiveCount.Should().Be(1);
+		allCount.Should().Be(3);
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
 	public async Task CreateAsync_ValidAccounts_ReturnsCreatedAccounts()
 	{
 		// Arrange

--- a/tests/Infrastructure.Tests/Services/AccountServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/AccountServiceTests.cs
@@ -76,6 +76,25 @@ public class AccountServiceTests
 	}
 
 	[Fact]
+	public async Task GetAllAsync_WithIsActive_FiltersAndReturnsCorrectCount()
+	{
+		// Arrange
+		List<AccountEntity> entities = AccountEntityGenerator.GenerateList(2);
+
+		_mockRepository.Setup(r => r.GetCountAsync(It.IsAny<CancellationToken>(), true)).ReturnsAsync(entities.Count);
+		_mockRepository.Setup(r => r.GetAllAsync(0, 50, It.IsAny<SortParams>(), It.IsAny<CancellationToken>(), true)).ReturnsAsync(entities);
+
+		// Act
+		PagedResult<Account> actual = await _service.GetAllAsync(0, 50, SortParams.Default, true, CancellationToken.None);
+
+		// Assert
+		Assert.Equal(entities.Count, actual.Data.Count);
+		Assert.Equal(entities.Count, actual.Total);
+		_mockRepository.Verify(r => r.GetCountAsync(It.IsAny<CancellationToken>(), true), Times.Once);
+		_mockRepository.Verify(r => r.GetAllAsync(0, 50, It.IsAny<SortParams>(), It.IsAny<CancellationToken>(), true), Times.Once);
+	}
+
+	[Fact]
 	public async Task GetByIdAsync_ExistingId_ReturnsAccount()
 	{
 		// Arrange

--- a/tests/Presentation.API.Tests/Controllers/Core/AccountsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/AccountsControllerTests.cs
@@ -114,7 +114,7 @@ public class AccountsControllerTests
 			.ReturnsAsync(new PagedResult<Account>(accounts, accounts.Count, 0, 50));
 
 		// Act
-		Results<Ok<AccountListResponse>, BadRequest<string>> rawResult = await _controller.GetAllAccounts(0, 50, null, null);
+		Results<Ok<AccountListResponse>, BadRequest<string>> rawResult = await _controller.GetAllAccounts(null, 0, 50, null, null);
 
 		// Assert
 		Ok<AccountListResponse> result = Assert.IsType<Ok<AccountListResponse>>(rawResult.Result);
@@ -132,7 +132,7 @@ public class AccountsControllerTests
 	public async Task GetAllAccounts_ReturnsBadRequest_WhenOffsetIsNegative(int offset, int limit)
 	{
 		// Act
-		Results<Ok<AccountListResponse>, BadRequest<string>> result = await _controller.GetAllAccounts(offset, limit, null, null);
+		Results<Ok<AccountListResponse>, BadRequest<string>> result = await _controller.GetAllAccounts(null, offset, limit, null, null);
 
 		// Assert
 		BadRequest<string> badRequestResult = Assert.IsType<BadRequest<string>>(result.Result);
@@ -146,7 +146,7 @@ public class AccountsControllerTests
 	public async Task GetAllAccounts_ReturnsBadRequest_WhenLimitIsOutOfRange(int offset, int limit)
 	{
 		// Act
-		Results<Ok<AccountListResponse>, BadRequest<string>> result = await _controller.GetAllAccounts(offset, limit, null, null);
+		Results<Ok<AccountListResponse>, BadRequest<string>> result = await _controller.GetAllAccounts(null, offset, limit, null, null);
 
 		// Assert
 		BadRequest<string> badRequestResult = Assert.IsType<BadRequest<string>>(result.Result);
@@ -163,7 +163,7 @@ public class AccountsControllerTests
 			.ThrowsAsync(new Exception());
 
 		// Act
-		Func<Task> act = () => _controller.GetAllAccounts(0, 50, null, null);
+		Func<Task> act = () => _controller.GetAllAccounts(null, 0, 50, null, null);
 
 		// Assert
 		await act.Should().ThrowAsync<Exception>();

--- a/tests/Presentation.API.Tests/Controllers/Core/AccountsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/AccountsControllerTests.cs
@@ -126,6 +126,29 @@ public class AccountsControllerTests
 		actualReturn.Limit.Should().Be(50);
 	}
 
+	[Fact]
+	public async Task GetAllAccounts_PassesIsActiveToQuery()
+	{
+		// Arrange
+		List<Account> accounts = AccountGenerator.GenerateList(1);
+		List<AccountResponse> expectedReturn = [.. accounts.Select(_mapper.ToResponse)];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetAllAccountsQuery>(q => q.Offset == 0 && q.Limit == 50 && q.IsActive == true),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Account>(accounts, accounts.Count, 0, 50));
+
+		// Act
+		Results<Ok<AccountListResponse>, BadRequest<string>> rawResult = await _controller.GetAllAccounts(true, 0, 50, null, null);
+
+		// Assert
+		Ok<AccountListResponse> result = Assert.IsType<Ok<AccountListResponse>>(rawResult.Result);
+		AccountListResponse actualReturn = result.Value!;
+
+		actualReturn.Data.Should().BeEquivalentTo(expectedReturn);
+		actualReturn.Total.Should().Be(accounts.Count);
+	}
+
 	[Theory]
 	[InlineData(-1, 50)]
 	[InlineData(-100, 50)]


### PR DESCRIPTION
## Summary
- Add `isActive` query parameter to GET `/api/accounts` so filtering happens server-side before pagination (fixes page 2 showing only 9 rows when Active filter is selected)
- Mirror the pattern already applied to categories/subcategories in RECEIPTS-433: repository, service, query, controller, OpenAPI spec, frontend hook, and page component all updated
- Remove client-side isActive filtering from `Accounts.tsx` and add `resetPage()` on filter change

## Test plan
- [x] 6 new backend tests: repository `GetAllAsync`/`GetCountAsync` with isActive, service overload, controller isActive passthrough
- [x] 2 new frontend hook tests: isActive=true passed to API, isActive=null omitted
- [x] 2 updated frontend page tests: verify `useAccounts` called with correct isActive param
- [x] All 1485 backend tests pass
- [x] All 1516 frontend tests pass
- [x] OpenAPI spec lint, drift check, and TypeScript type generation pass

Closes RECEIPTS-451

🤖 Generated with [Claude Code](https://claude.com/claude-code)