### PR TITLE
feat(client): add bulk YNAB sync UI (RECEIPTS-492)

### DIFF
--- a/src/client/src/components/YnabBulkSyncCard.test.tsx
+++ b/src/client/src/components/YnabBulkSyncCard.test.tsx
@@ -1,0 +1,250 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
+import { YnabBulkSyncCard } from "./YnabBulkSyncCard";
+
+const mockBulkPushMutate = vi.fn();
+const mockBulkMemoSyncMutate = vi.fn();
+
+vi.mock("@/hooks/useYnab", () => ({
+  useAllReceiptIds: vi.fn(() =>
+    mockQueryResult({
+      receiptIds: ["r1", "r2", "r3"],
+      totalReceipts: 3,
+      isLoading: false,
+    }),
+  ),
+  useBulkPushYnabTransactions: vi.fn(() =>
+    mockMutationResult({ mutate: mockBulkPushMutate }),
+  ),
+  useSyncYnabMemosBulk: vi.fn(() =>
+    mockMutationResult({ mutate: mockBulkMemoSyncMutate }),
+  ),
+  useMemoSyncSummary: vi.fn(() => null),
+}));
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  // Reset mock return values to defaults to avoid leaks between tests
+  const ynab = await import("@/hooks/useYnab");
+  vi.mocked(ynab.useAllReceiptIds).mockReturnValue(
+    mockQueryResult({
+      receiptIds: ["r1", "r2", "r3"],
+      totalReceipts: 3,
+      isLoading: false,
+    }),
+  );
+  vi.mocked(ynab.useBulkPushYnabTransactions).mockReturnValue(
+    mockMutationResult({ mutate: mockBulkPushMutate }),
+  );
+  vi.mocked(ynab.useSyncYnabMemosBulk).mockReturnValue(
+    mockMutationResult({ mutate: mockBulkMemoSyncMutate }),
+  );
+  vi.mocked(ynab.useMemoSyncSummary).mockReturnValue(null);
+});
+
+describe("YnabBulkSyncCard", () => {
+  it("renders the card with title and description", () => {
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(screen.getByText("Bulk YNAB Sync")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Push all receipts to YNAB or sync all transaction memos/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows receipt count in description", () => {
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(screen.getByText("(3 receipts)")).toBeInTheDocument();
+  });
+
+  it("renders both action buttons", () => {
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(
+      screen.getByRole("button", { name: "Push All to YNAB" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sync All Memos" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls bulkPush with all receipt IDs when push button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    await user.click(screen.getByRole("button", { name: "Push All to YNAB" }));
+
+    expect(mockBulkPushMutate).toHaveBeenCalledWith(["r1", "r2", "r3"]);
+  });
+
+  it("calls bulkMemoSync with all receipt IDs when memo sync button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    await user.click(screen.getByRole("button", { name: "Sync All Memos" }));
+
+    expect(mockBulkMemoSyncMutate).toHaveBeenCalledWith(
+      ["r1", "r2", "r3"],
+      expect.any(Object),
+    );
+  });
+
+  it("disables buttons when no receipts exist", async () => {
+    const { useAllReceiptIds } = await import("@/hooks/useYnab");
+    vi.mocked(useAllReceiptIds).mockReturnValue(
+      mockQueryResult({
+        receiptIds: [],
+        totalReceipts: 0,
+        isLoading: false,
+      }),
+    );
+
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(
+      screen.getByRole("button", { name: "Push All to YNAB" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Sync All Memos" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText("No receipts found. Create some receipts first."),
+    ).toBeInTheDocument();
+  });
+
+  it("disables buttons while receipts are loading", async () => {
+    const { useAllReceiptIds } = await import("@/hooks/useYnab");
+    vi.mocked(useAllReceiptIds).mockReturnValue(
+      mockQueryResult({
+        receiptIds: [],
+        totalReceipts: 0,
+        isLoading: true,
+      }),
+    );
+
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(
+      screen.getByRole("button", { name: "Push All to YNAB" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Sync All Memos" }),
+    ).toBeDisabled();
+  });
+
+  it("disables buttons while push is pending", async () => {
+    const { useBulkPushYnabTransactions } = await import("@/hooks/useYnab");
+    vi.mocked(useBulkPushYnabTransactions).mockReturnValue(
+      mockMutationResult({ isPending: true, mutate: mockBulkPushMutate }),
+    );
+
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(
+      screen.getByRole("button", { name: /Pushing to YNAB/ }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Sync All Memos" }),
+    ).toBeDisabled();
+  });
+
+  it("disables buttons while memo sync is pending", async () => {
+    const { useBulkPushYnabTransactions, useSyncYnabMemosBulk } =
+      await import("@/hooks/useYnab");
+    vi.mocked(useBulkPushYnabTransactions).mockReturnValue(
+      mockMutationResult({ mutate: mockBulkPushMutate }),
+    );
+    vi.mocked(useSyncYnabMemosBulk).mockReturnValue(
+      mockMutationResult({ isPending: true, mutate: mockBulkMemoSyncMutate }),
+    );
+
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(
+      screen.getByRole("button", { name: "Push All to YNAB" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /Syncing Memos/ }),
+    ).toBeDisabled();
+  });
+
+  it("shows push result badges after successful push", async () => {
+    const { useBulkPushYnabTransactions } = await import("@/hooks/useYnab");
+    vi.mocked(useBulkPushYnabTransactions).mockReturnValue(
+      mockMutationResult({
+        mutate: mockBulkPushMutate,
+        data: {
+          results: [
+            { receiptId: "r1", result: { success: true, pushedTransactions: [], error: null } },
+            { receiptId: "r2", result: { success: true, pushedTransactions: [], error: null } },
+            { receiptId: "r3", result: { success: false, pushedTransactions: [], error: "Unmapped categories" } },
+          ],
+        },
+      }),
+    );
+
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(screen.getByText("2 succeeded")).toBeInTheDocument();
+    expect(screen.getByText("1 failed")).toBeInTheDocument();
+  });
+
+  it("shows memo sync summary badges", async () => {
+    const { useBulkPushYnabTransactions, useMemoSyncSummary } =
+      await import("@/hooks/useYnab");
+    vi.mocked(useBulkPushYnabTransactions).mockReturnValue(
+      mockMutationResult({ mutate: mockBulkPushMutate }),
+    );
+    vi.mocked(useMemoSyncSummary).mockReturnValue({
+      synced: 5,
+      alreadySynced: 2,
+      noMatch: 1,
+      ambiguous: 0,
+      currencySkipped: 0,
+      failed: 1,
+      total: 9,
+    });
+
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(screen.getByText("5 synced")).toBeInTheDocument();
+    expect(screen.getByText("2 already synced")).toBeInTheDocument();
+    expect(screen.getByText("1 no match")).toBeInTheDocument();
+    expect(screen.getByText("1 failed")).toBeInTheDocument();
+  });
+
+  it("shows error alert when push fails", async () => {
+    const { useBulkPushYnabTransactions } = await import("@/hooks/useYnab");
+    vi.mocked(useBulkPushYnabTransactions).mockReturnValue(
+      mockMutationResult({
+        mutate: mockBulkPushMutate,
+        isError: true,
+      }),
+    );
+
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(
+      screen.getByText("Failed to push transactions to YNAB. Please try again."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error alert when memo sync fails", async () => {
+    const { useSyncYnabMemosBulk } = await import("@/hooks/useYnab");
+    vi.mocked(useSyncYnabMemosBulk).mockReturnValue(
+      mockMutationResult({
+        mutate: mockBulkMemoSyncMutate,
+        isError: true,
+      }),
+    );
+
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(
+      screen.getByText("Failed to sync memos to YNAB. Please try again."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/YnabBulkSyncCard.test.tsx
+++ b/src/client/src/components/YnabBulkSyncCard.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/hooks/useYnab", () => ({
     mockQueryResult({
       receiptIds: ["r1", "r2", "r3"],
       totalReceipts: 3,
+      isTruncated: false,
       isLoading: false,
     }),
   ),
@@ -32,6 +33,7 @@ beforeEach(async () => {
     mockQueryResult({
       receiptIds: ["r1", "r2", "r3"],
       totalReceipts: 3,
+      isTruncated: false,
       isLoading: false,
     }),
   );
@@ -98,6 +100,7 @@ describe("YnabBulkSyncCard", () => {
       mockQueryResult({
         receiptIds: [],
         totalReceipts: 0,
+        isTruncated: false,
         isLoading: false,
       }),
     );
@@ -121,6 +124,7 @@ describe("YnabBulkSyncCard", () => {
       mockQueryResult({
         receiptIds: [],
         totalReceipts: 0,
+        isTruncated: false,
         isLoading: true,
       }),
     );
@@ -246,5 +250,59 @@ describe("YnabBulkSyncCard", () => {
     expect(
       screen.getByText("Failed to sync memos to YNAB. Please try again."),
     ).toBeInTheDocument();
+  });
+
+  it("clears stale memo badges when re-syncing", async () => {
+    const user = userEvent.setup();
+    const { useMemoSyncSummary } = await import("@/hooks/useYnab");
+    vi.mocked(useMemoSyncSummary).mockReturnValue({
+      synced: 3,
+      alreadySynced: 0,
+      noMatch: 0,
+      ambiguous: 0,
+      currencySkipped: 0,
+      failed: 0,
+      total: 3,
+    });
+
+    renderWithProviders(<YnabBulkSyncCard />);
+    expect(screen.getByText("3 synced")).toBeInTheDocument();
+
+    // useMemoSyncSummary receives undefined when results are cleared
+    vi.mocked(useMemoSyncSummary).mockReturnValue(null);
+
+    await user.click(screen.getByRole("button", { name: "Sync All Memos" }));
+
+    // The mutate call's first arg should be receiptIds; the callback arg is second
+    expect(mockBulkMemoSyncMutate).toHaveBeenCalledWith(
+      ["r1", "r2", "r3"],
+      expect.any(Object),
+    );
+  });
+
+  it("shows truncation warning when receipt IDs are truncated", async () => {
+    const { useAllReceiptIds } = await import("@/hooks/useYnab");
+    vi.mocked(useAllReceiptIds).mockReturnValue(
+      mockQueryResult({
+        receiptIds: Array.from({ length: 500 }, (_, i) => `r${i}`),
+        totalReceipts: 750,
+        isTruncated: true,
+        isLoading: false,
+      }),
+    );
+
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(
+      screen.getByText(/Only 500 of 750 receipts could be loaded/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show truncation warning when all receipts loaded", () => {
+    renderWithProviders(<YnabBulkSyncCard />);
+
+    expect(
+      screen.queryByText(/receipts could be loaded/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/client/src/components/YnabBulkSyncCard.tsx
+++ b/src/client/src/components/YnabBulkSyncCard.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+import {
+  useAllReceiptIds,
+  useBulkPushYnabTransactions,
+  useSyncYnabMemosBulk,
+  useMemoSyncSummary,
+  type YnabMemoSyncResult,
+} from "@/hooks/useYnab";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Spinner } from "@/components/ui/spinner";
+
+export function YnabBulkSyncCard() {
+  const { receiptIds, totalReceipts, isLoading: receiptsLoading } =
+    useAllReceiptIds();
+  const bulkPush = useBulkPushYnabTransactions();
+  const bulkMemoSync = useSyncYnabMemosBulk();
+  const [memoResults, setMemoResults] = useState<
+    YnabMemoSyncResult[] | undefined
+  >();
+  const memoSummary = useMemoSyncSummary(memoResults);
+
+  const noReceipts = totalReceipts === 0 && !receiptsLoading;
+  const isBusy = bulkPush.isPending || bulkMemoSync.isPending;
+
+  function handleBulkPush() {
+    bulkPush.mutate(receiptIds);
+  }
+
+  function handleBulkMemoSync() {
+    bulkMemoSync.mutate(receiptIds, {
+      onSuccess: (data) => {
+        setMemoResults(data?.results as YnabMemoSyncResult[] | undefined);
+      },
+    });
+  }
+
+  const pushData = bulkPush.data;
+  const pushSucceeded =
+    pushData?.results?.filter((r) => r.result.success).length ?? 0;
+  const pushFailed =
+    pushData?.results?.filter((r) => !r.result.success).length ?? 0;
+  const pushTotal = pushData?.results?.length ?? 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Bulk YNAB Sync</CardTitle>
+        <CardDescription>
+          Push all receipts to YNAB or sync all transaction memos at once.
+          {totalReceipts > 0 && !receiptsLoading && (
+            <span className="ml-1">({totalReceipts} receipts)</span>
+          )}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Push All to YNAB */}
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="outline"
+              onClick={handleBulkPush}
+              disabled={isBusy || noReceipts || receiptsLoading}
+            >
+              {bulkPush.isPending ? (
+                <>
+                  <Spinner className="mr-2 h-3 w-3" />
+                  Pushing to YNAB...
+                </>
+              ) : (
+                "Push All to YNAB"
+              )}
+            </Button>
+
+            {pushData && pushTotal > 0 && (
+              <div className="flex gap-2">
+                {pushSucceeded > 0 && (
+                  <Badge
+                    variant="outline"
+                    className="border-green-300 text-green-600"
+                  >
+                    {pushSucceeded} succeeded
+                  </Badge>
+                )}
+                {pushFailed > 0 && (
+                  <Badge
+                    variant="outline"
+                    className="border-destructive/50 text-destructive"
+                  >
+                    {pushFailed} failed
+                  </Badge>
+                )}
+              </div>
+            )}
+          </div>
+
+          {pushData &&
+            pushData.results
+              ?.filter((r) => !r.result.success && r.result.error)
+              .map((r) => (
+                <Alert key={r.receiptId} variant="destructive">
+                  <AlertDescription>
+                    Receipt {r.receiptId.slice(0, 8)}...: {r.result.error}
+                  </AlertDescription>
+                </Alert>
+              ))}
+        </div>
+
+        {/* Sync All Memos */}
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="outline"
+              onClick={handleBulkMemoSync}
+              disabled={isBusy || noReceipts || receiptsLoading}
+            >
+              {bulkMemoSync.isPending ? (
+                <>
+                  <Spinner className="mr-2 h-3 w-3" />
+                  Syncing Memos...
+                </>
+              ) : (
+                "Sync All Memos"
+              )}
+            </Button>
+
+            {memoSummary && (
+              <div className="flex flex-wrap gap-2">
+                {memoSummary.synced > 0 && (
+                  <Badge variant="default">{memoSummary.synced} synced</Badge>
+                )}
+                {memoSummary.alreadySynced > 0 && (
+                  <Badge variant="secondary">
+                    {memoSummary.alreadySynced} already synced
+                  </Badge>
+                )}
+                {memoSummary.noMatch > 0 && (
+                  <Badge variant="secondary">
+                    {memoSummary.noMatch} no match
+                  </Badge>
+                )}
+                {memoSummary.ambiguous > 0 && (
+                  <Badge variant="outline">
+                    {memoSummary.ambiguous} ambiguous
+                  </Badge>
+                )}
+                {memoSummary.failed > 0 && (
+                  <Badge variant="destructive">
+                    {memoSummary.failed} failed
+                  </Badge>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {bulkPush.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Failed to push transactions to YNAB. Please try again.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {bulkMemoSync.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Failed to sync memos to YNAB. Please try again.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {noReceipts && (
+          <p className="text-sm text-muted-foreground">
+            No receipts found. Create some receipts first.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/client/src/components/YnabBulkSyncCard.tsx
+++ b/src/client/src/components/YnabBulkSyncCard.tsx
@@ -19,7 +19,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Spinner } from "@/components/ui/spinner";
 
 export function YnabBulkSyncCard() {
-  const { receiptIds, totalReceipts, isLoading: receiptsLoading } =
+  const { receiptIds, totalReceipts, isTruncated, isLoading: receiptsLoading } =
     useAllReceiptIds();
   const bulkPush = useBulkPushYnabTransactions();
   const bulkMemoSync = useSyncYnabMemosBulk();
@@ -36,6 +36,7 @@ export function YnabBulkSyncCard() {
   }
 
   function handleBulkMemoSync() {
+    setMemoResults(undefined);
     bulkMemoSync.mutate(receiptIds, {
       onSuccess: (data) => {
         setMemoResults(data?.results as YnabMemoSyncResult[] | undefined);
@@ -174,6 +175,16 @@ export function YnabBulkSyncCard() {
           <Alert variant="destructive">
             <AlertDescription>
               Failed to sync memos to YNAB. Please try again.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {isTruncated && (
+          <Alert>
+            <AlertDescription>
+              Only {receiptIds.length.toLocaleString()} of{" "}
+              {totalReceipts.toLocaleString()} receipts could be loaded. Some
+              receipts will not be included in the bulk sync.
             </AlertDescription>
           </Alert>
         )}

--- a/src/client/src/hooks/useYnab.test.ts
+++ b/src/client/src/hooks/useYnab.test.ts
@@ -40,6 +40,7 @@ import {
   useMemoSyncSummary,
   usePushYnabTransactions,
   useBulkPushYnabTransactions,
+  useAllReceiptIds,
 } from "./useYnab";
 
 function createWrapper() {
@@ -691,5 +692,51 @@ describe("useYnab", () => {
     expect(toast.success).toHaveBeenCalledWith(
       "Pushed 1/2 receipt(s) to YNAB",
     );
+  });
+
+  it("useAllReceiptIds returns receipt IDs on success", async () => {
+    const receipts = [
+      { id: "r1", location: "Store A", date: "2024-01-01", taxAmount: 5 },
+      { id: "r2", location: "Store B", date: "2024-01-02", taxAmount: 3 },
+    ];
+    (client.GET as Mock).mockResolvedValue({
+      data: { data: receipts, total: 2, offset: 0, limit: 10000 },
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useAllReceiptIds(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.receiptIds).toEqual(["r1", "r2"]);
+    expect(result.current.totalReceipts).toBe(2);
+    expect(client.GET).toHaveBeenCalledWith("/api/receipts", {
+      params: { query: { offset: 0, limit: 10000 } },
+    });
+  });
+
+  it("useAllReceiptIds returns empty array when data is undefined", async () => {
+    (client.GET as Mock).mockResolvedValue({
+      data: undefined,
+      error: "Server error",
+    });
+
+    const { result } = renderHook(() => useAllReceiptIds(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.receiptIds).toEqual([]);
+    expect(result.current.totalReceipts).toBe(0);
+  });
+
+  it("useAllReceiptIds respects enabled flag", () => {
+    const { result } = renderHook(() => useAllReceiptIds(false), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.receiptIds).toEqual([]);
+    expect(client.GET).not.toHaveBeenCalled();
   });
 });

--- a/src/client/src/hooks/useYnab.test.ts
+++ b/src/client/src/hooks/useYnab.test.ts
@@ -694,13 +694,13 @@ describe("useYnab", () => {
     );
   });
 
-  it("useAllReceiptIds returns receipt IDs on success", async () => {
+  it("useAllReceiptIds returns receipt IDs from a single page", async () => {
     const receipts = [
       { id: "r1", location: "Store A", date: "2024-01-01", taxAmount: 5 },
       { id: "r2", location: "Store B", date: "2024-01-02", taxAmount: 3 },
     ];
     (client.GET as Mock).mockResolvedValue({
-      data: { data: receipts, total: 2, offset: 0, limit: 10000 },
+      data: { data: receipts, total: 2, offset: 0, limit: 500 },
       error: undefined,
     });
 
@@ -711,8 +711,48 @@ describe("useYnab", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.receiptIds).toEqual(["r1", "r2"]);
     expect(result.current.totalReceipts).toBe(2);
+    expect(result.current.isTruncated).toBe(false);
     expect(client.GET).toHaveBeenCalledWith("/api/receipts", {
-      params: { query: { offset: 0, limit: 10000 } },
+      params: { query: { offset: 0, limit: 500 } },
+    });
+  });
+
+  it("useAllReceiptIds paginates through multiple pages", async () => {
+    const page1 = Array.from({ length: 500 }, (_, i) => ({
+      id: `r${i}`,
+      location: "Store",
+      date: "2024-01-01",
+      taxAmount: 0,
+    }));
+    const page2 = [
+      { id: "r500", location: "Store", date: "2024-01-01", taxAmount: 0 },
+      { id: "r501", location: "Store", date: "2024-01-01", taxAmount: 0 },
+    ];
+
+    (client.GET as Mock)
+      .mockResolvedValueOnce({
+        data: { data: page1, total: 502, offset: 0, limit: 500 },
+        error: undefined,
+      })
+      .mockResolvedValueOnce({
+        data: { data: page2, total: 502, offset: 500, limit: 500 },
+        error: undefined,
+      });
+
+    const { result } = renderHook(() => useAllReceiptIds(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.receiptIds).toHaveLength(502);
+    expect(result.current.totalReceipts).toBe(502);
+    expect(result.current.isTruncated).toBe(false);
+    expect(client.GET).toHaveBeenCalledTimes(2);
+    expect(client.GET).toHaveBeenCalledWith("/api/receipts", {
+      params: { query: { offset: 0, limit: 500 } },
+    });
+    expect(client.GET).toHaveBeenCalledWith("/api/receipts", {
+      params: { query: { offset: 500, limit: 500 } },
     });
   });
 
@@ -729,6 +769,7 @@ describe("useYnab", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.receiptIds).toEqual([]);
     expect(result.current.totalReceipts).toBe(0);
+    expect(result.current.isTruncated).toBe(false);
   });
 
   it("useAllReceiptIds respects enabled flag", () => {
@@ -737,6 +778,7 @@ describe("useYnab", () => {
     });
 
     expect(result.current.receiptIds).toEqual([]);
+    expect(result.current.isTruncated).toBe(false);
     expect(client.GET).not.toHaveBeenCalled();
   });
 });

--- a/src/client/src/hooks/useYnab.ts
+++ b/src/client/src/hooks/useYnab.ts
@@ -469,23 +469,48 @@ export function useBulkPushYnabTransactions() {
   });
 }
 
+const ALL_RECEIPTS_PAGE_SIZE = 500;
+
+async function fetchAllReceiptIds(): Promise<{
+  ids: string[];
+  total: number;
+}> {
+  const ids: string[] = [];
+  let offset = 0;
+  let total = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    const { data, error } = await client.GET("/api/receipts", {
+      params: { query: { offset, limit: ALL_RECEIPTS_PAGE_SIZE } },
+    });
+    if (error) throw error;
+    total = data?.total ?? 0;
+    const page = data?.data ?? [];
+    for (const r of page) {
+      if (r.id) ids.push(r.id);
+    }
+    if (page.length < ALL_RECEIPTS_PAGE_SIZE || ids.length >= total) {
+      break;
+    }
+    offset += ALL_RECEIPTS_PAGE_SIZE;
+  }
+
+  return { ids, total };
+}
+
 export function useAllReceiptIds(enabled = true) {
   const query = useQuery({
     queryKey: ["receipts", "all-ids"],
-    queryFn: async () => {
-      const { data, error } = await client.GET("/api/receipts", {
-        params: { query: { offset: 0, limit: 10000 } },
-      });
-      if (error) throw error;
-      return data;
-    },
+    queryFn: fetchAllReceiptIds,
     enabled,
   });
   return useMemo(
     () => ({
       ...query,
-      receiptIds: query.data?.data?.map((r) => r.id).filter(Boolean) as string[] ?? [],
+      receiptIds: query.data?.ids ?? [],
       totalReceipts: query.data?.total ?? 0,
+      isTruncated: (query.data?.total ?? 0) > (query.data?.ids.length ?? 0),
     }),
     [query],
   );

--- a/src/client/src/hooks/useYnab.ts
+++ b/src/client/src/hooks/useYnab.ts
@@ -469,6 +469,28 @@ export function useBulkPushYnabTransactions() {
   });
 }
 
+export function useAllReceiptIds(enabled = true) {
+  const query = useQuery({
+    queryKey: ["receipts", "all-ids"],
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/receipts", {
+        params: { query: { offset: 0, limit: 10000 } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    enabled,
+  });
+  return useMemo(
+    () => ({
+      ...query,
+      receiptIds: query.data?.data?.map((r) => r.id).filter(Boolean) as string[] ?? [],
+      totalReceipts: query.data?.total ?? 0,
+    }),
+    [query],
+  );
+}
+
 export function useYnabSyncStatus(transactionId: string | null) {
   return useQuery({
     queryKey: ["ynab", "sync-status", transactionId],

--- a/src/client/src/pages/settings/YnabSettings.test.tsx
+++ b/src/client/src/pages/settings/YnabSettings.test.tsx
@@ -47,6 +47,10 @@ vi.mock("@/hooks/useYnab", () => ({
   useDeleteYnabCategoryMapping: vi.fn(() => mockMutationResult()),
 }));
 
+vi.mock("@/components/YnabBulkSyncCard", () => ({
+  YnabBulkSyncCard: () => <div data-testid="ynab-bulk-sync-card">Bulk YNAB Sync</div>,
+}));
+
 describe("YnabSettings – Category Mapping", () => {
   it("shows 'Configure YNAB to map categories.' when notConfigured is true", async () => {
     const { useYnabBudgets } = await import("@/hooks/useYnab");
@@ -133,6 +137,49 @@ describe("YnabSettings – Category Mapping", () => {
         "No receipt item categories found. Create some receipts first.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("shows bulk sync card when YNAB is configured and budget is selected", async () => {
+    const { useYnabBudgets, useSelectedYnabBudget } = await import(
+      "@/hooks/useYnab"
+    );
+    vi.mocked(useYnabBudgets).mockReturnValue(
+      mockQueryResult({ budgets: [{ id: "b1", name: "Budget" }], isLoading: false, isError: false }),
+    );
+    vi.mocked(useSelectedYnabBudget).mockReturnValue(
+      mockQueryResult({ selectedBudgetId: "b1", isLoading: false }),
+    );
+
+    renderWithProviders(<YnabSettings />);
+
+    expect(screen.getByTestId("ynab-bulk-sync-card")).toBeInTheDocument();
+  });
+
+  it("hides bulk sync card when YNAB is not configured", async () => {
+    const { useYnabBudgets } = await import("@/hooks/useYnab");
+    vi.mocked(useYnabBudgets).mockReturnValue(
+      mockQueryResult({ budgets: [], isLoading: false, isError: true }),
+    );
+
+    renderWithProviders(<YnabSettings />);
+
+    expect(screen.queryByTestId("ynab-bulk-sync-card")).not.toBeInTheDocument();
+  });
+
+  it("hides bulk sync card when no budget is selected", async () => {
+    const { useYnabBudgets, useSelectedYnabBudget } = await import(
+      "@/hooks/useYnab"
+    );
+    vi.mocked(useYnabBudgets).mockReturnValue(
+      mockQueryResult({ budgets: [{ id: "b1", name: "Budget" }], isLoading: false, isError: false }),
+    );
+    vi.mocked(useSelectedYnabBudget).mockReturnValue(
+      mockQueryResult({ selectedBudgetId: null, isLoading: false }),
+    );
+
+    renderWithProviders(<YnabSettings />);
+
+    expect(screen.queryByTestId("ynab-bulk-sync-card")).not.toBeInTheDocument();
   });
 
   it("renders mapping rows when fully configured with categories", async () => {

--- a/src/client/src/pages/settings/YnabSettings.tsx
+++ b/src/client/src/pages/settings/YnabSettings.tsx
@@ -18,6 +18,7 @@ import {
   useUpdateYnabCategoryMapping,
   useDeleteYnabCategoryMapping,
 } from "@/hooks/useYnab";
+import { YnabBulkSyncCard } from "@/components/YnabBulkSyncCard";
 import {
   Card,
   CardContent,
@@ -398,6 +399,8 @@ export default function YnabSettings() {
           )}
         </CardContent>
       </Card>
+
+      {!notConfigured && selectedBudgetId && <YnabBulkSyncCard />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a **Bulk YNAB Sync** card to the YNAB Settings page with two actions: "Push All to YNAB" (bulk transaction push) and "Sync All Memos" (bulk memo sync)
- Card shows loading spinners during operations and displays success/failure result summaries
- Card only visible when YNAB is configured and a budget is selected

## Changes
- `src/client/src/hooks/useYnab.ts` — New `useAllReceiptIds` hook
- `src/client/src/components/YnabBulkSyncCard.tsx` — New bulk sync card component
- `src/client/src/pages/settings/YnabSettings.tsx` — Integrated bulk sync card
- 19 new tests across 3 test files (59 total passing)

## Test plan
- [x] `useAllReceiptIds` hook tests (success, error, enabled flag)
- [x] `YnabBulkSyncCard` component tests (render, click handlers, loading/disabled states, results, errors)
- [x] `YnabSettings` integration tests (card visibility conditions)
- [x] TypeScript type-check passes
- [x] All 59 tests pass

Generated with [Claude Code](https://claude.com/claude-code)