### PR TITLE
fix(client): clear unit price on form reset (RECEIPTS-471)

### DIFF
--- a/src/client/src/components/ui/currency-input.test.tsx
+++ b/src/client/src/components/ui/currency-input.test.tsx
@@ -174,4 +174,53 @@ describe("CurrencyInput", () => {
     expect(onChange).toHaveBeenCalledWith(42.5);
     expect(input).toHaveValue("42.50");
   });
+
+  it("clears displayed text when value prop is reset to 0 externally (e.g. form.reset())", async () => {
+    // Simulates the bug where CurrencyInput retains its internal text state
+    // after a parent form resets the value prop to 0.
+    function ResettableWrapper() {
+      const [value, setValue] = useState(25.99);
+      return (
+        <>
+          <CurrencyInput value={value} onChange={setValue} />
+          <button onClick={() => setValue(0)}>Reset</button>
+        </>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<ResettableWrapper />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("25.99");
+
+    // Simulate the parent resetting value to 0 (like form.reset())
+    await user.click(screen.getByText("Reset"));
+
+    // The input should now show empty (placeholder visible), not "25.99"
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("placeholder", "0.00");
+  });
+
+  it("updates displayed text when value prop changes to a new non-zero value externally", async () => {
+    function ExternalUpdateWrapper() {
+      const [value, setValue] = useState(10);
+      return (
+        <>
+          <CurrencyInput value={value} onChange={setValue} />
+          <button onClick={() => setValue(42.5)}>Update</button>
+        </>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<ExternalUpdateWrapper />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("10.00");
+
+    await user.click(screen.getByText("Update"));
+
+    expect(input).toHaveValue("42.50");
+  });
 });

--- a/src/client/src/components/ui/currency-input.test.tsx
+++ b/src/client/src/components/ui/currency-input.test.tsx
@@ -202,6 +202,40 @@ describe("CurrencyInput", () => {
     expect(input).toHaveAttribute("placeholder", "0.00");
   });
 
+  it("clears displayed text when value prop is reset to 0 while input is focused (Enter key submit)", async () => {
+    // This test exercises the actual bug scenario: the input has focus when
+    // the parent resets the value (e.g. form.handleSubmit → form.reset via Enter).
+    // When focused, displayValue reads from internal `text` state, so the sync
+    // logic must update `text` for the input to clear.
+    //
+    // We use a form wrapper that resets the value on submit (triggered by Enter),
+    // which mirrors the real wizard behavior without blurring the input.
+    function FormResetWrapper() {
+      const [value, setValue] = useState(0);
+      return (
+        <form onSubmit={(e) => { e.preventDefault(); setValue(0); }}>
+          <CurrencyInput value={value} onChange={setValue} />
+        </form>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<FormResetWrapper />);
+
+    const input = screen.getByRole("textbox");
+
+    // Focus the input and type a price (simulates user entering unit price)
+    await user.click(input);
+    await user.type(input, "5.99");
+    expect(input).toHaveValue("5.99");
+
+    // Press Enter to submit the form, which resets value to 0 without blurring.
+    await user.keyboard("{Enter}");
+
+    // The input should clear even though it still has focus
+    expect(input).toHaveValue("");
+  });
+
   it("updates displayed text when value prop changes to a new non-zero value externally", async () => {
     function ExternalUpdateWrapper() {
       const [value, setValue] = useState(10);

--- a/src/client/src/components/ui/currency-input.tsx
+++ b/src/client/src/components/ui/currency-input.tsx
@@ -24,6 +24,24 @@ export function CurrencyInput({
   const inputRef = useRef<HTMLInputElement>(null);
   const [focused, setFocused] = useState(false);
 
+  // Track the last value we reported via onChange so we can distinguish
+  // external prop changes (form.reset()) from echoed changes (user typing).
+  const [lastEmitted, setLastEmitted] = useState(value);
+
+  // Detect external prop changes (e.g. form.reset()) and sync internal text.
+  // This is the React-recommended pattern for adjusting state when a prop changes:
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
+    // Only sync text for external changes (value differs from what we last emitted).
+    // This avoids formatting partial input while the user is typing (e.g. "1" -> "1.00").
+    if (value !== lastEmitted) {
+      setText(value === 0 ? "" : formatDecimal(value));
+      setLastEmitted(value);
+    }
+  }
+
   // When not focused, show empty string for zero so placeholder is visible
   const displayValue = focused ? text : value === 0 ? "" : formatDecimal(value);
 
@@ -34,8 +52,10 @@ export function CurrencyInput({
     setText(raw);
     const num = parseFloat(raw);
     if (!isNaN(num)) {
+      setLastEmitted(num);
       onChange(num);
     } else if (raw === "" || raw === ".") {
+      setLastEmitted(0);
       onChange(0);
     }
   }
@@ -55,6 +75,7 @@ export function CurrencyInput({
     const num = parseFloat(text);
     const final = isNaN(num) ? 0 : num;
     setText(final === 0 ? "" : formatDecimal(final));
+    setLastEmitted(final);
     onChange(final);
     onBlur?.();
   }
@@ -68,7 +89,9 @@ export function CurrencyInput({
       parts.length > 1 ? `${parts[0]}.${parts[1].slice(0, 2)}` : cleaned;
     setText(limited);
     const num = parseFloat(limited);
-    onChange(isNaN(num) ? 0 : num);
+    const final = isNaN(num) ? 0 : num;
+    setLastEmitted(final);
+    onChange(final);
   }
 
   return (


### PR DESCRIPTION
## Summary
- Fixed `CurrencyInput` component not clearing its displayed value when the parent form resets the `value` prop (e.g., via `form.reset()` after creating an item with Enter key)
- Root cause: the component maintained internal `text` state that was never synced when the external `value` prop changed
- Added `lastEmitted` tracking to distinguish external prop changes from echoed user input, using React's recommended "adjusting state when a prop changes" pattern

Resolves RECEIPTS-471

## Test plan
- Added test: "clears displayed text when value prop is reset to 0 externally" -- simulates exact bug scenario
- Added test: "updates displayed text when value prop changes to a new non-zero value externally"
- All 13 CurrencyInput tests pass, all 49 Step3Items + ReceiptItemForm tests pass
- Manual verification: in the wizard Step 3, enter a unit price, press Enter to add an item, and confirm the unit price field clears