### PR TITLE
feat(client): add Backup & Restore UI in admin settings

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -20,6 +20,7 @@ import AdminUsers from "@/pages/AdminUsers";
 import AuditLog from "@/pages/AuditLog";
 import SecurityLog from "@/pages/SecurityLog";
 import RecycleBin from "@/pages/RecycleBin";
+import BackupRestore from "@/pages/BackupRestore";
 import NewReceipt from "@/pages/new-receipt/NewReceiptPage";
 import ScanReceipt from "@/pages/scan-receipt/ScanReceiptPage";
 import NotFound from "@/pages/NotFound";
@@ -80,6 +81,14 @@ export const routeConfig = [
             element: (
               <AdminRoute>
                 <AdminUsers />
+              </AdminRoute>
+            ),
+          },
+          {
+            path: "/admin/backup",
+            element: (
+              <AdminRoute>
+                <BackupRestore />
               </AdminRoute>
             ),
           },

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -126,6 +126,7 @@ const adminNavGroup: NavGroup = {
     { to: "/admin/users", label: "Users", description: "Manage user accounts" },
     { to: "/audit", label: "Audit", description: "View audit logs" },
     { to: "/trash", label: "Trash", description: "Recover deleted items" },
+    { to: "/admin/backup", label: "Backup", description: "Export and import data backups" },
   ],
 };
 
