### PR TITLE
test: add isActive filtering to MSW handlers for categories and subcategories

### DIFF
--- a/src/client/src/pages/Categories.integration.test.tsx
+++ b/src/client/src/pages/Categories.integration.test.tsx
@@ -2,14 +2,11 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/msw/server";
-import { categories } from "@/test/msw/fixtures/categories";
-import { createListHandlers } from "@/test/msw/handler-factories";
 import { renderWithQueryClient } from "@/test/test-utils";
 import Categories from "./Categories";
 
 beforeEach(() => {
   localStorage.clear();
-  server.use(...createListHandlers("categories", categories));
 });
 
 describe("Categories (integration)", () => {
@@ -58,6 +55,71 @@ describe("Categories (integration)", () => {
 
     // Electronics has null description, should show "--"
     expect(screen.getByText("--")).toBeInTheDocument();
+  });
+
+  it("defaults to showing only active categories", async () => {
+    renderWithQueryClient(<Categories />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    // Active categories visible
+    expect(screen.getByText("Tools")).toBeInTheDocument();
+    expect(screen.getByText("Electronics")).toBeInTheDocument();
+    // Inactive category filtered out
+    expect(screen.queryByText("Clothing")).not.toBeInTheDocument();
+
+    // Active tab selected
+    const activeTab = screen.getByRole("tab", { name: "Active" });
+    expect(activeTab).toHaveAttribute("data-state", "active");
+  });
+
+  it("shows inactive categories when Inactive tab is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Categories />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Inactive" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Clothing")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Groceries")).not.toBeInTheDocument();
+  });
+
+  it("shows all categories when All tab is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Categories />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("tab", { name: "All" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Clothing")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Groceries")).toBeInTheDocument();
+    expect(screen.getByText("Tools")).toBeInTheDocument();
+    expect(screen.getByText("Electronics")).toBeInTheDocument();
+  });
+
+  it("persists status filter in localStorage", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Categories />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("tab", { name: "All" }));
+
+    expect(localStorage.getItem("categories-status-filter")).toBe("all");
   });
 
   it("opens create dialog and submits a new category via API", async () => {

--- a/src/client/src/pages/Subcategories.integration.test.tsx
+++ b/src/client/src/pages/Subcategories.integration.test.tsx
@@ -4,17 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/msw/server";
 import { categories } from "@/test/msw/fixtures/categories";
-import { subcategories } from "@/test/msw/fixtures/subcategories";
-import { createListHandlers } from "@/test/msw/handler-factories";
 import { renderWithQueryClient } from "@/test/test-utils";
 import Subcategories from "./Subcategories";
 
 beforeEach(() => {
   localStorage.clear();
-  server.use(
-    ...createListHandlers("subcategories", subcategories),
-    ...createListHandlers("categories", categories),
-  );
 });
 
 describe("Subcategories (integration)", () => {
@@ -128,6 +122,85 @@ describe("Subcategories (integration)", () => {
     // Tools has 1 subcategory (Power Tools)
     const toolsHeader = screen.getByTestId(`category-header-${categories[1].id}`);
     expect(toolsHeader).toHaveTextContent("(1)");
+  });
+
+  it("defaults to showing only active subcategories", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Subcategories />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    // Expand Groceries to see subcategories
+    await user.click(screen.getByTestId(`category-header-${categories[0].id}`));
+
+    // Active subcategories visible
+    expect(screen.getByText("Dairy")).toBeInTheDocument();
+    expect(screen.getByText("Bakery")).toBeInTheDocument();
+    // Inactive subcategory filtered out
+    expect(screen.queryByText("Expired Coupons")).not.toBeInTheDocument();
+
+    // Active tab selected
+    const activeTab = screen.getByRole("tab", { name: "Active" });
+    expect(activeTab).toHaveAttribute("data-state", "active");
+  });
+
+  it("shows inactive subcategories when Inactive tab is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Subcategories />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Inactive" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    // Expand Groceries to see inactive subcategories
+    await user.click(screen.getByTestId(`category-header-${categories[0].id}`));
+
+    expect(screen.getByText("Expired Coupons")).toBeInTheDocument();
+    // Active subcategories should not be shown
+    expect(screen.queryByText("Dairy")).not.toBeInTheDocument();
+  });
+
+  it("shows all subcategories when All tab is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Subcategories />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("tab", { name: "All" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    // Expand Groceries to see all subcategories
+    await user.click(screen.getByTestId(`category-header-${categories[0].id}`));
+
+    expect(screen.getByText("Dairy")).toBeInTheDocument();
+    expect(screen.getByText("Bakery")).toBeInTheDocument();
+    expect(screen.getByText("Expired Coupons")).toBeInTheDocument();
+  });
+
+  it("persists status filter in localStorage", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Subcategories />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("tab", { name: "All" }));
+
+    expect(localStorage.getItem("subcategories-status-filter")).toBe("all");
   });
 
   it("opens create dialog and submits a new subcategory via API", async () => {

--- a/src/client/src/test/msw/fixtures/categories.ts
+++ b/src/client/src/test/msw/fixtures/categories.ts
@@ -21,4 +21,10 @@ export const categories: CategoryResponse[] = [
     description: null,
     isActive: true,
   },
+  {
+    id: "dddd4444-4444-4444-4444-444444444444",
+    name: "Clothing",
+    description: "Archived clothing category",
+    isActive: false,
+  },
 ];

--- a/src/client/src/test/msw/fixtures/index.ts
+++ b/src/client/src/test/msw/fixtures/index.ts
@@ -1,5 +1,7 @@
 export { loginRequest, tokenResponse } from "./auth";
 export { accounts } from "./accounts";
+export { categories } from "./categories";
+export { subcategories } from "./subcategories";
 export { receipts } from "./receipts";
 export { receiptItems } from "./receipt-items";
 export { transactions } from "./transactions";

--- a/src/client/src/test/msw/fixtures/subcategories.ts
+++ b/src/client/src/test/msw/fixtures/subcategories.ts
@@ -24,4 +24,11 @@ export const subcategories: SubcategoryResponse[] = [
     description: null,
     isActive: true,
   },
+  {
+    id: "eeee4444-4444-4444-4444-444444444444",
+    name: "Expired Coupons",
+    categoryId: "dddd1111-1111-1111-1111-111111111111",
+    description: "No longer valid coupon items",
+    isActive: false,
+  },
 ];

