### PR TITLE
fix(infrastructure): pass AdminSeed env vars to DbSeeder in AppHost (RECEIPTS-503)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -100,6 +100,22 @@ dotnet run --project src/Presentation/API/API.csproj
 
 The API does not self-migrate or self-seed. You must run DbMigrator and DbSeeder before starting the API. Re-run DbMigrator after pulling new migrations.
 
+### Admin User Seeding
+
+The DbSeeder creates an initial admin user when `AdminSeed__Email` and `AdminSeed__Password` are set. Under **Aspire**, these are passed automatically via `AppHost.cs`. For **standalone** runs, set the environment variables manually:
+
+```bash
+export AdminSeed__Email=admin@receipts.local
+export AdminSeed__Password="Admin123!@#"
+export AdminSeed__FirstName=Admin
+export AdminSeed__LastName=User
+dotnet run --project src/Tools/DbSeeder/DbSeeder.csproj
+```
+
+If the variables are absent, the seeder logs a warning and seeds only roles (no admin user). The seed is not recorded in `__SeedHistory` when admin config is missing, so you can re-run the seeder with the correct variables later.
+
+> **Tip:** The `src/Tools/DbSeeder/appsettings.Development.json` file provides these defaults automatically when running with `DOTNET_ENVIRONMENT=Development` (the default for `dotnet run`).
+
 ## Build and Test
 
 ```bash

--- a/src/Infrastructure/Services/DatabaseSeederService.cs
+++ b/src/Infrastructure/Services/DatabaseSeederService.cs
@@ -46,6 +46,10 @@ public static class DatabaseSeederService
 
 		if (string.IsNullOrWhiteSpace(adminEmail) || string.IsNullOrWhiteSpace(adminPassword))
 		{
+			logger.LogWarning(
+				"AdminSeed configuration is missing (AdminSeed:Email and/or AdminSeed:Password not set). " +
+				"Roles were seeded but no admin user was created. " +
+				"Set AdminSeed__Email and AdminSeed__Password environment variables to seed an admin user.");
 			return;
 		}
 

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -12,10 +12,14 @@ IResourceBuilder<ProjectResource> migrator = builder.AddProject<Projects.DbMigra
 	.WithReference(db)
 	.WaitFor(db);
 
-// DbSeeder: seeds roles, then exits
+// DbSeeder: seeds roles and admin user, then exits
 IResourceBuilder<ProjectResource> seeder = builder.AddProject<Projects.DbSeeder>("db-seeder")
 	.WithReference(db)
-	.WaitForCompletion(migrator);
+	.WaitForCompletion(migrator)
+	.WithEnvironment("AdminSeed__Email", "admin@receipts.local")
+	.WithEnvironment("AdminSeed__Password", "Admin123!@#")
+	.WithEnvironment("AdminSeed__FirstName", "Admin")
+	.WithEnvironment("AdminSeed__LastName", "User");
 
 // API: starts after seeder completes
 IResourceBuilder<ProjectResource> api = builder.AddProject<Projects.API>("api")

--- a/src/Tools/DbSeeder/appsettings.Development.json
+++ b/src/Tools/DbSeeder/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+	"AdminSeed": {
+		"Email": "admin@receipts.local",
+		"Password": "Admin123!@#",
+		"FirstName": "Admin",
+		"LastName": "User"
+	}
+}

--- a/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs
@@ -377,4 +377,59 @@ public class DatabaseSeederServiceTests : IDisposable
 			.WithMessage("*Admin role*Admin role assignment failed*");
 		_mockUserManager.Verify(u => u.DeleteAsync(It.IsAny<ApplicationUser>()), Times.Never);
 	}
+
+	[Fact]
+	public async Task SeedRolesAndAdminAsync_WhenAdminConfigMissing_LogsWarningAndDoesNotRecordSeedHistory()
+	{
+		// Arrange — build a service provider with no admin seed config
+		IConfiguration emptyAdminConfig = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>())
+			.Build();
+
+		Mock<IRoleStore<IdentityRole>> roleStore = new();
+		Mock<RoleManager<IdentityRole>> roleManager = new(roleStore.Object, null!, null!, null!, null!);
+		roleManager.Setup(r => r.RoleExistsAsync(It.IsAny<string>())).ReturnsAsync(true);
+
+		Mock<IUserStore<ApplicationUser>> userStore = new();
+		Mock<UserManager<ApplicationUser>> userManager = new(userStore.Object, null!, null!, null!, null!, null!, null!, null!, null!);
+
+		Mock<ILogger> mockLogger = new();
+		Mock<ILoggerFactory> mockLoggerFactory = new();
+		mockLoggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(mockLogger.Object);
+
+		DbContextOptions<ApplicationDbContext> dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+
+		ServiceCollection services = new();
+		services.AddSingleton(roleManager.Object);
+		services.AddSingleton(userManager.Object);
+		services.AddSingleton<IConfiguration>(emptyAdminConfig);
+		services.AddSingleton<ILoggerFactory>(mockLoggerFactory.Object);
+		services.AddScoped(_ => new ApplicationDbContext(dbOptions));
+
+		using ServiceProvider sp = services.BuildServiceProvider();
+
+		// Act
+		await DatabaseSeederService.SeedRolesAndAdminAsync(sp);
+
+		// Assert — warning was logged
+		mockLogger.Verify(
+			l => l.Log(
+				LogLevel.Warning,
+				It.IsAny<EventId>(),
+				It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("AdminSeed configuration is missing")),
+				null,
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			Times.Once);
+
+		// Assert — seed history was NOT recorded (so a retry with config will work)
+		await using ApplicationDbContext db = new(dbOptions);
+		bool recorded = await db.SeedHistory.AnyAsync(s => s.SeedId == "RolesAndAdmin_v1");
+		recorded.Should().BeFalse();
+
+		// Assert — no user operations attempted
+		userManager.Verify(u => u.FindByEmailAsync(It.IsAny<string>()), Times.Never);
+		userManager.Verify(u => u.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
+	}
 }


### PR DESCRIPTION
## Summary
- Add `.WithEnvironment()` calls for all four `AdminSeed__*` env vars to the DbSeeder resource in `AppHost.cs`, so fresh Aspire starts seed the admin user automatically
- Add `LogWarning` in `DatabaseSeederService` when admin config is missing (previously a silent return)
- Create `src/Tools/DbSeeder/appsettings.Development.json` with AdminSeed defaults for standalone runs
- Document admin user seeding in `docs/development.md`

## Problem
On a fresh database (or after Docker volume reset), `aspire run` would seed only roles but not the admin user because `AdminSeed__*` env vars were not passed from AppHost to the DbSeeder project. Login would fail silently with no admin account available.

## Changes
| File | Change |
|------|--------|
| `src/Receipts.AppHost/AppHost.cs` | Add 4 `.WithEnvironment()` calls for AdminSeed config |
| `src/Infrastructure/Services/DatabaseSeederService.cs` | Add `LogWarning` when admin config is absent |
| `src/Tools/DbSeeder/appsettings.Development.json` | New file with AdminSeed defaults for standalone runs |
| `docs/development.md` | Add "Admin User Seeding" documentation section |
| `tests/Infrastructure.Tests/Services/DatabaseSeederServiceTests.cs` | Add test for warning log + no seed history when config missing |

## Audit
Reviewed all Aspire-managed projects for similar config gaps:
- **DbMigrator:** Only needs DB connection — no gap
- **DbExporter:** Only needs DB connection, not in AppHost — no gap
- **API:** Has own `appsettings.Development.json` — no gap

## Test plan
- [x] New test `SeedRolesAndAdminAsync_WhenAdminConfigMissing_LogsWarningAndDoesNotRecordSeedHistory` passes
- [x] All 433 unit tests pass
- [x] Build succeeds with 0 errors
- [ ] Manual: run `aspire run` with fresh DB volume and verify admin user is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)