### PR TITLE
feat(api): add YNAB delta sync (RECEIPTS-495)

### DIFF
--- a/src/Application/Interfaces/Services/IYnabApiClient.cs
+++ b/src/Application/Interfaces/Services/IYnabApiClient.cs
@@ -9,7 +9,7 @@ public interface IYnabApiClient
 	Task<List<YnabCategory>> GetCategoriesAsync(string budgetId, CancellationToken cancellationToken);
 	Task<YnabTransaction?> GetTransactionAsync(string budgetId, string transactionId, CancellationToken cancellationToken);
 	Task<YnabCreateTransactionResponse> CreateTransactionAsync(string budgetId, YnabCreateTransactionRequest request, CancellationToken cancellationToken);
-	Task<List<YnabTransaction>> GetTransactionsByDateAsync(string budgetId, DateOnly sinceDate, CancellationToken cancellationToken);
+	Task<YnabTransactionsResult> GetTransactionsByDateAsync(string budgetId, DateOnly sinceDate, long? lastKnowledgeOfServer = null, CancellationToken cancellationToken = default);
 	Task UpdateTransactionMemoAsync(string budgetId, string transactionId, string memo, CancellationToken cancellationToken);
 	bool IsConfigured { get; }
 }

--- a/src/Application/Models/Ynab/YnabTransactionsResult.cs
+++ b/src/Application/Models/Ynab/YnabTransactionsResult.cs
@@ -1,0 +1,3 @@
+namespace Application.Models.Ynab;
+
+public record YnabTransactionsResult(List<YnabTransaction> Transactions, long ServerKnowledge);

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -51,6 +51,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 	public virtual DbSet<YnabSelectedBudgetEntity> YnabSelectedBudgets { get; set; } = null!;
 	public virtual DbSet<YnabAccountMappingEntity> YnabAccountMappings { get; set; } = null!;
 	public virtual DbSet<YnabCategoryMappingEntity> YnabCategoryMappings { get; set; } = null!;
+	public virtual DbSet<YnabServerKnowledgeEntity> YnabServerKnowledge { get; set; } = null!;
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
@@ -202,7 +203,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
 	private List<AuditEntry> CollectAuditEntries()
 	{
-		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity), typeof(SeedHistoryEntry), typeof(YnabSyncRecordEntity), typeof(YnabSelectedBudgetEntity), typeof(YnabAccountMappingEntity), typeof(YnabCategoryMappingEntity)];
+		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity), typeof(SeedHistoryEntry), typeof(YnabSyncRecordEntity), typeof(YnabSelectedBudgetEntity), typeof(YnabAccountMappingEntity), typeof(YnabCategoryMappingEntity), typeof(YnabServerKnowledgeEntity)];
 		List<AuditEntry> auditEntries = [];
 		DateTimeOffset now = DateTimeOffset.UtcNow;
 

--- a/src/Infrastructure/Configurations/YnabServerKnowledgeEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/YnabServerKnowledgeEntityConfiguration.cs
@@ -1,0 +1,16 @@
+using Infrastructure.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Configurations;
+
+public class YnabServerKnowledgeEntityConfiguration : IEntityTypeConfiguration<YnabServerKnowledgeEntity>
+{
+	public void Configure(EntityTypeBuilder<YnabServerKnowledgeEntity> builder)
+	{
+		builder.HasKey(e => e.BudgetId);
+
+		builder.Property(e => e.BudgetId)
+			.HasMaxLength(36);
+	}
+}

