### PR TITLE
feat: item code as primary field with location-filtered suggestions

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -1408,6 +1408,52 @@ paths:
               schema:
                 type: string
 
+  /api/receipt-items/suggestions:
+    get:
+      operationId: GetReceiptItemSuggestions
+      tags: [ReceiptItems]
+      summary: Get item code suggestions from receipt history
+      description: |
+        Returns suggestions for receipt item entry based on historical receipt items.
+        Groups items by itemCode and optionally filters by location. Falls back to
+        all-location matches when no location-specific results exist.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: itemCode
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+          description: Partial or full item code to search for
+        - name: location
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Receipt location to filter suggestions by
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 10
+            minimum: 1
+            maximum: 50
+          description: Maximum number of suggestions to return
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ReceiptItemSuggestionResponse"
+
   /api/receipt-items/{id}/restore:
     post:
       operationId: RestoreReceiptItem
@@ -4429,6 +4475,34 @@ components:
         limit:
           type: integer
           format: int32
+
+    ReceiptItemSuggestionResponseMatchType:
+      type: string
+      description: "'location' if matched with the specified location, 'global' if fallback to all locations"
+      enum: [location, global]
+
+    ReceiptItemSuggestionResponse:
+      type: object
+      required: [itemCode, description, category, unitPrice, matchType]
+      properties:
+        itemCode:
+          type: string
+          description: The item code that matched the search
+        description:
+          type: string
+          description: Most recent description for this item code
+        category:
+          type: string
+          description: Most recent category for this item code
+        subcategory:
+          type: ["string", "null"]
+          description: Most recent subcategory for this item code
+        unitPrice:
+          type: number
+          format: double
+          description: Most recent unit price for this item code
+        matchType:
+          $ref: "#/components/schemas/ReceiptItemSuggestionResponseMatchType"
 
     # ── Transaction ──────────────────────────────
 

--- a/src/Application/Interfaces/Services/IReceiptItemService.cs
+++ b/src/Application/Interfaces/Services/IReceiptItemService.cs
@@ -1,4 +1,5 @@
 using Application.Models;
+using Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
 using Domain.Core;
 
 namespace Application.Interfaces.Services;
@@ -8,4 +9,5 @@ public interface IReceiptItemService : ISoftDeletableService<ReceiptItem>
 	Task<PagedResult<ReceiptItem>> GetByReceiptIdAsync(Guid receiptId, int offset, int limit, SortParams sort, CancellationToken cancellationToken);
 	Task<List<ReceiptItem>> CreateAsync(List<ReceiptItem> models, Guid receiptId, CancellationToken cancellationToken);
 	Task UpdateAsync(List<ReceiptItem> models, Guid receiptId, CancellationToken cancellationToken);
+	Task<List<ReceiptItemSuggestion>> GetSuggestionsAsync(string itemCode, string? location, int limit, CancellationToken cancellationToken);
 }

--- a/src/Application/Queries/Core/ReceiptItem/GetReceiptItemSuggestions/GetReceiptItemSuggestionsQuery.cs
+++ b/src/Application/Queries/Core/ReceiptItem/GetReceiptItemSuggestions/GetReceiptItemSuggestionsQuery.cs
@@ -1,0 +1,5 @@
+using Application.Interfaces;
+
+namespace Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
+
+public record GetReceiptItemSuggestionsQuery(string ItemCode, string? Location, int Limit = 10) : IQuery<IEnumerable<ReceiptItemSuggestion>>;

--- a/src/Application/Queries/Core/ReceiptItem/GetReceiptItemSuggestions/GetReceiptItemSuggestionsQueryHandler.cs
+++ b/src/Application/Queries/Core/ReceiptItem/GetReceiptItemSuggestions/GetReceiptItemSuggestionsQueryHandler.cs
@@ -1,0 +1,12 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
+
+public class GetReceiptItemSuggestionsQueryHandler(IReceiptItemService receiptItemService) : IRequestHandler<GetReceiptItemSuggestionsQuery, IEnumerable<ReceiptItemSuggestion>>
+{
+	public async Task<IEnumerable<ReceiptItemSuggestion>> Handle(GetReceiptItemSuggestionsQuery request, CancellationToken cancellationToken)
+	{
+		return await receiptItemService.GetSuggestionsAsync(request.ItemCode, request.Location, request.Limit, cancellationToken);
+	}
+}

--- a/src/Application/Queries/Core/ReceiptItem/GetReceiptItemSuggestions/ReceiptItemSuggestion.cs
+++ b/src/Application/Queries/Core/ReceiptItem/GetReceiptItemSuggestions/ReceiptItemSuggestion.cs
@@ -1,0 +1,11 @@
+namespace Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
+
+public class ReceiptItemSuggestion
+{
+	public required string ItemCode { get; set; }
+	public required string Description { get; set; }
+	public required string Category { get; set; }
+	public string? Subcategory { get; set; }
+	public decimal UnitPrice { get; set; }
+	public required string MatchType { get; set; }
+}

--- a/src/Infrastructure/Interfaces/Repositories/IReceiptItemRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/IReceiptItemRepository.cs
@@ -1,4 +1,5 @@
 using Application.Models;
+using Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
 using Infrastructure.Entities.Core;
 
 namespace Infrastructure.Interfaces.Repositories;
@@ -17,4 +18,5 @@ public interface IReceiptItemRepository
 	Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken);
 	Task<int> GetCountAsync(CancellationToken cancellationToken);
 	Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken);
