### PR TITLE
fix(client): subcategory filter UUID and dead items link

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -574,9 +574,27 @@ paths:
                     type: string
                   receiptItemCount:
                     type: integer
+                  affectedReceipts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        date:
+                          type: string
+                          format: date
+                        location:
+                          type: string
+                      required:
+                        - id
+                        - date
+                        - location
                 required:
                   - message
                   - receiptItemCount
+                  - affectedReceipts
 
   /api/subcategories/deleted:
     get:

--- a/src/Application/Interfaces/Services/ISubcategoryService.cs
+++ b/src/Application/Interfaces/Services/ISubcategoryService.cs
@@ -11,4 +11,5 @@ public interface ISubcategoryService : ISoftDeletableService<Subcategory>
 	Task<PagedResult<Subcategory>> GetByCategoryIdAsync(Guid categoryId, int offset, int limit, SortParams sort, CancellationToken cancellationToken);
 	Task<PagedResult<Subcategory>> GetByCategoryIdAsync(Guid categoryId, int offset, int limit, SortParams sort, bool? isActive, CancellationToken cancellationToken);
 	Task<int> GetReceiptItemCountBySubcategoryNameAsync(string subcategoryName, CancellationToken cancellationToken);
+	Task<List<(Guid ReceiptId, DateOnly Date, string Location)>> GetAffectedReceiptsBySubcategoryNameAsync(string subcategoryName, int limit, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Interfaces/Repositories/ISubcategoryRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/ISubcategoryRepository.cs
@@ -18,4 +18,5 @@ public interface ISubcategoryRepository
 	Task DeleteAsync(List<Guid> ids, CancellationToken cancellationToken);
 	Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken);
 	Task<int> GetReceiptItemCountBySubcategoryNameAsync(string subcategoryName, CancellationToken cancellationToken);
+	Task<List<(Guid ReceiptId, DateOnly Date, string Location)>> GetAffectedReceiptsBySubcategoryNameAsync(string subcategoryName, int limit, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Repositories/SubcategoryRepository.cs
+++ b/src/Infrastructure/Repositories/SubcategoryRepository.cs
@@ -177,4 +177,17 @@ public class SubcategoryRepository(IDbContextFactory<ApplicationDbContext> conte
 			.IgnoreQueryFilters()
 			.CountAsync(ri => ri.Subcategory == subcategoryName, cancellationToken);
 	}
+
+	public async Task<List<(Guid ReceiptId, DateOnly Date, string Location)>> GetAffectedReceiptsBySubcategoryNameAsync(string subcategoryName, int limit, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		return await context.ReceiptItems
+			.Where(ri => ri.Subcategory == subcategoryName)
+			.Select(ri => ri.Receipt!)
+			.Distinct()
+			.OrderByDescending(r => r.Date)
+			.Take(limit)
+			.Select(r => ValueTuple.Create(r.Id, r.Date, r.Location))
+			.ToListAsync(cancellationToken);
+	}
 }

--- a/src/Infrastructure/Services/SubcategoryService.cs
+++ b/src/Infrastructure/Services/SubcategoryService.cs
@@ -102,4 +102,9 @@ public class SubcategoryService(ISubcategoryRepository repository, SubcategoryMa
 	{
 		return await repository.GetReceiptItemCountBySubcategoryNameAsync(subcategoryName, cancellationToken);
 	}
+
+	public async Task<List<(Guid ReceiptId, DateOnly Date, string Location)>> GetAffectedReceiptsBySubcategoryNameAsync(string subcategoryName, int limit, CancellationToken cancellationToken)
+	{
+		return await repository.GetAffectedReceiptsBySubcategoryNameAsync(subcategoryName, limit, cancellationToken);
+	}
 }

--- a/src/Presentation/API/Controllers/Core/SubcategoriesController.cs
+++ b/src/Presentation/API/Controllers/Core/SubcategoriesController.cs
@@ -212,7 +212,13 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 		if (receiptItemCount > 0)
 		{
 			logger.LogWarning("Subcategory {Id} cannot be deleted — {Count} receipt items reference it", id, receiptItemCount);
-			return TypedResults.Conflict<object>(new { message = $"Cannot delete — {receiptItemCount} receipt item(s) use this subcategory", receiptItemCount });
+			List<(Guid ReceiptId, DateOnly Date, string Location)> affected = await subcategoryService.GetAffectedReceiptsBySubcategoryNameAsync(subcategory.Name, 20, HttpContext.RequestAborted);
+			return TypedResults.Conflict<object>(new
+			{
+				message = $"Cannot delete — {receiptItemCount} receipt item(s) use this subcategory",
+				receiptItemCount,
+				affectedReceipts = affected.Select(r => new { id = r.ReceiptId, date = r.Date.ToString("yyyy-MM-dd"), location = r.Location }).ToList()
+			});
 		}
 
 		DeleteSubcategoryCommand command = new([id]);

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",