@@ -212,6 +213,7 @@ export function Layout() {
     { to: "/admin/users", label: "Users" },
     { to: "/audit", label: "Audit" },
     { to: "/trash", label: "Trash" },
+    { to: "/admin/backup", label: "Backup" },
   ];
 
   return (

--- a/src/client/src/hooks/useBreadcrumbs.ts
+++ b/src/client/src/hooks/useBreadcrumbs.ts
@@ -14,6 +14,7 @@ const routeLabels: Record<string, string> = {
   "/audit": "Audit Log",
   "/trash": "Recycle Bin",
   "/admin/users": "User Management",
+  "/admin/backup": "Backup & Restore",
   "/login": "Login",
   "/change-password": "Change Password",
 };

--- a/src/client/src/pages/BackupRestore.test.tsx
+++ b/src/client/src/pages/BackupRestore.test.tsx
@@ -1,0 +1,457 @@
+import { screen } from "@testing-library/react";
+import { renderWithQueryClient } from "@/test/test-utils";
+import BackupRestore from "./BackupRestore";
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useMutation: vi.fn(() => ({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })),
+  };
+});
+
+vi.mock("@/lib/toast", () => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAccessToken: vi.fn(() => "mock-token"),
+}));
+
+describe("BackupRestore", () => {
+  it("renders the page heading", () => {
+    renderWithQueryClient(<BackupRestore />);
+    expect(
+      screen.getByRole("heading", { name: /backup & restore/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the description text", () => {
+    renderWithQueryClient(<BackupRestore />);
+    expect(
+      screen.getByText(/export or import a portable sqlite backup/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Export Backup card", () => {
+    renderWithQueryClient(<BackupRestore />);
+    expect(
+      screen.getByText(/export backup/i, { selector: "[data-slot='card-title']" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/download a complete sqlite backup/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Import Backup card", () => {
+    renderWithQueryClient(<BackupRestore />);
+    expect(
+      screen.getByText(/import backup/i, { selector: "[data-slot='card-title']" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/upload a previously exported sqlite backup/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Export Backup button", () => {
+    renderWithQueryClient(<BackupRestore />);
+    expect(
+      screen.getByRole("button", { name: /export backup/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Import Backup button as disabled when no file is selected", () => {
+    renderWithQueryClient(<BackupRestore />);
+    const importBtn = screen.getByRole("button", { name: /import backup/i });
+    expect(importBtn).toBeDisabled();
+  });
+
+  it("renders the file input for uploading backups", () => {
+    renderWithQueryClient(<BackupRestore />);
+    expect(document.getElementById("backup-file")).toBeInTheDocument();
+  });
+
+  it("renders the info alert about what backups include", () => {
+    renderWithQueryClient(<BackupRestore />);
+    expect(
+      screen.getByText(/backups include all receipts/i),
+    ).toBeInTheDocument();
+  });
+
+  it("enables Import Backup button when a file is selected", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test"], "backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    const importBtn = screen.getByRole("button", { name: /import backup/i });
+    expect(importBtn).not.toBeDisabled();
+  });
+
+  it("shows selected file name and size after file selection", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test-data"], "my-backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    expect(screen.getByText(/selected: my-backup\.sqlite/i)).toBeInTheDocument();
+  });
+
+  it("opens confirmation dialog when Import Backup is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test"], "backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    await user.click(
+      screen.getByRole("button", { name: /import backup/i }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /confirm import/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/importing a backup will update existing records/i),
+    ).toBeInTheDocument();
+  });
+
+  it("closes confirmation dialog when Cancel is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test"], "backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    await user.click(
+      screen.getByRole("button", { name: /import backup/i }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /confirm import/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: /confirm import/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("calls mutate when import is confirmed", async () => {
+    const mockMutate = vi.fn();
+    const { useMutation } = await import("@tanstack/react-query");
+    vi.mocked(useMutation).mockImplementation((() => ({
+      mutate: mockMutate,
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test"], "backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    await user.click(
+      screen.getByRole("button", { name: /import backup/i }),
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /confirm import/i }),
+    );
+
+    // The import mutation is the second useMutation call
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it("calls export mutation when Export Backup is clicked", async () => {
+    const mockMutate = vi.fn();
+    const { useMutation } = await import("@tanstack/react-query");
+    vi.mocked(useMutation).mockImplementation((() => ({
+      mutate: mockMutate,
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithQueryClient(<BackupRestore />);
+
+    await user.click(
+      screen.getByRole("button", { name: /export backup/i }),
+    );
+
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it("shows Exporting state when export mutation is pending", async () => {
+    const { useMutation } = await import("@tanstack/react-query");
+    let callCount = 0;
+    vi.mocked(useMutation).mockImplementation((() => {
+      callCount++;
+      if (callCount === 1) {
+        // export mutation
+        return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: true };
+      }
+      // import mutation
+      return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+    }) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<BackupRestore />);
+
+    const exportBtn = screen.getByRole("button", { name: /exporting/i });
+    expect(exportBtn).toBeDisabled();
+  });
+
+  it("shows Importing state when import mutation is pending", async () => {
+    const { useMutation } = await import("@tanstack/react-query");
+    let callCount = 0;
+    vi.mocked(useMutation).mockImplementation((() => {
+      callCount++;
+      if (callCount === 1) {
+        // export mutation
+        return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+      }
+      // import mutation
+      return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: true };
+    }) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<BackupRestore />);
+
+    const importBtn = screen.getByRole("button", { name: /importing/i });
+    expect(importBtn).toBeDisabled();
+  });
+
+  it("shows success toast when export mutation succeeds", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const { showSuccess } = await import("@/lib/toast");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn(() => {
+        if (opts?.onSuccess) {
+          opts.onSuccess(undefined, undefined, undefined);
+        }
+      }),
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<BackupRestore />);
+    await user.click(
+      screen.getByRole("button", { name: /export backup/i }),
+    );
+
+    await vi.waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith("Backup exported successfully.");
+    });
+  });
+
+  it("shows error toast when export mutation fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const { showError } = await import("@/lib/toast");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => ({
+      mutate: vi.fn(() => {
+        if (opts?.onError) {
+          opts.onError(new Error("Export failed (500)."), undefined, undefined);
+        }
+      }),
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<BackupRestore />);
+    await user.click(
+      screen.getByRole("button", { name: /export backup/i }),
+    );
+
+    await vi.waitFor(() => {
+      expect(showError).toHaveBeenCalledWith("Export failed (500).");
+    });
+  });
+
+  it("shows success toast when import mutation succeeds", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const { showSuccess } = await import("@/lib/toast");
+
+    let callCount = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => {
+      callCount++;
+      if (callCount === 1) {
+        // export mutation
+        return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+      }
+      // import mutation
+      return {
+        mutate: vi.fn(() => {
+          if (opts?.onSuccess) {
+            opts.onSuccess(
+              { recordsImported: 10, recordsUpdated: 5, recordsSkipped: 2 },
+              undefined,
+              undefined,
+            );
+          }
+        }),
+        mutateAsync: vi.fn(),
+        isPending: false,
+      };
+    }) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test"], "backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    await user.click(
+      screen.getByRole("button", { name: /import backup/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /confirm import/i }),
+    );
+
+    await vi.waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith(
+        "Import complete: 10 imported, 5 updated, 2 skipped.",
+      );
+    });
+  });
+
+  it("shows error toast when import mutation fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+    const { showError } = await import("@/lib/toast");
+
+    let callCount = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useMutation).mockImplementation(((opts: any) => {
+      callCount++;
+      if (callCount === 1) {
+        // export mutation
+        return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+      }
+      // import mutation
+      return {
+        mutate: vi.fn(() => {
+          if (opts?.onError) {
+            opts.onError(
+              new Error("Invalid or corrupt backup file."),
+              undefined,
+              undefined,
+            );
+          }
+        }),
+        mutateAsync: vi.fn(),
+        isPending: false,
+      };
+    }) as unknown as typeof useMutation);
+
+    renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test"], "backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    await user.click(
+      screen.getByRole("button", { name: /import backup/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /confirm import/i }),
+    );
+
+    await vi.waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(
+        "Invalid or corrupt backup file.",
+      );
+    });
+  });
+
+  it("shows file details in the confirmation dialog", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test-data-content"], "my-backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    await user.click(
+      screen.getByRole("button", { name: /import backup/i }),
+    );
+
+    expect(screen.getByText(/file: my-backup\.sqlite/i)).toBeInTheDocument();
+  });
+
+  it("closes confirmation dialog via Escape key", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test"], "backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    await user.click(
+      screen.getByRole("button", { name: /import backup/i }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /confirm import/i }),
+    ).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: /confirm import/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("accepts .sqlite files in the file input", () => {
+    renderWithQueryClient(<BackupRestore />);
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    expect(fileInput.accept).toBe(".sqlite,.db");
+  });
+});

--- a/src/client/src/pages/BackupRestore.test.tsx
+++ b/src/client/src/pages/BackupRestore.test.tsx
@@ -454,4 +454,66 @@ describe("BackupRestore", () => {
     const fileInput = document.getElementById("backup-file") as HTMLInputElement;
     expect(fileInput.accept).toBe(".sqlite,.db");
   });
+
+  it("does not close confirmation dialog via Escape while import is pending", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const { useMutation } = await import("@tanstack/react-query");
+
+    // Start with isPending = false so the user can open the dialog,
+    // then switch to isPending = true to simulate an in-flight import
+    let importPending = false;
+    let callCount = 0;
+    vi.mocked(useMutation).mockImplementation((() => {
+      callCount++;
+      if (callCount % 2 === 1) {
+        // export mutation (odd calls)
+        return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+      }
+      // import mutation (even calls) - pending state is dynamic
+      return {
+        mutate: vi.fn(() => {
+          importPending = true;
+        }),
+        mutateAsync: vi.fn(),
+        get isPending() {
+          return importPending;
+        },
+      };
+    }) as unknown as typeof useMutation);
+
+    const { rerender } = renderWithQueryClient(<BackupRestore />);
+
+    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const testFile = new File(["test"], "backup.sqlite", {
+      type: "application/octet-stream",
+    });
+    await user.upload(fileInput, testFile);
+
+    // Open the confirmation dialog
+    await user.click(
+      screen.getByRole("button", { name: /import backup/i }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /confirm import/i }),
+    ).toBeInTheDocument();
+
+    // Click Confirm Import (this triggers mutate, setting importPending = true)
+    await user.click(
+      screen.getByRole("button", { name: /confirm import/i }),
+    );
+
+    // Re-render to pick up the pending state change
+    // Reset mock call count for the re-render
+    callCount = 0;
+    rerender(<BackupRestore />);
+
+    // The dialog should still be visible after pressing Escape because import is pending
+    await user.keyboard("{Escape}");
+
+    // Dialog should remain open since import is pending
+    expect(
+      screen.getByRole("heading", { name: /confirm import/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/BackupRestore.tsx
+++ b/src/client/src/pages/BackupRestore.tsx
@@ -1,0 +1,265 @@
+import { useState, useRef } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { getAccessToken } from "@/lib/auth";
+import { showSuccess, showError } from "@/lib/toast";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Spinner } from "@/components/ui/spinner";
+import { DatabaseBackup, Upload, Download, AlertTriangle } from "lucide-react";
+
+const baseUrl = import.meta.env.VITE_API_URL ?? "";
+
+function formatFileSize(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function BackupRestore() {
+  usePageTitle("Backup & Restore");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [confirmImportOpen, setConfirmImportOpen] = useState(false);
+
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      const token = getAccessToken();
+      const res = await fetch(`${baseUrl}/api/backup/export`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        signal: AbortSignal.timeout(300_000), // 5-minute timeout for large exports
+      });
+
+      if (!res.ok) {
+        if (res.status === 403) throw new Error("You do not have permission to export backups.");
+        throw new Error(`Export failed (${res.status}).`);
+      }
+
+      const blob = await res.blob();
+      const disposition = res.headers.get("Content-Disposition");
+      let filename = `receipts-backup-${new Date().toISOString().slice(0, 10)}.sqlite`;
+      if (disposition) {
+        const match = disposition.match(/filename="?([^";\n]+)"?/);
+        if (match) filename = match[1];
+      }
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    },
+    onSuccess: () => {
+      showSuccess("Backup exported successfully.");
+    },
+    onError: (error: Error) => {
+      showError(error.message);
+    },
+  });
+
+  const importMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const token = getAccessToken();
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await fetch(`${baseUrl}/api/backup/import`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        body: formData,
+        signal: AbortSignal.timeout(300_000), // 5-minute timeout for large imports
+      });
+
+      if (!res.ok) {
+        if (res.status === 400) throw new Error("Invalid or corrupt backup file.");
+        if (res.status === 403) throw new Error("You do not have permission to import backups.");
+        throw new Error(`Import failed (${res.status}).`);
+      }
+
+      return res.json() as Promise<{
+        recordsImported: number;
+        recordsUpdated: number;
+        recordsSkipped: number;
+      }>;
+    },
+    onSuccess: (data) => {
+      showSuccess(
+        `Import complete: ${data.recordsImported} imported, ${data.recordsUpdated} updated, ${data.recordsSkipped} skipped.`,
+      );
+      setSelectedFile(null);
+      setConfirmImportOpen(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    },
+    onError: (error: Error) => {
+      showError(error.message);
+      setConfirmImportOpen(false);
+    },
+  });
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0] ?? null;
+    setSelectedFile(file);
+  }
+
+  function handleImportClick() {
+    if (!selectedFile) return;
+    setConfirmImportOpen(true);
+  }
+
+  function handleConfirmImport() {
+    if (!selectedFile) return;
+    importMutation.mutate(selectedFile);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Backup & Restore</h1>
+        <p className="text-sm text-muted-foreground">
+          Export or import a portable SQLite backup of your data
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* Export Card */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Download className="h-5 w-5" />
+              Export Backup
+            </CardTitle>
+            <CardDescription>
+              Download a complete SQLite backup of all your data. This file can
+              be used to restore your data on another instance or recover from
+              data loss.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button
+              onClick={() => exportMutation.mutate()}
+              disabled={exportMutation.isPending}
+              className="w-full"
+            >
+              {exportMutation.isPending && <Spinner size="sm" />}
+              {exportMutation.isPending ? "Exporting..." : "Export Backup"}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {/* Import Card */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Upload className="h-5 w-5" />
+              Import Backup
+            </CardTitle>
+            <CardDescription>
+              Upload a previously exported SQLite backup file. Existing records
+              will be updated and new records will be added.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label htmlFor="backup-file" className="sr-only">
+                Select backup file
+              </label>
+              <input
+                ref={fileInputRef}
+                id="backup-file"
+                type="file"
+                accept=".sqlite,.db"
+                onChange={handleFileChange}
+                className="block w-full text-sm text-muted-foreground file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90 file:cursor-pointer"
+              />
+              {selectedFile && (
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Selected: {selectedFile.name} ({formatFileSize(selectedFile.size)})
+                </p>
+              )}
+            </div>
+            <Button
+              onClick={handleImportClick}
+              disabled={!selectedFile || importMutation.isPending}
+              variant="outline"
+              className="w-full"
+            >
+              {importMutation.isPending && <Spinner size="sm" />}
+              {importMutation.isPending ? "Importing..." : "Import Backup"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Alert>
+        <DatabaseBackup className="h-4 w-4" />
+        <AlertDescription>
+          Backups include all receipts, transactions, accounts, categories, and
+          related data. User accounts and authentication settings are not
+          included in backups for security reasons.
+        </AlertDescription>
+      </Alert>
+
+      {/* Import Confirmation Dialog */}
+      <Dialog open={confirmImportOpen} onOpenChange={setConfirmImportOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-yellow-500" />
+              Confirm Import
+            </DialogTitle>
+            <DialogDescription>
+              Importing a backup will update existing records and add new ones.
+              This action may modify your current data.
+            </DialogDescription>
+          </DialogHeader>
+          {selectedFile && (
+            <p className="text-sm text-muted-foreground">
+              File: {selectedFile.name} ({formatFileSize(selectedFile.size)})
+            </p>
+          )}
+          <div className="flex gap-2 justify-end">
+            <Button
+              variant="outline"
+              onClick={() => setConfirmImportOpen(false)}
+              disabled={importMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirmImport}
+              disabled={importMutation.isPending}
+            >
+              {importMutation.isPending && <Spinner size="sm" />}
+              {importMutation.isPending ? "Importing..." : "Confirm Import"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+export default BackupRestore;

--- a/src/client/src/pages/BackupRestore.tsx
+++ b/src/client/src/pages/BackupRestore.tsx
@@ -26,8 +26,11 @@ const baseUrl = import.meta.env.VITE_API_URL ?? "";
 
 function formatFileSize(bytes: number): string {
   if (bytes === 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
   return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
 }
 
@@ -223,7 +226,12 @@ function BackupRestore() {
       </Alert>
 
       {/* Import Confirmation Dialog */}
-      <Dialog open={confirmImportOpen} onOpenChange={setConfirmImportOpen}>
+      <Dialog
+        open={confirmImportOpen}
+        onOpenChange={(open) => {
+          if (!importMutation.isPending) setConfirmImportOpen(open);
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Adds a new admin-only **Backup & Restore** page at `/admin/backup` with export (SQLite download) and import (file upload with confirmation dialog) capabilities
- Integrates into the admin navigation menu (desktop dropdown + mobile drawer) and breadcrumbs
- Uses direct `fetch` calls with Bearer auth for binary file operations; backend endpoints (`POST /api/backup/export` and `POST /api/backup/import`) will be implemented in RECEIPTS-464 and RECEIPTS-465

Resolves RECEIPTS-466

### Assumptions (backend not yet built)
- Export endpoint: `POST /api/backup/export` returns `application/octet-stream` with `Content-Disposition` header
- Import endpoint: `POST /api/backup/import` accepts `multipart/form-data` and returns `{ recordsImported, recordsUpdated, recordsSkipped }`
- Both endpoints require admin role (403 for non-admins)

## Test plan
- 23 unit tests covering rendering, file selection, confirmation dialog flow, mutation callbacks (success/error), pending states, and accessibility
- Verified all existing tests (App, Layout, Breadcrumbs) still pass
- All 9 pre-commit checks pass (lint, format, build, drift, .NET tests, TS types, React lint)