### PR TITLE
feat(client): add inline active/inactive toggle to account rows

### DIFF
--- a/src/client/src/components/ui/switch.tsx
+++ b/src/client/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent shadow-xs transition-colors focus-visible:ring-[3px] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background pointer-events-none block size-4 rounded-full ring-0 shadow-lg transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -403,6 +403,110 @@ describe("Accounts", () => {
     expect(localStorage.getItem("accounts-status-filter")).toBe("all");
   });
 
+  it("renders a switch toggle on each account row", async () => {
+    const items = [
+      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }),
+      mockAccountResponse({ id: "2", accountCode: "ACC-002", name: "Savings", isActive: false }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Accounts />);
+    const switches = screen.getAllByRole("switch");
+    expect(switches).toHaveLength(2);
+    expect(switches[0]).toHaveAttribute("aria-checked", "true");
+    expect(switches[1]).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("calls updateAccount.mutate when switch is toggled", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useUpdateAccount } = await import("@/hooks/useAccounts");
+    vi.mocked(useUpdateAccount).mockReturnValue(mockMutationResult({
+      mutate: mockMutate,
+      isPending: false,
+    }));
+
+    const items = [
+      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Accounts />);
+    const switchEl = screen.getByRole("switch");
+    await user.click(switchEl);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "1",
+        accountCode: "ACC-001",
+        name: "Checking",
+        isActive: false,
+      }),
+    );
+  });
+
+  it("does not open edit dialog when switch is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      mockAccountResponse({ id: "1", accountCode: "ACC-001", name: "Checking", isActive: true }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Accounts />);
+    const switchEl = screen.getByRole("switch");
+    await user.click(switchEl);
+
+    expect(screen.queryByRole("heading", { name: /edit account/i })).not.toBeInTheDocument();
+  });
+
   it("passes isActive=false to useAccounts when Inactive tab is selected", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const inactiveItems = [

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -23,6 +23,7 @@ import { NoResults } from "@/components/NoResults";
 import { Pagination } from "@/components/Pagination";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Dialog,
@@ -93,6 +94,15 @@ function Accounts() {
     toggleSort(column);
     resetPage();
   }, [toggleSort, resetPage]);
+
+  const handleToggleActive = useCallback((account: AccountResponse, checked: boolean) => {
+    updateAccount.mutate({
+      id: account.id,
+      accountCode: account.accountCode,
+      name: account.name,
+      isActive: checked,
+    });
+  }, [updateAccount]);
 
   const data = (accountsData as AccountResponse[] | undefined) ?? [];
 
@@ -223,11 +233,18 @@ function Accounts() {
                         />
                       </TableCell>
                       <TableCell>
-                        <Badge
-                          variant={account.isActive ? "default" : "secondary"}
-                        >
-                          {account.isActive ? "Active" : "Inactive"}
-                        </Badge>
+                        <div className="flex items-center gap-2">
+                          <Switch
+                            checked={account.isActive}
+                            onCheckedChange={(checked) => handleToggleActive(account, checked)}
+                            aria-label={`Toggle ${account.name} active status`}
+                          />
+                          <Badge
+                            variant={account.isActive ? "default" : "secondary"}
+                          >
+                            {account.isActive ? "Active" : "Inactive"}
+                          </Badge>
+                        </div>
                       </TableCell>
                       <TableCell>
                         <Link to={`/transactions?accountId=${account.id}`} className="text-sm text-primary hover:underline">


### PR DESCRIPTION
## Summary
- Add a Switch component on each account row to toggle isActive directly without opening the edit modal
- Wire the switch to the existing `useUpdateAccount` mutation (toast on success/error already handled)
- Create a new `switch.tsx` shadcn/ui component using Radix UI primitives

Closes RECEIPTS-449

## Test plan
- [x] Switch renders on every account row (unit test)
- [x] Clicking switch calls `updateAccount.mutate` with toggled `isActive` (unit test)
- [x] Switch click does not open the edit dialog (unit test)
- [x] All 1523 existing tests pass
- [ ] Manual: verify toggle works end-to-end with running backend

Generated with [Claude Code](https://claude.com/claude-code)