### PR TITLE
refactor(client): remove pricing selector and consolidate item entry

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.29",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.29",
+      "version": "0.1.33",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",

--- a/src/client/src/components/ItemTemplateForm.test.tsx
+++ b/src/client/src/components/ItemTemplateForm.test.tsx
@@ -21,22 +21,6 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
   useFormShortcuts: vi.fn(),
 }));
 
-vi.mock("@/hooks/useEnumMetadata", () => ({
-  useEnumMetadata: vi.fn(() => ({
-    adjustmentTypes: [],
-    authEventTypes: [],
-    pricingModes: [{ value: "quantity", label: "Quantity" }, { value: "flat", label: "Flat" }],
-    auditActions: [],
-    entityTypes: [],
-    adjustmentTypeLabels: {},
-    authEventLabels: {},
-    pricingModeLabels: { quantity: "Quantity", flat: "Flat" },
-    auditActionLabels: {},
-    entityTypeLabels: {},
-    isLoading: false,
-  })),
-}));
-
 vi.mock("@/hooks/useCategories", () => ({
   useCategories: vi.fn(() => ({
     data: [
@@ -150,7 +134,6 @@ describe("ItemTemplateForm", () => {
     expect(screen.getByText("Default Category (optional)")).toBeInTheDocument();
     expect(screen.getByText("Default Subcategory (optional)")).toBeInTheDocument();
     expect(screen.getByText("Default Unit Price (optional)")).toBeInTheDocument();
-    expect(screen.getByText("Default Pricing Mode (optional)")).toBeInTheDocument();
     expect(screen.getByText("Default Item Code (optional)")).toBeInTheDocument();
   });
 

--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
-import { useEnumMetadata } from "@/hooks/useEnumMetadata";
 import { useCategories } from "@/hooks/useCategories";
 import { useSubcategoriesByCategoryId } from "@/hooks/useSubcategories";
 import { Combobox } from "@/components/ui/combobox";
@@ -53,7 +52,6 @@ export function ItemTemplateForm({
 }: ItemTemplateFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
   useFormShortcuts({ formRef });
-  const { pricingModes } = useEnumMetadata();
 
   const { data: categories } = useCategories();
   const categoryOptions =
@@ -177,44 +175,22 @@ export function ItemTemplateForm({
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          <FormField
-            control={form.control}
-            name="defaultUnitPrice"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Default Unit Price (optional)</FormLabel>
-                <FormControl>
-                  <CurrencyInput
-                    value={field.value ?? 0}
-                    onChange={field.onChange}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="defaultPricingMode"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Default Pricing Mode (optional)</FormLabel>
-                <FormControl>
-                  <Combobox
-                    options={pricingModes}
-                    value={field.value ?? ""}
-                    onValueChange={field.onChange}
-                    placeholder="Select pricing mode..."
-                    searchPlaceholder="Search modes..."
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+        <FormField
+          control={form.control}
+          name="defaultUnitPrice"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Default Unit Price (optional)</FormLabel>
+              <FormControl>
+                <CurrencyInput
+                  value={field.value ?? 0}
+                  onChange={field.onChange}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/src/client/src/components/ReceiptItemForm.test.tsx
+++ b/src/client/src/components/ReceiptItemForm.test.tsx
@@ -7,22 +7,6 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
   useFormShortcuts: vi.fn(),
 }));
 
-vi.mock("@/hooks/useEnumMetadata", () => ({
-  useEnumMetadata: vi.fn(() => ({
-    adjustmentTypes: [],
-    authEventTypes: [],
-    pricingModes: [{ value: "quantity", label: "Quantity" }, { value: "flat", label: "Flat" }],
-    auditActions: [],
-    entityTypes: [],
-    adjustmentTypeLabels: {},
-    authEventLabels: {},
-    pricingModeLabels: { quantity: "Quantity", flat: "Flat" },
-    auditActionLabels: {},
-    entityTypeLabels: {},
-    isLoading: false,
-  })),
-}));
-
 vi.mock("@/hooks/useReceipts", () => ({
   useReceipts: vi.fn(() => ({
     data: [
@@ -115,7 +99,6 @@ describe("ReceiptItemForm", () => {
     expect(screen.getByText("Receipt")).toBeInTheDocument();
     expect(screen.getByText("Item Code")).toBeInTheDocument();
     expect(screen.getByText("Description")).toBeInTheDocument();
-    expect(screen.getByText("Pricing Mode")).toBeInTheDocument();
     expect(screen.getByLabelText("Quantity")).toBeInTheDocument();
     expect(screen.getByLabelText("Unit Price")).toBeInTheDocument();
     expect(screen.getByText("Category")).toBeInTheDocument();
@@ -133,7 +116,7 @@ describe("ReceiptItemForm", () => {
           receiptId: "r-1",
           receiptItemCode: "ITM-001",
           description: "Whole Milk",
-          pricingMode: "quantity",
+
           quantity: 2,
           unitPrice: 3.99,
           category: "Groceries",
@@ -187,7 +170,7 @@ describe("ReceiptItemForm", () => {
           receiptId: "r-1",
           receiptItemCode: "ITM-001",
           description: "Milk",
-          pricingMode: "quantity",
+
           quantity: 3,
           unitPrice: 2.50,
           category: "Groceries",
@@ -208,7 +191,7 @@ describe("ReceiptItemForm", () => {
           receiptId: "r-1",
           receiptItemCode: "ITM-001",
           description: "Milk",
-          pricingMode: "quantity",
+
           quantity: 1,
           unitPrice: 3.99,
           category: "Groceries",
@@ -232,7 +215,7 @@ describe("ReceiptItemForm", () => {
     });
   });
 
-  it("defaults quantity to 1 and pricing mode to 'quantity'", () => {
+  it("defaults quantity to 1", () => {
     render(<ReceiptItemForm {...defaultProps} />);
 
     expect(screen.getByLabelText("Quantity")).toBeInTheDocument();
@@ -303,7 +286,7 @@ describe("ReceiptItemForm", () => {
           receiptId: "r-1",
           receiptItemCode: "ITM-001",
           description: "Bananas",
-          pricingMode: "quantity",
+
           quantity: 1,
           unitPrice: 1.29,
           category: "Groceries",

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -71,8 +71,9 @@ const receiptItemSchema = z.object({
 
 type ReceiptItemSchemaValues = z.output<typeof receiptItemSchema>;
 
+/** The form always emits pricingMode: "quantity" — flat pricing has been removed from the UI. */
 export type ReceiptItemFormValues = ReceiptItemSchemaValues & {
-  pricingMode: "quantity" | "flat";
+  pricingMode: "quantity";
 };
 
 interface ReceiptItemFormProps {

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -4,7 +4,6 @@ import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Fuse from "fuse.js";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
-import { useEnumMetadata } from "@/hooks/useEnumMetadata";
 import { useFieldHistory } from "@/hooks/useFieldHistory";
 import { useReceipts } from "@/hooks/useReceipts";
 import { useCategories } from "@/hooks/useCategories";
@@ -64,17 +63,17 @@ const receiptItemSchema = z.object({
   receiptId: z.string().min(1, "Receipt is required"),
   receiptItemCode: z.string().min(1, "Item code is required"),
   description: z.string().min(1, "Description is required"),
-  pricingMode: z.enum(["flat", "quantity"], { message: "Pricing mode is required" }),
   quantity: z.number().positive("Quantity must be positive"),
   unitPrice: z.number().min(0, "Unit price must be non-negative"),
   category: z.string().min(1, "Category is required"),
   subcategory: z.string().min(1, "Subcategory is required"),
-}).refine(
-  (data) => data.pricingMode !== "flat" || data.quantity === 1,
-  { message: "Quantity must be 1 for flat pricing", path: ["quantity"] }
-);
+});
 
-export type ReceiptItemFormValues = z.output<typeof receiptItemSchema>;
+type ReceiptItemSchemaValues = z.output<typeof receiptItemSchema>;
+
+export type ReceiptItemFormValues = ReceiptItemSchemaValues & {
+  pricingMode: "quantity" | "flat";
+};
 
 interface ReceiptItemFormProps {
   mode: "create" | "edit";
@@ -99,7 +98,6 @@ export function ReceiptItemForm({
 }: ReceiptItemFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
   useFormShortcuts({ formRef });
-  const { pricingModes } = useEnumMetadata();
   const { options: descriptionHistoryOptions, add: addDescriptionHistory } =
     useFieldHistory(itemDescriptionHistory);
   const { options: itemCodeOptions, add: addItemCodeHistory } =
@@ -140,14 +138,13 @@ export function ReceiptItemForm({
     [categories],
   );
 
-  const form = useForm<ReceiptItemFormValues>({
+  const form = useForm<ReceiptItemSchemaValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolver: zodResolver(receiptItemSchema) as any,
     defaultValues: {
       receiptId: "",
       receiptItemCode: "",
       description: "",
-      pricingMode: "quantity",
       quantity: 1,
       unitPrice: 0,
       category: "",
@@ -189,10 +186,8 @@ export function ReceiptItemForm({
     [form],
   );
 
-  const watchedPricingMode = form.watch("pricingMode");
   const watchedQuantity = form.watch("quantity");
   const watchedUnitPrice = form.watch("unitPrice");
-  const isFlat = watchedPricingMode === "flat";
 
   // Resolve location: use prop if provided, otherwise derive from selected receipt
   const watchedReceiptId = form.watch("receiptId");
@@ -260,17 +255,7 @@ export function ReceiptItemForm({
     setItemCodeAutocompleteOpen(false);
   }
 
-  const handlePricingModeChange = useCallback(
-    (value: string) => {
-      form.setValue("pricingMode", value as "flat" | "quantity", { shouldValidate: true });
-      if (value === "flat") {
-        form.setValue("quantity", 1);
-      }
-    },
-    [form],
-  );
-
-  async function handleFormSubmit(values: ReceiptItemFormValues) {
+  async function handleFormSubmit(values: ReceiptItemSchemaValues) {
     // Persist field values for future autocomplete before calling onSubmit.
     // Like location history, these are valid user input regardless of whether
     // the server mutation succeeds.
@@ -289,7 +274,7 @@ export function ReceiptItemForm({
       });
     }
 
-    onSubmit(values);
+    onSubmit({ ...values, pricingMode: "quantity" });
   }
 
   const computedTotal = (watchedQuantity ?? 0) * (watchedUnitPrice ?? 0);
@@ -623,78 +608,6 @@ export function ReceiptItemForm({
           )}
         />
 
-        <FormField
-          control={form.control}
-          name="pricingMode"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Pricing Mode</FormLabel>
-              <FormControl>
-                <Combobox
-                  options={pricingModes}
-                  value={field.value}
-                  onValueChange={handlePricingModeChange}
-                  placeholder="Select pricing mode..."
-                  searchPlaceholder="Search modes..."
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <div className="grid grid-cols-2 gap-4">
-          {!isFlat && (
-            <FormField
-              control={form.control}
-              name="quantity"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Quantity</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="number"
-                      step="1"
-                      aria-required="true"
-                      {...field}
-                      onChange={(e) => field.onChange(e.target.valueAsNumber)}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                  {serverErrors?.quantity && (
-                    <p className="text-sm font-medium text-destructive">
-                      {serverErrors.quantity}
-                    </p>
-                  )}
-                </FormItem>
-              )}
-            />
-          )}
-
-          <FormField
-            control={form.control}
-            name="unitPrice"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{isFlat ? "Price" : "Unit Price"}</FormLabel>
-                <FormControl>
-                  <CurrencyInput {...field} />
-                </FormControl>
-                <FormMessage />
-                {serverErrors?.unitPrice && (
-                  <p className="text-sm font-medium text-destructive">
-                    {serverErrors.unitPrice}
-                  </p>
-                )}
-              </FormItem>
-            )}
-          />
-        </div>
-
-        <div className="text-sm text-muted-foreground">
-          Total: {formatCurrency(computedTotal)}
-        </div>
-
         <div className="grid grid-cols-2 gap-4">
           <FormField
             control={form.control}
@@ -747,6 +660,56 @@ export function ReceiptItemForm({
               </FormItem>
             )}
           />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="quantity"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Quantity</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    step="1"
+                    aria-required="true"
+                    {...field}
+                    onChange={(e) => field.onChange(e.target.valueAsNumber)}
+                  />
+                </FormControl>
+                <FormMessage />
+                {serverErrors?.quantity && (
+                  <p className="text-sm font-medium text-destructive">
+                    {serverErrors.quantity}
+                  </p>
+                )}
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="unitPrice"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Unit Price</FormLabel>
+                <FormControl>
+                  <CurrencyInput {...field} />
+                </FormControl>
+                <FormMessage />
+                {serverErrors?.unitPrice && (
+                  <p className="text-sm font-medium text-destructive">
+                    {serverErrors.unitPrice}
+                  </p>
+                )}
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="text-sm text-muted-foreground">
+          Total: {formatCurrency(computedTotal)}
         </div>
 
         <div className="flex justify-end gap-2 pt-4">

--- a/src/client/src/components/ReceiptItemsCard.test.tsx
+++ b/src/client/src/components/ReceiptItemsCard.test.tsx
@@ -5,25 +5,6 @@ import { ReceiptItemsCard } from "./ReceiptItemsCard";
 import { renderWithQueryClient } from "@/test/test-utils";
 import { mockMutationResult } from "@/test/mock-hooks";
 
-vi.mock("@/hooks/useEnumMetadata", () => ({
-  useEnumMetadata: vi.fn(() => ({
-    adjustmentTypes: [],
-    authEventTypes: [],
-    pricingModes: [
-      { value: "quantity", label: "Quantity" },
-      { value: "flat", label: "Flat" },
-    ],
-    auditActions: [],
-    entityTypes: [],
-    adjustmentTypeLabels: {},
-    authEventLabels: {},
-    pricingModeLabels: { quantity: "Quantity", flat: "Flat" },
-    auditActionLabels: {},
-    entityTypeLabels: {},
-    isLoading: false,
-  })),
-}));
-
 vi.mock("@/hooks/useReceipts", () => ({
   useReceipts: vi.fn(() => ({
     data: [],

--- a/src/client/src/components/ReceiptItemsCard.tsx
+++ b/src/client/src/components/ReceiptItemsCard.tsx
@@ -301,7 +301,6 @@ export function ReceiptItemsCard({
                 receiptId,
                 receiptItemCode: editItem.receiptItemCode ?? "",
                 description: editItem.description,
-                pricingMode: (editItem.pricingMode as "flat" | "quantity") ?? "quantity",
                 quantity: editItem.quantity,
                 unitPrice: editItem.unitPrice,
                 category: editItem.category,

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -49,20 +49,14 @@ import {
 } from "@/components/ui/table";
 import { Plus, Trash2, Loader2, Sparkles } from "lucide-react";
 
-const itemSchema = z
-  .object({
-    receiptItemCode: z.string().optional().default(""),
-    description: z.string().min(1, "Description is required"),
-    pricingMode: z.enum(["quantity", "flat"]),
-    quantity: z.number().positive("Quantity must be positive"),
-    unitPrice: z.number().min(0, "Unit price must be non-negative"),
-    category: z.string().min(1, "Category is required"),
-    subcategory: z.string().optional().default(""),
-  })
-  .refine((data) => data.pricingMode !== "flat" || data.quantity === 1, {
-    message: "Quantity must be 1 for flat pricing",
-    path: ["quantity"],
-  });
+const itemSchema = z.object({
+  receiptItemCode: z.string().optional().default(""),
+  description: z.string().min(1, "Description is required"),
+  quantity: z.number().positive("Quantity must be positive"),
+  unitPrice: z.number().min(0, "Unit price must be non-negative"),
+  category: z.string().min(1, "Category is required"),
+  subcategory: z.string().optional().default(""),
+});
 
 type ItemFormValues = z.output<typeof itemSchema>;
 
@@ -102,7 +96,6 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     defaultValues: {
       receiptItemCode: "",
       description: "",
-      pricingMode: "quantity",
       quantity: 1,
       unitPrice: 0,
       category: "",
@@ -114,7 +107,6 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
   const itemCode = form.watch("receiptItemCode");
   const description = form.watch("description");
   const selectedCategory = form.watch("category");
-  const pricingMode = form.watch("pricingMode");
 
   // Item code autocomplete
   const [showItemCodeSuggestions, setShowItemCodeSuggestions] = useState(false);
@@ -223,15 +215,6 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
       if (suggestion.defaultUnitPrice != null) {
         form.setValue("unitPrice", suggestion.defaultUnitPrice);
       }
-      if (
-        suggestion.defaultPricingMode === "quantity" ||
-        suggestion.defaultPricingMode === "flat"
-      ) {
-        form.setValue("pricingMode", suggestion.defaultPricingMode);
-        if (suggestion.defaultPricingMode === "flat") {
-          form.setValue("quantity", 1);
-        }
-      }
       if (suggestion.defaultItemCode) {
         form.setValue("receiptItemCode", suggestion.defaultItemCode);
       }
@@ -272,7 +255,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
         id: generateId(),
         receiptItemCode: values.receiptItemCode ?? "",
         description: values.description,
-        pricingMode: values.pricingMode,
+        pricingMode: "quantity",
         quantity: values.quantity,
         unitPrice: values.unitPrice,
         category: values.category,
@@ -282,7 +265,6 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
       form.reset({
         receiptItemCode: "",
         description: "",
-        pricingMode: "quantity",
         quantity: 1,
         unitPrice: 0,
         category: values.category,
@@ -534,6 +516,10 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                 )}
               />
 
+            </div>
+
+            {/* Row 2: Subcategory, Quantity, Unit Price, Add Item */}
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end">
               <FormField
                 control={form.control}
                 name="subcategory"
@@ -584,34 +570,6 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                   </FormItem>
                 )}
               />
-            </div>
-
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-[auto_auto_auto_1fr] sm:items-end">
-              <FormField
-                control={form.control}
-                name="pricingMode"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Pricing</FormLabel>
-                    <FormControl>
-                      <Combobox
-                        options={[
-                          { value: "quantity", label: "Quantity" },
-                          { value: "flat", label: "Flat" },
-                        ]}
-                        value={field.value}
-                        onValueChange={(v) => {
-                          field.onChange(v);
-                          if (v === "flat") form.setValue("quantity", 1);
-                        }}
-                        placeholder="Mode..."
-                        searchPlaceholder="Search modes..."
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
 
               <FormField
                 control={form.control}
@@ -625,7 +583,6 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                         step="any"
                         min="0.01"
                         className="w-20"
-                        disabled={pricingMode === "flat"}
                         {...field}
                         onChange={(e) => field.onChange(Number(e.target.value))}
                       />
@@ -640,9 +597,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                 name="unitPrice"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel required>
-                      {pricingMode === "flat" ? "Price" : "Unit Price"}
-                    </FormLabel>
+                    <FormLabel required>Unit Price</FormLabel>
                     <FormControl>
                       <CurrencyInput {...field} />
                     </FormControl>

--- a/src/client/src/pages/wizard/Step3Items.test.tsx
+++ b/src/client/src/pages/wizard/Step3Items.test.tsx
@@ -112,8 +112,8 @@ describe("Step3Items", () => {
   it("renders the form fields", () => {
     renderWithProviders(<Step3Items {...defaultProps} />);
     expect(screen.getByText("Description")).toBeInTheDocument();
-    // "Quantity" appears as both a label and a select option; verify at least one exists
-    expect(screen.getAllByText("Quantity").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Quantity")).toBeInTheDocument();
+    expect(screen.getByText("Unit Price")).toBeInTheDocument();
   });
 
   it("renders Back and Next buttons", () => {
@@ -309,10 +309,8 @@ describe("Step3Items", () => {
     const descInput = screen.getByPlaceholderText("Item description");
     await user.type(descInput, "Bananas");
 
-    // Select category via combobox - find the category combobox (skip pricing mode combobox)
+    // Select category via combobox
     const comboboxes = screen.getAllByRole("combobox");
-    // comboboxes: [description (role=combobox), pricingMode, category, subcategory]
-    // Find the one with "Select category..." text
     const categoryCombobox = comboboxes.find(
       (cb) => cb.textContent?.includes("Select category"),
     );
@@ -801,38 +799,10 @@ describe("Step3Items", () => {
     expect(rows.length).toBe(3);
   });
 
-  it("disables quantity input when pricing mode is flat", () => {
+  it("renders quantity input as enabled (no pricing mode selector)", () => {
     renderWithProviders(<Step3Items {...defaultProps} />);
-    // The quantity input should be enabled by default (pricing mode = quantity)
     const qtyInput = screen.getByLabelText("Quantity");
     expect(qtyInput).not.toBeDisabled();
-  });
-
-  it("shows Price label when pricing mode is flat", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Step3Items {...defaultProps} />);
-
-    // Initially shows "Unit Price"
-    expect(screen.getByText("Unit Price")).toBeInTheDocument();
-
-    // Switch to flat pricing mode via the combobox
-    const comboboxes = screen.getAllByRole("combobox");
-    const pricingCombobox = comboboxes.find(
-      (cb) => cb.textContent?.includes("Quantity"),
-    );
-    if (pricingCombobox) {
-      await user.click(pricingCombobox);
-      const flatOption = await screen.findByRole("option", { name: /flat/i });
-      await user.click(flatOption);
-
-      // After switching to flat, the label changes to "Price"
-      await vi.waitFor(() => {
-        expect(screen.getByText("Price")).toBeInTheDocument();
-      });
-
-      // Quantity should be disabled
-      expect(screen.getByLabelText("Quantity")).toBeDisabled();
-    }
   });
 
   it("clears subcategory when category changes", async () => {

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -50,20 +50,14 @@ import {
 import { Plus, Trash2, Loader2, Sparkles } from "lucide-react";
 import type { WizardReceiptItem } from "./wizardReducer";
 
-const itemSchema = z
-  .object({
-    receiptItemCode: z.string().optional().default(""),
-    description: z.string().min(1, "Description is required"),
-    pricingMode: z.enum(["quantity", "flat"]),
-    quantity: z.number().positive("Quantity must be positive"),
-    unitPrice: z.number().min(0, "Unit price must be non-negative"),
-    category: z.string().min(1, "Category is required"),
-    subcategory: z.string().optional().default(""),
-  })
-  .refine((data) => data.pricingMode !== "flat" || data.quantity === 1, {
-    message: "Quantity must be 1 for flat pricing",
-    path: ["quantity"],
-  });
+const itemSchema = z.object({
+  receiptItemCode: z.string().optional().default(""),
+  description: z.string().min(1, "Description is required"),
+  quantity: z.number().positive("Quantity must be positive"),
+  unitPrice: z.number().min(0, "Unit price must be non-negative"),
+  category: z.string().min(1, "Category is required"),
+  subcategory: z.string().optional().default(""),
+});
 
 type ItemFormValues = z.output<typeof itemSchema>;
 
@@ -105,7 +99,6 @@ export function Step3Items({
     defaultValues: {
       receiptItemCode: "",
       description: "",
-      pricingMode: "quantity",
       quantity: 1,
       unitPrice: 0,
       category: "",
@@ -210,8 +203,6 @@ export function Step3Items({
     [subcategories],
   );
 
-  const pricingMode = form.watch("pricingMode");
-
   const subtotal = useMemo(
     () => items.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0),
     [items],
@@ -232,15 +223,6 @@ export function Step3Items({
       }
       if (suggestion.defaultUnitPrice != null) {
         form.setValue("unitPrice", suggestion.defaultUnitPrice);
-      }
-      if (
-        suggestion.defaultPricingMode === "quantity" ||
-        suggestion.defaultPricingMode === "flat"
-      ) {
-        form.setValue("pricingMode", suggestion.defaultPricingMode);
-        if (suggestion.defaultPricingMode === "flat") {
-          form.setValue("quantity", 1);
-        }
       }
       if (suggestion.defaultItemCode) {
         form.setValue("receiptItemCode", suggestion.defaultItemCode);
@@ -282,7 +264,7 @@ export function Step3Items({
         id: generateId(),
         receiptItemCode: values.receiptItemCode ?? "",
         description: values.description,
-        pricingMode: values.pricingMode,
+        pricingMode: "quantity",
         quantity: values.quantity,
         unitPrice: values.unitPrice,
         category: values.category,
@@ -292,7 +274,6 @@ export function Step3Items({
       form.reset({
         receiptItemCode: "",
         description: "",
-        pricingMode: "quantity",
         quantity: 1,
         unitPrice: 0,
         category: values.category,
@@ -332,8 +313,10 @@ export function Step3Items({
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(handleAdd)}
-            className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+            className="space-y-4"
           >
+            {/* Row 1: Item Code, Description, Category */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <FormField
               control={form.control}
               name="receiptItemCode"
@@ -507,69 +490,6 @@ export function Step3Items({
 
             <FormField
               control={form.control}
-              name="pricingMode"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Pricing Mode</FormLabel>
-                  <FormControl>
-                    <Combobox
-                      options={[
-                        { value: "quantity", label: "Quantity" },
-                        { value: "flat", label: "Flat" },
-                      ]}
-                      value={field.value}
-                      onValueChange={(v) => {
-                        field.onChange(v);
-                        if (v === "flat") form.setValue("quantity", 1);
-                      }}
-                      placeholder="Select pricing mode..."
-                      searchPlaceholder="Search modes..."
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="quantity"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Quantity</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="number"
-                      step="any"
-                      min="0.01"
-                      disabled={pricingMode === "flat"}
-                      {...field}
-                      onChange={(e) => field.onChange(Number(e.target.value))}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="unitPrice"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    {pricingMode === "flat" ? "Price" : "Unit Price"}
-                  </FormLabel>
-                  <FormControl>
-                    <CurrencyInput {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
               name="category"
               render={({ field }) => (
                 <FormItem>
@@ -610,57 +530,94 @@ export function Step3Items({
                 </FormItem>
               )}
             />
+            </div>
 
-            <FormField
-              control={form.control}
-              name="subcategory"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Subcategory (optional)</FormLabel>
-                  <FormControl>
-                    <Combobox
-                      options={subcategoryOptions}
-                      value={field.value ?? ""}
-                      onValueChange={(v: string) => {
-                        field.onChange(v);
-                        const isExisting = subcategoryOptions.some(
-                          (o) => o.value === v,
-                        );
-                        if (
-                          !isExisting &&
-                          v &&
-                          selectedCategoryObj?.id &&
-                          !pendingSubcategories.current.has(v)
-                        ) {
-                          pendingSubcategories.current.add(v);
-                          createSubcategory.mutate(
-                            {
-                              categoryId: selectedCategoryObj.id,
-                              name: v,
-                              isActive: true,
-                            },
-                            {
-                              onSettled: () => {
-                                pendingSubcategories.current.delete(v);
-                              },
-                            },
+            {/* Row 2: Subcategory, Quantity, Unit Price, Add Item */}
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end">
+              <FormField
+                control={form.control}
+                name="subcategory"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Subcategory (optional)</FormLabel>
+                    <FormControl>
+                      <Combobox
+                        options={subcategoryOptions}
+                        value={field.value ?? ""}
+                        onValueChange={(v: string) => {
+                          field.onChange(v);
+                          const isExisting = subcategoryOptions.some(
+                            (o) => o.value === v,
                           );
-                        }
-                      }}
-                      placeholder="Select subcategory..."
-                      searchPlaceholder="Search subcategories..."
-                      emptyMessage="No subcategories found."
-                      allowCustom
-                      disabled={!selectedCategory}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                          if (
+                            !isExisting &&
+                            v &&
+                            selectedCategoryObj?.id &&
+                            !pendingSubcategories.current.has(v)
+                          ) {
+                            pendingSubcategories.current.add(v);
+                            createSubcategory.mutate(
+                              {
+                                categoryId: selectedCategoryObj.id,
+                                name: v,
+                                isActive: true,
+                              },
+                              {
+                                onSettled: () => {
+                                  pendingSubcategories.current.delete(v);
+                                },
+                              },
+                            );
+                          }
+                        }}
+                        placeholder="Select subcategory..."
+                        searchPlaceholder="Search subcategories..."
+                        emptyMessage="No subcategories found."
+                        allowCustom
+                        disabled={!selectedCategory}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <div className="sm:col-span-2 lg:col-span-3 flex justify-end">
-              <Button type="submit" variant="secondary" size="sm">
+              <FormField
+                control={form.control}
+                name="quantity"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Quantity</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="any"
+                        min="0.01"
+                        className="w-20"
+                        {...field}
+                        onChange={(e) => field.onChange(Number(e.target.value))}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="unitPrice"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Unit Price</FormLabel>
+                    <FormControl>
+                      <CurrencyInput {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button type="submit" variant="secondary" size="sm" className="sm:mb-0.5">
                 <Plus className="mr-1 h-4 w-4" />
                 Add Item
               </Button>


### PR DESCRIPTION
## Summary
- Removed the pricing type selector (flat vs per-unit) from all item entry forms — flat pricing is just quantity=1 with the default, so the selector was unnecessary
- Reorganized inline item entry forms (wizard Step3Items, LineItemsSection) into two rows: Row 1 (Item Code, Description, Category) and Row 2 (Subcategory, Quantity, Unit Price, Add Item)
- Removed the Default Pricing Mode field from ItemTemplateForm
- Hardcoded `pricingMode: "quantity"` for API compatibility — the backend schema is unchanged

Resolves RECEIPTS-474

## Test plan
- All 1546 frontend tests pass
- All 384 backend tests pass
- Pre-commit hooks (build, lint, format, type-check) all pass
- Verify item entry in the wizard (Step 3) shows two-row layout without pricing selector
- Verify item entry in the new-receipt page shows two-row layout without pricing selector
- Verify item entry in the receipt detail dialog works without pricing selector
- Verify item templates form no longer shows Default Pricing Mode field
- Confirm existing receipt items with pricingMode=flat still display correctly (read-only)