--- a/src/Infrastructure/Entities/Core/YnabServerKnowledgeEntity.cs
+++ b/src/Infrastructure/Entities/Core/YnabServerKnowledgeEntity.cs
@@ -1,0 +1,8 @@
+namespace Infrastructure.Entities.Core;
+
+public class YnabServerKnowledgeEntity
+{
+	public string BudgetId { get; set; } = string.Empty;
+	public long ServerKnowledge { get; set; }
+	public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/src/Infrastructure/Interfaces/Repositories/IYnabServerKnowledgeRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/IYnabServerKnowledgeRepository.cs
@@ -1,0 +1,7 @@
+namespace Infrastructure.Interfaces.Repositories;
+
+public interface IYnabServerKnowledgeRepository
+{
+	Task<long?> GetAsync(string budgetId, CancellationToken cancellationToken);
+	Task UpsertAsync(string budgetId, long serverKnowledge, CancellationToken cancellationToken);
+}

--- a/src/Infrastructure/Migrations/20260406033815_AddYnabServerKnowledge.Designer.cs
+++ b/src/Infrastructure/Migrations/20260406033815_AddYnabServerKnowledge.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406033815_AddYnabServerKnowledge")]
+    partial class AddYnabServerKnowledge
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -988,8 +991,7 @@ namespace Infrastructure.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("LocalTransactionId", "SyncType")
-                        .IsUnique()
-                        .HasFilter("\"DeletedAt\" IS NULL");
+                        .IsUnique();
 
                     b.ToTable("YnabSyncRecords");
                 });
@@ -1219,7 +1221,7 @@ namespace Infrastructure.Migrations
                     b.HasOne("Infrastructure.Entities.Core.TransactionEntity", "Transaction")
                         .WithMany()
                         .HasForeignKey("LocalTransactionId")
-                        .OnDelete(DeleteBehavior.ClientCascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Transaction");

--- a/src/Infrastructure/Migrations/20260406033815_AddYnabServerKnowledge.cs
+++ b/src/Infrastructure/Migrations/20260406033815_AddYnabServerKnowledge.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddYnabServerKnowledge : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.CreateTable(
+			name: "YnabServerKnowledge",
+			columns: table => new
+			{
+				BudgetId = table.Column<string>(type: "text", maxLength: 36, nullable: false),
+				ServerKnowledge = table.Column<long>(type: "bigint", nullable: false),
+				UpdatedAt = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false)
+			},
+			constraints: table =>
+			{
+				table.PrimaryKey("PK_YnabServerKnowledge", x => x.BudgetId);
+			});
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropTable(
+			name: "YnabServerKnowledge");
+	}
+}