+	Task<List<ReceiptItemSuggestion>> GetSuggestionsAsync(string itemCode, string? location, int limit, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Repositories/ReceiptItemRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptItemRepository.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Application.Models;
+using Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
 using Infrastructure.Entities.Core;
 using Infrastructure.Extensions;
 using Infrastructure.Interfaces.Repositories;
@@ -194,5 +195,60 @@ public class ReceiptItemRepository(IDbContextFactory<ApplicationDbContext> conte
 		entity.CascadeDeletedByParentId = null;
 		await context.SaveChangesAsync(cancellationToken);
 		return true;
+	}
+
+	public async Task<List<ReceiptItemSuggestion>> GetSuggestionsAsync(string itemCode, string? location, int limit, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		string lowerItemCode = itemCode.ToLowerInvariant();
+
+		// Try location-filtered results first
+		if (!string.IsNullOrWhiteSpace(location))
+		{
+			string lowerLocation = location.ToLowerInvariant();
+
+			List<ReceiptItemSuggestion> locationResults = await context.ReceiptItems
+				.AsNoTracking()
+				.Where(ri => ri.ReceiptItemCode != null && ri.ReceiptItemCode != "")
+				.Where(ri => ri.Receipt != null && ri.Receipt.Location.ToLower() == lowerLocation)
+				.Where(ri => ri.ReceiptItemCode!.ToLower().Contains(lowerItemCode))
+				.GroupBy(ri => ri.ReceiptItemCode!.ToLower())
+				.Select(g => new ReceiptItemSuggestion
+				{
+					ItemCode = g.OrderByDescending(ri => ri.Id).First().ReceiptItemCode!,
+					Description = g.OrderByDescending(ri => ri.Id).First().Description,
+					Category = g.OrderByDescending(ri => ri.Id).First().Category,
+					Subcategory = g.OrderByDescending(ri => ri.Id).First().Subcategory,
+					UnitPrice = g.OrderByDescending(ri => ri.Id).First().UnitPrice,
+					MatchType = "location",
+				})
+				.Take(limit)
+				.ToListAsync(cancellationToken);
+
+			if (locationResults.Count > 0)
+			{
+				return locationResults;
+			}
+		}
+
+		// Fall back to all-location matches
+		List<ReceiptItemSuggestion> globalResults = await context.ReceiptItems
+			.AsNoTracking()
+			.Where(ri => ri.ReceiptItemCode != null && ri.ReceiptItemCode != "")
+			.Where(ri => ri.ReceiptItemCode!.ToLower().Contains(lowerItemCode))
+			.GroupBy(ri => ri.ReceiptItemCode!.ToLower())
+			.Select(g => new ReceiptItemSuggestion
+			{
+				ItemCode = g.OrderByDescending(ri => ri.Id).First().ReceiptItemCode!,
+				Description = g.OrderByDescending(ri => ri.Id).First().Description,
+				Category = g.OrderByDescending(ri => ri.Id).First().Category,
+				Subcategory = g.OrderByDescending(ri => ri.Id).First().Subcategory,
+				UnitPrice = g.OrderByDescending(ri => ri.Id).First().UnitPrice,
+				MatchType = "global",
+			})
+			.Take(limit)
+			.ToListAsync(cancellationToken);
+
+		return globalResults;
 	}
 }

--- a/src/Infrastructure/Services/ReceiptItemService.cs
+++ b/src/Infrastructure/Services/ReceiptItemService.cs
@@ -1,5 +1,6 @@
 using Application.Interfaces.Services;
 using Application.Models;
+using Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
 using Domain.Core;
 using Infrastructure.Entities.Core;
 using Infrastructure.Interfaces.Repositories;
@@ -82,5 +83,10 @@ public class ReceiptItemService(IReceiptItemRepository repository, ReceiptItemMa
 	public async Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken)
 	{
 		return await repository.RestoreAsync(id, cancellationToken);
+	}
+
+	public async Task<List<ReceiptItemSuggestion>> GetSuggestionsAsync(string itemCode, string? location, int limit, CancellationToken cancellationToken)
+	{
+		return await repository.GetSuggestionsAsync(itemCode, location, limit, cancellationToken);
 	}
 }

--- a/src/Presentation/API/Controllers/Core/ReceiptItemsController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptItemsController.cs
@@ -7,6 +7,7 @@ using Application.Commands.ReceiptItem.Restore;
 using Application.Commands.ReceiptItem.Update;
 using Application.Models;
 using Application.Queries.Core.ReceiptItem;
+using Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
 using Asp.Versioning;
 using Domain.Core;
 using MediatR;
@@ -32,6 +33,7 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	public const string RouteDelete = "";
 	public const string RouteGetDeleted = "deleted";
 	public const string RouteRestore = "{id}/restore";
+	public const string RouteGetSuggestions = "suggestions";
 
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get a receipt item by ID")]
@@ -229,5 +231,26 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 
 		await notifier.NotifyUpdated("receipt-item", id);
 		return TypedResults.NoContent();
+	}
+
+	[HttpGet(RouteGetSuggestions)]
+	[EndpointSummary("Get item code suggestions from receipt history")]
+	[EndpointDescription("Returns suggestions for receipt item entry based on historical receipt items, grouped by itemCode and optionally filtered by location.")]
+	public async Task<Ok<List<ReceiptItemSuggestionResponse>>> GetSuggestions([FromQuery] string itemCode, [FromQuery] string? location = null, [FromQuery] int limit = 10)
+	{
+		GetReceiptItemSuggestionsQuery query = new(itemCode, location, limit);
+		IEnumerable<ReceiptItemSuggestion> results = await mediator.Send(query);
+
+		List<ReceiptItemSuggestionResponse> response = [.. results.Select(r => new ReceiptItemSuggestionResponse
+		{
+			ItemCode = r.ItemCode,
+			Description = r.Description,
+			Category = r.Category,
+			Subcategory = r.Subcategory,
+			UnitPrice = (double)r.UnitPrice,
+			MatchType = r.MatchType == "location" ? ReceiptItemSuggestionResponseMatchType.Location : ReceiptItemSuggestionResponseMatchType.Global,
+		})];
+
+		return TypedResults.Ok(response);
 	}
 }

