### PR TITLE
fix(client): streamline required-field validation markers to avoid layout shift

### DIFF
--- a/src/client/src/components/AccountForm.test.tsx
+++ b/src/client/src/components/AccountForm.test.tsx
@@ -20,8 +20,8 @@ describe("AccountForm", () => {
   it("renders in create mode with empty fields and correct submit button text", () => {
     render(<AccountForm {...defaultProps} />);
 
-    expect(screen.getByLabelText("Account Code")).toHaveValue("");
-    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(screen.getByLabelText(/^Account Code/)).toHaveValue("");
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("");
     expect(screen.getByRole("button", { name: /create account/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
   });
@@ -35,8 +35,8 @@ describe("AccountForm", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Account Code")).toHaveValue("ACC-001");
-    expect(screen.getByLabelText("Name")).toHaveValue("Checking");
+    expect(screen.getByLabelText(/^Account Code/)).toHaveValue("ACC-001");
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("Checking");
     expect(screen.getByRole("checkbox")).not.toBeChecked();
     expect(screen.getByRole("button", { name: /update account/i })).toBeInTheDocument();
   });
@@ -45,8 +45,8 @@ describe("AccountForm", () => {
     const user = userEvent.setup();
     render(<AccountForm {...defaultProps} />);
 
-    await user.type(screen.getByLabelText("Account Code"), "ACC-002");
-    await user.type(screen.getByLabelText("Name"), "Savings");
+    await user.type(screen.getByLabelText(/^Account Code/), "ACC-002");
+    await user.type(screen.getByLabelText(/^Name/), "Savings");
     await user.click(screen.getByRole("button", { name: /create account/i }));
 
     await waitFor(() => {

--- a/src/client/src/components/AccountForm.tsx
+++ b/src/client/src/components/AccountForm.tsx
@@ -76,7 +76,7 @@ export function AccountForm({
           name="accountCode"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Account Code</FormLabel>
+              <FormLabel required>Account Code</FormLabel>
               <FormControl>
                 <Input aria-required="true" {...field} />
               </FormControl>
@@ -90,7 +90,7 @@ export function AccountForm({
           name="name"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Name</FormLabel>
+              <FormLabel required>Name</FormLabel>
               <FormControl>
                 <Input aria-required="true" {...field} />
               </FormControl>

--- a/src/client/src/components/AdjustmentForm.test.tsx
+++ b/src/client/src/components/AdjustmentForm.test.tsx
@@ -42,8 +42,8 @@ describe("AdjustmentForm", () => {
   it("renders in create mode with correct submit button text and fields", () => {
     render(<AdjustmentForm {...defaultProps} />);
 
-    expect(screen.getByText("Type")).toBeInTheDocument();
-    expect(screen.getByText("Amount")).toBeInTheDocument();
+    expect(screen.getByText(/^Type/)).toBeInTheDocument();
+    expect(screen.getByText(/^Amount/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /add adjustment/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
   });
@@ -144,7 +144,7 @@ describe("AdjustmentForm", () => {
     );
 
     // The description field is a Combobox; click its trigger to open
-    const descCombobox = screen.getByLabelText("Description");
+    const descCombobox = screen.getByLabelText(/^Description/);
     await user.click(descCombobox);
 
     await waitFor(() => {
@@ -167,7 +167,7 @@ describe("AdjustmentForm", () => {
       />,
     );
 
-    const descCombobox = screen.getByLabelText("Description");
+    const descCombobox = screen.getByLabelText(/^Description/);
     await user.click(descCombobox);
 
     await waitFor(() => {
@@ -190,7 +190,7 @@ describe("AdjustmentForm", () => {
     );
 
     // Open the description combobox and type a custom value
-    const descCombobox = screen.getByLabelText("Description");
+    const descCombobox = screen.getByLabelText(/^Description/);
     await user.click(descCombobox);
     const searchInput = screen.getByPlaceholderText("Search descriptions...");
     await user.type(searchInput, "Loyalty bonus");

--- a/src/client/src/components/AdjustmentForm.tsx
+++ b/src/client/src/components/AdjustmentForm.tsx
@@ -86,7 +86,7 @@ export function AdjustmentForm({
           name="type"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Type</FormLabel>
+              <FormLabel required>Type</FormLabel>
               <FormControl>
                 <Combobox
                   options={adjustmentTypes}
@@ -111,7 +111,7 @@ export function AdjustmentForm({
           name="amount"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Amount</FormLabel>
+              <FormLabel required>Amount</FormLabel>
               <FormControl>
                 <CurrencyInput {...field} />
               </FormControl>
@@ -131,7 +131,7 @@ export function AdjustmentForm({
             name="description"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Description</FormLabel>
+                <FormLabel required>Description</FormLabel>
                 <FormControl>
                   <Combobox
                     options={adjustmentDescOptions}

--- a/src/client/src/components/CategoryForm.test.tsx
+++ b/src/client/src/components/CategoryForm.test.tsx
@@ -20,7 +20,7 @@ describe("CategoryForm", () => {
   it("renders in create mode with empty fields and correct submit button text", () => {
     render(<CategoryForm {...defaultProps} />);
 
-    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("");
     expect(screen.getByLabelText("Description (optional)")).toHaveValue("");
     expect(screen.getByRole("button", { name: /create category/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
@@ -35,7 +35,7 @@ describe("CategoryForm", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Name")).toHaveValue("Groceries");
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("Groceries");
     expect(screen.getByLabelText("Description (optional)")).toHaveValue("Food items");
     expect(screen.getByRole("button", { name: /update category/i })).toBeInTheDocument();
   });
@@ -44,7 +44,7 @@ describe("CategoryForm", () => {
     const user = userEvent.setup();
     render(<CategoryForm {...defaultProps} />);
 
-    await user.type(screen.getByLabelText("Name"), "Utilities");
+    await user.type(screen.getByLabelText(/^Name/), "Utilities");
     await user.type(screen.getByLabelText("Description (optional)"), "Monthly bills");
     await user.click(screen.getByRole("button", { name: /create category/i }));
 
@@ -88,7 +88,7 @@ describe("CategoryForm", () => {
     const user = userEvent.setup();
     render(<CategoryForm {...defaultProps} />);
 
-    await user.type(screen.getByLabelText("Name"), "Transport");
+    await user.type(screen.getByLabelText(/^Name/), "Transport");
     await user.click(screen.getByRole("button", { name: /create category/i }));
 
     await waitFor(() => {

--- a/src/client/src/components/CategoryForm.tsx
+++ b/src/client/src/components/CategoryForm.tsx
@@ -58,7 +58,7 @@ export function CategoryForm({
           name="name"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Name</FormLabel>
+              <FormLabel required>Name</FormLabel>
               <FormControl>
                 <Input aria-required="true" {...field} />
               </FormControl>

--- a/src/client/src/components/ItemTemplateForm.test.tsx
+++ b/src/client/src/components/ItemTemplateForm.test.tsx
@@ -55,7 +55,7 @@ describe("ItemTemplateForm", () => {
   it("renders in create mode with empty fields and correct submit button text", () => {
     render(<ItemTemplateForm {...defaultProps} />);
 
-    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("");
     expect(screen.getByLabelText("Description (optional)")).toHaveValue("");
     expect(screen.getByLabelText("Default Item Code (optional)")).toHaveValue("");
     expect(screen.getByRole("button", { name: /create template/i })).toBeInTheDocument();
@@ -79,7 +79,7 @@ describe("ItemTemplateForm", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Name")).toHaveValue("Milk");
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("Milk");
     expect(screen.getByLabelText("Description (optional)")).toHaveValue("Whole milk");
     expect(screen.getByLabelText("Default Item Code (optional)")).toHaveValue("MLK-001");
     expect(screen.getByRole("button", { name: /update template/i })).toBeInTheDocument();
@@ -89,7 +89,7 @@ describe("ItemTemplateForm", () => {
     const user = userEvent.setup();
     render(<ItemTemplateForm {...defaultProps} />);
 
-    await user.type(screen.getByLabelText("Name"), "Bread");
+    await user.type(screen.getByLabelText(/^Name/), "Bread");
     await user.click(screen.getByRole("button", { name: /create template/i }));
 
     await waitFor(() => {

--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -106,7 +106,7 @@ export function ItemTemplateForm({
           name="name"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Name</FormLabel>
+              <FormLabel required>Name</FormLabel>
               <FormControl>
                 <Input aria-required="true" {...field} />
               </FormControl>

--- a/src/client/src/components/ReceiptForm.test.tsx
+++ b/src/client/src/components/ReceiptForm.test.tsx
@@ -69,7 +69,7 @@ describe("ReceiptForm", () => {
     // Click the "Use ..." button to select the custom value
     await user.click(screen.getByText(/Use "Target"/));
 
-    await user.type(screen.getByLabelText("Date"), "2024-03-01");
+    await user.type(screen.getByLabelText(/^Date/), "2024-03-01");
     await user.click(
       screen.getByRole("button", { name: /create receipt/i }),
     );
@@ -125,14 +125,14 @@ describe("ReceiptForm", () => {
   it("renders date input field", () => {
     render(<ReceiptForm {...defaultProps} />);
 
-    expect(screen.getByLabelText("Date")).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Date/)).toBeInTheDocument();
   });
 
   it("associates Location label with the combobox trigger via id", () => {
     render(<ReceiptForm {...defaultProps} />);
 
     const combobox = screen.getByRole("combobox");
-    const label = screen.getByText("Location");
+    const label = screen.getByText(/^Location/);
 
     // FormControl's Slot passes id to the Combobox trigger button;
     // FormLabel sets htmlFor to the same id, creating the association.
@@ -164,7 +164,7 @@ describe("ReceiptForm", () => {
     expect(screen.getByRole("combobox")).toHaveTextContent("Target");
 
     // Fill remaining fields and submit
-    await user.type(screen.getByLabelText("Date"), "2024-05-10");
+    await user.type(screen.getByLabelText(/^Date/), "2024-05-10");
     await user.click(
       screen.getByRole("button", { name: /create receipt/i }),
     );
@@ -190,7 +190,7 @@ describe("ReceiptForm", () => {
     await user.type(searchInput, "Costco");
     await user.click(screen.getByText(/Use "Costco"/));
 
-    await user.type(screen.getByLabelText("Date"), "2024-06-01");
+    await user.type(screen.getByLabelText(/^Date/), "2024-06-01");
     await user.click(
       screen.getByRole("button", { name: /create receipt/i }),
     );

--- a/src/client/src/components/ReceiptForm.tsx
+++ b/src/client/src/components/ReceiptForm.tsx
@@ -75,7 +75,7 @@ export function ReceiptForm({
           name="location"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Location</FormLabel>
+              <FormLabel required>Location</FormLabel>
               <FormControl>
                 <Combobox
                   options={locationOptions}
@@ -98,7 +98,7 @@ export function ReceiptForm({
           name="date"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Date</FormLabel>
+              <FormLabel required>Date</FormLabel>
               <FormControl>
                 <DateInput aria-required="true" {...field} />
               </FormControl>

--- a/src/client/src/components/ReceiptHeaderForm.test.tsx
+++ b/src/client/src/components/ReceiptHeaderForm.test.tsx
@@ -29,7 +29,7 @@ describe("ReceiptHeaderForm", () => {
   it("renders all form fields", () => {
     render(<ReceiptHeaderForm {...defaultProps} />);
     expect(screen.getByRole("combobox")).toBeInTheDocument();
-    expect(screen.getByRole("textbox", { name: /^date$/i })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /^date/i })).toBeInTheDocument();
     expect(screen.getByText(/tax amount/i)).toBeInTheDocument();
   });
 

--- a/src/client/src/components/ReceiptHeaderForm.tsx
+++ b/src/client/src/components/ReceiptHeaderForm.tsx
@@ -68,7 +68,7 @@ export function ReceiptHeaderForm({
           name="location"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Location</FormLabel>
+              <FormLabel required>Location</FormLabel>
               <FormControl>
                 <Combobox
                   options={locationOptions}
@@ -96,7 +96,7 @@ export function ReceiptHeaderForm({
           name="date"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Date</FormLabel>
+              <FormLabel required>Date</FormLabel>
               <FormControl>
                 <DateInput aria-required="true" {...field} />
               </FormControl>

--- a/src/client/src/components/ReceiptItemForm.test.tsx
+++ b/src/client/src/components/ReceiptItemForm.test.tsx
@@ -96,13 +96,13 @@ describe("ReceiptItemForm", () => {
   it("renders in create mode with correct submit button text and all field labels", () => {
     render(<ReceiptItemForm {...defaultProps} />);
 
-    expect(screen.getByText("Receipt")).toBeInTheDocument();
-    expect(screen.getByText("Item Code")).toBeInTheDocument();
-    expect(screen.getByText("Description")).toBeInTheDocument();
-    expect(screen.getByLabelText("Quantity")).toBeInTheDocument();
-    expect(screen.getByLabelText("Unit Price")).toBeInTheDocument();
-    expect(screen.getByText("Category")).toBeInTheDocument();
-    expect(screen.getByText("Subcategory")).toBeInTheDocument();
+    expect(screen.getByText(/^Receipt/)).toBeInTheDocument();
+    expect(screen.getByText(/^Item Code/)).toBeInTheDocument();
+    expect(screen.getByText(/^Description/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Quantity/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Unit Price/)).toBeInTheDocument();
+    expect(screen.getByText(/^Category/)).toBeInTheDocument();
+    expect(screen.getByText(/^Subcategory/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /create item/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
   });
@@ -218,8 +218,8 @@ describe("ReceiptItemForm", () => {
   it("defaults quantity to 1", () => {
     render(<ReceiptItemForm {...defaultProps} />);
 
-    expect(screen.getByLabelText("Quantity")).toBeInTheDocument();
-    expect(screen.getByLabelText("Unit Price")).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Quantity/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Unit Price/)).toBeInTheDocument();
   });
 
   it("shows recent description history and item template groups in description autocomplete", async () => {
@@ -231,7 +231,7 @@ describe("ReceiptItemForm", () => {
 
     render(<ReceiptItemForm {...defaultProps} />);
 
-    const descriptionInput = screen.getByLabelText("Description");
+    const descriptionInput = screen.getByLabelText(/^Description/);
     await user.click(descriptionInput);
 
     // History entries should appear under "Recent Descriptions"
@@ -246,7 +246,7 @@ describe("ReceiptItemForm", () => {
     const user = userEvent.setup();
     render(<ReceiptItemForm {...defaultProps} />);
 
-    const descriptionInput = screen.getByLabelText("Description");
+    const descriptionInput = screen.getByLabelText(/^Description/);
     await user.type(descriptionInput, "Milk");
 
     // Fuzzy-matched template should appear under "Item Templates"
@@ -264,7 +264,7 @@ describe("ReceiptItemForm", () => {
 
     render(<ReceiptItemForm {...defaultProps} />);
 
-    const descriptionInput = screen.getByLabelText("Description");
+    const descriptionInput = screen.getByLabelText(/^Description/);
     await user.click(descriptionInput);
 
     await waitFor(() => {
@@ -337,7 +337,7 @@ describe("ReceiptItemForm", () => {
     render(<ReceiptItemForm {...defaultProps} />);
 
     // Open the category combobox
-    const categoryCombobox = screen.getByLabelText("Category");
+    const categoryCombobox = screen.getByLabelText(/^Category/);
     await user.click(categoryCombobox);
 
     // Type a non-existent category (like a store name)

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -362,7 +362,7 @@ export function ReceiptItemForm({
             name="receiptId"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Receipt</FormLabel>
+                <FormLabel required>Receipt</FormLabel>
                 <FormControl>
                   <Combobox
                     options={receiptOptions}
@@ -387,7 +387,7 @@ export function ReceiptItemForm({
           name="receiptItemCode"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Item Code</FormLabel>
+              <FormLabel required>Item Code</FormLabel>
               <Popover
                 open={isItemCodePopoverOpen}
                 onOpenChange={setItemCodeAutocompleteOpen}
@@ -513,7 +513,7 @@ export function ReceiptItemForm({
           name="description"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Description</FormLabel>
+              <FormLabel required>Description</FormLabel>
               <Popover
                 open={isDescriptionPopoverOpen}
                 onOpenChange={setAutocompleteOpen}
@@ -615,7 +615,7 @@ export function ReceiptItemForm({
             name="category"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Category</FormLabel>
+                <FormLabel required>Category</FormLabel>
                 <FormControl>
                   <Combobox
                     options={categoryOptions}
@@ -640,7 +640,7 @@ export function ReceiptItemForm({
             name="subcategory"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Subcategory</FormLabel>
+                <FormLabel required>Subcategory</FormLabel>
                 <FormControl>
                   <Combobox
                     options={subcategoryOptions}

--- a/src/client/src/components/ReceiptTransactionForm.tsx
+++ b/src/client/src/components/ReceiptTransactionForm.tsx
@@ -84,7 +84,7 @@ export function ReceiptTransactionForm({
           name="accountId"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Account</FormLabel>
+              <FormLabel required>Account</FormLabel>
               <FormControl>
                 <Combobox
                   options={accountOptions}
@@ -112,7 +112,7 @@ export function ReceiptTransactionForm({
           name="amount"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Amount</FormLabel>
+              <FormLabel required>Amount</FormLabel>
               <FormControl>
                 <CurrencyInput {...field} />
               </FormControl>
@@ -131,7 +131,7 @@ export function ReceiptTransactionForm({
           name="date"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Date</FormLabel>
+              <FormLabel required>Date</FormLabel>
               <FormControl>
                 <DateInput aria-required="true" {...field} />
               </FormControl>

--- a/src/client/src/components/SubcategoryForm.test.tsx
+++ b/src/client/src/components/SubcategoryForm.test.tsx
@@ -33,7 +33,7 @@ describe("SubcategoryForm", () => {
     render(<SubcategoryForm {...defaultProps} />);
 
     // Name is now a Combobox (button), not an Input
-    expect(screen.getByLabelText("Name")).toHaveTextContent(
+    expect(screen.getByLabelText(/^Name/)).toHaveTextContent(
       "Select or type a name...",
     );
     expect(screen.getByLabelText("Description (optional)")).toHaveValue("");
@@ -51,7 +51,7 @@ describe("SubcategoryForm", () => {
     );
 
     // Name is a Combobox; it shows the value as text content
-    expect(screen.getByLabelText("Name")).toHaveTextContent("Produce");
+    expect(screen.getByLabelText(/^Name/)).toHaveTextContent("Produce");
     expect(screen.getByLabelText("Description (optional)")).toHaveValue("Fresh produce");
     expect(screen.getByRole("button", { name: /update subcategory/i })).toBeInTheDocument();
   });
@@ -104,7 +104,7 @@ describe("SubcategoryForm", () => {
     );
 
     // Name is a Combobox with allowCustom; type a custom value
-    const nameCombobox = screen.getByLabelText("Name");
+    const nameCombobox = screen.getByLabelText(/^Name/);
     await user.click(nameCombobox);
     const searchInput = screen.getByPlaceholderText("Search names...");
     await user.type(searchInput, "Dairy");
@@ -128,7 +128,7 @@ describe("SubcategoryForm", () => {
 
     render(<SubcategoryForm {...defaultProps} />);
 
-    const nameCombobox = screen.getByLabelText("Name");
+    const nameCombobox = screen.getByLabelText(/^Name/);
     await user.click(nameCombobox);
 
     await waitFor(() => {
@@ -146,7 +146,7 @@ describe("SubcategoryForm", () => {
 
     render(<SubcategoryForm {...defaultProps} />);
 
-    const nameCombobox = screen.getByLabelText("Name");
+    const nameCombobox = screen.getByLabelText(/^Name/);
     await user.click(nameCombobox);
 
     await waitFor(() => {
@@ -168,7 +168,7 @@ describe("SubcategoryForm", () => {
     );
 
     // Type a custom name
-    const nameCombobox = screen.getByLabelText("Name");
+    const nameCombobox = screen.getByLabelText(/^Name/);
     await user.click(nameCombobox);
     const searchInput = screen.getByPlaceholderText("Search names...");
     await user.type(searchInput, "Bakery");

--- a/src/client/src/components/SubcategoryForm.tsx
+++ b/src/client/src/components/SubcategoryForm.tsx
@@ -85,7 +85,7 @@ export function SubcategoryForm({
           name="name"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Name</FormLabel>
+              <FormLabel required>Name</FormLabel>
               <FormControl>
                 <Combobox
                   options={subcategoryNameOptions}
@@ -108,7 +108,7 @@ export function SubcategoryForm({
           name="categoryId"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Category</FormLabel>
+              <FormLabel required>Category</FormLabel>
               <FormControl>
                 <Combobox
                   options={categoryOptions}

--- a/src/client/src/components/ui/form.tsx
+++ b/src/client/src/components/ui/form.tsx
@@ -98,10 +98,6 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
   const { error, formMessageId } = useFormField()
   const body = error ? String(error?.message ?? "") : props.children
 
-  if (!body) {
-    return null
-  }
-
   return (
     <p
       data-slot="form-message"

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -395,7 +395,7 @@ function AdminUsers() {
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Email</FormLabel>
+                    <FormLabel required>Email</FormLabel>
                     <FormControl>
                       <Input
                         type="email"
@@ -412,7 +412,7 @@ function AdminUsers() {
                 name="password"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Password</FormLabel>
+                    <FormLabel required>Password</FormLabel>
                     <FormControl>
                       <PasswordInput
                         placeholder="At least 8 characters"
@@ -428,7 +428,7 @@ function AdminUsers() {
                 name="role"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Role</FormLabel>
+                    <FormLabel required>Role</FormLabel>
                     <FormControl>
                       <Combobox
                         options={ROLE_OPTIONS}
@@ -505,7 +505,7 @@ function AdminUsers() {
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Email</FormLabel>
+                    <FormLabel required>Email</FormLabel>
                     <FormControl>
                       <Input type="email" {...field} />
                     </FormControl>
@@ -518,7 +518,7 @@ function AdminUsers() {
                 name="role"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Role</FormLabel>
+                    <FormLabel required>Role</FormLabel>
                     <FormControl>
                       <Combobox
                         options={ROLE_OPTIONS}
@@ -595,7 +595,7 @@ function AdminUsers() {
                 name="newPassword"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>New Password</FormLabel>
+                    <FormLabel required>New Password</FormLabel>
                     <FormControl>
                       <PasswordInput
                         placeholder="At least 8 characters"

--- a/src/client/src/pages/ApiKeys.tsx
+++ b/src/client/src/pages/ApiKeys.tsx
@@ -288,7 +288,7 @@ function ApiKeys() {
                 name="name"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Name</FormLabel>
+                    <FormLabel required>Name</FormLabel>
                     <FormControl>
                       <Input
                         placeholder="e.g. Paperless Integration"

--- a/src/client/src/pages/ChangePassword.tsx
+++ b/src/client/src/pages/ChangePassword.tsx
@@ -105,7 +105,7 @@ function ChangePassword() {
               name="currentPassword"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Current Password</FormLabel>
+                  <FormLabel required>Current Password</FormLabel>
                   <FormControl>
                     <PasswordInput
                       placeholder="Enter your current password"
@@ -122,7 +122,7 @@ function ChangePassword() {
               name="newPassword"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>New Password</FormLabel>
+                  <FormLabel required>New Password</FormLabel>
                   <FormControl>
                     <PasswordInput
                       placeholder="At least 8 characters"
@@ -139,7 +139,7 @@ function ChangePassword() {
               name="confirmPassword"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Confirm New Password</FormLabel>
+                  <FormLabel required>Confirm New Password</FormLabel>
                   <FormControl>
                     <PasswordInput
                       placeholder="Re-enter your new password"

--- a/src/client/src/pages/Login.tsx
+++ b/src/client/src/pages/Login.tsx
@@ -86,7 +86,7 @@ function Login() {
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Email</FormLabel>
+                    <FormLabel required>Email</FormLabel>
                     <FormControl>
                       <Input
                         type="email"
@@ -104,7 +104,7 @@ function Login() {
                 name="password"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Password</FormLabel>
+                    <FormLabel required>Password</FormLabel>
                     <FormControl>
                       <PasswordInput
                         placeholder="Enter your password"

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -133,7 +133,7 @@ describe("NewReceiptPage", () => {
 
   it("renders all three sections", () => {
     renderWithProviders(<NewReceiptPage />);
-    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByText(/^Location/)).toBeInTheDocument();
     expect(screen.getByTestId("transactions-section")).toBeInTheDocument();
     expect(screen.getByTestId("line-items-section")).toBeInTheDocument();
   });

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -158,7 +158,7 @@ export function TransactionsSection({
               name="accountId"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Account</FormLabel>
+                  <FormLabel required>Account</FormLabel>
                   <FormControl>
                     <Combobox
                       ref={accountRef}
@@ -181,7 +181,7 @@ export function TransactionsSection({
               name="amount"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Amount</FormLabel>
+                  <FormLabel required>Amount</FormLabel>
                   <FormControl>
                     <CurrencyInput {...field} />
                   </FormControl>
@@ -195,7 +195,7 @@ export function TransactionsSection({
               name="date"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Date</FormLabel>
+                  <FormLabel required>Date</FormLabel>
                   <FormControl>
                     <DateInput aria-required="true" {...field} />
                   </FormControl>

--- a/src/client/src/pages/wizard/Step1TripDetails.tsx
+++ b/src/client/src/pages/wizard/Step1TripDetails.tsx
@@ -78,7 +78,7 @@ export function Step1TripDetails({ data, onNext }: Step1Props) {
               name="location"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Location</FormLabel>
+                  <FormLabel required>Location</FormLabel>
                   <FormControl>
                     <Combobox
                       ref={locationRef}
@@ -102,7 +102,7 @@ export function Step1TripDetails({ data, onNext }: Step1Props) {
               name="date"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Date</FormLabel>
+                  <FormLabel required>Date</FormLabel>
                   <FormControl>
                     <DateInput
                       aria-required="true"

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -170,7 +170,7 @@ export function Step2Transactions({
               name="accountId"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Account</FormLabel>
+                  <FormLabel required>Account</FormLabel>
                   <FormControl>
                     <Combobox
                       ref={accountRef}
@@ -193,7 +193,7 @@ export function Step2Transactions({
               name="amount"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Amount</FormLabel>
+                  <FormLabel required>Amount</FormLabel>
                   <FormControl>
                     <CurrencyInput {...field} />
                   </FormControl>
@@ -207,7 +207,7 @@ export function Step2Transactions({
               name="date"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Date</FormLabel>
+                  <FormLabel required>Date</FormLabel>
                   <FormControl>
                     <DateInput aria-required="true" {...field} />
                   </FormControl>

--- a/src/client/src/pages/wizard/Step3Items.test.tsx
+++ b/src/client/src/pages/wizard/Step3Items.test.tsx
@@ -111,9 +111,9 @@ describe("Step3Items", () => {
 
   it("renders the form fields", () => {
     renderWithProviders(<Step3Items {...defaultProps} />);
-    expect(screen.getByText("Description")).toBeInTheDocument();
-    expect(screen.getByText("Quantity")).toBeInTheDocument();
-    expect(screen.getByText("Unit Price")).toBeInTheDocument();
+    expect(screen.getByText(/^Description/)).toBeInTheDocument();
+    expect(screen.getByText(/^Quantity/)).toBeInTheDocument();
+    expect(screen.getByText(/^Unit Price/)).toBeInTheDocument();
   });
 
   it("renders Back and Next buttons", () => {
@@ -826,7 +826,7 @@ describe("Step3Items", () => {
 
   it("renders quantity input as enabled (no pricing mode selector)", () => {
     renderWithProviders(<Step3Items {...defaultProps} />);
-    const qtyInput = screen.getByLabelText("Quantity");
+    const qtyInput = screen.getByLabelText(/^Quantity/);
     expect(qtyInput).not.toBeDisabled();
   });
 

--- a/src/client/src/pages/wizard/Step3Items.tsx
+++ b/src/client/src/pages/wizard/Step3Items.tsx
@@ -367,7 +367,7 @@ export function Step3Items({
               name="receiptItemCode"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Item Code</FormLabel>
+                  <FormLabel required>Item Code</FormLabel>
                   <Popover
                     open={isItemCodeSuggestionsOpen}
                     onOpenChange={setShowItemCodeSuggestions}
@@ -450,7 +450,7 @@ export function Step3Items({
               name="description"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Description</FormLabel>
+                  <FormLabel required>Description</FormLabel>
                   <Popover
                     open={isSuggestionsOpen}
                     onOpenChange={setShowSuggestions}
@@ -538,7 +538,7 @@ export function Step3Items({
               name="category"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Category</FormLabel>
+                  <FormLabel required>Category</FormLabel>
                   <FormControl>
                     <Combobox
                       options={categoryOptions}


### PR DESCRIPTION
## Summary
- **FormMessage** now always renders its `<p>` element (never returns `null`), preventing DOM insertion/removal that caused layout shift inside `FormItem`'s CSS grid
- Added `required` prop to `FormLabel` on every field backed by a required Zod validation rule across all 15+ form components, giving users an upfront red asterisk indicator for mandatory fields
- Updated all affected test files to use regex matchers for label text that now includes the asterisk character

Resolves RECEIPTS-469

## Test plan
- Run `npx vitest run` from `src/client/` -- all 135 form-related tests pass
- Pre-commit hooks pass (384 backend tests, TypeScript type check, ESLint)
- Visually verify forms show red asterisks next to required field labels
- Verify that submitting a form with empty required fields shows the red border on inputs (via `aria-invalid` styling) without any visible layout jump