### PR TITLE
fix(client): filter account selectors to active-only in receipt forms (RECEIPTS-475)

### DIFF
--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -55,11 +55,10 @@ export function ItemTemplateForm({
   useFormShortcuts({ formRef });
   const { pricingModes } = useEnumMetadata();
 
-  const { data: categories } = useCategories();
+  const { data: categories } = useCategories(0, 50, undefined, undefined, true);
   const categoryOptions =
     (categories as { id: string; name: string; isActive: boolean }[] | undefined)
-      ?.filter((c) => c.isActive)
-      .map((c) => ({
+      ?.map((c) => ({
         value: c.name,
         label: c.name,
       })) ?? [];
@@ -88,12 +87,11 @@ export function ItemTemplateForm({
     )?.id ?? null;
 
   const { data: subcategoriesData } =
-    useSubcategoriesByCategoryId(selectedCategoryId);
+    useSubcategoriesByCategoryId(selectedCategoryId, 0, 200, undefined, undefined, true);
 
   const subcategoryOptions =
     (subcategoriesData as { id: string; name: string; isActive: boolean }[] | undefined)
-      ?.filter((s) => s.isActive)
-      .map((s) => ({
+      ?.map((s) => ({
         value: s.name,
         label: s.name,
       })) ?? [];

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -106,7 +106,7 @@ export function ReceiptItemForm({
     useFieldHistory(itemCodeHistory);
 
   const { data: receipts, isLoading: receiptsLoading } = useReceipts();
-  const { data: categories } = useCategories();
+  const { data: categories } = useCategories(0, 50, undefined, undefined, true);
   const { data: itemTemplatesData } = useItemTemplates();
   const templates = useMemo(
     () => (itemTemplatesData as ItemTemplate[] | undefined) ?? [],
@@ -165,7 +165,7 @@ export function ReceiptItemForm({
   }, [categories, watchedCategory]);
 
   const { data: subcategoriesData } =
-    useSubcategoriesByCategoryId(selectedCategoryId);
+    useSubcategoriesByCategoryId(selectedCategoryId, 0, 200, undefined, undefined, true);
   const createSubcategory = useCreateSubcategory();
 
   const subcategoryOptions = useMemo(

--- a/src/client/src/components/ReceiptTransactionForm.tsx
+++ b/src/client/src/components/ReceiptTransactionForm.tsx
@@ -49,7 +49,7 @@ export function ReceiptTransactionForm({
   const formRef = useRef<HTMLFormElement>(null);
   useFormShortcuts({ formRef });
 
-  const { data: accounts, isLoading: accountsLoading } = useAccounts();
+  const { data: accounts, isLoading: accountsLoading } = useAccounts(0, 50, undefined, undefined, true);
 
   const accountOptions = useMemo(
     () =>

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -86,7 +86,7 @@ interface LineItemsSectionProps {
 export function LineItemsSection({ items, onChange, location }: LineItemsSectionProps) {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const suggestionsListId = "new-receipt-suggestions-list";
-  const { data: categories } = useCategories();
+  const { data: categories } = useCategories(0, 50, undefined, undefined, true);
 
   const categoryOptions = useMemo(
     () =>
@@ -194,6 +194,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
 
   const { data: subcategories } = useSubcategoriesByCategoryId(
     selectedCategoryObj?.id ?? "",
+    0, 200, undefined, undefined, true,
   );
   const createSubcategory = useCreateSubcategory();
   const pendingSubcategories = useRef(new Set<string>());

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -58,7 +58,7 @@ export function TransactionsSection({
 }: TransactionsSectionProps) {
   const formRef = useRef<HTMLFormElement>(null);
   const accountRef = useRef<HTMLButtonElement>(null);
-  const { data: accounts } = useAccounts();
+  const { data: accounts } = useAccounts(0, 50, undefined, undefined, true);
   useFormShortcuts({ formRef });
 
   const accountOptions = useMemo(

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -59,7 +59,7 @@ export function Step2Transactions({
   const [transactions, setTransactions] = useState<WizardTransaction[]>(data);
   const formRef = useRef<HTMLFormElement>(null);
   const accountRef = useRef<HTMLButtonElement>(null);
-  const { data: accounts } = useAccounts();
+  const { data: accounts } = useAccounts(0, 50, undefined, undefined, true);
   useFormShortcuts({ formRef });
 
   const accountOptions = useMemo(

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -87,7 +87,7 @@ export function Step3Items({
   const [items, setItems] = useState<WizardReceiptItem[]>(data);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const suggestionsListId = "step3-suggestions-list";
-  const { data: categories } = useCategories();
+  const { data: categories } = useCategories(0, 50, undefined, undefined, true);
 
   const categoryOptions = useMemo(
     () =>
@@ -198,6 +198,7 @@ export function Step3Items({
 
   const { data: subcategories } = useSubcategoriesByCategoryId(
     selectedCategoryObj?.id ?? "",
+    0, 200, undefined, undefined, true,
   );
   const createSubcategory = useCreateSubcategory();
   const pendingSubcategories = useRef(new Set<string>());

--- a/src/client/src/test/msw/handlers/accounts.ts
+++ b/src/client/src/test/msw/handlers/accounts.ts
@@ -6,10 +6,16 @@ export const accountHandlers = [
     const url = new URL(request.url);
     const offset = Number(url.searchParams.get("offset") ?? 0);
     const limit = Number(url.searchParams.get("limit") ?? 50);
-    const page = accounts.slice(offset, offset + limit);
+    const isActiveParam = url.searchParams.get("isActive");
+    let filtered = accounts;
+    if (isActiveParam !== null) {
+      const isActive = isActiveParam === "true";
+      filtered = accounts.filter((a) => a.isActive === isActive);
+    }
+    const page = filtered.slice(offset, offset + limit);
     return HttpResponse.json({
       data: page,
-      total: accounts.length,
+      total: filtered.length,
       offset,
       limit,
     });


### PR DESCRIPTION
## Summary
- Receipt creation forms (new-receipt page, wizard Step 2/3, receipt detail transaction/item forms) were calling `useAccounts()`, `useCategories()`, and `useSubcategoriesByCategoryId()` without an `isActive` filter, causing inactive reference data to appear in dropdowns
- Added `isActive: true` to all hook calls in receipt-entry contexts so only active accounts, categories, and subcategories appear in selection dropdowns
- Updated the MSW accounts handler to respect the `isActive` query parameter for accurate test behavior
- Removed redundant client-side `.filter(c => c.isActive)` in `ItemTemplateForm` now that server-side filtering handles it

Resolves RECEIPTS-475

## Assumptions
- The wizard Step4Review page (`Step4Review.tsx`) is left unfiltered because it resolves account names for display only (not selection), and needs to handle accounts that may have been deactivated between wizard steps
- `GlobalSearchDialog` and `SubcategoryForm` category selectors are left unfiltered since admin/search contexts should show all entities

## Test plan
- All 1547 existing frontend tests pass
- Verify receipt creation forms only show active accounts in the account dropdown
- Verify line item forms only show active categories and subcategories
- Verify the Accounts list page still works with its status filter tabs
- Verify the wizard review step still resolves account names correctly