--- a/src/Infrastructure/Repositories/YnabServerKnowledgeRepository.cs
+++ b/src/Infrastructure/Repositories/YnabServerKnowledgeRepository.cs
@@ -1,0 +1,38 @@
+using Infrastructure.Entities.Core;
+using Infrastructure.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Repositories;
+
+public class YnabServerKnowledgeRepository(IDbContextFactory<ApplicationDbContext> contextFactory) : IYnabServerKnowledgeRepository
+{
+	public async Task<long?> GetAsync(string budgetId, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		YnabServerKnowledgeEntity? entity = await context.YnabServerKnowledge.FindAsync([budgetId], cancellationToken);
+		return entity?.ServerKnowledge;
+	}
+
+	public async Task UpsertAsync(string budgetId, long serverKnowledge, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		YnabServerKnowledgeEntity? existing = await context.YnabServerKnowledge.FindAsync([budgetId], cancellationToken);
+
+		if (existing is not null)
+		{
+			existing.ServerKnowledge = serverKnowledge;
+			existing.UpdatedAt = DateTimeOffset.UtcNow;
+		}
+		else
+		{
+			context.YnabServerKnowledge.Add(new YnabServerKnowledgeEntity
+			{
+				BudgetId = budgetId,
+				ServerKnowledge = serverKnowledge,
+				UpdatedAt = DateTimeOffset.UtcNow,
+			});
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -156,6 +156,7 @@ public static class InfrastructureService
 			.AddScoped<IYnabAccountMappingService, YnabAccountMappingService>()
 			.AddScoped<IYnabCategoryMappingService, YnabCategoryMappingService>()
 			.AddScoped<IYnabMemoSyncService, YnabMemoSyncService>()
+			.AddScoped<IYnabServerKnowledgeRepository, YnabServerKnowledgeRepository>()
 			.AddSingleton<IYnabSplitCalculator, YnabSplitCalculator>();
 
 		services.AddMemoryCache();

--- a/src/Infrastructure/Services/YnabApiClient.cs
+++ b/src/Infrastructure/Services/YnabApiClient.cs
@@ -170,15 +170,21 @@ public class YnabApiClient(
 		return new YnabCreateTransactionResponse(transactionId);
 	}
 
-	public async Task<List<YnabTransaction>> GetTransactionsByDateAsync(string budgetId, DateOnly sinceDate, CancellationToken cancellationToken)
+	public async Task<YnabTransactionsResult> GetTransactionsByDateAsync(string budgetId, DateOnly sinceDate, long? lastKnowledgeOfServer = null, CancellationToken cancellationToken = default)
 	{
 		string encodedBudgetId = Uri.EscapeDataString(budgetId);
 		string formattedDate = sinceDate.ToString("yyyy-MM-dd");
 
-		YnabTransactionsListResponseEnvelope envelope = await GetAsync<YnabTransactionsListResponseEnvelope>(
-			$"budgets/{encodedBudgetId}/transactions?since_date={formattedDate}", cancellationToken);
+		string url = $"budgets/{encodedBudgetId}/transactions?since_date={formattedDate}";
+		if (lastKnowledgeOfServer.HasValue)
+		{
+			url += $"&last_knowledge_of_server={lastKnowledgeOfServer.Value}";
+		}
 
-		return envelope.Data.Transactions
+		YnabTransactionsListResponseEnvelope envelope = await GetAsync<YnabTransactionsListResponseEnvelope>(
+			url, cancellationToken);
+
+		List<YnabTransaction> transactions = envelope.Data.Transactions
 			.Where(t => !t.Deleted)
 			.Select(t => new YnabTransaction(
 				t.Id,
@@ -191,6 +197,8 @@ public class YnabApiClient(
 				t.CategoryId,
 				t.PayeeName))
 			.ToList();
+
+		return new YnabTransactionsResult(transactions, envelope.Data.ServerKnowledge);
 	}
 
 	public async Task UpdateTransactionMemoAsync(string budgetId, string transactionId, string memo, CancellationToken cancellationToken)

--- a/src/Infrastructure/Services/YnabMemoSyncService.cs
+++ b/src/Infrastructure/Services/YnabMemoSyncService.cs
@@ -14,6 +14,7 @@ public class YnabMemoSyncService(
 	IYnabSyncRecordService syncRecordService,
 	ITransactionRepository transactionRepository,
 	IReceiptRepository receiptRepository,
+	IYnabServerKnowledgeRepository serverKnowledgeRepository,
 	ILogger<YnabMemoSyncService> logger) : IYnabMemoSyncService
 {
 	internal const int YnabMemoMaxLength = 200;
@@ -115,11 +116,14 @@ public class YnabMemoSyncService(
 			return new YnabMemoSyncResult(transaction.Id, receipt.Id, YnabMemoSyncOutcome.AlreadySynced, existingRecord.YnabTransactionId, null, null);
 		}
 
-		// Fetch YNAB transactions for the same date
+		// Fetch YNAB transactions for the same date using delta sync when possible
 		List<YnabTransaction> ynabTransactions;
 		try
 		{
-			ynabTransactions = await ynabClient.GetTransactionsByDateAsync(budgetId, transaction.Date, cancellationToken);
+			long? lastKnowledge = await serverKnowledgeRepository.GetAsync(budgetId, cancellationToken);
+			YnabTransactionsResult result = await ynabClient.GetTransactionsByDateAsync(budgetId, transaction.Date, lastKnowledge, cancellationToken);
+			ynabTransactions = result.Transactions;
+			await serverKnowledgeRepository.UpsertAsync(budgetId, result.ServerKnowledge, cancellationToken);
 		}
 		catch (Exception ex)
 		{

--- a/src/Infrastructure/Services/YnabMemoSyncService.cs
+++ b/src/Infrastructure/Services/YnabMemoSyncService.cs
@@ -116,12 +116,14 @@ public class YnabMemoSyncService(
 			return new YnabMemoSyncResult(transaction.Id, receipt.Id, YnabMemoSyncOutcome.AlreadySynced, existingRecord.YnabTransactionId, null, null);
 		}
 
-		// Fetch YNAB transactions for the same date using delta sync when possible
+		// Fetch YNAB transactions for the same date.
+		// NOTE: Do NOT use delta sync (last_knowledge_of_server) here — memo matching
+		// requires the full set of transactions on a date, not just changed ones.
+		// Delta sync is available on the API client for polling/change-detection consumers.
 		List<YnabTransaction> ynabTransactions;
 		try
 		{
-			long? lastKnowledge = await serverKnowledgeRepository.GetAsync(budgetId, cancellationToken);
-			YnabTransactionsResult result = await ynabClient.GetTransactionsByDateAsync(budgetId, transaction.Date, lastKnowledge, cancellationToken);
+			YnabTransactionsResult result = await ynabClient.GetTransactionsByDateAsync(budgetId, transaction.Date, cancellationToken: cancellationToken);
 			ynabTransactions = result.Transactions;
 			await serverKnowledgeRepository.UpsertAsync(budgetId, result.ServerKnowledge, cancellationToken);
 		}

--- a/src/Infrastructure/Ynab/Models/YnabTransactionResponse.cs
+++ b/src/Infrastructure/Ynab/Models/YnabTransactionResponse.cs
@@ -30,6 +30,9 @@ internal sealed class YnabTransactionsListResponseData
 {
 	[JsonPropertyName("transactions")]
 	public List<YnabTransactionDto> Transactions { get; set; } = [];
+
+	[JsonPropertyName("server_knowledge")]
+	public long ServerKnowledge { get; set; }
 }
 
 /// <summary>

--- a/tests/Infrastructure.Tests/Services/YnabApiClientTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabApiClientTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Text.Json;
-using Application.Interfaces.Services;
+using Application.Models.Ynab;
 using FluentAssertions;
 using Infrastructure.Services;
 using Infrastructure.Ynab;
@@ -353,5 +353,143 @@ public class YnabApiClientTests
 
 		// Act & Assert
 		client.IsConfigured.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task GetTransactionsByDateAsync_ReturnsTransactionsAndServerKnowledge()
+	{
+		// Arrange
+		string json = JsonSerializer.Serialize(new
+		{
+			data = new
+			{
+				transactions = new[]
+				{
+					new { id = "tx-1", date = "2026-04-01", amount = -25500, memo = "Groceries", cleared = "cleared", approved = true, account_id = "acc-1", category_id = "cat-1", payee_name = "Walmart", deleted = false },
+				},
+				server_knowledge = 1234
+			}
+		});
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		// Act
+		YnabTransactionsResult result = await client.GetTransactionsByDateAsync(
+			"budget-1", new DateOnly(2026, 4, 1), cancellationToken: CancellationToken.None);
+
+		// Assert
+		result.Transactions.Should().ContainSingle();
+		result.Transactions[0].Id.Should().Be("tx-1");
+		result.Transactions[0].Amount.Should().Be(-25500);
+		result.ServerKnowledge.Should().Be(1234);
+	}
+
+	[Fact]
+	public async Task GetTransactionsByDateAsync_FiltersDeletedTransactions()
+	{
+		// Arrange
+		string json = JsonSerializer.Serialize(new
+		{
+			data = new
+			{
+				transactions = new[]
+				{
+					new { id = "tx-1", date = "2026-04-01", amount = -10000, memo = (string?)null, cleared = "cleared", approved = true, account_id = "acc-1", category_id = "cat-1", payee_name = "Store", deleted = false },
+					new { id = "tx-2", date = "2026-04-01", amount = -20000, memo = (string?)null, cleared = "cleared", approved = true, account_id = "acc-1", category_id = "cat-1", payee_name = "Deleted Store", deleted = true },
+				},
+				server_knowledge = 5678
+			}
+		});
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		// Act
+		YnabTransactionsResult result = await client.GetTransactionsByDateAsync(
+			"budget-1", new DateOnly(2026, 4, 1), cancellationToken: CancellationToken.None);
+
+		// Assert
+		result.Transactions.Should().ContainSingle();
+		result.Transactions[0].Id.Should().Be("tx-1");
+		result.ServerKnowledge.Should().Be(5678);
+	}
+
+	[Fact]
+	public async Task GetTransactionsByDateAsync_PassesLastKnowledgeOfServerQueryParam()
+	{
+		// Arrange
+		string json = JsonSerializer.Serialize(new
+		{
+			data = new
+			{
+				transactions = Array.Empty<object>(),
+				server_knowledge = 9999
+			}
+		});
+
+		Uri? capturedUri = null;
+		Mock<HttpMessageHandler> handlerMock = new();
+		handlerMock.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.Returns((HttpRequestMessage req, CancellationToken _) =>
+			{
+				capturedUri = req.RequestUri;
+				return Task.FromResult(new HttpResponseMessage
+				{
+					StatusCode = HttpStatusCode.OK,
+					Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+				});
+			});
+
+		YnabApiClient client = CreateClient(handlerMock.Object);
+
+		// Act
+		await client.GetTransactionsByDateAsync(
+			"budget-1", new DateOnly(2026, 4, 1), lastKnowledgeOfServer: 42, cancellationToken: CancellationToken.None);
+
+		// Assert
+		capturedUri.Should().NotBeNull();
+		capturedUri!.ToString().Should().Contain("last_knowledge_of_server=42");
+	}
+
+	[Fact]
+	public async Task GetTransactionsByDateAsync_OmitsLastKnowledgeOfServerWhenNull()
+	{
+		// Arrange
+		string json = JsonSerializer.Serialize(new
+		{
+			data = new
+			{
+				transactions = Array.Empty<object>(),
+				server_knowledge = 100
+			}
+		});
+
+		Uri? capturedUri = null;
+		Mock<HttpMessageHandler> handlerMock = new();
+		handlerMock.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.Returns((HttpRequestMessage req, CancellationToken _) =>
+			{
+				capturedUri = req.RequestUri;
+				return Task.FromResult(new HttpResponseMessage
+				{
+					StatusCode = HttpStatusCode.OK,
+					Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+				});
+			});
+
+		YnabApiClient client = CreateClient(handlerMock.Object);
+
+		// Act
+		await client.GetTransactionsByDateAsync(
+			"budget-1", new DateOnly(2026, 4, 1), cancellationToken: CancellationToken.None);
+
+		// Assert
+		capturedUri.Should().NotBeNull();
+		capturedUri!.ToString().Should().NotContain("last_knowledge_of_server");
 	}
 }

--- a/tests/Infrastructure.Tests/Services/YnabMemoSyncServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabMemoSyncServiceTests.cs
@@ -17,6 +17,7 @@ public class YnabMemoSyncServiceTests
 	private readonly Mock<IYnabSyncRecordService> _syncRecordServiceMock = new();
 	private readonly Mock<ITransactionRepository> _transactionRepoMock = new();
 	private readonly Mock<IReceiptRepository> _receiptRepoMock = new();
+	private readonly Mock<IYnabServerKnowledgeRepository> _serverKnowledgeRepoMock = new();
 	private readonly Mock<ILogger<YnabMemoSyncService>> _loggerMock = new();
 	private readonly YnabMemoSyncService _service;
 
@@ -26,12 +27,20 @@ public class YnabMemoSyncServiceTests
 
 	public YnabMemoSyncServiceTests()
 	{
+		_serverKnowledgeRepoMock
+			.Setup(r => r.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((long?)null);
+		_serverKnowledgeRepoMock
+			.Setup(r => r.UpsertAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+			.Returns(Task.CompletedTask);
+
 		_service = new YnabMemoSyncService(
 			_ynabClientMock.Object,
 			_budgetSelectionMock.Object,
 			_syncRecordServiceMock.Object,
 			_transactionRepoMock.Object,
 			_receiptRepoMock.Object,
+			_serverKnowledgeRepoMock.Object,
 			_loggerMock.Object);
 	}
 
@@ -174,8 +183,8 @@ public class YnabMemoSyncServiceTests
 		// YNAB amount should be negated: 25.50 * 1000 = 25500, negated = -25500
 		YnabTransaction ynabTx = CreateYnabTransaction("yt-1", transaction.Date, -25500, "Walmart");
 		_ynabClientMock
-			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<CancellationToken>()))
-			.ReturnsAsync([ynabTx]);
+			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabTransactionsResult([ynabTx], 42));
 
 		SetupSyncRecordCreation();
 		SetupSyncRecordUpdate();
@@ -206,8 +215,8 @@ public class YnabMemoSyncServiceTests
 
 		YnabTransaction ynabTx = CreateYnabTransaction("yt-1", transaction.Date, 25500, "Walmart");
 		_ynabClientMock
-			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<CancellationToken>()))
-			.ReturnsAsync([ynabTx]);
+			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabTransactionsResult([ynabTx], 42));
 
 		// Act
 		List<YnabMemoSyncResult> results = await _service.SyncMemosByReceiptAsync(receipt.Id, CancellationToken.None);
@@ -268,8 +277,8 @@ public class YnabMemoSyncServiceTests
 		YnabTransaction ynabTx2 = CreateYnabTransaction("yt-2", transaction.Date, -50000, "Walmart Supercenter");
 
 		_ynabClientMock
-			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<CancellationToken>()))
-			.ReturnsAsync([ynabTx1, ynabTx2]);
+			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabTransactionsResult([ynabTx1, ynabTx2], 42));
 
 		// Act
 		List<YnabMemoSyncResult> results = await _service.SyncMemosByReceiptAsync(receipt.Id, CancellationToken.None);
