### PR TITLE
fix(api): separate Sentry DSNs, fix item similarity 500

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,8 +80,9 @@ jobs:
           build-args: |
             VITE_APP_VERSION=${{ github.ref_name }}
             VITE_COMMIT_HASH=${{ github.sha }}
-            VITE_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+            VITE_SENTRY_DSN=${{ secrets.SENTRY_FRONTEND_DSN }}
             VITE_SENTRY_ENVIRONMENT=production
+            SENTRY_BACKEND_DSN=${{ secrets.SENTRY_BACKEND_DSN }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=${{ secrets.SENTRY_ORG }}
             SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gosu curl && \
     rm -rf /var/lib/apt/lists/*
 
+ARG SENTRY_BACKEND_DSN=
+ENV SENTRY_BACKEND_DSN=${SENTRY_BACKEND_DSN}
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV ASPNETCORE_URLS=http://+:8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_SERVICE_NAME=receipts-api
       - SENTRY_DSN=${SENTRY_DSN:-}
+      - SENTRY_BACKEND_DSN=${SENTRY_BACKEND_DSN:-}
     depends_on:
       db:
         condition: service_healthy

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -191,9 +191,9 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 			{
 				edges.Add(new DescriptionSimilarityEdge(
 					reader.GetString(0),
-					reader.GetInt32(1),
+					(int)reader.GetInt64(1),
 					reader.GetString(2),
-					reader.GetInt32(3),
+					(int)reader.GetInt64(3),
 					reader.GetDouble(4)));
 			}
 		}

--- a/src/Presentation/API/Program.cs
+++ b/src/Presentation/API/Program.cs
@@ -18,7 +18,7 @@ builder.AddApplicationConfiguration();
 // Configure Sentry error tracking (disabled when SENTRY_DSN is empty/missing)
 builder.WebHost.UseSentry(o =>
 {
-	o.Dsn = builder.Configuration["SENTRY_DSN"] ?? "";
+	o.Dsn = builder.Configuration["SENTRY_BACKEND_DSN"] ?? builder.Configuration["SENTRY_DSN"] ?? "";
 	o.Environment = builder.Environment.EnvironmentName;
 	o.TracesSampleRate = 0.1;
 	o.SendDefaultPii = false;


### PR DESCRIPTION
## Summary
- **Sentry DSN separation:** Frontend and backend now use distinct Sentry DSNs (`SENTRY_FRONTEND_DSN` / `SENTRY_BACKEND_DSN`). The backend falls back to `SENTRY_DSN` for backwards compatibility.
- **Item similarity 500 fix:** PostgreSQL `COUNT(*)` returns `bigint` but the code used `GetInt32()`, causing `InvalidCastException`. Changed to `GetInt64()` with safe cast.

## Changes
- `.github/workflows/docker-publish.yml` -- Use `SENTRY_FRONTEND_DSN` for Vite, add `SENTRY_BACKEND_DSN` build arg
- `Dockerfile` -- Add `ARG`/`ENV SENTRY_BACKEND_DSN` in runtime stage
- `src/Presentation/API/Program.cs` -- Read `SENTRY_BACKEND_DSN` with fallback to `SENTRY_DSN`
- `docker-compose.yml` -- Add `SENTRY_BACKEND_DSN` to app service environment
- `src/Infrastructure/Services/ReportService.cs` -- Fix `GetInt32` -> `GetInt64` for PostgreSQL bigint `COUNT(*)`

Closes RECEIPTS-467

## Test plan
- [x] All 1525 unit tests pass
- [x] Build succeeds with 0 errors
- [x] Verified Sentry DSN fallback chain in Program.cs
- [x] Verified PostgreSQL type alignment (COUNT(*) -> bigint -> GetInt64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)