### PR TITLE
feat(api): add SQLite backup export endpoint and CLI tool (RECEIPTS-464)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="MediatR" Version="14.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />

--- a/Receipts.slnx
+++ b/Receipts.slnx
@@ -12,6 +12,7 @@
   </Folder>
   <Folder Name="/src/Tools/">
     <Project Path="src/Tools/DbMigrator/DbMigrator.csproj" />
+    <Project Path="src/Tools/DbExporter/DbExporter.csproj" />
     <Project Path="src/Tools/DbSeeder/DbSeeder.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -3617,6 +3617,31 @@ paths:
               schema:
                 $ref: "#/components/schemas/EarliestReceiptYearResponse"
 
+  # ──────────────────────────────────────────────
+  # Backup
+  # ──────────────────────────────────────────────
+
+  /api/backup/export:
+    post:
+      operationId: ExportBackup
+      tags: [Backup]
+      summary: Export database to a portable SQLite file
+      description: >
+        Generates a SQLite database containing all domain data (accounts,
+        categories, receipts, items, transactions, adjustments, item templates).
+        Admin-only. Soft-deleted records are excluded.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      responses:
+        "200":
+          description: SQLite database file
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+
 components:
   schemas:
     # ── Reports ───────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-acdc0e53",
+  "name": "agent-a1b1c3ef",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/Application/Interfaces/Services/IBackupService.cs
+++ b/src/Application/Interfaces/Services/IBackupService.cs
@@ -1,0 +1,10 @@
+namespace Application.Interfaces.Services;
+
+public interface IBackupService
+{
+	/// <summary>
+	/// Exports all domain data from the database to a portable SQLite file.
+	/// Returns the path to the generated SQLite file.
+	/// </summary>
+	Task<string> ExportToSqliteAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" />

--- a/src/Infrastructure/Services/BackupService.cs
+++ b/src/Infrastructure/Services/BackupService.cs
@@ -1,0 +1,371 @@
+using Application.Interfaces.Services;
+using Infrastructure.Entities.Core;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Services;
+
+public class BackupService(
+	IDbContextFactory<ApplicationDbContext> dbContextFactory,
+	ILogger<BackupService> logger) : IBackupService
+{
+	public async Task<string> ExportToSqliteAsync(CancellationToken cancellationToken = default)
+	{
+		string tempPath = Path.Combine(Path.GetTempPath(), $"receipts-backup-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid():N}.db");
+		logger.LogInformation("Starting SQLite export to {Path}", tempPath);
+
+		await using ApplicationDbContext source = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+		string connectionString = $"Data Source={tempPath}";
+		await using SqliteConnection sqlite = new(connectionString);
+		await sqlite.OpenAsync(cancellationToken);
+
+		await using SqliteTransaction transaction = (SqliteTransaction)await sqlite.BeginTransactionAsync(cancellationToken);
+
+		try
+		{
+			await CreateSchemaAsync(sqlite, cancellationToken);
+			await ExportAccountsAsync(source, sqlite, cancellationToken);
+			await ExportCategoriesAsync(source, sqlite, cancellationToken);
+			await ExportSubcategoriesAsync(source, sqlite, cancellationToken);
+			await ExportItemTemplatesAsync(source, sqlite, cancellationToken);
+			await ExportReceiptsAsync(source, sqlite, cancellationToken);
+			await ExportReceiptItemsAsync(source, sqlite, cancellationToken);
+			await ExportTransactionsAsync(source, sqlite, cancellationToken);
+			await ExportAdjustmentsAsync(source, sqlite, cancellationToken);
+			await WriteMetadataAsync(sqlite, cancellationToken);
+
+			await transaction.CommitAsync(cancellationToken);
+		}
+		catch
+		{
+			await transaction.RollbackAsync(cancellationToken);
+			if (File.Exists(tempPath))
+			{
+				File.Delete(tempPath);
+			}
+			throw;
+		}
+
+		logger.LogInformation("SQLite export completed: {Path}", tempPath);
+		return tempPath;
+	}
+
+	internal static async Task CreateSchemaAsync(SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		string[] ddl =
+		[
+			"""
+			CREATE TABLE backup_metadata (
+				key TEXT NOT NULL PRIMARY KEY,
+				value TEXT NOT NULL
+			)
+			""",
+			"""
+			CREATE TABLE accounts (
+				id TEXT NOT NULL PRIMARY KEY,
+				account_code TEXT NOT NULL,
+				name TEXT NOT NULL,
+				is_active INTEGER NOT NULL
+			)
+			""",
+			"""
+			CREATE TABLE categories (
+				id TEXT NOT NULL PRIMARY KEY,
+				name TEXT NOT NULL,
+				description TEXT,
+				is_active INTEGER NOT NULL
+			)
+			""",
+			"""
+			CREATE TABLE subcategories (
+				id TEXT NOT NULL PRIMARY KEY,
+				name TEXT NOT NULL,
+				category_id TEXT NOT NULL,
+				description TEXT,
+				is_active INTEGER NOT NULL,
+				FOREIGN KEY (category_id) REFERENCES categories(id)
+			)
+			""",
+			"""
+			CREATE TABLE item_templates (
+				id TEXT NOT NULL PRIMARY KEY,
+				name TEXT NOT NULL,
+				default_category TEXT,
+				default_subcategory TEXT,
+				default_unit_price TEXT,
+				default_unit_price_currency TEXT,
+				default_pricing_mode TEXT,
+				default_item_code TEXT,
+				description TEXT
+			)
+			""",
+			"""
+			CREATE TABLE receipts (
+				id TEXT NOT NULL PRIMARY KEY,
+				location TEXT NOT NULL,
+				date TEXT NOT NULL,
+				tax_amount TEXT NOT NULL,
+				tax_amount_currency TEXT NOT NULL
+			)
+			""",
+			"""
+			CREATE TABLE receipt_items (
+				id TEXT NOT NULL PRIMARY KEY,
+				receipt_id TEXT NOT NULL,
+				receipt_item_code TEXT,
+				description TEXT NOT NULL,
+				quantity TEXT NOT NULL,
+				unit_price TEXT NOT NULL,
+				unit_price_currency TEXT NOT NULL,
+				total_amount TEXT NOT NULL,
+				total_amount_currency TEXT NOT NULL,
+				category TEXT NOT NULL,
+				subcategory TEXT,
+				pricing_mode TEXT NOT NULL,
+				FOREIGN KEY (receipt_id) REFERENCES receipts(id)
+			)
+			""",
+			"""
+			CREATE TABLE transactions (
+				id TEXT NOT NULL PRIMARY KEY,
+				receipt_id TEXT NOT NULL,
+				account_id TEXT NOT NULL,
+				amount TEXT NOT NULL,
+				amount_currency TEXT NOT NULL,
+				date TEXT NOT NULL,
+				FOREIGN KEY (receipt_id) REFERENCES receipts(id),
+				FOREIGN KEY (account_id) REFERENCES accounts(id)
+			)
+			""",
+			"""
+			CREATE TABLE adjustments (
+				id TEXT NOT NULL PRIMARY KEY,
+				receipt_id TEXT NOT NULL,
+				type TEXT NOT NULL,
+				amount TEXT NOT NULL,
+				amount_currency TEXT NOT NULL,
+				description TEXT,
+				FOREIGN KEY (receipt_id) REFERENCES receipts(id)
+			)
+			""",
+		];
+
+		foreach (string sql in ddl)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportAccountsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<AccountEntity> accounts = await source.Accounts.AsNoTracking().ToListAsync(cancellationToken);
+
+		const string sql = "INSERT INTO accounts (id, account_code, name, is_active) VALUES ($id, $code, $name, $active)";
+		foreach (AccountEntity account in accounts)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", account.Id.ToString());
+			cmd.Parameters.AddWithValue("$code", account.AccountCode);
+			cmd.Parameters.AddWithValue("$name", account.Name);
+			cmd.Parameters.AddWithValue("$active", account.IsActive ? 1 : 0);
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportCategoriesAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<CategoryEntity> categories = await source.Categories
+			.AsNoTracking()
+			.Where(c => c.DeletedAt == null)
+			.ToListAsync(cancellationToken);
+
+		const string sql = "INSERT INTO categories (id, name, description, is_active) VALUES ($id, $name, $desc, $active)";
+		foreach (CategoryEntity category in categories)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", category.Id.ToString());
+			cmd.Parameters.AddWithValue("$name", category.Name);
+			cmd.Parameters.AddWithValue("$desc", (object?)category.Description ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$active", category.IsActive ? 1 : 0);
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportSubcategoriesAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<SubcategoryEntity> subcategories = await source.Subcategories
+			.AsNoTracking()
+			.Where(s => s.DeletedAt == null)
+			.ToListAsync(cancellationToken);
+
+		const string sql = "INSERT INTO subcategories (id, name, category_id, description, is_active) VALUES ($id, $name, $catId, $desc, $active)";
+		foreach (SubcategoryEntity sub in subcategories)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", sub.Id.ToString());
+			cmd.Parameters.AddWithValue("$name", sub.Name);
+			cmd.Parameters.AddWithValue("$catId", sub.CategoryId.ToString());
+			cmd.Parameters.AddWithValue("$desc", (object?)sub.Description ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$active", sub.IsActive ? 1 : 0);
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportItemTemplatesAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<ItemTemplateEntity> templates = await source.ItemTemplates
+			.AsNoTracking()
+			.Where(t => t.DeletedAt == null)
+			.ToListAsync(cancellationToken);
+
+		const string sql = """
+			INSERT INTO item_templates (id, name, default_category, default_subcategory,
+				default_unit_price, default_unit_price_currency, default_pricing_mode,
+				default_item_code, description)
+			VALUES ($id, $name, $cat, $subcat, $price, $priceCurrency, $pricingMode, $itemCode, $desc)
+			""";
+
+		foreach (ItemTemplateEntity template in templates)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", template.Id.ToString());
+			cmd.Parameters.AddWithValue("$name", template.Name);
+			cmd.Parameters.AddWithValue("$cat", (object?)template.DefaultCategory ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$subcat", (object?)template.DefaultSubcategory ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$price", template.DefaultUnitPrice.HasValue ? template.DefaultUnitPrice.Value.ToString("G") : DBNull.Value);
+			cmd.Parameters.AddWithValue("$priceCurrency", template.DefaultUnitPriceCurrency.HasValue ? template.DefaultUnitPriceCurrency.Value.ToString() : DBNull.Value);
+			cmd.Parameters.AddWithValue("$pricingMode", (object?)template.DefaultPricingMode ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$itemCode", (object?)template.DefaultItemCode ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$desc", (object?)template.Description ?? DBNull.Value);
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportReceiptsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<ReceiptEntity> receipts = await source.Receipts
+			.AsNoTracking()
+			.Where(r => r.DeletedAt == null)
+			.ToListAsync(cancellationToken);
+
+		const string sql = "INSERT INTO receipts (id, location, date, tax_amount, tax_amount_currency) VALUES ($id, $loc, $date, $tax, $taxCurrency)";
+		foreach (ReceiptEntity receipt in receipts)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", receipt.Id.ToString());
+			cmd.Parameters.AddWithValue("$loc", receipt.Location);
+			cmd.Parameters.AddWithValue("$date", receipt.Date.ToString("O"));
+			cmd.Parameters.AddWithValue("$tax", receipt.TaxAmount.ToString("G"));
+			cmd.Parameters.AddWithValue("$taxCurrency", receipt.TaxAmountCurrency.ToString());
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportReceiptItemsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<ReceiptItemEntity> items = await source.ReceiptItems
+			.AsNoTracking()
+			.Where(i => i.DeletedAt == null)
+			.ToListAsync(cancellationToken);
+
+		const string sql = """
+			INSERT INTO receipt_items (id, receipt_id, receipt_item_code, description, quantity,
+				unit_price, unit_price_currency, total_amount, total_amount_currency,
+				category, subcategory, pricing_mode)
+			VALUES ($id, $receiptId, $itemCode, $desc, $qty, $unitPrice, $unitPriceCurrency,
+				$totalAmt, $totalAmtCurrency, $cat, $subcat, $pricingMode)
+			""";
+
+		foreach (ReceiptItemEntity item in items)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", item.Id.ToString());
+			cmd.Parameters.AddWithValue("$receiptId", item.ReceiptId.ToString());
+			cmd.Parameters.AddWithValue("$itemCode", (object?)item.ReceiptItemCode ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$desc", item.Description);
+			cmd.Parameters.AddWithValue("$qty", item.Quantity.ToString("G"));
+			cmd.Parameters.AddWithValue("$unitPrice", item.UnitPrice.ToString("G"));
+			cmd.Parameters.AddWithValue("$unitPriceCurrency", item.UnitPriceCurrency.ToString());
+			cmd.Parameters.AddWithValue("$totalAmt", item.TotalAmount.ToString("G"));
+			cmd.Parameters.AddWithValue("$totalAmtCurrency", item.TotalAmountCurrency.ToString());
+			cmd.Parameters.AddWithValue("$cat", item.Category);
+			cmd.Parameters.AddWithValue("$subcat", (object?)item.Subcategory ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$pricingMode", item.PricingMode.ToString());
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportTransactionsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<TransactionEntity> transactions = await source.Transactions
+			.AsNoTracking()
+			.Where(t => t.DeletedAt == null)
+			.ToListAsync(cancellationToken);
+
+		const string sql = "INSERT INTO transactions (id, receipt_id, account_id, amount, amount_currency, date) VALUES ($id, $receiptId, $accountId, $amt, $amtCurrency, $date)";
+		foreach (TransactionEntity txn in transactions)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", txn.Id.ToString());
+			cmd.Parameters.AddWithValue("$receiptId", txn.ReceiptId.ToString());
+			cmd.Parameters.AddWithValue("$accountId", txn.AccountId.ToString());
+			cmd.Parameters.AddWithValue("$amt", txn.Amount.ToString("G"));
+			cmd.Parameters.AddWithValue("$amtCurrency", txn.AmountCurrency.ToString());
+			cmd.Parameters.AddWithValue("$date", txn.Date.ToString("O"));
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportAdjustmentsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<AdjustmentEntity> adjustments = await source.Adjustments
+			.AsNoTracking()
+			.Where(a => a.DeletedAt == null)
+			.ToListAsync(cancellationToken);
+
+		const string sql = "INSERT INTO adjustments (id, receipt_id, type, amount, amount_currency, description) VALUES ($id, $receiptId, $type, $amt, $amtCurrency, $desc)";
+		foreach (AdjustmentEntity adj in adjustments)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", adj.Id.ToString());
+			cmd.Parameters.AddWithValue("$receiptId", adj.ReceiptId.ToString());
+			cmd.Parameters.AddWithValue("$type", adj.Type.ToString());
+			cmd.Parameters.AddWithValue("$amt", adj.Amount.ToString("G"));
+			cmd.Parameters.AddWithValue("$amtCurrency", adj.AmountCurrency.ToString());
+			cmd.Parameters.AddWithValue("$desc", (object?)adj.Description ?? DBNull.Value);
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task WriteMetadataAsync(SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		Dictionary<string, string> metadata = new()
+		{
+			["export_version"] = "1",
+			["exported_at"] = DateTimeOffset.UtcNow.ToString("O"),
+			["format"] = "receipts-sqlite-backup",
+		};
+
+		const string sql = "INSERT INTO backup_metadata (key, value) VALUES ($key, $value)";
+		foreach (KeyValuePair<string, string> kv in metadata)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$key", kv.Key);
+			cmd.Parameters.AddWithValue("$value", kv.Value);
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -139,6 +139,7 @@ public static class InfrastructureService
 			.AddScoped<ITrashService, TrashService>()
 			.AddScoped<IDashboardService, DashboardService>()
 			.AddScoped<IReportService, ReportService>()
+			.AddScoped<IBackupService, BackupService>()
 			.AddScoped<IImageStorageService, LocalImageStorageService>()
 			.AddScoped<IImageProcessingService, ImageProcessingService>();
 

--- a/src/Presentation/API/Controllers/BackupController.cs
+++ b/src/Presentation/API/Controllers/BackupController.cs
@@ -1,0 +1,52 @@
+using Application.Interfaces.Services;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+[ApiVersion("1.0")]
+[ApiController]
+[Route("api/backup")]
+[Authorize(Policy = "RequireAdmin")]
+public class BackupController(
+	IBackupService backupService,
+	ILogger<BackupController> logger) : ControllerBase
+{
+	[HttpPost("export")]
+	[EndpointSummary("Export database to a portable SQLite file")]
+	[EndpointDescription("Generates a SQLite database containing all domain data (accounts, categories, receipts, items, transactions, adjustments, item templates). Admin-only. Soft-deleted records are excluded.")]
+	public async Task<Results<FileStreamHttpResult, StatusCodeHttpResult>> Export(CancellationToken cancellationToken)
+	{
+		string? filePath = null;
+		try
+		{
+			filePath = await backupService.ExportToSqliteAsync(cancellationToken);
+
+			FileStream stream;
+			try
+			{
+				stream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.None,
+					bufferSize: 81920, FileOptions.DeleteOnClose | FileOptions.SequentialScan);
+			}
+			catch
+			{
+				if (System.IO.File.Exists(filePath))
+				{
+					System.IO.File.Delete(filePath);
+				}
+
+				throw;
+			}
+
+			string fileName = $"receipts-backup-{DateTime.UtcNow:yyyyMMdd-HHmmss}.db";
+			return TypedResults.Stream(stream, "application/octet-stream", fileName);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			logger.LogError(ex, "Failed to export database backup");
+			return TypedResults.StatusCode(StatusCodes.Status500InternalServerError);
+		}
+	}
+}

--- a/src/Tools/DbExporter/DbExporter.csproj
+++ b/src/Tools/DbExporter/DbExporter.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\..\Infrastructure\Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Receipts.ServiceDefaults\Receipts.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tools/DbExporter/Program.cs
+++ b/src/Tools/DbExporter/Program.cs
@@ -1,0 +1,51 @@
+using Application.Interfaces.Services;
+using Infrastructure;
+using Infrastructure.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+builder.AddServiceDefaults();
+
+if (!InfrastructureService.IsDatabaseConfigured(builder.Configuration))
+{
+	Console.Error.WriteLine("Database is not configured. Set POSTGRES_* env vars or an Aspire connection string.");
+	return 1;
+}
+
+builder.Services.RegisterInfrastructureServices(builder.Configuration);
+
+IHost host = builder.Build();
+try
+{
+	await host.StartAsync();
+
+	ILogger logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("DbExporter");
+
+	string? outputPath = args.Length > 0 ? args[0] : null;
+
+	using IServiceScope scope = host.Services.CreateScope();
+	IBackupService backupService = scope.ServiceProvider.GetRequiredService<IBackupService>();
+
+	logger.LogInformation("Exporting database to SQLite...");
+	string exportedPath = await backupService.ExportToSqliteAsync();
+
+	if (outputPath is not null)
+	{
+		File.Move(exportedPath, outputPath, overwrite: true);
+		logger.LogInformation("Backup saved to {Path}", outputPath);
+	}
+	else
+	{
+		logger.LogInformation("Backup saved to {Path}", exportedPath);
+	}
+
+	await host.StopAsync();
+	return 0;
+}
+catch (Exception ex)
+{
+	Console.Error.WriteLine($"Export failed: {ex}");
+	return 1;
+}

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",

--- a/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
+++ b/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="FluentAssertions" />

--- a/tests/Infrastructure.Tests/Services/BackupServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/BackupServiceTests.cs
@@ -1,0 +1,359 @@
+using Common;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Infrastructure.Tests.Services;
+
+public class BackupServiceTests : IDisposable
+{
+	private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
+	private readonly BackupService _service;
+	private readonly List<string> _tempFiles = [];
+
+	public BackupServiceTests()
+	{
+		DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase(databaseName: $"BackupTest_{Guid.NewGuid()}")
+			.Options;
+
+		_dbContextFactory = new TestDbContextFactory(options);
+		_service = new BackupService(_dbContextFactory, NullLogger<BackupService>.Instance);
+	}
+
+	[Fact]
+	public async Task ExportToSqliteAsync_EmptyDatabase_CreatesFileWithSchemaAndMetadata()
+	{
+		// Act
+		string path = await _service.ExportToSqliteAsync();
+		_tempFiles.Add(path);
+
+		// Assert
+		File.Exists(path).Should().BeTrue();
+
+		await using SqliteConnection conn = new($"Data Source={path}");
+		await conn.OpenAsync();
+
+		// Verify all tables exist
+		string[] expectedTables = ["backup_metadata", "accounts", "categories", "subcategories",
+			"item_templates", "receipts", "receipt_items", "transactions", "adjustments"];
+
+		foreach (string table in expectedTables)
+		{
+			await using SqliteCommand cmd = conn.CreateCommand();
+			cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name=$name";
+			cmd.Parameters.AddWithValue("$name", table);
+			object? result = await cmd.ExecuteScalarAsync();
+			result.Should().NotBeNull($"table '{table}' should exist");
+		}
+
+		// Verify metadata
+		await using SqliteCommand metaCmd = conn.CreateCommand();
+		metaCmd.CommandText = "SELECT value FROM backup_metadata WHERE key='format'";
+		string? format = (string?)await metaCmd.ExecuteScalarAsync();
+		format.Should().Be("receipts-sqlite-backup");
+
+		await using SqliteCommand versionCmd = conn.CreateCommand();
+		versionCmd.CommandText = "SELECT value FROM backup_metadata WHERE key='export_version'";
+		string? version = (string?)await versionCmd.ExecuteScalarAsync();
+		version.Should().Be("1");
+	}
+
+	[Fact]
+	public async Task ExportToSqliteAsync_WithAccounts_ExportsAllAccounts()
+	{
+		// Arrange
+		await using (ApplicationDbContext ctx = await _dbContextFactory.CreateDbContextAsync())
+		{
+			ctx.Accounts.AddRange(
+				new AccountEntity { Id = Guid.NewGuid(), AccountCode = "1000", Name = "Checking", IsActive = true },
+				new AccountEntity { Id = Guid.NewGuid(), AccountCode = "2000", Name = "Savings", IsActive = false });
+			await ctx.SaveChangesAsync();
+		}
+
+		// Act
+		string path = await _service.ExportToSqliteAsync();
+		_tempFiles.Add(path);
+
+		// Assert
+		await using SqliteConnection conn = new($"Data Source={path}");
+		await conn.OpenAsync();
+
+		await using SqliteCommand cmd = conn.CreateCommand();
+		cmd.CommandText = "SELECT COUNT(*) FROM accounts";
+		long count = (long)(await cmd.ExecuteScalarAsync())!;
+		count.Should().Be(2);
+
+		cmd.CommandText = "SELECT name FROM accounts WHERE account_code='1000'";
+		string? name = (string?)await cmd.ExecuteScalarAsync();
+		name.Should().Be("Checking");
+
+		cmd.CommandText = "SELECT is_active FROM accounts WHERE account_code='2000'";
+		long isActive = (long)(await cmd.ExecuteScalarAsync())!;
+		isActive.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task ExportToSqliteAsync_WithCategories_ExcludesSoftDeleted()
+	{
+		// Arrange
+		await using (ApplicationDbContext ctx = await _dbContextFactory.CreateDbContextAsync())
+		{
+			ctx.Categories.AddRange(
+				new CategoryEntity { Id = Guid.NewGuid(), Name = "Active", IsActive = true },
+				new CategoryEntity { Id = Guid.NewGuid(), Name = "Deleted", IsActive = true, DeletedAt = DateTimeOffset.UtcNow });
+			await ctx.SaveChangesAsync();
+		}
+
+		// Act
+		string path = await _service.ExportToSqliteAsync();
+		_tempFiles.Add(path);
+
+		// Assert
+		await using SqliteConnection conn = new($"Data Source={path}");
+		await conn.OpenAsync();
+
+		await using SqliteCommand cmd = conn.CreateCommand();
+		cmd.CommandText = "SELECT COUNT(*) FROM categories";
+		long count = (long)(await cmd.ExecuteScalarAsync())!;
+		count.Should().Be(1);
+
+		cmd.CommandText = "SELECT name FROM categories";
+		string? name = (string?)await cmd.ExecuteScalarAsync();
+		name.Should().Be("Active");
+	}
+
+	[Fact]
+	public async Task ExportToSqliteAsync_WithReceipts_ExportsReceiptData()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+
+		await using (ApplicationDbContext ctx = await _dbContextFactory.CreateDbContextAsync())
+		{
+			ctx.Accounts.Add(new AccountEntity { Id = accountId, AccountCode = "1000", Name = "Checking", IsActive = true });
+
+			ctx.Receipts.Add(new ReceiptEntity
+			{
+				Id = receiptId,
+				Location = "Test Store",
+				Date = new DateOnly(2024, 1, 15),
+				TaxAmount = 5.50m,
+				TaxAmountCurrency = Currency.USD,
+			});
+
+			ctx.ReceiptItems.Add(new ReceiptItemEntity
+			{
+				Id = Guid.NewGuid(),
+				ReceiptId = receiptId,
+				Description = "Test Item",
+				Quantity = 2,
+				UnitPrice = 10.00m,
+				UnitPriceCurrency = Currency.USD,
+				TotalAmount = 20.00m,
+				TotalAmountCurrency = Currency.USD,
+				Category = "Food",
+				PricingMode = PricingMode.Quantity,
+			});
+
+			ctx.Transactions.Add(new TransactionEntity
+			{
+				Id = Guid.NewGuid(),
+				ReceiptId = receiptId,
+				AccountId = accountId,
+				Amount = 25.50m,
+				AmountCurrency = Currency.USD,
+				Date = new DateOnly(2024, 1, 15),
+			});
+
+			ctx.Adjustments.Add(new AdjustmentEntity
+			{
+				Id = Guid.NewGuid(),
+				ReceiptId = receiptId,
+				Type = AdjustmentType.Tip,
+				Amount = 3.00m,
+				AmountCurrency = Currency.USD,
+				Description = "Tip",
+			});
+
+			await ctx.SaveChangesAsync();
+		}
+
+		// Act
+		string path = await _service.ExportToSqliteAsync();
+		_tempFiles.Add(path);
+
+		// Assert
+		await using SqliteConnection conn = new($"Data Source={path}");
+		await conn.OpenAsync();
+
+		await using SqliteCommand cmd = conn.CreateCommand();
+
+		cmd.CommandText = "SELECT COUNT(*) FROM receipts";
+		((long)(await cmd.ExecuteScalarAsync())!).Should().Be(1);
+
+		cmd.CommandText = "SELECT location FROM receipts";
+		((string?)(await cmd.ExecuteScalarAsync())).Should().Be("Test Store");
+
+		cmd.CommandText = "SELECT COUNT(*) FROM receipt_items";
+		((long)(await cmd.ExecuteScalarAsync())!).Should().Be(1);
+
+		cmd.CommandText = "SELECT description FROM receipt_items";
+		((string?)(await cmd.ExecuteScalarAsync())).Should().Be("Test Item");
+
+		cmd.CommandText = "SELECT COUNT(*) FROM transactions";
+		((long)(await cmd.ExecuteScalarAsync())!).Should().Be(1);
+
+		cmd.CommandText = "SELECT COUNT(*) FROM adjustments";
+		((long)(await cmd.ExecuteScalarAsync())!).Should().Be(1);
+
+		cmd.CommandText = "SELECT type FROM adjustments";
+		((string?)(await cmd.ExecuteScalarAsync())).Should().Be("Tip");
+	}
+
+	[Fact]
+	public async Task ExportToSqliteAsync_WithSubcategories_ExportsWithForeignKeys()
+	{
+		// Arrange
+		Guid categoryId = Guid.NewGuid();
+
+		await using (ApplicationDbContext ctx = await _dbContextFactory.CreateDbContextAsync())
+		{
+			ctx.Categories.Add(new CategoryEntity
+			{
+				Id = categoryId,
+				Name = "Groceries",
+				IsActive = true,
+			});
+			ctx.Subcategories.Add(new SubcategoryEntity
+			{
+				Id = Guid.NewGuid(),
+				Name = "Produce",
+				CategoryId = categoryId,
+				IsActive = true,
+			});
+			await ctx.SaveChangesAsync();
+		}
+
+		// Act
+		string path = await _service.ExportToSqliteAsync();
+		_tempFiles.Add(path);
+
+		// Assert
+		await using SqliteConnection conn = new($"Data Source={path}");
+		await conn.OpenAsync();
+
+		await using SqliteCommand cmd = conn.CreateCommand();
+		cmd.CommandText = "SELECT COUNT(*) FROM subcategories";
+		long count = (long)(await cmd.ExecuteScalarAsync())!;
+		count.Should().Be(1);
+
+		cmd.CommandText = "SELECT category_id FROM subcategories";
+		string? catId = (string?)await cmd.ExecuteScalarAsync();
+		catId.Should().Be(categoryId.ToString());
+	}
+
+	[Fact]
+	public async Task ExportToSqliteAsync_WithItemTemplates_ExportsTemplateData()
+	{
+		// Arrange
+		await using (ApplicationDbContext ctx = await _dbContextFactory.CreateDbContextAsync())
+		{
+			ctx.ItemTemplates.Add(new ItemTemplateEntity
+			{
+				Id = Guid.NewGuid(),
+				Name = "Milk",
+				DefaultCategory = "Groceries",
+				DefaultSubcategory = "Dairy",
+				DefaultUnitPrice = 4.99m,
+				DefaultUnitPriceCurrency = Currency.USD,
+				DefaultPricingMode = "Quantity",
+				DefaultItemCode = "MILK001",
+				Description = "Whole milk",
+			});
+			await ctx.SaveChangesAsync();
+		}
+
+		// Act
+		string path = await _service.ExportToSqliteAsync();
+		_tempFiles.Add(path);
+
+		// Assert
+		await using SqliteConnection conn = new($"Data Source={path}");
+		await conn.OpenAsync();
+
+		await using SqliteCommand cmd = conn.CreateCommand();
+		cmd.CommandText = "SELECT COUNT(*) FROM item_templates";
+		long count = (long)(await cmd.ExecuteScalarAsync())!;
+		count.Should().Be(1);
+
+		cmd.CommandText = "SELECT name FROM item_templates";
+		string? name = (string?)await cmd.ExecuteScalarAsync();
+		name.Should().Be("Milk");
+	}
+
+	[Fact]
+	public async Task CreateSchemaAsync_CreatesAllExpectedTables()
+	{
+		// Arrange
+		string path = Path.GetTempFileName();
+		_tempFiles.Add(path);
+
+		await using SqliteConnection conn = new($"Data Source={path}");
+		await conn.OpenAsync();
+
+		// Act
+		await BackupService.CreateSchemaAsync(conn, CancellationToken.None);
+
+		// Assert
+		await using SqliteCommand cmd = conn.CreateCommand();
+		cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name";
+		await using SqliteDataReader reader = await cmd.ExecuteReaderAsync();
+
+		List<string> tables = [];
+		while (await reader.ReadAsync())
+		{
+			tables.Add(reader.GetString(0));
+		}
+
+		tables.Should().Contain("backup_metadata");
+		tables.Should().Contain("accounts");
+		tables.Should().Contain("categories");
+		tables.Should().Contain("subcategories");
+		tables.Should().Contain("item_templates");
+		tables.Should().Contain("receipts");
+		tables.Should().Contain("receipt_items");
+		tables.Should().Contain("transactions");
+		tables.Should().Contain("adjustments");
+	}
+
+	public void Dispose()
+	{
+		foreach (string path in _tempFiles)
+		{
+			try
+			{
+				if (File.Exists(path))
+				{
+					File.Delete(path);
+				}
+			}
+			catch
+			{
+				// Best effort cleanup
+			}
+		}
+
+		GC.SuppressFinalize(this);
+	}
+
+	private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options) : IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => new(options);
+		public Task<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) => Task.FromResult(new ApplicationDbContext(options));
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/BackupControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/BackupControllerTests.cs
@@ -1,0 +1,94 @@
+using API.Controllers;
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Presentation.API.Tests.Controllers;
+
+public class BackupControllerTests : IDisposable
+{
+	private readonly Mock<IBackupService> _backupServiceMock;
+	private readonly Mock<ILogger<BackupController>> _loggerMock;
+	private readonly BackupController _controller;
+	private readonly List<string> _tempFiles = [];
+
+	public BackupControllerTests()
+	{
+		_backupServiceMock = new Mock<IBackupService>();
+		_loggerMock = ControllerTestHelpers.GetLoggerMock<BackupController>();
+		_controller = new BackupController(_backupServiceMock.Object, _loggerMock.Object);
+	}
+
+	[Fact]
+	public async Task Export_Success_ReturnsFileStream()
+	{
+		// Arrange
+		string tempFile = Path.GetTempFileName();
+		_tempFiles.Add(tempFile);
+		await File.WriteAllTextAsync(tempFile, "test-sqlite-content");
+
+		_backupServiceMock.Setup(s => s.ExportToSqliteAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(tempFile);
+
+		// Act
+		var result = await _controller.Export(CancellationToken.None);
+
+		// Assert
+		FileStreamHttpResult fileResult = result.Result.Should().BeOfType<FileStreamHttpResult>().Subject;
+		fileResult.ContentType.Should().Be("application/octet-stream");
+		fileResult.FileDownloadName.Should().StartWith("receipts-backup-");
+		fileResult.FileDownloadName.Should().EndWith(".db");
+	}
+
+	[Fact]
+	public async Task Export_ServiceThrows_Returns500()
+	{
+		// Arrange
+		_backupServiceMock.Setup(s => s.ExportToSqliteAsync(It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("Database error"));
+
+		// Act
+		var result = await _controller.Export(CancellationToken.None);
+
+		// Assert
+		result.Result.Should().BeOfType<StatusCodeHttpResult>()
+			.Which.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+	}
+
+	[Fact]
+	public async Task Export_CancellationRequested_PropagatesException()
+	{
+		// Arrange
+		_backupServiceMock.Setup(s => s.ExportToSqliteAsync(It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new OperationCanceledException());
+
+		// Act
+		Func<Task> act = () => _controller.Export(CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	public void Dispose()
+	{
+		foreach (string path in _tempFiles)
+		{
+			try
+			{
+				if (File.Exists(path))
+				{
+					File.Delete(path);
+				}
+			}
+			catch
+			{
+				// Best effort cleanup
+			}
+		}
+
+		GC.SuppressFinalize(this);
+	}
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/backup/export` admin-only endpoint that exports all domain data to a portable SQLite file (accounts, categories, subcategories, item templates, receipts, receipt items, transactions, adjustments). Soft-deleted records are excluded. File is streamed with auto-cleanup (`DeleteOnClose`).
- Add `DbExporter` CLI tool for command-line backups reusing the same `BackupService` infrastructure.
- Fix HTTP method mismatch: changed from `GET` to `POST` to match the already-merged Backup & Restore UI (`BackupRestore.tsx` from RECEIPTS-466).

## Details
- `IBackupService` interface in Application layer, `BackupService` implementation in Infrastructure layer
- SQLite schema with 9 tables (8 domain + metadata), parameterized inserts, transactional export with rollback on failure
- OpenAPI spec updated with `POST /api/backup/export` operation
- 10 new tests: `BackupServiceTests` (7 tests covering schema creation, entity export, soft-delete exclusion, FK relationships, item templates) + `BackupControllerTests` (3 tests covering success stream, 500 on error, cancellation propagation)

## Test plan
- [ ] All 1708 unit tests pass (verified locally)
- [ ] OpenAPI spec drift check passes
- [ ] TypeScript type-check passes
- [ ] ESLint passes
- [ ] CI pipeline passes
- [ ] Manual test: navigate to Admin > Backup & Restore, click Export, verify `.db` file downloads

Closes RECEIPTS-464

🤖 Generated with [Claude Code](https://claude.com/claude-code)