### PR TITLE
Filter internal YNAB category groups from category list (RECEIPTS-496)

### DIFF
--- a/src/Infrastructure/Services/YnabApiClient.cs
+++ b/src/Infrastructure/Services/YnabApiClient.cs
@@ -25,6 +25,12 @@ public class YnabApiClient(
 	private const string AccountsCacheKeyPrefix = "ynab:accounts:";
 	private const string CategoriesCacheKeyPrefix = "ynab:categories:";
 
+	private static readonly HashSet<string> ExcludedCategoryGroups = new(StringComparer.OrdinalIgnoreCase)
+	{
+		"Internal Master Category",
+		"Credit Card Payments",
+	};
+
 	private readonly YnabClientOptions _options = new();
 
 	private string? Pat => configuration[ConfigurationVariables.YnabPat];
@@ -80,7 +86,7 @@ public class YnabApiClient(
 			$"budgets/{Uri.EscapeDataString(budgetId)}/categories", cancellationToken);
 
 		List<YnabCategory> categories = envelope.Data.CategoryGroups
-			.Where(g => !g.Deleted)
+			.Where(g => !g.Deleted && !ExcludedCategoryGroups.Contains(g.Name))
 			.SelectMany(g => g.Categories
 				.Where(c => !c.Deleted)
 				.Select(c => new YnabCategory(

--- a/tests/Infrastructure.Tests/Services/YnabApiClientTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabApiClientTests.cs
@@ -162,6 +162,177 @@ public class YnabApiClientTests
 	}
 
 	[Fact]
+	public async Task GetCategoriesAsync_FiltersInternalMasterCategoryGroup()
+	{
+		// Arrange
+		string json = JsonSerializer.Serialize(new
+		{
+			data = new
+			{
+				category_groups = new object[]
+				{
+					new
+					{
+						id = "group-internal", name = "Internal Master Category", hidden = false, deleted = false,
+						categories = new[]
+						{
+							new { id = "cat-tbb", category_group_id = "group-internal", category_group_name = "Internal Master Category", name = "To be Budgeted", hidden = false, deleted = false },
+						}
+					},
+					new
+					{
+						id = "group-normal", name = "Everyday Expenses", hidden = false, deleted = false,
+						categories = new[]
+						{
+							new { id = "cat-groceries", category_group_id = "group-normal", category_group_name = "Everyday Expenses", name = "Groceries", hidden = false, deleted = false },
+						}
+					},
+				}
+			}
+		});
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		// Act
+		var categories = await client.GetCategoriesAsync("budget-1", CancellationToken.None);
+
+		// Assert
+		categories.Should().HaveCount(1);
+		categories[0].Name.Should().Be("Groceries");
+		categories[0].CategoryGroupName.Should().Be("Everyday Expenses");
+	}
+
+	[Fact]
+	public async Task GetCategoriesAsync_FiltersCreditCardPaymentsGroup()
+	{
+		// Arrange
+		string json = JsonSerializer.Serialize(new
+		{
+			data = new
+			{
+				category_groups = new object[]
+				{
+					new
+					{
+						id = "group-cc", name = "Credit Card Payments", hidden = false, deleted = false,
+						categories = new[]
+						{
+							new { id = "cat-visa", category_group_id = "group-cc", category_group_name = "Credit Card Payments", name = "Visa", hidden = false, deleted = false },
+						}
+					},
+					new
+					{
+						id = "group-normal", name = "Monthly Bills", hidden = false, deleted = false,
+						categories = new[]
+						{
+							new { id = "cat-rent", category_group_id = "group-normal", category_group_name = "Monthly Bills", name = "Rent", hidden = false, deleted = false },
+						}
+					},
+				}
+			}
+		});
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		// Act
+		var categories = await client.GetCategoriesAsync("budget-1", CancellationToken.None);
+
+		// Assert
+		categories.Should().HaveCount(1);
+		categories[0].Name.Should().Be("Rent");
+	}
+
+	[Fact]
+	public async Task GetCategoriesAsync_FiltersDeletedGroupsAndInternalGroups()
+	{
+		// Arrange
+		string json = JsonSerializer.Serialize(new
+		{
+			data = new
+			{
+				category_groups = new object[]
+				{
+					new
+					{
+						id = "group-deleted", name = "Old Group", hidden = false, deleted = true,
+						categories = new[]
+						{
+							new { id = "cat-old", category_group_id = "group-deleted", category_group_name = "Old Group", name = "Old Category", hidden = false, deleted = false },
+						}
+					},
+					new
+					{
+						id = "group-internal", name = "Internal Master Category", hidden = false, deleted = false,
+						categories = new[]
+						{
+							new { id = "cat-tbb", category_group_id = "group-internal", category_group_name = "Internal Master Category", name = "To be Budgeted", hidden = false, deleted = false },
+						}
+					},
+					new
+					{
+						id = "group-cc", name = "Credit Card Payments", hidden = false, deleted = false,
+						categories = new[]
+						{
+							new { id = "cat-visa", category_group_id = "group-cc", category_group_name = "Credit Card Payments", name = "Visa", hidden = false, deleted = false },
+						}
+					},
+					new
+					{
+						id = "group-normal", name = "Fun Money", hidden = false, deleted = false,
+						categories = new[]
+						{
+							new { id = "cat-hobbies", category_group_id = "group-normal", category_group_name = "Fun Money", name = "Hobbies", hidden = false, deleted = false },
+						}
+					},
+				}
+			}
+		});
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		// Act
+		var categories = await client.GetCategoriesAsync("budget-1", CancellationToken.None);
+
+		// Assert
+		categories.Should().HaveCount(1);
+		categories[0].Name.Should().Be("Hobbies");
+		categories[0].CategoryGroupName.Should().Be("Fun Money");
+	}
+
+	[Fact]
+	public async Task GetCategoriesAsync_ReturnsNormalCategories_ExcludingDeletedCategories()
+	{
+		// Arrange
+		string json = JsonSerializer.Serialize(new
+		{
+			data = new
+			{
+				category_groups = new object[]
+				{
+					new
+					{
+						id = "group-1", name = "Everyday Expenses", hidden = false, deleted = false,
+						categories = new[]
+						{
+							new { id = "cat-1", category_group_id = "group-1", category_group_name = "Everyday Expenses", name = "Groceries", hidden = false, deleted = false },
+							new { id = "cat-2", category_group_id = "group-1", category_group_name = "Everyday Expenses", name = "Deleted Cat", hidden = false, deleted = true },
+						}
+					},
+				}
+			}
+		});
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		// Act
+		var categories = await client.GetCategoriesAsync("budget-1", CancellationToken.None);
+
+		// Assert
+		categories.Should().HaveCount(1);
+		categories[0].Name.Should().Be("Groceries");
+	}
+
+	[Fact]
 	public void IsConfigured_ReturnsFalse_WhenPatIsMissing()
 	{
 		// Arrange


### PR DESCRIPTION
## Summary
- Filter out YNAB's "Internal Master Category" and "Credit Card Payments" groups from `GetCategoriesAsync` so users cannot map receipt categories to internal system categories
- Add a `HashSet<string>` constant with excluded group names and an additional `.Where()` clause at the group level
- Add 4 unit tests covering both internal groups, deleted groups, and deleted individual categories

## Test plan
- [x] `GetCategoriesAsync_FiltersInternalMasterCategoryGroup` -- verifies Internal Master Category group is excluded
- [x] `GetCategoriesAsync_FiltersCreditCardPaymentsGroup` -- verifies Credit Card Payments group is excluded
- [x] `GetCategoriesAsync_FiltersDeletedGroupsAndInternalGroups` -- verifies all filter types work together
- [x] `GetCategoriesAsync_ReturnsNormalCategories_ExcludingDeletedCategories` -- verifies normal flow + deleted category filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)