--- a/src/client/src/components/ReceiptItemForm.test.tsx
+++ b/src/client/src/components/ReceiptItemForm.test.tsx
@@ -88,6 +88,15 @@ vi.mock("@/lib/format", async (importOriginal) => {
   };
 });
 
+vi.mock("@/hooks/useReceiptItemSuggestions", () => ({
+  useReceiptItemSuggestions: vi.fn(() => ({
+    data: undefined,
+    isFetching: false,
+    isSuccess: false,
+    isLoading: false,
+  })),
+}));
+
 describe("ReceiptItemForm", () => {
   const defaultProps = {
     mode: "create" as const,
@@ -133,8 +142,8 @@ describe("ReceiptItemForm", () => {
       />,
     );
 
-    // Item Code is a Combobox; it shows the value as text content
-    expect(screen.getByLabelText("Item Code")).toHaveTextContent("ITM-001");
+    // Item Code is now an Input; check its value
+    expect(screen.getByPlaceholderText("Enter item code...")).toHaveValue("ITM-001");
     expect(screen.getByRole("button", { name: /update item/i })).toBeInTheDocument();
   });
 
@@ -320,7 +329,7 @@ describe("ReceiptItemForm", () => {
     expect(storedItemCodes).toContain("ITM-001");
   });
 
-  it("shows saved item codes in the item code Combobox dropdown", async () => {
+  it("shows saved item codes in the item code autocomplete dropdown", async () => {
     const user = userEvent.setup();
     localStorage.setItem(
       "receipts:item-code-history",
@@ -329,9 +338,10 @@ describe("ReceiptItemForm", () => {
 
     render(<ReceiptItemForm {...defaultProps} />);
 
-    // The Item Code field is a Combobox; click its trigger to open
-    const itemCodeCombobox = screen.getByLabelText("Item Code");
-    await user.click(itemCodeCombobox);
+    // The Item Code field is now an Input with autocomplete popover;
+    // type a partial match to trigger the dropdown
+    const itemCodeInput = screen.getByPlaceholderText("Enter item code...");
+    await user.type(itemCodeInput, "ITM");
 
     await waitFor(() => {
       expect(screen.getByText("ITM-001")).toBeInTheDocument();

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -13,6 +13,7 @@ import {
   useCreateSubcategory,
 } from "@/hooks/useSubcategories";
 import { useItemTemplates } from "@/hooks/useItemTemplates";
+import { useReceiptItemSuggestions } from "@/hooks/useReceiptItemSuggestions";
 import {
   itemDescriptionHistory,
   itemCodeHistory,
@@ -34,6 +35,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { Badge } from "@/components/ui/badge";
 import {
   Form,
   FormControl,
@@ -44,6 +46,7 @@ import {
 } from "@/components/ui/form";
 import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
+import { Loader2 } from "lucide-react";
 
 interface ItemTemplate {
   id: string;
@@ -81,6 +84,7 @@ interface ReceiptItemFormProps {
   isSubmitting?: boolean;
   serverErrors?: Record<string, string>;
   hideReceiptField?: boolean;
+  location?: string | null;
 }
 
 export function ReceiptItemForm({
@@ -91,6 +95,7 @@ export function ReceiptItemForm({
   isSubmitting,
   serverErrors,
   hideReceiptField,
+  location,
 }: ReceiptItemFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
   useFormShortcuts({ formRef });
@@ -188,6 +193,72 @@ export function ReceiptItemForm({
   const watchedQuantity = form.watch("quantity");
   const watchedUnitPrice = form.watch("unitPrice");
   const isFlat = watchedPricingMode === "flat";
+
+  // Resolve location: use prop if provided, otherwise derive from selected receipt
+  const watchedReceiptId = form.watch("receiptId");
+  const resolvedLocation = useMemo(() => {
+    if (location) return location;
+    if (!watchedReceiptId || !receipts) return null;
+    const receipt = (receipts as { id: string; location: string }[])?.find(
+      (r) => r.id === watchedReceiptId,
+    );
+    return receipt?.location ?? null;
+  }, [location, watchedReceiptId, receipts]);
+
+  // Item code autocomplete state
+  const [itemCodeInput, setItemCodeInput] = useState(
+    defaultValues?.receiptItemCode ?? "",
+  );
+  const [itemCodeAutocompleteOpen, setItemCodeAutocompleteOpen] = useState(false);
+  const itemCodeListId = "item-code-autocomplete-list";
+
+  const { data: itemCodeSuggestions, isFetching: isFetchingItemCodeSuggestions } =
+    useReceiptItemSuggestions(itemCodeInput, resolvedLocation, {
+      enabled: itemCodeAutocompleteOpen && itemCodeInput.length >= 1,
+    });
+
+  // Filter item code history entries that match the current input
+  const itemCodeHistoryMatches = useMemo(() => {
+    if (!itemCodeInput) return itemCodeOptions;
+    const lower = itemCodeInput.toLowerCase();
+    return itemCodeOptions.filter((opt) =>
+      opt.label.toLowerCase().includes(lower),
+    );
+  }, [itemCodeOptions, itemCodeInput]);
+
+  const isItemCodePopoverOpen =
+    itemCodeAutocompleteOpen &&
+    ((itemCodeSuggestions && itemCodeSuggestions.length > 0) ||
+      itemCodeHistoryMatches.length > 0);
+
+  const handleItemCodeKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        setItemCodeAutocompleteOpen(false);
+      } else if (e.key === "ArrowDown" && isItemCodePopoverOpen) {
+        e.preventDefault();
+        const list = document.getElementById(itemCodeListId);
+        const firstItem = list?.querySelector("[cmdk-item]") as HTMLElement | null;
+        firstItem?.focus();
+      }
+    },
+    [isItemCodePopoverOpen, itemCodeListId],
+  );
+
+  function applySuggestion(suggestion: NonNullable<typeof itemCodeSuggestions>[number]) {
+    form.setValue("receiptItemCode", suggestion.itemCode);
+    setItemCodeInput(suggestion.itemCode);
+    form.setValue("description", suggestion.description);
+    setDescriptionInput(suggestion.description);
+    form.setValue("category", suggestion.category);
+    if (suggestion.subcategory) {
+      form.setValue("subcategory", suggestion.subcategory);
+    }
+    if (suggestion.unitPrice != null) {
+      form.setValue("unitPrice", suggestion.unitPrice);
+    }
+    setItemCodeAutocompleteOpen(false);
+  }
 
   const handlePricingModeChange = useCallback(
     (value: string) => {
@@ -331,18 +402,111 @@ export function ReceiptItemForm({
           render={({ field }) => (
             <FormItem>
               <FormLabel>Item Code</FormLabel>
-              <FormControl>
-                <Combobox
-                  options={itemCodeOptions}
-                  value={field.value}
-                  onValueChange={field.onChange}
-                  placeholder="Select or type an item code..."
-                  searchPlaceholder="Search item codes..."
-                  emptyMessage="Type to add a new item code"
-                  allowCustom
-                  aria-required="true"
-                />
-              </FormControl>
+              <Popover
+                open={isItemCodePopoverOpen}
+                onOpenChange={setItemCodeAutocompleteOpen}
+              >
+                <PopoverAnchor asChild>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        role="combobox"
+                        aria-required="true"
+                        aria-autocomplete="list"
+                        aria-expanded={isItemCodePopoverOpen}
+                        aria-controls={itemCodeListId}
+                        placeholder="Enter item code..."
+                        {...field}
+                        value={itemCodeInput}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          setItemCodeInput(val);
+                          field.onChange(val);
+                          setItemCodeAutocompleteOpen(true);
+                        }}
+                        onFocus={() => {
+                          if (itemCodeInput.length >= 1 || itemCodeHistoryMatches.length > 0) {
+                            setItemCodeAutocompleteOpen(true);
+                          }
+                        }}
+                        onKeyDown={handleItemCodeKeyDown}
+                        autoComplete="off"
+                      />
+                      {isFetchingItemCodeSuggestions && itemCodeInput.length >= 1 && (
+                        <>
+                          <Loader2 className="absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" aria-hidden="true" />
+                          <span className="sr-only" role="status">Loading suggestions...</span>
+                        </>
+                      )}
+                    </div>
+                  </FormControl>
+                </PopoverAnchor>
+                <PopoverContent
+                  className="w-[--radix-popover-trigger-width] p-0"
+                  align="start"
+                  onOpenAutoFocus={(e) => e.preventDefault()}
+                  onInteractOutside={() => setItemCodeAutocompleteOpen(false)}
+                >
+                  <Command>
+                    <CommandList id={itemCodeListId}>
+                      <CommandEmpty>No suggestions found.</CommandEmpty>
+                      {itemCodeHistoryMatches.length > 0 && (
+                        <CommandGroup heading="Recent Item Codes">
+                          {itemCodeHistoryMatches.slice(0, 5).map((opt) => (
+                            <CommandItem
+                              key={`history-${opt.value}`}
+                              value={`history: ${opt.label}`}
+                              onSelect={() => {
+                                setItemCodeInput(opt.value);
+                                field.onChange(opt.value);
+                                setItemCodeAutocompleteOpen(false);
+                              }}
+                            >
+                              <span>{opt.label}</span>
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      )}
+                      {itemCodeSuggestions && itemCodeSuggestions.length > 0 && (
+                        <CommandGroup heading="Suggestions">
+                          {itemCodeSuggestions.map((suggestion) => (
+                            <CommandItem
+                              key={`${suggestion.itemCode}-${suggestion.matchType}`}
+                              value={`${suggestion.itemCode} ${suggestion.description}`}
+                              onSelect={() => applySuggestion(suggestion)}
+                            >
+                              <div className="flex w-full items-center justify-between">
+                                <div className="flex flex-col gap-0.5">
+                                  <span className="font-medium font-mono">
+                                    {suggestion.itemCode}
+                                  </span>
+                                  <span className="text-xs text-muted-foreground">
+                                    {suggestion.description}
+                                    {suggestion.category
+                                      ? ` · ${suggestion.category}`
+                                      : ""}
+                                    {suggestion.unitPrice != null
+                                      ? ` · ${formatCurrency(suggestion.unitPrice)}`
+                                      : ""}
+                                  </span>
+                                </div>
+                                <Badge
+                                  variant="outline"
+                                  className="text-[10px] px-1.5 py-0"
+                                >
+                                  {suggestion.matchType === "location"
+                                    ? "Location"
+                                    : "Global"}
+                                </Badge>
+                              </div>
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      )}
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
               <FormMessage />
               {serverErrors?.receiptItemCode && (
                 <p className="text-sm font-medium text-destructive">

--- a/src/client/src/components/ReceiptItemsCard.tsx
+++ b/src/client/src/components/ReceiptItemsCard.tsx
@@ -54,12 +54,14 @@ interface ReceiptItemsCardProps {
   receiptId: string;
   items: ReceiptItem[];
   subtotal: number;
+  location?: string | null;
 }
 
 export function ReceiptItemsCard({
   receiptId,
   items,
   subtotal,
+  location,
 }: ReceiptItemsCardProps) {
   const queryClient = useQueryClient();
   const createReceiptItem = useCreateReceiptItem();
@@ -278,6 +280,7 @@ export function ReceiptItemsCard({
             serverErrors={serverErrors}
             onCancel={() => setCreateOpen(false)}
             onSubmit={handleCreate}
+            location={location}
           />
         </DialogContent>
       </Dialog>
@@ -309,6 +312,7 @@ export function ReceiptItemsCard({
               serverErrors={serverErrors}
               onCancel={() => setEditItem(null)}
               onSubmit={handleUpdate}
+              location={location}
             />
           )}
         </DialogContent>

--- a/src/client/src/hooks/useReceiptItemSuggestions.test.ts
+++ b/src/client/src/hooks/useReceiptItemSuggestions.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+// Mock debounce to return immediately
+vi.mock("./useDebouncedValue", () => ({
+  useDebouncedValue: (value: string) => value,
+}));
+
+import client from "@/lib/api-client";
+import { useReceiptItemSuggestions } from "./useReceiptItemSuggestions";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useReceiptItemSuggestions", () => {
+  it("does not fetch when itemCode is empty", () => {
+    const { result } = renderHook(() => useReceiptItemSuggestions(""), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.GET).not.toHaveBeenCalled();
+  });
+
+  it("fetches suggestions when itemCode is >= 1 char", async () => {
+    const suggestions = [
+      {
+        itemCode: "MILK-GAL",
+        description: "Whole Milk",
+        category: "Groceries",
+        subcategory: "Dairy",
+        unitPrice: 3.99,
+        matchType: "location",
+      },
+    ];
+    (client.GET as Mock).mockResolvedValue({ data: suggestions, error: undefined });
+
+    const { result } = renderHook(
+      () => useReceiptItemSuggestions("M", "Walmart"),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(suggestions);
+    expect(client.GET).toHaveBeenCalledWith("/api/receipt-items/suggestions", {
+      params: { query: { itemCode: "M", location: "Walmart", limit: 10 } },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("does not fetch when enabled is false", () => {
+    const { result } = renderHook(
+      () => useReceiptItemSuggestions("MILK", "Walmart", { enabled: false }),
+      { wrapper: createWrapper() },
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.GET).not.toHaveBeenCalled();
+  });
+
+  it("passes null location as undefined in query params", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: [], error: undefined });
+
+    const { result } = renderHook(
+      () => useReceiptItemSuggestions("MILK", null),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/receipt-items/suggestions", {
+      params: { query: { itemCode: "MILK", location: undefined, limit: 10 } },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("passes custom limit", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: [], error: undefined });
+
+    const { result } = renderHook(
+      () => useReceiptItemSuggestions("MILK", "Walmart", { limit: 5 }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/receipt-items/suggestions", {
+      params: { query: { itemCode: "MILK", location: "Walmart", limit: 5 } },
+      signal: expect.any(AbortSignal),
+    });
+  });
+});

--- a/src/client/src/hooks/useReceiptItemSuggestions.ts
+++ b/src/client/src/hooks/useReceiptItemSuggestions.ts
@@ -1,0 +1,41 @@
+import { useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+import { useDebouncedValue } from "./useDebouncedValue";
+
+export function useReceiptItemSuggestions(
+  itemCode: string,
+  location?: string | null,
+  options?: { limit?: number; enabled?: boolean },
+) {
+  const debouncedItemCode = useDebouncedValue(itemCode, 300);
+  const enabled =
+    (options?.enabled ?? true) && debouncedItemCode.length >= 1;
+
+  return useQuery({
+    queryKey: [
+      "receiptItemSuggestions",
+      debouncedItemCode,
+      location,
+      options?.limit,
+    ],
+    enabled,
+    queryFn: async ({ signal }) => {
+      const { data, error } = await client.GET(
+        "/api/receipt-items/suggestions",
+        {
+          params: {
+            query: {
+              itemCode: debouncedItemCode,
+              location: location ?? undefined,
+              limit: options?.limit ?? 10,
+            },
+          },
+          signal,
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    staleTime: 30_000,
+  });
+}

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -161,6 +161,7 @@ function ReceiptDetail() {
             receiptId={id}
             items={trip.receipt.items}
             subtotal={subtotal}
+            location={trip.receipt.receipt.location}
           />
 
           {/* Adjustments Table (read-only) */}

--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -43,6 +43,16 @@ vi.mock("@/hooks/useSimilarItems", () => ({
   ),
 }));
 
+vi.mock("@/hooks/useReceiptItemSuggestions", () => ({
+  useReceiptItemSuggestions: vi.fn(() =>
+    mockQueryResult({
+      data: undefined,
+      isFetching: false,
+      isSuccess: false,
+    }),
+  ),
+}));
+
 describe("LineItemsSection", () => {
   const defaultProps = {
     items: [] as ReceiptLineItem[],

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -12,6 +12,7 @@ import {
   useSimilarItems,
   useCategoryRecommendations,
 } from "@/hooks/useSimilarItems";
+import { useReceiptItemSuggestions } from "@/hooks/useReceiptItemSuggestions";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -79,9 +80,10 @@ export interface ReceiptLineItem {
 interface LineItemsSectionProps {
   items: ReceiptLineItem[];
   onChange: (items: ReceiptLineItem[]) => void;
+  location?: string | null;
 }
 
-export function LineItemsSection({ items, onChange }: LineItemsSectionProps) {
+export function LineItemsSection({ items, onChange, location }: LineItemsSectionProps) {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const suggestionsListId = "new-receipt-suggestions-list";
   const { data: categories } = useCategories();
@@ -108,9 +110,63 @@ export function LineItemsSection({ items, onChange }: LineItemsSectionProps) {
     },
   });
 
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const itemCode = form.watch("receiptItemCode");
   const description = form.watch("description");
   const selectedCategory = form.watch("category");
   const pricingMode = form.watch("pricingMode");
+
+  // Item code autocomplete
+  const [showItemCodeSuggestions, setShowItemCodeSuggestions] = useState(false);
+  const itemCodeSuggestionsListId = "new-receipt-item-code-suggestions-list";
+
+  const { data: itemCodeSuggestions, isFetching: isFetchingItemCodeSuggestions } =
+    useReceiptItemSuggestions(itemCode ?? "", location, {
+      enabled: showItemCodeSuggestions && (itemCode ?? "").length >= 1,
+    });
+
+  const hasItemCodeResults = itemCodeSuggestions && itemCodeSuggestions.length > 0;
+  const hasNoItemCodeResultsMessage =
+    (itemCode ?? "").length >= 1 &&
+    !isFetchingItemCodeSuggestions &&
+    itemCodeSuggestions &&
+    itemCodeSuggestions.length === 0;
+  const isItemCodeSuggestionsOpen =
+    showItemCodeSuggestions && (hasItemCodeResults || hasNoItemCodeResultsMessage);
+
+  const applyItemCodeSuggestion = useCallback(
+    (suggestion: NonNullable<typeof itemCodeSuggestions>[number]) => {
+      form.setValue("receiptItemCode", suggestion.itemCode);
+      form.setValue("description", suggestion.description);
+      if (suggestion.category) {
+        form.setValue("category", suggestion.category);
+      }
+      if (suggestion.subcategory) {
+        form.setValue("subcategory", suggestion.subcategory);
+      }
+      if (suggestion.unitPrice != null) {
+        form.setValue("unitPrice", suggestion.unitPrice);
+      }
+      setShowItemCodeSuggestions(false);
+    },
+    [form],
+  );
+
+  const handleItemCodeKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        setShowItemCodeSuggestions(false);
+      } else if (e.key === "ArrowDown" && isItemCodeSuggestionsOpen) {
+        e.preventDefault();
+        const list = document.getElementById(itemCodeSuggestionsListId);
+        const firstItem = list?.querySelector(
+          "[cmdk-item]",
+        ) as HTMLElement | null;
+        firstItem?.focus();
+      }
+    },
+    [isItemCodeSuggestionsOpen, itemCodeSuggestionsListId],
+  );
 
   const { data: similarItems, isFetching: isFetchingSimilar } =
     useSimilarItems(description, { enabled: showSuggestions });
@@ -261,6 +317,89 @@ export function LineItemsSection({ items, onChange }: LineItemsSectionProps) {
             className="space-y-4"
           >
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <FormField
+                control={form.control}
+                name="receiptItemCode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Item Code</FormLabel>
+                    <Popover
+                      open={isItemCodeSuggestionsOpen}
+                      onOpenChange={setShowItemCodeSuggestions}
+                    >
+                      <PopoverAnchor asChild>
+                        <FormControl>
+                          <div className="relative">
+                            <Input
+                              role="combobox"
+                              placeholder="e.g. MILK-GAL"
+                              aria-autocomplete="list"
+                              aria-expanded={isItemCodeSuggestionsOpen}
+                              aria-controls={itemCodeSuggestionsListId}
+                              autoComplete="off"
+                              {...field}
+                              onFocus={() => setShowItemCodeSuggestions(true)}
+                              onKeyDown={handleItemCodeKeyDown}
+                            />
+                            {isFetchingItemCodeSuggestions && (itemCode ?? "").length >= 1 && (
+                              <>
+                                <Loader2 className="absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" aria-hidden="true" />
+                                <span className="sr-only" role="status">Loading suggestions...</span>
+                              </>
+                            )}
+                          </div>
+                        </FormControl>
+                      </PopoverAnchor>
+                      <PopoverContent
+                        className="w-[--radix-popover-trigger-width] p-0"
+                        align="start"
+                        onOpenAutoFocus={(e) => e.preventDefault()}
+                        onInteractOutside={() => setShowItemCodeSuggestions(false)}
+                      >
+                        <Command shouldFilter={false}>
+                          <CommandList id={itemCodeSuggestionsListId}>
+                            <CommandEmpty>No suggestions found</CommandEmpty>
+                            {itemCodeSuggestions?.map((suggestion) => (
+                              <CommandItem
+                                key={`${suggestion.itemCode}-${suggestion.matchType}`}
+                                value={`${suggestion.itemCode} ${suggestion.description}`}
+                                onSelect={() => applyItemCodeSuggestion(suggestion)}
+                              >
+                                <div className="flex w-full items-center justify-between">
+                                  <div className="flex flex-col gap-0.5">
+                                    <span className="font-medium font-mono">
+                                      {suggestion.itemCode}
+                                    </span>
+                                    <span className="text-xs text-muted-foreground">
+                                      {suggestion.description}
+                                      {suggestion.category
+                                        ? ` · ${suggestion.category}`
+                                        : ""}
+                                      {suggestion.unitPrice != null
+                                        ? ` · ${formatCurrency(suggestion.unitPrice)}`
+                                        : ""}
+                                    </span>
+                                  </div>
+                                  <Badge
+                                    variant="outline"
+                                    className="text-[10px] px-1.5 py-0"
+                                  >
+                                    {suggestion.matchType === "location"
+                                      ? "Location"
+                                      : "Global"}
+                                  </Badge>
+                                </div>
+                              </CommandItem>
+                            ))}
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
               <FormField
                 control={form.control}
                 name="description"
@@ -447,21 +586,7 @@ export function LineItemsSection({ items, onChange }: LineItemsSectionProps) {
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-[auto_auto_auto_auto_1fr] sm:items-end">
-              <FormField
-                control={form.control}
-                name="receiptItemCode"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Item Code</FormLabel>
-                    <FormControl>
-                      <Input placeholder="e.g. MILK-GAL" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-[auto_auto_auto_1fr] sm:items-end">
               <FormField
                 control={form.control}
                 name="pricingMode"

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -263,7 +263,7 @@ export default function NewReceiptPage() {
             )}
 
           {/* Line Items */}
-          <LineItemsSection items={items} onChange={setItems} />
+          <LineItemsSection items={items} onChange={setItems} location={location} />
         </div>
 
         {/* Right column — sticky balance sidebar */}

--- a/src/client/src/pages/wizard/NewReceipt.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.tsx
@@ -156,6 +156,7 @@ export default function NewReceipt() {
             goNext();
           }}
           onBack={goBack}
+          location={state.receipt.location}
         />
       )}
       {state.currentStep === 3 && (

--- a/src/client/src/pages/wizard/Step3Items.test.tsx
+++ b/src/client/src/pages/wizard/Step3Items.test.tsx
@@ -60,6 +60,15 @@ vi.mock("@/hooks/useSimilarItems", () => ({
   useCategoryRecommendations: () => useCategoryRecommendationsMock(),
 }));
 
+vi.mock("@/hooks/useReceiptItemSuggestions", () => ({
+  useReceiptItemSuggestions: () =>
+    mockQueryResult({
+      data: undefined,
+      isFetching: false,
+      isSuccess: false,
+    }),
+}));
+
 describe("Step3Items", () => {
   const defaultProps = {
     data: [],

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -12,6 +12,7 @@ import {
   useSimilarItems,
   useCategoryRecommendations,
 } from "@/hooks/useSimilarItems";
+import { useReceiptItemSuggestions } from "@/hooks/useReceiptItemSuggestions";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -72,6 +73,7 @@ interface Step3Props {
   transactionTotal: number;
   onNext: (data: WizardReceiptItem[]) => void;
   onBack: () => void;
+  location?: string | null;
 }
 
 export function Step3Items({
@@ -80,6 +82,7 @@ export function Step3Items({
   transactionTotal,
   onNext,
   onBack,
+  location,
 }: Step3Props) {
   const [items, setItems] = useState<WizardReceiptItem[]>(data);
   const [showSuggestions, setShowSuggestions] = useState(false);
@@ -110,8 +113,62 @@ export function Step3Items({
     },
   });
 
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const itemCode = form.watch("receiptItemCode");
   const description = form.watch("description");
   const selectedCategory = form.watch("category");
+
+  // Item code autocomplete
+  const [showItemCodeSuggestions, setShowItemCodeSuggestions] = useState(false);
+  const itemCodeSuggestionsListId = "step3-item-code-suggestions-list";
+
+  const { data: itemCodeSuggestions, isFetching: isFetchingItemCodeSuggestions } =
+    useReceiptItemSuggestions(itemCode ?? "", location, {
+      enabled: showItemCodeSuggestions && (itemCode ?? "").length >= 1,
+    });
+
+  const hasItemCodeResults = itemCodeSuggestions && itemCodeSuggestions.length > 0;
+  const hasNoItemCodeResultsMessage =
+    (itemCode ?? "").length >= 1 &&
+    !isFetchingItemCodeSuggestions &&
+    itemCodeSuggestions &&
+    itemCodeSuggestions.length === 0;
+  const isItemCodeSuggestionsOpen =
+    showItemCodeSuggestions && (hasItemCodeResults || hasNoItemCodeResultsMessage);
+
+  const applyItemCodeSuggestion = useCallback(
+    (suggestion: NonNullable<typeof itemCodeSuggestions>[number]) => {
+      form.setValue("receiptItemCode", suggestion.itemCode);
+      form.setValue("description", suggestion.description);
+      if (suggestion.category) {
+        form.setValue("category", suggestion.category);
+      }
+      if (suggestion.subcategory) {
+        form.setValue("subcategory", suggestion.subcategory);
+      }
+      if (suggestion.unitPrice != null) {
+        form.setValue("unitPrice", suggestion.unitPrice);
+      }
+      setShowItemCodeSuggestions(false);
+    },
+    [form],
+  );
+
+  const handleItemCodeKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        setShowItemCodeSuggestions(false);
+      } else if (e.key === "ArrowDown" && isItemCodeSuggestionsOpen) {
+        e.preventDefault();
+        const list = document.getElementById(itemCodeSuggestionsListId);
+        const firstItem = list?.querySelector(
+          "[cmdk-item]",
+        ) as HTMLElement | null;
+        firstItem?.focus();
+      }
+    },
+    [isItemCodeSuggestionsOpen, itemCodeSuggestionsListId],
+  );
 
   const { data: similarItems, isFetching: isFetchingSimilar } =
     useSimilarItems(description, { enabled: showSuggestions });
@@ -282,10 +339,79 @@ export function Step3Items({
               name="receiptItemCode"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Item Code (optional)</FormLabel>
-                  <FormControl>
-                    <Input placeholder="e.g. MILK-GAL" {...field} />
-                  </FormControl>
+                  <FormLabel>Item Code</FormLabel>
+                  <Popover
+                    open={isItemCodeSuggestionsOpen}
+                    onOpenChange={setShowItemCodeSuggestions}
+                  >
+                    <PopoverAnchor asChild>
+                      <FormControl>
+                        <div className="relative">
+                          <Input
+                            role="combobox"
+                            placeholder="e.g. MILK-GAL"
+                            aria-autocomplete="list"
+                            aria-expanded={isItemCodeSuggestionsOpen}
+                            aria-controls={itemCodeSuggestionsListId}
+                            autoComplete="off"
+                            {...field}
+                            onFocus={() => setShowItemCodeSuggestions(true)}
+                            onKeyDown={handleItemCodeKeyDown}
+                          />
+                          {isFetchingItemCodeSuggestions && (itemCode ?? "").length >= 1 && (
+                            <>
+                              <Loader2 className="absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" aria-hidden="true" />
+                              <span className="sr-only" role="status">Loading suggestions...</span>
+                            </>
+                          )}
+                        </div>
+                      </FormControl>
+                    </PopoverAnchor>
+                    <PopoverContent
+                      className="w-[--radix-popover-trigger-width] p-0"
+                      align="start"
+                      onOpenAutoFocus={(e) => e.preventDefault()}
+                      onInteractOutside={() => setShowItemCodeSuggestions(false)}
+                    >
+                      <Command shouldFilter={false}>
+                        <CommandList id={itemCodeSuggestionsListId}>
+                          <CommandEmpty>No suggestions found</CommandEmpty>
+                          {itemCodeSuggestions?.map((suggestion) => (
+                            <CommandItem
+                              key={`${suggestion.itemCode}-${suggestion.matchType}`}
+                              value={`${suggestion.itemCode} ${suggestion.description}`}
+                              onSelect={() => applyItemCodeSuggestion(suggestion)}
+                            >
+                              <div className="flex w-full items-center justify-between">
+                                <div className="flex flex-col gap-0.5">
+                                  <span className="font-medium font-mono">
+                                    {suggestion.itemCode}
+                                  </span>
+                                  <span className="text-xs text-muted-foreground">
+                                    {suggestion.description}
+                                    {suggestion.category
+                                      ? ` · ${suggestion.category}`
+                                      : ""}
+                                    {suggestion.unitPrice != null
+                                      ? ` · ${formatCurrency(suggestion.unitPrice)}`
+                                      : ""}
+                                  </span>
+                                </div>
+                                <Badge
+                                  variant="outline"
+                                  className="text-[10px] px-1.5 py-0"
+                                >
+                                  {suggestion.matchType === "location"
+                                    ? "Location"
+                                    : "Global"}
+                                </Badge>
+                              </div>
+                            </CommandItem>
+                          ))}
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
                   <FormMessage />
                 </FormItem>
               )}

--- a/tests/Application.Tests/Queries/Core/ReceiptItem/GetReceiptItemSuggestionsQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Core/ReceiptItem/GetReceiptItemSuggestionsQueryHandlerTests.cs
@@ -1,0 +1,67 @@
+using Application.Interfaces.Services;
+using Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Core.ReceiptItem;
+
+public class GetReceiptItemSuggestionsQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ShouldReturnSuggestions_WhenServiceReturnsResults()
+	{
+		List<ReceiptItemSuggestion> expected =
+		[
+			new()
+			{
+				ItemCode = "MILK-GAL",
+				Description = "Whole Milk",
+				Category = "Groceries",
+				Subcategory = "Dairy",
+				UnitPrice = 3.99m,
+				MatchType = "location",
+			},
+		];
+
+		Mock<IReceiptItemService> mockService = new();
+		mockService
+			.Setup(s => s.GetSuggestionsAsync("MILK", "Walmart", 10, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetReceiptItemSuggestionsQueryHandler handler = new(mockService.Object);
+		GetReceiptItemSuggestionsQuery query = new("MILK", "Walmart", 10);
+		IEnumerable<ReceiptItemSuggestion> result = await handler.Handle(query, CancellationToken.None);
+
+		result.Should().BeEquivalentTo(expected);
+	}
+
+	[Fact]
+	public async Task Handle_ShouldReturnEmpty_WhenServiceReturnsNoResults()
+	{
+		Mock<IReceiptItemService> mockService = new();
+		mockService
+			.Setup(s => s.GetSuggestionsAsync("XYZ", null, 10, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+
+		GetReceiptItemSuggestionsQueryHandler handler = new(mockService.Object);
+		GetReceiptItemSuggestionsQuery query = new("XYZ", null, 10);
+		IEnumerable<ReceiptItemSuggestion> result = await handler.Handle(query, CancellationToken.None);
+
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Handle_ShouldPassAllParameters_ToService()
+	{
+		Mock<IReceiptItemService> mockService = new();
+		mockService
+			.Setup(s => s.GetSuggestionsAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+
+		GetReceiptItemSuggestionsQueryHandler handler = new(mockService.Object);
+		GetReceiptItemSuggestionsQuery query = new("TEST", "Target", 5);
+		await handler.Handle(query, CancellationToken.None);
+
+		mockService.Verify(s => s.GetSuggestionsAsync("TEST", "Target", 5, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/Core/ReceiptItem/GetReceiptItemSuggestionsQueryTests.cs
+++ b/tests/Application.Tests/Queries/Core/ReceiptItem/GetReceiptItemSuggestionsQueryTests.cs
@@ -1,0 +1,31 @@
+using Application.Queries.Core.ReceiptItem.GetReceiptItemSuggestions;
+
+namespace Application.Tests.Queries.Core.ReceiptItem;
+
+public class GetReceiptItemSuggestionsQueryTests
+{
+	[Fact]
+	public void Query_CanBeCreated()
+	{
+		GetReceiptItemSuggestionsQuery query = new("MILK", "Walmart", 10);
+		Assert.Equal("MILK", query.ItemCode);
+		Assert.Equal("Walmart", query.Location);
+		Assert.Equal(10, query.Limit);
+	}
+
+	[Fact]
+	public void Query_WithNullLocation_CanBeCreated()
+	{
+		GetReceiptItemSuggestionsQuery query = new("MILK", null, 5);
+		Assert.Equal("MILK", query.ItemCode);
+		Assert.Null(query.Location);
+		Assert.Equal(5, query.Limit);
+	}
+
+	[Fact]
+	public void Query_WithDefaultLimit_UsesDefault()
+	{
+		GetReceiptItemSuggestionsQuery query = new("MILK", "Walmart");
+		Assert.Equal(10, query.Limit);
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/receipt-items/suggestions` endpoint that queries historical receipt items grouped by itemCode, filtered by the receipt's location with a global fallback
- Make Item Code the primary entry field (first in form) across all three receipt item form surfaces: `ReceiptItemForm`, `LineItemsSection`, `Step3Items`
- Selecting a suggestion auto-populates description, category, subcategory, and unitPrice

## Test plan
- [x] All 1491 .NET unit tests pass
- [x] All 1525 frontend tests pass (149 test files)
- [x] 11 new tests added (query, handler, hook)
- [x] OpenAPI spec lint clean, no drift
- [x] TypeScript compiles with no errors
- [x] ESLint passes with no errors

Closes RECEIPTS-452

🤖 Generated with [Claude Code](https://claude.com/claude-code)