--- a/src/client/src/hooks/useSubcategories.ts
+++ b/src/client/src/hooks/useSubcategories.ts
@@ -99,9 +99,16 @@ export function useUpdateSubcategory() {
   });
 }
 
+export interface AffectedReceipt {
+  id: string;
+  date: string;
+  location: string;
+}
+
 export interface DeleteSubcategoryConflict {
   message: string;
   receiptItemCount: number;
+  affectedReceipts: AffectedReceipt[];
 }
 
 export function useDeleteSubcategory() {
@@ -125,7 +132,11 @@ export function useDeleteSubcategory() {
       toast.success("Subcategory deleted");
     },
     onError: (error: unknown) => {
-      const err = error as { conflict?: boolean; message?: string; receiptItemCount?: number };
+      const err = error as { conflict?: boolean; message?: string; receiptItemCount?: number; affectedReceipts?: AffectedReceipt[] };
+      if (err.conflict && err.affectedReceipts) {
+        // Conflict with affected receipts — handled by the component via onError callback
+        return;
+      }
       if (err.conflict) {
         toast.error(err.message ?? "Cannot delete — receipt items reference this subcategory");
       } else {

--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -371,4 +371,27 @@ describe("Subcategories", () => {
       screen.getByRole("heading", { name: /create subcategory/i }),
     ).toBeInTheDocument();
   });
+
+  it("does not render receipt-items links in expanded rows", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    await user.click(screen.getByRole("button", { name: /expand all/i }));
+
+    const links = screen.getAllByRole("link");
+    const receiptItemLinks = links.filter((link) =>
+      link.getAttribute("href")?.includes("/receipt-items"),
+    );
+    expect(receiptItemLinks).toHaveLength(0);
+  });
+
+  it("renders 5 table columns (no Related column)", async () => {
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    const columnHeaders = screen.getAllByRole("columnheader");
+    expect(columnHeaders).toHaveLength(5);
+    expect(screen.queryByText("Related")).not.toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -8,6 +8,7 @@ import {
   useUpdateSubcategory,
   useDeleteSubcategory,
 } from "@/hooks/useSubcategories";
+import type { AffectedReceipt } from "@/hooks/useSubcategories";
 import { usePermission } from "@/hooks/usePermission";
 import { useCategories } from "@/hooks/useCategories";
 import { usePageTitle } from "@/hooks/usePageTitle";
@@ -110,6 +111,11 @@ function Subcategories() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editSubcategory, setEditSubcategory] =
     useState<SubcategoryResponse | null>(null);
+  const [conflictData, setConflictData] = useState<{
+    subcategoryName: string;
+    receiptItemCount: number;
+    affectedReceipts: AffectedReceipt[];
+  } | null>(null);
   const [filterValues, setFilterValues] = useState<FilterValues>({
     categoryId: "all",
   });
@@ -117,7 +123,7 @@ function Subcategories() {
     new Set(),
   );
 
-  const anyDialogOpen = createOpen || editSubcategory !== null;
+  const anyDialogOpen = createOpen || editSubcategory !== null || conflictData !== null;
 
   useEffect(() => {
     function onNewItem() {
@@ -311,7 +317,7 @@ function Subcategories() {
 
       {hasActiveFilter && (
         <ActiveFilterBanner
-          message={`Showing subcategories for category: ${categoryMap.get(linkParams.categoryId!) ?? linkParams.categoryId}`}
+          message={`Showing subcategories for category: ${categoryMap.get(linkParams.categoryId!) ?? "Unknown category"}`}
           onClear={clearParams}
         />
       )}
@@ -347,7 +353,6 @@ function Subcategories() {
                   <TableHead>Category</TableHead>
                   <TableHead>Description</TableHead>
                   <SortableTableHead column="isActive" label="Status" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
-                  <TableHead>Related</TableHead>
                   <TableHead className="w-24">Actions</TableHead>
                 </TableRow>
               </TableHeader>
@@ -363,7 +368,7 @@ function Subcategories() {
                         onClick={() => toggleCategory(categoryId)}
                         data-testid={`category-header-${categoryId}`}
                       >
-                        <TableCell colSpan={6}>
+                        <TableCell colSpan={5}>
                           <div className="flex items-center gap-2 font-medium">
                             {isExpanded ? (
                               <ChevronDown className="h-4 w-4" />
@@ -429,11 +434,6 @@ function Subcategories() {
                                 </Badge>
                               </TableCell>
                               <TableCell>
-                                <Link to={`/receipt-items?subcategory=${encodeURIComponent(subcategory.name)}`} className="text-sm text-primary hover:underline">
-                                  Items
-                                </Link>
-                              </TableCell>
-                              <TableCell>
                                 <div className="flex gap-1">
                                   <Button
                                     variant="ghost"
@@ -467,7 +467,18 @@ function Subcategories() {
                                           <AlertDialogCancel>Cancel</AlertDialogCancel>
                                           <AlertDialogAction
                                             variant="destructive"
-                                            onClick={() => deleteSubcategory.mutate(subcategory.id)}
+                                            onClick={() => deleteSubcategory.mutate(subcategory.id, {
+                                              onError: (error: unknown) => {
+                                                const err = error as { conflict?: boolean; message?: string; receiptItemCount?: number; affectedReceipts?: AffectedReceipt[] };
+                                                if (err.conflict && err.affectedReceipts) {
+                                                  setConflictData({
+                                                    subcategoryName: subcategory.name,
+                                                    receiptItemCount: err.receiptItemCount ?? 0,
+                                                    affectedReceipts: err.affectedReceipts,
+                                                  });
+                                                }
+                                              },
+                                            })}
                                           >
                                             Delete
                                           </AlertDialogAction>
@@ -543,6 +554,50 @@ function Subcategories() {
                 );
               }}
             />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Conflict Dialog — shown when deletion is blocked by receipt items */}
+      <Dialog
+        open={conflictData !== null}
+        onOpenChange={(open) => !open && setConflictData(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Cannot Delete Subcategory</DialogTitle>
+          </DialogHeader>
+          {conflictData && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                <strong>{conflictData.subcategoryName}</strong> cannot be deleted because{" "}
+                {conflictData.receiptItemCount} receipt item(s) use this subcategory.
+                Re-categorize the items on these receipts first:
+              </p>
+              <ul className="max-h-64 space-y-1 overflow-y-auto text-sm">
+                {conflictData.affectedReceipts.map((receipt) => (
+                  <li key={receipt.id}>
+                    <Link
+                      to={`/receipts/${receipt.id}`}
+                      className="text-primary hover:underline"
+                      onClick={() => setConflictData(null)}
+                    >
+                      {receipt.date} &mdash; {receipt.location}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+              {conflictData.receiptItemCount > conflictData.affectedReceipts.length && (
+                <p className="text-xs text-muted-foreground">
+                  and {conflictData.receiptItemCount - conflictData.affectedReceipts.length} more receipt(s)
+                </p>
+              )}
+              <div className="flex justify-end">
+                <Button variant="outline" onClick={() => setConflictData(null)}>
+                  Close
+                </Button>
+              </div>
+            </div>
           )}
         </DialogContent>
       </Dialog>

--- a/tests/Presentation.API.Tests/Controllers/Core/SubcategoriesControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/SubcategoriesControllerTests.cs
@@ -435,6 +435,13 @@ public class SubcategoriesControllerTests
 		_subcategoryServiceMock.Setup(s => s.GetReceiptItemCountBySubcategoryNameAsync(subcategory.Name, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(5);
 
+		_subcategoryServiceMock.Setup(s => s.GetAffectedReceiptsBySubcategoryNameAsync(subcategory.Name, 20, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new List<(Guid ReceiptId, DateOnly Date, string Location)>
+			{
+				(Guid.NewGuid(), new DateOnly(2026, 1, 15), "Store A"),
+				(Guid.NewGuid(), new DateOnly(2026, 2, 20), "Store B"),
+			});
+
 		// Act
 		Results<NoContent, NotFound, Conflict<object>> result = await _controller.DeleteSubcategory(subcategory.Id);
 


### PR DESCRIPTION
## Summary
- **Remove dead `/receipt-items` link** from subcategory rows (route removed in RECEIPTS-422, redirects to bare `/receipts`)
- **Add conflict dialog** with affected receipt links when subcategory deletion is blocked by a 409 (replaces unhelpful toast)
- **Fix ActiveFilterBanner** fallback from raw UUID to "Unknown category"
- **Backend**: new `GetAffectedReceiptsBySubcategoryNameAsync` returns receipt ID/date/location in 409 response
- **OpenAPI spec** updated with `affectedReceipts` array schema

Closes RECEIPTS-460

## Test plan
- [x] 1522 .NET tests pass (including updated controller conflict test)
- [x] 1534 frontend tests pass (2 new: no receipt-items links, 5 columns instead of 6)
- [x] TypeScript type check passes
- [x] OpenAPI spec lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)