### PR TITLE
fix(client): clean up form validation states

### DIFF
--- a/src/client/src/components/ui/currency-input.tsx
+++ b/src/client/src/components/ui/currency-input.tsx
@@ -88,7 +88,7 @@ export function CurrencyInput({
         onBlur={handleBlur}
         onPaste={handlePaste}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
           "pl-7 text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
           className,
         )}

--- a/src/client/src/components/ui/form.tsx
+++ b/src/client/src/components/ui/form.tsx
@@ -44,18 +44,22 @@ function FormItem({ className, ...props }: React.ComponentProps<"div">) {
 
 function FormLabel({
   className,
+  required,
+  children,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
-  const { error, formItemId } = useFormField()
+}: React.ComponentProps<typeof LabelPrimitive.Root> & { required?: boolean }) {
+  const { formItemId } = useFormField()
 
   return (
     <Label
       data-slot="form-label"
-      data-error={!!error}
-      className={cn("data-[error=true]:text-destructive", className)}
+      className={cn(className)}
       htmlFor={formItemId}
       {...props}
-    />
+    >
+      {children}
+      {required && <span className="text-destructive ml-0.5">*</span>}
+    </Label>
   )
 }
 
@@ -102,7 +106,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn("text-destructive text-sm", className)}
+      className={cn("sr-only", className)}
       {...props}
     >
       {body}

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -405,7 +405,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                 name="description"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Description</FormLabel>
+                    <FormLabel required>Description</FormLabel>
                     <Popover
                       open={isSuggestionsOpen}
                       onOpenChange={setShowSuggestions}
@@ -496,7 +496,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                 name="category"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Category</FormLabel>
+                    <FormLabel required>Category</FormLabel>
                     <FormControl>
                       <Combobox
                         options={categoryOptions}
@@ -618,7 +618,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                 name="quantity"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Qty</FormLabel>
+                    <FormLabel required>Qty</FormLabel>
                     <FormControl>
                       <Input
                         type="number"
@@ -640,7 +640,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                 name="unitPrice"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>
+                    <FormLabel required>
                       {pricingMode === "flat" ? "Price" : "Unit Price"}
                     </FormLabel>
                     <FormControl>

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -209,7 +209,7 @@ export default function NewReceiptPage({
                 name="location"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="flex items-center gap-2">
+                    <FormLabel required className="flex items-center gap-2">
                       Location
                       <ConfidenceIndicator confidence={confidenceMap?.location} />
                     </FormLabel>
@@ -236,7 +236,7 @@ export default function NewReceiptPage({
                 name="date"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="flex items-center gap-2">
+                    <FormLabel required className="flex items-center gap-2">
                       Date
                       <ConfidenceIndicator confidence={confidenceMap?.date} />
                     </FormLabel>


### PR DESCRIPTION
## Summary
- Remove red label text on validation error — inputs show red border only
- Add `*` asterisk after required field labels
- Make `FormMessage` screen-reader-only (accessible but visually hidden)
- Add `aria-invalid` border styling to `CurrencyInput`

## Test plan
- [ ] Invalid fields show red border only
- [ ] Required fields show `*` after label
- [ ] Screen readers still announce error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)