### PR TITLE
feat(client): allow inline editing of line items during receipt creation

### DIFF
--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -178,4 +178,170 @@ describe("LineItemsSection", () => {
     );
     expect(screen.getByText("Household / Cleaning")).toBeInTheDocument();
   });
+
+  // --- Inline editing tests ---
+
+  it("shows edit button for each item row", () => {
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity",
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it("enters edit mode when edit button is clicked", async () => {
+    const user = userEvent.setup();
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity",
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(screen.getByLabelText("Edit description")).toBeInTheDocument();
+    expect(screen.getByLabelText("Edit quantity")).toBeInTheDocument();
+    expect(screen.getByLabelText("Edit unit price")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it("saves edited values and calls onChange", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity",
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection items={items} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const descInput = screen.getByLabelText("Edit description");
+    await user.clear(descInput);
+    await user.type(descInput, "Whole Milk");
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ description: "Whole Milk" }),
+    ]);
+  });
+
+  it("cancels editing without calling onChange", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity",
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection items={items} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const descInput = screen.getByLabelText("Edit description");
+    await user.clear(descInput);
+    await user.type(descInput, "Changed");
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    // onChange should not have been called for editing (only for remove)
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+  });
+
+  it("does not save when description is empty", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity",
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection items={items} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const descInput = screen.getByLabelText("Edit description");
+    await user.clear(descInput);
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    // Should still be in edit mode (save rejected)
+    expect(screen.getByLabelText("Edit description")).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("disables quantity input in edit mode for flat pricing items", async () => {
+    const user = userEvent.setup();
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Service Fee",
+        pricingMode: "flat",
+        quantity: 1,
+        unitPrice: 25,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(screen.getByLabelText("Edit quantity")).toBeDisabled();
+  });
 });

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useRef } from "react";
+import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { generateId } from "@/lib/id";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
@@ -323,8 +323,8 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
   const saveEditing = useCallback(() => {
     if (!editingItemId) return;
     if (!editDraft.description.trim()) return;
-    if (editDraft.quantity <= 0) return;
-    if (editDraft.unitPrice < 0) return;
+    if (!Number.isFinite(editDraft.quantity) || editDraft.quantity <= 0) return;
+    if (!Number.isFinite(editDraft.unitPrice) || editDraft.unitPrice < 0) return;
 
     onChange(
       items.map((item) =>
@@ -340,6 +340,13 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     );
     setEditingItemId(null);
   }, [editingItemId, editDraft, items, onChange]);
+
+  // Clear stale editing state when the edited item is removed externally
+  useEffect(() => {
+    if (editingItemId && !items.some((i) => i.id === editingItemId)) {
+      setEditingItemId(null);
+    }
+  }, [items, editingItemId]);
 
   return (
     <Card>

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -47,7 +47,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Plus, Trash2, Loader2, Sparkles } from "lucide-react";
+import { Plus, Trash2, Loader2, Sparkles, Pencil, Check, X } from "lucide-react";
 
 const itemSchema = z
   .object({
@@ -299,6 +299,47 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     },
     [items, onChange],
   );
+
+  const [editingItemId, setEditingItemId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<{
+    description: string;
+    quantity: number;
+    unitPrice: number;
+  }>({ description: "", quantity: 1, unitPrice: 0 });
+
+  const startEditing = useCallback((item: ReceiptLineItem) => {
+    setEditingItemId(item.id);
+    setEditDraft({
+      description: item.description,
+      quantity: item.quantity,
+      unitPrice: item.unitPrice,
+    });
+  }, []);
+
+  const cancelEditing = useCallback(() => {
+    setEditingItemId(null);
+  }, []);
+
+  const saveEditing = useCallback(() => {
+    if (!editingItemId) return;
+    if (!editDraft.description.trim()) return;
+    if (editDraft.quantity <= 0) return;
+    if (editDraft.unitPrice < 0) return;
+
+    onChange(
+      items.map((item) =>
+        item.id === editingItemId
+          ? {
+              ...item,
+              description: editDraft.description.trim(),
+              quantity: editDraft.quantity,
+              unitPrice: editDraft.unitPrice,
+            }
+          : item,
+      ),
+    );
+    setEditingItemId(null);
+  }, [editingItemId, editDraft, items, onChange]);
 
   return (
     <Card>
@@ -676,30 +717,112 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
               </TableRow>
             </TableHeader>
             <TableBody>
-              {items.map((item) => (
-                <TableRow key={item.id}>
-                  <TableCell>{item.description}</TableCell>
-                  <TableCell>{item.quantity}</TableCell>
-                  <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
-                  <TableCell>
-                    {formatCurrency(item.quantity * item.unitPrice)}
-                  </TableCell>
-                  <TableCell>
-                    {item.category}
-                    {item.subcategory ? ` / ${item.subcategory}` : ""}
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleRemove(item.id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                      <span className="sr-only">Remove</span>
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
+              {items.map((item) =>
+                editingItemId === item.id ? (
+                  <TableRow key={item.id}>
+                    <TableCell>
+                      <Input
+                        value={editDraft.description}
+                        onChange={(e) =>
+                          setEditDraft((d) => ({
+                            ...d,
+                            description: e.target.value,
+                          }))
+                        }
+                        aria-label="Edit description"
+                        className="h-8"
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        type="number"
+                        step="any"
+                        min="0.01"
+                        value={editDraft.quantity}
+                        onChange={(e) =>
+                          setEditDraft((d) => ({
+                            ...d,
+                            quantity: Number(e.target.value),
+                          }))
+                        }
+                        aria-label="Edit quantity"
+                        className="h-8 w-20"
+                        disabled={item.pricingMode === "flat"}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <CurrencyInput
+                        value={editDraft.unitPrice}
+                        onChange={(v) =>
+                          setEditDraft((d) => ({ ...d, unitPrice: v }))
+                        }
+                        aria-label="Edit unit price"
+                        className="h-8"
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {formatCurrency(editDraft.quantity * editDraft.unitPrice)}
+                    </TableCell>
+                    <TableCell>
+                      {item.category}
+                      {item.subcategory ? ` / ${item.subcategory}` : ""}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={saveEditing}
+                          aria-label="Save"
+                        >
+                          <Check className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={cancelEditing}
+                          aria-label="Cancel"
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  <TableRow key={item.id}>
+                    <TableCell>{item.description}</TableCell>
+                    <TableCell>{item.quantity}</TableCell>
+                    <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
+                    <TableCell>
+                      {formatCurrency(item.quantity * item.unitPrice)}
+                    </TableCell>
+                    <TableCell>
+                      {item.category}
+                      {item.subcategory ? ` / ${item.subcategory}` : ""}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => startEditing(item)}
+                          aria-label="Edit"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRemove(item.id)}
+                          aria-label="Remove"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
             </TableBody>
           </Table>
         )}

--- a/src/client/src/pages/wizard/Step3Items.test.tsx
+++ b/src/client/src/pages/wizard/Step3Items.test.tsx
@@ -859,4 +859,182 @@ describe("Step3Items", () => {
     }
     // This exercises the category onValueChange handler that clears subcategory
   });
+
+  // --- Inline editing tests ---
+
+  it("shows edit button for each item row", () => {
+    const items = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity" as const,
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(<Step3Items {...defaultProps} data={items} />);
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it("enters edit mode when edit button is clicked", async () => {
+    const user = userEvent.setup();
+    const items = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity" as const,
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(<Step3Items {...defaultProps} data={items} />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    // Should show editable fields
+    expect(screen.getByLabelText("Edit description")).toBeInTheDocument();
+    expect(screen.getByLabelText("Edit quantity")).toBeInTheDocument();
+    expect(screen.getByLabelText("Edit unit price")).toBeInTheDocument();
+    // Should show save and cancel buttons
+    expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it("populates edit fields with current item values", async () => {
+    const user = userEvent.setup();
+    const items = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity" as const,
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(<Step3Items {...defaultProps} data={items} />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(screen.getByLabelText("Edit description")).toHaveValue("Milk");
+    expect(screen.getByLabelText("Edit quantity")).toHaveValue(2);
+  });
+
+  it("saves edited values when save is clicked", async () => {
+    const user = userEvent.setup();
+    const onNext = vi.fn();
+    const items = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity" as const,
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <Step3Items {...defaultProps} data={items} onNext={onNext} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const descInput = screen.getByLabelText("Edit description");
+    await user.clear(descInput);
+    await user.type(descInput, "Whole Milk");
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    // Should exit edit mode and show updated value
+    expect(screen.queryByLabelText("Edit description")).not.toBeInTheDocument();
+    expect(screen.getByText("Whole Milk")).toBeInTheDocument();
+  });
+
+  it("cancels editing without saving changes", async () => {
+    const user = userEvent.setup();
+    const items = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity" as const,
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(<Step3Items {...defaultProps} data={items} />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const descInput = screen.getByLabelText("Edit description");
+    await user.clear(descInput);
+    await user.type(descInput, "Changed Value");
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    // Should exit edit mode and show original value
+    expect(screen.queryByLabelText("Edit description")).not.toBeInTheDocument();
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+    expect(screen.queryByText("Changed Value")).not.toBeInTheDocument();
+  });
+
+  it("does not save when description is empty", async () => {
+    const user = userEvent.setup();
+    const items = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Milk",
+        pricingMode: "quantity" as const,
+        quantity: 2,
+        unitPrice: 3.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(<Step3Items {...defaultProps} data={items} />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const descInput = screen.getByLabelText("Edit description");
+    await user.clear(descInput);
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    // Should still be in edit mode (save rejected)
+    expect(screen.getByLabelText("Edit description")).toBeInTheDocument();
+  });
+
+  it("disables quantity input in edit mode for flat pricing items", async () => {
+    const user = userEvent.setup();
+    const items = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: "Service Fee",
+        pricingMode: "flat" as const,
+        quantity: 1,
+        unitPrice: 25,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(<Step3Items {...defaultProps} data={items} />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(screen.getByLabelText("Edit quantity")).toBeDisabled();
+  });
 });

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -47,7 +47,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Plus, Trash2, Loader2, Sparkles } from "lucide-react";
+import { Plus, Trash2, Loader2, Sparkles, Pencil, Check, X } from "lucide-react";
 import type { WizardReceiptItem } from "./wizardReducer";
 
 const itemSchema = z
@@ -306,6 +306,47 @@ export function Step3Items({
   const handleRemove = useCallback((id: string) => {
     setItems((prev) => prev.filter((item) => item.id !== id));
   }, []);
+
+  const [editingItemId, setEditingItemId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<{
+    description: string;
+    quantity: number;
+    unitPrice: number;
+  }>({ description: "", quantity: 1, unitPrice: 0 });
+
+  const startEditing = useCallback((item: WizardReceiptItem) => {
+    setEditingItemId(item.id);
+    setEditDraft({
+      description: item.description,
+      quantity: item.quantity,
+      unitPrice: item.unitPrice,
+    });
+  }, []);
+
+  const cancelEditing = useCallback(() => {
+    setEditingItemId(null);
+  }, []);
+
+  const saveEditing = useCallback(() => {
+    if (!editingItemId) return;
+    if (!editDraft.description.trim()) return;
+    if (editDraft.quantity <= 0) return;
+    if (editDraft.unitPrice < 0) return;
+
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === editingItemId
+          ? {
+              ...item,
+              description: editDraft.description.trim(),
+              quantity: editDraft.quantity,
+              unitPrice: editDraft.unitPrice,
+            }
+          : item,
+      ),
+    );
+    setEditingItemId(null);
+  }, [editingItemId, editDraft]);
 
   const handleNext = useCallback(() => {
     onNext(items);
@@ -681,30 +722,112 @@ export function Step3Items({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {items.map((item) => (
-                <TableRow key={item.id}>
-                  <TableCell>{item.description}</TableCell>
-                  <TableCell>{item.quantity}</TableCell>
-                  <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
-                  <TableCell>
-                    {formatCurrency(item.quantity * item.unitPrice)}
-                  </TableCell>
-                  <TableCell>
-                    {item.category}
-                    {item.subcategory ? ` / ${item.subcategory}` : ""}
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleRemove(item.id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                      <span className="sr-only">Remove</span>
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
+              {items.map((item) =>
+                editingItemId === item.id ? (
+                  <TableRow key={item.id}>
+                    <TableCell>
+                      <Input
+                        value={editDraft.description}
+                        onChange={(e) =>
+                          setEditDraft((d) => ({
+                            ...d,
+                            description: e.target.value,
+                          }))
+                        }
+                        aria-label="Edit description"
+                        className="h-8"
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        type="number"
+                        step="any"
+                        min="0.01"
+                        value={editDraft.quantity}
+                        onChange={(e) =>
+                          setEditDraft((d) => ({
+                            ...d,
+                            quantity: Number(e.target.value),
+                          }))
+                        }
+                        aria-label="Edit quantity"
+                        className="h-8 w-20"
+                        disabled={item.pricingMode === "flat"}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <CurrencyInput
+                        value={editDraft.unitPrice}
+                        onChange={(v) =>
+                          setEditDraft((d) => ({ ...d, unitPrice: v }))
+                        }
+                        aria-label="Edit unit price"
+                        className="h-8"
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {formatCurrency(editDraft.quantity * editDraft.unitPrice)}
+                    </TableCell>
+                    <TableCell>
+                      {item.category}
+                      {item.subcategory ? ` / ${item.subcategory}` : ""}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={saveEditing}
+                          aria-label="Save"
+                        >
+                          <Check className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={cancelEditing}
+                          aria-label="Cancel"
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  <TableRow key={item.id}>
+                    <TableCell>{item.description}</TableCell>
+                    <TableCell>{item.quantity}</TableCell>
+                    <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
+                    <TableCell>
+                      {formatCurrency(item.quantity * item.unitPrice)}
+                    </TableCell>
+                    <TableCell>
+                      {item.category}
+                      {item.subcategory ? ` / ${item.subcategory}` : ""}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => startEditing(item)}
+                          aria-label="Edit"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRemove(item.id)}
+                          aria-label="Remove"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
             </TableBody>
           </Table>
         )}

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -330,8 +330,8 @@ export function Step3Items({
   const saveEditing = useCallback(() => {
     if (!editingItemId) return;
     if (!editDraft.description.trim()) return;
-    if (editDraft.quantity <= 0) return;
-    if (editDraft.unitPrice < 0) return;
+    if (!Number.isFinite(editDraft.quantity) || editDraft.quantity <= 0) return;
+    if (!Number.isFinite(editDraft.unitPrice) || editDraft.unitPrice < 0) return;
 
     setItems((prev) =>
       prev.map((item) =>


### PR DESCRIPTION
## Summary
- Added inline edit functionality to the line items table in both the wizard (Step3Items) and new-receipt (LineItemsSection) flows
- Clicking the pencil icon on a table row converts description, quantity, and unit price cells into editable inputs with save/cancel buttons
- Validates that description is non-empty, quantity is positive, and unit price is non-negative before saving; disables quantity editing for flat-priced items

Resolves RECEIPTS-473

## Test plan
- Added 7 new tests to Step3Items.test.tsx covering: edit button rendering, entering edit mode, field population, saving changes, canceling edits, empty-description rejection, and flat-pricing quantity disabling
- Added 6 new tests to LineItemsSection.test.tsx covering the same scenarios plus verifying onChange callback behavior
- All 1560 frontend tests pass; all 384 backend tests pass; pre-commit hooks pass cleanly