### PR TITLE
refactor(api): extract IsConfigured check into action filter (RECEIPTS-499)

### DIFF
--- a/src/Presentation/API/Controllers/YnabController.cs
+++ b/src/Presentation/API/Controllers/YnabController.cs
@@ -1,3 +1,4 @@
+using API.Filters;
 using API.Generated.Dtos;
 using API.Mapping.Core;
 using Application.Commands.Ynab.AccountMapping;
@@ -30,14 +31,9 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 	[EndpointSummary("List YNAB budgets")]
 	[EndpointDescription("Returns the list of budgets from the connected YNAB account.")]
 	[ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+	[RequireYnabConfigured]
 	public async Task<Results<Ok<YnabBudgetListResponse>, StatusCodeHttpResult>> GetBudgets(CancellationToken cancellationToken)
 	{
-		if (!ynabClient.IsConfigured)
-		{
-			logger.LogWarning("YNAB API client is not configured — missing personal access token");
-			return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
-		}
-
 		try
 		{
 			List<YnabBudget> budgets = await mediator.Send(new GetYnabBudgetsQuery(), cancellationToken);
@@ -54,14 +50,9 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 	[EndpointSummary("List YNAB accounts")]
 	[EndpointDescription("Returns the list of open/active accounts from the selected YNAB budget.")]
 	[ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+	[RequireYnabConfigured]
 	public async Task<Results<Ok<YnabAccountListResponse>, StatusCodeHttpResult>> GetAccounts(CancellationToken cancellationToken)
 	{
-		if (!ynabClient.IsConfigured)
-		{
-			logger.LogWarning("YNAB API client is not configured — missing personal access token");
-			return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
-		}
-
 		try
 		{
 			YnabBudgetSelection selection = await mediator.Send(new GetSelectedYnabBudgetQuery(), cancellationToken);
@@ -87,14 +78,9 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 	[EndpointSummary("List YNAB categories")]
 	[EndpointDescription("Returns all YNAB categories for the selected budget, grouped by category group, with hidden categories excluded.")]
 	[ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+	[RequireYnabConfigured]
 	public async Task<Results<Ok<YnabCategoryListResponse>, StatusCodeHttpResult>> GetCategories(CancellationToken cancellationToken)
 	{
-		if (!ynabClient.IsConfigured)
-		{
-			logger.LogWarning("YNAB API client is not configured — missing personal access token");
-			return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
-		}
-
 		string? budgetId = await budgetSelectionService.GetSelectedBudgetIdAsync(cancellationToken);
 		if (string.IsNullOrEmpty(budgetId))
 		{
@@ -314,16 +300,11 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 	[EndpointSummary("Sync YNAB memo for a receipt")]
 	[EndpointDescription("Matches local transactions to YNAB transactions and updates their memos with a receipt link.")]
 	[ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+	[RequireYnabConfigured]
 	public async Task<Results<Ok<YnabMemoSyncResponse>, StatusCodeHttpResult>> SyncMemos(
 		[FromBody] SyncYnabMemosRequest request,
 		CancellationToken cancellationToken)
 	{
-		if (!ynabClient.IsConfigured)
-		{
-			logger.LogWarning("YNAB API client is not configured — missing personal access token");
-			return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
-		}
-
 		try
 		{
 			List<YnabMemoSyncResult> results = await mediator.Send(new SyncYnabMemosCommand(request.ReceiptId), cancellationToken);
@@ -340,16 +321,11 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 	[EndpointSummary("Push receipt transactions to YNAB")]
 	[EndpointDescription("Creates split transactions in YNAB from a single receipt. Allocates tax and adjustments proportionally across item categories.")]
 	[ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+	[RequireYnabConfigured]
 	public async Task<Results<Ok<PushYnabTransactionsResponse>, BadRequest<PushYnabTransactionsResponse>, StatusCodeHttpResult>> PushTransactions(
 		[FromBody] PushYnabTransactionsRequest request,
 		CancellationToken cancellationToken)
 	{
-		if (!ynabClient.IsConfigured)
-		{
-			logger.LogWarning("YNAB API client is not configured — missing personal access token");
-			return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
-		}
-
 		try
 		{
 			PushYnabTransactionsResult result = await mediator.Send(
@@ -375,16 +351,11 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 	[EndpointSummary("Bulk sync YNAB memos")]
 	[EndpointDescription("Batch syncs YNAB memos for multiple receipts.")]
 	[ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+	[RequireYnabConfigured]
 	public async Task<Results<Ok<YnabMemoSyncResponse>, StatusCodeHttpResult>> SyncMemosBulk(
 		[FromBody] SyncYnabMemosBulkRequest request,
 		CancellationToken cancellationToken)
 	{
-		if (!ynabClient.IsConfigured)
-		{
-			logger.LogWarning("YNAB API client is not configured — missing personal access token");
-			return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
-		}
-
 		try
 		{
 			List<YnabMemoSyncResult> results = await mediator.Send(
@@ -402,16 +373,11 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 	[EndpointSummary("Resolve ambiguous YNAB memo sync")]
 	[EndpointDescription("Resolves an ambiguous match by linking a local transaction to a specific YNAB transaction.")]
 	[ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+	[RequireYnabConfigured]
 	public async Task<Results<Ok<YnabMemoSyncResultItem>, StatusCodeHttpResult>> ResolveMemoSync(
 		[FromBody] ResolveYnabMemoSyncRequest request,
 		CancellationToken cancellationToken)
 	{
-		if (!ynabClient.IsConfigured)
-		{
-			logger.LogWarning("YNAB API client is not configured — missing personal access token");
-			return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
-		}
-
 		try
 		{
 			YnabMemoSyncResult result = await mediator.Send(
@@ -438,16 +404,11 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 	[EndpointSummary("Push transactions for multiple receipts to YNAB")]
 	[EndpointDescription("Creates split transactions in YNAB for each receipt in the batch. Each receipt is processed independently.")]
 	[ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+	[RequireYnabConfigured]
 	public async Task<Results<Ok<BulkPushYnabTransactionsResponse>, StatusCodeHttpResult>> BulkPushTransactions(
 		[FromBody] BulkPushYnabTransactionsRequest request,
 		CancellationToken cancellationToken)
 	{
-		if (!ynabClient.IsConfigured)
-		{
-			logger.LogWarning("YNAB API client is not configured — missing personal access token");
-			return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
-		}
-
 		try
 		{
 			BulkPushYnabTransactionsResult result = await mediator.Send(

--- a/src/Presentation/API/Filters/RequireYnabConfiguredAttribute.cs
+++ b/src/Presentation/API/Filters/RequireYnabConfiguredAttribute.cs
@@ -1,0 +1,28 @@
+using Application.Interfaces.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace API.Filters;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class RequireYnabConfiguredAttribute : TypeFilterAttribute
+{
+	public RequireYnabConfiguredAttribute() : base(typeof(RequireYnabConfiguredFilter))
+	{
+	}
+
+	private class RequireYnabConfiguredFilter(IYnabApiClient ynabClient, ILogger<RequireYnabConfiguredAttribute> logger) : IAsyncActionFilter
+	{
+		public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+		{
+			if (!ynabClient.IsConfigured)
+			{
+				logger.LogWarning("YNAB API client is not configured — missing personal access token");
+				context.Result = new StatusCodeResult(StatusCodes.Status503ServiceUnavailable);
+				return;
+			}
+
+			await next();
+		}
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/YnabAccountMappingControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/YnabAccountMappingControllerTests.cs
@@ -223,8 +223,6 @@ public class YnabAccountMappingControllerTests
 	public async Task GetAccounts_Returns200_WithActiveAccounts()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
-
 		_mediatorMock.Setup(m => m.Send(
 			It.IsAny<GetSelectedYnabBudgetQuery>(),
 			It.IsAny<CancellationToken>()))
@@ -252,26 +250,9 @@ public class YnabAccountMappingControllerTests
 	}
 
 	[Fact]
-	public async Task GetAccounts_Returns503_WhenNotConfigured()
-	{
-		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(false);
-
-		// Act
-		Results<Ok<YnabAccountListResponse>, StatusCodeHttpResult> result =
-			await _controller.GetAccounts(CancellationToken.None);
-
-		// Assert
-		StatusCodeHttpResult statusResult = Assert.IsType<StatusCodeHttpResult>(result.Result);
-		statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
-	}
-
-	[Fact]
 	public async Task GetAccounts_ReturnsEmptyList_WhenNoBudgetSelected()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
-
 		_mediatorMock.Setup(m => m.Send(
 			It.IsAny<GetSelectedYnabBudgetQuery>(),
 			It.IsAny<CancellationToken>()))

--- a/tests/Presentation.API.Tests/Controllers/YnabControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/YnabControllerTests.cs
@@ -49,7 +49,7 @@ public class YnabControllerTests
 	public async Task GetBudgets_Returns200_WithBudgetList_WhenConfigured()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 
 		List<YnabBudget> budgets =
 		[
@@ -72,24 +72,10 @@ public class YnabControllerTests
 	}
 
 	[Fact]
-	public async Task GetBudgets_Returns503_WhenNotConfigured()
-	{
-		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(false);
-
-		// Act
-		Results<Ok<YnabBudgetListResponse>, StatusCodeHttpResult> result = await _controller.GetBudgets(CancellationToken.None);
-
-		// Assert
-		StatusCodeHttpResult statusResult = Assert.IsType<StatusCodeHttpResult>(result.Result);
-		statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
-	}
-
-	[Fact]
 	public async Task GetBudgets_Returns503_OnYnabAuthException()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 
 		_mediatorMock.Setup(m => m.Send(
 			It.IsAny<GetYnabBudgetsQuery>(),
@@ -148,7 +134,7 @@ public class YnabControllerTests
 	public async Task GetCategories_Returns200_WithCategories_WhenConfigured()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 		_budgetSelectionMock.Setup(s => s.GetSelectedBudgetIdAsync(It.IsAny<CancellationToken>()))
 			.ReturnsAsync("budget-1");
 
@@ -174,24 +160,10 @@ public class YnabControllerTests
 	}
 
 	[Fact]
-	public async Task GetCategories_Returns503_WhenNotConfigured()
-	{
-		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(false);
-
-		// Act
-		Results<Ok<YnabCategoryListResponse>, StatusCodeHttpResult> result = await _controller.GetCategories(CancellationToken.None);
-
-		// Assert
-		StatusCodeHttpResult statusResult = Assert.IsType<StatusCodeHttpResult>(result.Result);
-		statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
-	}
-
-	[Fact]
 	public async Task GetCategories_Returns503_WhenNoBudgetSelected()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 		_budgetSelectionMock.Setup(s => s.GetSelectedBudgetIdAsync(It.IsAny<CancellationToken>()))
 			.ReturnsAsync((string?)null);
 
@@ -419,7 +391,7 @@ public class YnabControllerTests
 	public async Task SyncMemos_Returns200_WithResults_WhenConfigured()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 
 		Guid receiptId = Guid.NewGuid();
 		Guid txId = Guid.NewGuid();
@@ -446,26 +418,10 @@ public class YnabControllerTests
 	}
 
 	[Fact]
-	public async Task SyncMemos_Returns503_WhenNotConfigured()
-	{
-		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(false);
-
-		SyncYnabMemosRequest request = new() { ReceiptId = Guid.NewGuid() };
-
-		// Act
-		Results<Ok<YnabMemoSyncResponse>, StatusCodeHttpResult> result = await _controller.SyncMemos(request, CancellationToken.None);
-
-		// Assert
-		StatusCodeHttpResult statusResult = Assert.IsType<StatusCodeHttpResult>(result.Result);
-		statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
-	}
-
-	[Fact]
 	public async Task SyncMemos_Returns503_OnYnabAuthException()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 
 		_mediatorMock.Setup(m => m.Send(
 			It.IsAny<SyncYnabMemosCommand>(),
@@ -486,7 +442,7 @@ public class YnabControllerTests
 	public async Task SyncMemosBulk_Returns200_WithResults_WhenConfigured()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 
 		Guid receiptId = Guid.NewGuid();
 		List<Application.Models.Ynab.YnabMemoSyncResult> results =
@@ -510,26 +466,10 @@ public class YnabControllerTests
 	}
 
 	[Fact]
-	public async Task SyncMemosBulk_Returns503_WhenNotConfigured()
-	{
-		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(false);
-
-		SyncYnabMemosBulkRequest request = new() { ReceiptIds = [Guid.NewGuid()] };
-
-		// Act
-		Results<Ok<YnabMemoSyncResponse>, StatusCodeHttpResult> result = await _controller.SyncMemosBulk(request, CancellationToken.None);
-
-		// Assert
-		StatusCodeHttpResult statusResult = Assert.IsType<StatusCodeHttpResult>(result.Result);
-		statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
-	}
-
-	[Fact]
 	public async Task ResolveMemoSync_Returns200_WithResult_WhenConfigured()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 
 		Guid txId = Guid.NewGuid();
 		Application.Models.Ynab.YnabMemoSyncResult expected = new(
@@ -551,26 +491,10 @@ public class YnabControllerTests
 	}
 
 	[Fact]
-	public async Task ResolveMemoSync_Returns503_WhenNotConfigured()
-	{
-		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(false);
-
-		ResolveYnabMemoSyncRequest request = new() { LocalTransactionId = Guid.NewGuid(), YnabTransactionId = "yt-1" };
-
-		// Act
-		Results<Ok<YnabMemoSyncResultItem>, StatusCodeHttpResult> result = await _controller.ResolveMemoSync(request, CancellationToken.None);
-
-		// Assert
-		StatusCodeHttpResult statusResult = Assert.IsType<StatusCodeHttpResult>(result.Result);
-		statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
-	}
-
-	[Fact]
 	public async Task PushTransactions_Returns200_OnSuccess()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 		Guid receiptId = Guid.NewGuid();
 		Guid txId = Guid.NewGuid();
 
@@ -602,7 +526,7 @@ public class YnabControllerTests
 	public async Task PushTransactions_Returns400_OnFailure()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 		Guid receiptId = Guid.NewGuid();
 
 		PushYnabTransactionsResult pushResult = new(false, [],
@@ -627,26 +551,10 @@ public class YnabControllerTests
 	}
 
 	[Fact]
-	public async Task PushTransactions_Returns503_WhenNotConfigured()
-	{
-		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(false);
-		PushYnabTransactionsRequest request = new() { ReceiptId = Guid.NewGuid() };
-
-		// Act
-		Results<Ok<PushYnabTransactionsResponse>, BadRequest<PushYnabTransactionsResponse>, StatusCodeHttpResult> result =
-			await _controller.PushTransactions(request, CancellationToken.None);
-
-		// Assert
-		StatusCodeHttpResult statusResult = Assert.IsType<StatusCodeHttpResult>(result.Result);
-		statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
-	}
-
-	[Fact]
 	public async Task BulkPushTransactions_Returns200_WithResults()
 	{
 		// Arrange
-		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+
 		Guid receiptId1 = Guid.NewGuid();
 		Guid receiptId2 = Guid.NewGuid();
 

--- a/tests/Presentation.API.Tests/Controllers/YnabControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/YnabControllerTests.cs
@@ -49,8 +49,6 @@ public class YnabControllerTests
 	public async Task GetBudgets_Returns200_WithBudgetList_WhenConfigured()
 	{
 		// Arrange
-
-
 		List<YnabBudget> budgets =
 		[
 			new("budget-1", "My Budget"),
@@ -75,8 +73,6 @@ public class YnabControllerTests
 	public async Task GetBudgets_Returns503_OnYnabAuthException()
 	{
 		// Arrange
-
-
 		_mediatorMock.Setup(m => m.Send(
 			It.IsAny<GetYnabBudgetsQuery>(),
 			It.IsAny<CancellationToken>()))
@@ -134,7 +130,6 @@ public class YnabControllerTests
 	public async Task GetCategories_Returns200_WithCategories_WhenConfigured()
 	{
 		// Arrange
-
 		_budgetSelectionMock.Setup(s => s.GetSelectedBudgetIdAsync(It.IsAny<CancellationToken>()))
 			.ReturnsAsync("budget-1");
 
@@ -163,7 +158,6 @@ public class YnabControllerTests
 	public async Task GetCategories_Returns503_WhenNoBudgetSelected()
 	{
 		// Arrange
-
 		_budgetSelectionMock.Setup(s => s.GetSelectedBudgetIdAsync(It.IsAny<CancellationToken>()))
 			.ReturnsAsync((string?)null);
 
@@ -391,8 +385,6 @@ public class YnabControllerTests
 	public async Task SyncMemos_Returns200_WithResults_WhenConfigured()
 	{
 		// Arrange
-
-
 		Guid receiptId = Guid.NewGuid();
 		Guid txId = Guid.NewGuid();
 		List<Application.Models.Ynab.YnabMemoSyncResult> results =
@@ -421,8 +413,6 @@ public class YnabControllerTests
 	public async Task SyncMemos_Returns503_OnYnabAuthException()
 	{
 		// Arrange
-
-
 		_mediatorMock.Setup(m => m.Send(
 			It.IsAny<SyncYnabMemosCommand>(),
 			It.IsAny<CancellationToken>()))
@@ -442,8 +432,6 @@ public class YnabControllerTests
 	public async Task SyncMemosBulk_Returns200_WithResults_WhenConfigured()
 	{
 		// Arrange
-
-
 		Guid receiptId = Guid.NewGuid();
 		List<Application.Models.Ynab.YnabMemoSyncResult> results =
 		[
@@ -469,8 +457,6 @@ public class YnabControllerTests
 	public async Task ResolveMemoSync_Returns200_WithResult_WhenConfigured()
 	{
 		// Arrange
-
-
 		Guid txId = Guid.NewGuid();
 		Application.Models.Ynab.YnabMemoSyncResult expected = new(
 			txId, Guid.NewGuid(), Application.Models.Ynab.YnabMemoSyncOutcome.Synced, "yt-1", null, null);
@@ -494,7 +480,6 @@ public class YnabControllerTests
 	public async Task PushTransactions_Returns200_OnSuccess()
 	{
 		// Arrange
-
 		Guid receiptId = Guid.NewGuid();
 		Guid txId = Guid.NewGuid();
 
@@ -526,7 +511,6 @@ public class YnabControllerTests
 	public async Task PushTransactions_Returns400_OnFailure()
 	{
 		// Arrange
-
 		Guid receiptId = Guid.NewGuid();
 
 		PushYnabTransactionsResult pushResult = new(false, [],
@@ -554,7 +538,6 @@ public class YnabControllerTests
 	public async Task BulkPushTransactions_Returns200_WithResults()
 	{
 		// Arrange
-
 		Guid receiptId1 = Guid.NewGuid();
 		Guid receiptId2 = Guid.NewGuid();
 

--- a/tests/Presentation.API.Tests/Filters/RequireYnabConfiguredAttributeTests.cs
+++ b/tests/Presentation.API.Tests/Filters/RequireYnabConfiguredAttributeTests.cs
@@ -1,0 +1,85 @@
+using API.Filters;
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Presentation.API.Tests.Filters;
+
+public class RequireYnabConfiguredAttributeTests
+{
+	private readonly Mock<IYnabApiClient> _ynabClientMock = new();
+	private readonly Mock<ILogger<RequireYnabConfiguredAttribute>> _loggerMock = new();
+
+	private ActionExecutingContext CreateContext()
+	{
+		DefaultHttpContext httpContext = new();
+		ActionContext actionContext = new(httpContext, new RouteData(), new ActionDescriptor());
+		return new ActionExecutingContext(
+			actionContext,
+			[],
+			new Dictionary<string, object?>(),
+			new object());
+	}
+
+	private IAsyncActionFilter CreateFilter()
+	{
+		ServiceCollection services = new();
+		services.AddSingleton(_ynabClientMock.Object);
+		services.AddSingleton(_loggerMock.Object);
+		ServiceProvider provider = services.BuildServiceProvider();
+
+		RequireYnabConfiguredAttribute attribute = new();
+		IFilterFactory factory = (IFilterFactory)attribute;
+		return (IAsyncActionFilter)factory.CreateInstance(provider);
+	}
+
+	[Fact]
+	public async Task OnActionExecutionAsync_WhenConfigured_CallsNext()
+	{
+		// Arrange
+		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+		IAsyncActionFilter filter = CreateFilter();
+		ActionExecutingContext context = CreateContext();
+		bool nextCalled = false;
+
+		// Act
+		await filter.OnActionExecutionAsync(context, () =>
+		{
+			nextCalled = true;
+			return Task.FromResult<ActionExecutedContext>(null!);
+		});
+
+		// Assert
+		nextCalled.Should().BeTrue();
+		context.Result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task OnActionExecutionAsync_WhenNotConfigured_Returns503()
+	{
+		// Arrange
+		_ynabClientMock.Setup(c => c.IsConfigured).Returns(false);
+		IAsyncActionFilter filter = CreateFilter();
+		ActionExecutingContext context = CreateContext();
+		bool nextCalled = false;
+
+		// Act
+		await filter.OnActionExecutionAsync(context, () =>
+		{
+			nextCalled = true;
+			return Task.FromResult<ActionExecutedContext>(null!);
+		});
+
+		// Assert
+		nextCalled.Should().BeFalse();
+		StatusCodeResult statusCodeResult = Assert.IsType<StatusCodeResult>(context.Result);
+		statusCodeResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+	}
+}


### PR DESCRIPTION
## Summary
- Extract the repeated `ynabClient.IsConfigured` guard clause (8 occurrences) from `YnabController` into a `[RequireYnabConfigured]` action filter attribute
- The `TypeFilterAttribute` + `IAsyncActionFilter` resolves `IYnabApiClient` via DI and returns 503 Service Unavailable when YNAB_PAT is not configured
- Remove 7 redundant `*_WhenNotConfigured` controller tests, replace with 2 targeted filter tests

## Test plan
- [x] `RequireYnabConfiguredAttributeTests.OnActionExecutionAsync_WhenConfigured_CallsNext` -- verifies pass-through
- [x] `RequireYnabConfiguredAttributeTests.OnActionExecutionAsync_WhenNotConfigured_Returns503` -- verifies 503 response
- [x] All 1963 unit tests pass with no regressions
- [x] Build succeeds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)