### PR TITLE
feat(client): default transaction date to receipt date on entry form

### DIFF
--- a/src/client/src/components/ReceiptTransactionsCard.test.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.test.tsx
@@ -259,6 +259,23 @@ describe("ReceiptTransactionsCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("pre-fills the date field with receiptDate in the create dialog", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        receiptDate="2024-01-15"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /add transaction/i }),
+    );
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    expect(dateInput).toHaveValue("01/15/2024");
+  });
+
   it("opens edit dialog when Edit button is clicked", async () => {
     const user = userEvent.setup();
     renderWithQueryClient(

--- a/src/client/src/components/ReceiptTransactionsCard.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.tsx
@@ -55,12 +55,14 @@ interface TransactionRow {
 
 interface ReceiptTransactionsCardProps {
   receiptId: string;
+  receiptDate?: string;
   transactions: TransactionRow[];
   transactionsTotal: number;
 }
 
 export function ReceiptTransactionsCard({
   receiptId,
+  receiptDate,
   transactions,
   transactionsTotal,
 }: ReceiptTransactionsCardProps) {
@@ -256,6 +258,7 @@ export function ReceiptTransactionsCard({
           </DialogHeader>
           <ReceiptTransactionForm
             mode="create"
+            defaultValues={receiptDate ? { date: receiptDate } : undefined}
             isSubmitting={createTransaction.isPending}
             serverErrors={serverErrors}
             onCancel={() => setCreateOpen(false)}

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -231,6 +231,7 @@ function ReceiptDetail() {
 
           <ReceiptTransactionsCard
             receiptId={id}
+            receiptDate={trip.receipt.receipt.date}
             transactions={trip.transactions}
             transactionsTotal={transactionsTotal}
           />

--- a/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult } from "@/test/mock-hooks";
@@ -118,7 +118,7 @@ describe("TransactionsSection", () => {
     expect(onChange).toHaveBeenCalledWith([]);
   });
 
-  it("syncs transaction date when defaultDate changes and date field is empty", () => {
+  it("syncs transaction date when defaultDate changes and date field is empty", async () => {
     const { rerender } = renderWithProviders(
       <TransactionsSection {...defaultProps} defaultDate="" />,
     );
@@ -127,13 +127,15 @@ describe("TransactionsSection", () => {
     expect(dateInput).toHaveValue("");
 
     // Update the defaultDate prop (simulating the receipt date being set)
-    rerender(
-      <TransactionsSection {...defaultProps} defaultDate="2024-03-20" />,
-    );
+    await act(async () => {
+      rerender(
+        <TransactionsSection {...defaultProps} defaultDate="2024-03-20" />,
+      );
+    });
     expect(dateInput).toHaveValue("03/20/2024");
   });
 
-  it("syncs transaction date when defaultDate changes and date matches previous default", () => {
+  it("syncs transaction date when defaultDate changes and date matches previous default", async () => {
     const { rerender } = renderWithProviders(
       <TransactionsSection {...defaultProps} defaultDate="2024-01-15" />,
     );
@@ -141,9 +143,11 @@ describe("TransactionsSection", () => {
     expect(dateInput).toHaveValue("01/15/2024");
 
     // Change the receipt date
-    rerender(
-      <TransactionsSection {...defaultProps} defaultDate="2024-03-20" />,
-    );
+    await act(async () => {
+      rerender(
+        <TransactionsSection {...defaultProps} defaultDate="2024-03-20" />,
+      );
+    });
     expect(dateInput).toHaveValue("03/20/2024");
   });
 

--- a/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
@@ -118,6 +118,35 @@ describe("TransactionsSection", () => {
     expect(onChange).toHaveBeenCalledWith([]);
   });
 
+  it("syncs transaction date when defaultDate changes and date field is empty", () => {
+    const { rerender } = renderWithProviders(
+      <TransactionsSection {...defaultProps} defaultDate="" />,
+    );
+    // The date input should be empty initially
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    expect(dateInput).toHaveValue("");
+
+    // Update the defaultDate prop (simulating the receipt date being set)
+    rerender(
+      <TransactionsSection {...defaultProps} defaultDate="2024-03-20" />,
+    );
+    expect(dateInput).toHaveValue("03/20/2024");
+  });
+
+  it("syncs transaction date when defaultDate changes and date matches previous default", () => {
+    const { rerender } = renderWithProviders(
+      <TransactionsSection {...defaultProps} defaultDate="2024-01-15" />,
+    );
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    expect(dateInput).toHaveValue("01/15/2024");
+
+    // Change the receipt date
+    rerender(
+      <TransactionsSection {...defaultProps} defaultDate="2024-03-20" />,
+    );
+    expect(dateInput).toHaveValue("03/20/2024");
+  });
+
   it("displays running total with existing transactions", () => {
     const transactions = [
       { id: "1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -97,7 +97,7 @@ export function TransactionsSection({
       defaultDate !== prevDefaultDateRef.current &&
       (currentDate === "" || currentDate === prevDefaultDateRef.current)
     ) {
-      form.setValue("date", defaultDate);
+      form.setValue("date", defaultDate, { shouldValidate: true });
     }
     prevDefaultDateRef.current = defaultDate;
   }, [defaultDate, form]);

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -89,6 +89,19 @@ export function TransactionsSection({
     },
   });
 
+  // Sync the date field when the receipt date changes and the field is empty
+  const prevDefaultDateRef = useRef(defaultDate);
+  useEffect(() => {
+    const currentDate = form.getValues("date");
+    if (
+      defaultDate !== prevDefaultDateRef.current &&
+      (currentDate === "" || currentDate === prevDefaultDateRef.current)
+    ) {
+      form.setValue("date", defaultDate);
+    }
+    prevDefaultDateRef.current = defaultDate;
+  }, [defaultDate, form]);
+
   const runningTotal = useMemo(
     () => transactions.reduce((sum, t) => sum + t.amount, 0),
     [transactions],

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -98,7 +98,7 @@ export function Step2Transactions({
       receiptDate !== prevReceiptDateRef.current &&
       (currentDate === "" || currentDate === prevReceiptDateRef.current)
     ) {
-      form.setValue("date", receiptDate);
+      form.setValue("date", receiptDate, { shouldValidate: true });
     }
     prevReceiptDateRef.current = receiptDate;
   }, [receiptDate, form]);

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -90,6 +90,19 @@ export function Step2Transactions({
     },
   });
 
+  // Sync the date field when the receipt date changes and the field is empty
+  const prevReceiptDateRef = useRef(receiptDate);
+  useEffect(() => {
+    const currentDate = form.getValues("date");
+    if (
+      receiptDate !== prevReceiptDateRef.current &&
+      (currentDate === "" || currentDate === prevReceiptDateRef.current)
+    ) {
+      form.setValue("date", receiptDate);
+    }
+    prevReceiptDateRef.current = receiptDate;
+  }, [receiptDate, form]);
+
   const runningTotal = useMemo(
     () => transactions.reduce((sum, t) => sum + t.amount, 0),
     [transactions],


### PR DESCRIPTION
## Summary
- When adding a transaction on the New Receipt page, the transaction date field now automatically syncs to the receipt date when the receipt date is set or changed (and the transaction date is empty or still matches the previous default)
- Applied the same sync behavior to the wizard Step 2 transactions form
- On the Receipt Detail page, the "Add Transaction" dialog now pre-fills the date field with the receipt's date

Resolves RECEIPTS-468

## Test plan
- Open the New Receipt page, leave the date field empty, then set a receipt date -- verify the transaction date field updates to match
- Change the receipt date -- verify the transaction date updates if it was still the old default
- Manually type a different transaction date, then change the receipt date -- verify the custom date is preserved
- In the wizard, go to Step 2 and verify the transaction date defaults to the receipt date from Step 1
- On the Receipt Detail page, click "Add Transaction" and verify the date is pre-filled with the receipt date
- Run `npx vitest run` from `src/client` -- all tests pass including 3 new ones