@@ -294,8 +303,8 @@ public class YnabMemoSyncServiceTests
 
 		// Empty YNAB transactions
 		_ynabClientMock
-			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<CancellationToken>()))
-			.ReturnsAsync([]);
+			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabTransactionsResult([], 42));
 
 		// Act
 		List<YnabMemoSyncResult> results = await _service.SyncMemosByReceiptAsync(receipt.Id, CancellationToken.None);
@@ -336,7 +345,7 @@ public class YnabMemoSyncServiceTests
 		results[0].Outcome.Should().Be(YnabMemoSyncOutcome.AlreadySynced);
 		// Should NOT call YNAB API
 		_ynabClientMock.Verify(c => c.GetTransactionsByDateAsync(
-			It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()), Times.Never);
+			It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 
 	[Fact]
@@ -355,8 +364,8 @@ public class YnabMemoSyncServiceTests
 		YnabTransaction ynabTx = new("yt-1", transaction.Date, -25500, existingMemo, "cleared", true, "acc-1", null, "Walmart");
 
 		_ynabClientMock
-			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<CancellationToken>()))
-			.ReturnsAsync([ynabTx]);
+			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabTransactionsResult([ynabTx], 42));
 
 		SetupSyncRecordCreation();
 		SetupSyncRecordUpdate();