--- a/src/client/src/test/msw/handlers/categories.ts
+++ b/src/client/src/test/msw/handlers/categories.ts
@@ -10,7 +10,7 @@ export const categoryHandlers = [
     let filtered = categories;
     if (isActiveParam !== null) {
       const isActive = isActiveParam === "true";
-      filtered = categories.filter((c) => c.isActive === isActive);
+      filtered = filtered.filter((c) => c.isActive === isActive);
     }
     const page = filtered.slice(offset, offset + limit);
     return HttpResponse.json({

--- a/src/client/src/test/msw/handlers/categories.ts
+++ b/src/client/src/test/msw/handlers/categories.ts
@@ -1,0 +1,45 @@
+import { http, HttpResponse } from "msw";
+import { categories } from "../fixtures";
+
+export const categoryHandlers = [
+  http.get("*/api/categories", ({ request }) => {
+    const url = new URL(request.url);
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Number(url.searchParams.get("limit") ?? 50);
+    const isActiveParam = url.searchParams.get("isActive");
+    let filtered = categories;
+    if (isActiveParam !== null) {
+      const isActive = isActiveParam === "true";
+      filtered = categories.filter((c) => c.isActive === isActive);
+    }
+    const page = filtered.slice(offset, offset + limit);
+    return HttpResponse.json({
+      data: page,
+      total: filtered.length,
+      offset,
+      limit,
+    });
+  }),
+
+  http.get("*/api/categories/:id", ({ params }) => {
+    const category = categories.find((c) => c.id === params.id);
+    if (!category) return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+    return HttpResponse.json(category);
+  }),
+
+  http.post("*/api/categories", async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({
+      id: "00000000-0000-0000-0000-000000000002",
+      ...body,
+    });
+  }),
+
+  http.put("*/api/categories/batch", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.put("*/api/categories/:id", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/src/client/src/test/msw/handlers/index.ts
+++ b/src/client/src/test/msw/handlers/index.ts
@@ -1,5 +1,7 @@
 import { authHandlers } from "./auth";
 import { accountHandlers } from "./accounts";
+import { categoryHandlers } from "./categories";
+import { subcategoryHandlers } from "./subcategories";
 import { receiptHandlers } from "./receipts";
 import { receiptItemHandlers } from "./receipt-items";
 import { transactionHandlers } from "./transactions";
@@ -10,6 +12,8 @@ import { scanHandlers } from "./scan";
 export const handlers = [
   ...authHandlers,
   ...accountHandlers,
+  ...categoryHandlers,
+  ...subcategoryHandlers,
   ...receiptHandlers,
   ...receiptItemHandlers,
   ...transactionHandlers,

--- a/src/client/src/test/msw/handlers/subcategories.ts
+++ b/src/client/src/test/msw/handlers/subcategories.ts
@@ -1,0 +1,49 @@
+import { http, HttpResponse } from "msw";
+import { subcategories } from "../fixtures";
+
+export const subcategoryHandlers = [
+  http.get("*/api/subcategories", ({ request }) => {
+    const url = new URL(request.url);
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Number(url.searchParams.get("limit") ?? 50);
+    const isActiveParam = url.searchParams.get("isActive");
+    const categoryId = url.searchParams.get("categoryId");
+    let filtered = subcategories;
+    if (isActiveParam !== null) {
+      const isActive = isActiveParam === "true";
+      filtered = filtered.filter((s) => s.isActive === isActive);
+    }
+    if (categoryId !== null) {
+      filtered = filtered.filter((s) => s.categoryId === categoryId);
+    }
+    const page = filtered.slice(offset, offset + limit);
+    return HttpResponse.json({
+      data: page,
+      total: filtered.length,
+      offset,
+      limit,
+    });
+  }),
+
+  http.get("*/api/subcategories/:id", ({ params }) => {
+    const subcategory = subcategories.find((s) => s.id === params.id);
+    if (!subcategory) return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+    return HttpResponse.json(subcategory);
+  }),
+
+  http.post("*/api/subcategories", async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({
+      id: "00000000-0000-0000-0000-000000000003",
+      ...body,
+    });
+  }),
+
+  http.put("*/api/subcategories/batch", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.put("*/api/subcategories/:id", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+];


### PR DESCRIPTION
## Summary
- Create dedicated MSW handlers for categories and subcategories with `isActive` query parameter filtering, following the accounts handler pattern from RECEIPTS-475
- Add inactive fixture entries (Clothing category, Expired Coupons subcategory) to validate filtering behavior
- Add integration tests for Active/Inactive/All tab filtering on both Categories and Subcategories pages
- Register new handlers in the MSW handler index and export fixtures

Resolves RECEIPTS-476

## Test plan
- Run `npx vitest run --config vitest.integration.config.ts src/pages/Categories.integration.test.tsx src/pages/Subcategories.integration.test.tsx` and verify all new isActive filtering tests pass
- Run `npx vitest run` to confirm no unit test regressions
- 8 new integration tests: defaults to active, shows inactive, shows all, persists filter (x2 for categories and subcategories)