### PR TITLE
fix(api): add soft-delete filter to YnabSyncRecords unique index (RECEIPTS-502)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "receipts",
+  "name": "agent-af517ee8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/Infrastructure/Configurations/YnabSyncRecordEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/YnabSyncRecordEntityConfiguration.cs
@@ -18,7 +18,8 @@ public class YnabSyncRecordEntityConfiguration : IEntityTypeConfiguration<YnabSy
 			.HasMaxLength(2000);
 
 		builder.HasIndex(e => new { e.LocalTransactionId, e.SyncType })
-			.IsUnique();
+			.IsUnique()
+			.HasFilter("\"DeletedAt\" IS NULL");
 
 		builder.HasOne(e => e.Transaction)
 			.WithMany()

--- a/src/Infrastructure/Migrations/20260406040542_AddSoftDeleteFilterToYnabSyncRecordIndex.Designer.cs
+++ b/src/Infrastructure/Migrations/20260406040542_AddSoftDeleteFilterToYnabSyncRecordIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406040542_AddSoftDeleteFilterToYnabSyncRecordIndex")]
+    partial class AddSoftDeleteFilterToYnabSyncRecordIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260406040542_AddSoftDeleteFilterToYnabSyncRecordIndex.cs
+++ b/src/Infrastructure/Migrations/20260406040542_AddSoftDeleteFilterToYnabSyncRecordIndex.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddSoftDeleteFilterToYnabSyncRecordIndex : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropIndex(
+			name: "IX_YnabSyncRecords_LocalTransactionId_SyncType",
+			table: "YnabSyncRecords");
+
+		migrationBuilder.CreateIndex(
+			name: "IX_YnabSyncRecords_LocalTransactionId_SyncType",
+			table: "YnabSyncRecords",
+			columns: new[] { "LocalTransactionId", "SyncType" },
+			unique: true,
+			filter: "\"DeletedAt\" IS NULL");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropIndex(
+			name: "IX_YnabSyncRecords_LocalTransactionId_SyncType",
+			table: "YnabSyncRecords");
+
+		migrationBuilder.CreateIndex(
+			name: "IX_YnabSyncRecords_LocalTransactionId_SyncType",
+			table: "YnabSyncRecords",
+			columns: new[] { "LocalTransactionId", "SyncType" },
+			unique: true);
+	}
+}

--- a/src/Infrastructure/Services/TrashService.cs
+++ b/src/Infrastructure/Services/TrashService.cs
@@ -20,6 +20,11 @@ public class TrashService(ApplicationDbContext context) : ITrashService
 			.Where(e => e.DeletedAt != null)
 			.ExecuteDeleteAsync(cancellationToken);
 
+		await context.YnabSyncRecords
+			.IgnoreQueryFilters()
+			.Where(e => e.DeletedAt != null)
+			.ExecuteDeleteAsync(cancellationToken);
+
 		await context.Transactions
 			.IgnoreQueryFilters()
 			.Where(e => e.DeletedAt != null)

--- a/tests/Infrastructure.Tests/Repositories/SoftDeleteTests.cs
+++ b/tests/Infrastructure.Tests/Repositories/SoftDeleteTests.cs
@@ -565,6 +565,55 @@ public class SoftDeleteTests
 	}
 
 	[Fact]
+	public async Task SoftDelete_YnabSyncRecord_AllowsReCreationAfterSoftDelete()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		AccountEntity account = AccountEntityGenerator.Generate();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receiptId: receipt.Id, accountId: account.Id);
+
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.Accounts.AddAsync(account);
+			await context.Receipts.AddAsync(receipt);
+			await context.Transactions.AddAsync(transaction);
+			YnabSyncRecordEntity syncRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id);
+			await context.YnabSyncRecords.AddAsync(syncRecord);
+			await context.SaveChangesAsync();
+		}
+
+		// Act - soft-delete the sync record
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			YnabSyncRecordEntity record = await context.YnabSyncRecords.FirstAsync();
+			context.YnabSyncRecords.Remove(record);
+			await context.SaveChangesAsync();
+		}
+
+		// Act - create a new sync record with the same (LocalTransactionId, SyncType) pair
+		YnabSyncRecordEntity newRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id);
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.YnabSyncRecords.AddAsync(newRecord);
+			await context.SaveChangesAsync();
+		}
+
+		// Assert - both records should exist (one soft-deleted, one active)
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<YnabSyncRecordEntity> allRecords = await context.YnabSyncRecords.IgnoreQueryFilters().ToListAsync();
+			allRecords.Should().HaveCount(2);
+
+			List<YnabSyncRecordEntity> activeRecords = await context.YnabSyncRecords.ToListAsync();
+			activeRecords.Should().HaveCount(1);
+			activeRecords[0].Id.Should().Be(newRecord.Id);
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
 	public async Task SoftDelete_YnabSyncRecord_SetsDeletedAtOnDelete()
 	{
 		// Arrange


### PR DESCRIPTION
## Summary
- Add `.HasFilter("\"DeletedAt\" IS NULL")` to the `(LocalTransactionId, SyncType)` unique index in `YnabSyncRecordEntityConfiguration`, matching the pattern used by Category, Subcategory, and ItemTemplate entities
- Add `YnabSyncRecords` to `TrashService.PurgeAllDeletedAsync` (before Transactions due to FK dependency order)
- Generate EF Core migration for the index change
- Audit all other soft-deletable entities — only YnabSyncRecordEntity had the gap

## Test plan
- [x] New test `SoftDelete_YnabSyncRecord_AllowsReCreationAfterSoftDelete` verifies re-creation after soft-delete succeeds
- [x] All 1969 unit tests pass
- [x] Build succeeds with 0 errors

Closes RECEIPTS-502

🤖 Generated with [Claude Code](https://claude.com/claude-code)