@@ -422,7 +431,7 @@ public class YnabMemoSyncServiceTests
 		SetupNoExistingSyncRecord(transaction.Id);
 
 		_ynabClientMock
-			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<CancellationToken>()))
+			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
 			.ThrowsAsync(new HttpRequestException("YNAB API error"));
 
 		// Act
@@ -465,8 +474,8 @@ public class YnabMemoSyncServiceTests
 		SetupNoExistingSyncRecordForAny();
 
 		_ynabClientMock
-			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync([]);
+			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, It.IsAny<DateOnly>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabTransactionsResult([], 42));
 
 		// Act
 		List<YnabMemoSyncResult> results = await _service.SyncMemosBulkAsync(

--- a/tests/Infrastructure.Tests/Services/YnabMemoSyncServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabMemoSyncServiceTests.cs
@@ -657,6 +657,72 @@ public class YnabMemoSyncServiceTests
 
 	#endregion
 
+	#region Server Knowledge Tests
+
+	[Fact]
+	public async Task SyncMemosByReceipt_StoresServerKnowledgeAfterFetch()
+	{
+		// Arrange
+		SetupBudgetSelection(BudgetId);
+		ReceiptEntity receipt = CreateReceipt("Walmart");
+		TransactionEntity transaction = CreateTransaction(receipt.Id, 25.50m);
+
+		SetupReceiptRepo(receipt);
+		SetupTransactionRepo(receipt.Id, [transaction]);
+		SetupNoExistingSyncRecord(transaction.Id);
+
+		YnabTransaction ynabTx = CreateYnabTransaction("yt-1", transaction.Date, -25500, "Walmart");
+		_ynabClientMock
+			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabTransactionsResult([ynabTx], 5678));
+
+		SetupSyncRecordCreation();
+		SetupSyncRecordUpdate();
+		_ynabClientMock
+			.Setup(c => c.UpdateTransactionMemoAsync(BudgetId, "yt-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.Returns(Task.CompletedTask);
+
+		// Act
+		await _service.SyncMemosByReceiptAsync(receipt.Id, CancellationToken.None);
+
+		// Assert: server knowledge was persisted with the value from the API response
+		_serverKnowledgeRepoMock.Verify(
+			r => r.UpsertAsync(BudgetId, 5678, It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task SyncMemosByReceipt_DoesNotPassServerKnowledgeToApiClient()
+	{
+		// Arrange: memo sync should do full fetches, NOT delta sync
+		SetupBudgetSelection(BudgetId);
+		ReceiptEntity receipt = CreateReceipt("Walmart");
+		TransactionEntity transaction = CreateTransaction(receipt.Id, 25.50m);
+
+		SetupReceiptRepo(receipt);
+		SetupTransactionRepo(receipt.Id, [transaction]);
+		SetupNoExistingSyncRecord(transaction.Id);
+
+		// Set up server knowledge repo to return a stored value
+		_serverKnowledgeRepoMock
+			.Setup(r => r.GetAsync(BudgetId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(999L);
+
+		_ynabClientMock
+			.Setup(c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabTransactionsResult([], 1000));
+
+		// Act
+		await _service.SyncMemosByReceiptAsync(receipt.Id, CancellationToken.None);
+
+		// Assert: API client was called WITHOUT lastKnowledgeOfServer (null, not 999)
+		_ynabClientMock.Verify(
+			c => c.GetTransactionsByDateAsync(BudgetId, transaction.Date, null, It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	#endregion
+
 	#region Helpers
 
 	private void SetupBudgetSelection(string? budgetId)


### PR DESCRIPTION
## Summary
- Add `last_knowledge_of_server` support to the YNAB API client for delta sync polling
- Create `YnabServerKnowledge` entity and repository to persist the server knowledge token per budget
- Wire memo sync to store the token on each fetch (full fetch for matching, token persisted for future delta consumers)
- Add 6 new unit tests covering delta sync behavior

## Details
The YNAB API supports a `last_knowledge_of_server` parameter that enables delta requests, returning only transactions that changed since the last query. This PR adds the plumbing to support it:

1. **API response parsing** — `server_knowledge` field is now parsed from YNAB transaction list responses
2. **API client** — `GetTransactionsByDateAsync` accepts an optional `lastKnowledgeOfServer` parameter and returns `YnabTransactionsResult` (wrapping both the transaction list and the server knowledge value)
3. **Persistence** — New `YnabServerKnowledge` table (keyed by `BudgetId`) stores the latest token via `IYnabServerKnowledgeRepository`
4. **Memo sync** — Correctly uses full fetches for matching (needs all transactions on a date), but persists the server knowledge for future delta sync consumers

## Test plan
- [x] `GetTransactionsByDateAsync` returns transactions and server_knowledge
- [x] Deleted transactions are filtered from results
- [x] `last_knowledge_of_server` query param is passed when provided
- [x] `last_knowledge_of_server` is omitted when null
- [x] Memo sync stores server knowledge after API fetch
- [x] Memo sync does NOT pass server knowledge for matching queries
- [x] All 1974 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)