### PR TITLE
fix(api): remediate YNAB push handler bugs (RECEIPTS-506)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -6439,6 +6439,8 @@ components:
       properties:
         receiptIds:
           type: array
+          minItems: 1
+          maxItems: 100
           items:
             type: string
             format: uuid

--- a/src/Application/Commands/Ynab/PushTransactions/BulkPushYnabTransactionsCommandHandler.cs
+++ b/src/Application/Commands/Ynab/PushTransactions/BulkPushYnabTransactionsCommandHandler.cs
@@ -26,9 +26,17 @@ public class BulkPushYnabTransactionsCommandHandler(IMediator mediator, IYnabRat
 
 		foreach (Guid receiptId in request.ReceiptIds)
 		{
-			PushYnabTransactionsResult result = await mediator.Send(
-				new PushYnabTransactionsCommand(receiptId), cancellationToken);
-			results.Add(new ReceiptPushResult(receiptId, result));
+			try
+			{
+				PushYnabTransactionsResult result = await mediator.Send(
+					new PushYnabTransactionsCommand(receiptId), cancellationToken);
+				results.Add(new ReceiptPushResult(receiptId, result));
+			}
+			catch (Exception ex)
+			{
+				PushYnabTransactionsResult failureResult = new(false, [], Error: $"Unexpected error: {ex.Message}");
+				results.Add(new ReceiptPushResult(receiptId, failureResult));
+			}
 		}
 
 		return new BulkPushYnabTransactionsResult(results);

--- a/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
+++ b/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
@@ -99,15 +99,15 @@ public class PushYnabTransactionsCommandHandler(
 			return new PushYnabTransactionsResult(false, [], Error: "Some transaction accounts are not mapped to YNAB accounts.");
 		}
 
-		// 5. Check no transaction is already synced
+		// 5. Skip already-synced transactions (allows retry after partial push)
+		HashSet<Guid> alreadySyncedIds = [];
 		foreach (Domain.Core.Transaction tx in transactions)
 		{
 			YnabSyncRecordDto? existingSync = await syncRecordService.GetByTransactionAndTypeAsync(
 				tx.Id, YnabSyncType.TransactionPush, cancellationToken);
 			if (existingSync is not null && existingSync.SyncStatus == YnabSyncStatus.Synced)
 			{
-				return new PushYnabTransactionsResult(false, [],
-					Error: $"Transaction {tx.Id} has already been synced to YNAB.");
+				alreadySyncedIds.Add(tx.Id);
 			}
 		}
 
@@ -130,20 +130,27 @@ public class PushYnabTransactionsCommandHandler(
 		foreach (YnabTransactionSplit txSplit in splitResult.TransactionSplits)
 		{
 			Domain.Core.Transaction localTx = transactions.First(t => t.Id == txSplit.LocalTransactionId);
+
+			// Skip already-synced transactions (Bug 1: allows retry after partial push)
+			if (alreadySyncedIds.Contains(localTx.Id))
+			{
+				continue;
+			}
+
 			string ynabAccountId = accountToYnabId[localTx.AccountId];
 
-			// Compute import_id for deduplication
+			// Compute import_id for deduplication (includes receipt prefix to avoid cross-receipt collision)
 			(long Milliunits, DateOnly Date) importIdKey = (txSplit.TotalMilliunits, localTx.Date);
 			int occurrence = importIdOccurrences.TryGetValue(importIdKey, out int current) ? current + 1 : 1;
 			importIdOccurrences[importIdKey] = occurrence;
-			string importId = YnabImportId.Generate(txSplit.TotalMilliunits, localTx.Date, occurrence);
-
-			// Create sync record (Pending)
-			YnabSyncRecordDto syncRecord = await syncRecordService.CreateAsync(
-				localTx.Id, budgetId, YnabSyncType.TransactionPush, cancellationToken);
+			string importId = YnabImportId.Generate(txSplit.TotalMilliunits, localTx.Date, request.ReceiptId, occurrence);
 
 			try
 			{
+				// Create sync record (Pending) — inside try so DB failure is caught (Bug 3)
+				YnabSyncRecordDto syncRecord = await syncRecordService.CreateAsync(
+					localTx.Id, budgetId, YnabSyncType.TransactionPush, cancellationToken);
+
 				// Build sub-transactions
 				List<YnabSubTransaction>? subTransactions = null;
 				string? categoryId = null;
@@ -174,9 +181,24 @@ public class PushYnabTransactionsCommandHandler(
 				YnabCreateTransactionResponse ynabResponse = await ynabApiClient.CreateTransactionAsync(
 					budgetId, ynabRequest, cancellationToken);
 
-				// Update sync record to Synced
-				await syncRecordService.UpdateStatusAsync(
-					syncRecord.Id, YnabSyncStatus.Synced, ynabResponse.TransactionId, null, cancellationToken);
+				// Update sync record to Synced — separate error handling (Bug 6)
+				try
+				{
+					await syncRecordService.UpdateStatusAsync(
+						syncRecord.Id, YnabSyncStatus.Synced, ynabResponse.TransactionId, null, cancellationToken);
+				}
+				catch (Exception statusEx)
+				{
+					// YNAB TX already created; don't mark as Failed. Return success with warning.
+					pushedTransactions.Add(new PushedTransactionInfo(
+						localTx.Id,
+						ynabResponse.TransactionId,
+						txSplit.TotalMilliunits,
+						txSplit.SubTransactions.Count));
+
+					return new PushYnabTransactionsResult(true, pushedTransactions,
+						Error: $"YNAB transaction created but sync record update failed for transaction {localTx.Id}: {statusEx.Message}");
+				}
 
 				pushedTransactions.Add(new PushedTransactionInfo(
 					localTx.Id,
@@ -186,12 +208,8 @@ public class PushYnabTransactionsCommandHandler(
 			}
 			catch (Exception ex)
 			{
-				// Update sync record to Failed
-				await syncRecordService.UpdateStatusAsync(
-					syncRecord.Id, YnabSyncStatus.Failed, null, ex.Message, cancellationToken);
-
 				return new PushYnabTransactionsResult(false, pushedTransactions,
-					Error: $"Failed to create YNAB transaction for local transaction {localTx.Id}: {ex.Message}");
+					Error: $"Failed to push YNAB transaction for local transaction {localTx.Id}: {ex.Message}");
 			}
 		}
 

--- a/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
+++ b/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
@@ -145,10 +145,11 @@ public class PushYnabTransactionsCommandHandler(
 			importIdOccurrences[importIdKey] = occurrence;
 			string importId = YnabImportId.Generate(txSplit.TotalMilliunits, localTx.Date, request.ReceiptId, occurrence);
 
+			YnabSyncRecordDto? syncRecord = null;
 			try
 			{
 				// Create sync record (Pending) — inside try so DB failure is caught (Bug 3)
-				YnabSyncRecordDto syncRecord = await syncRecordService.CreateAsync(
+				syncRecord = await syncRecordService.CreateAsync(
 					localTx.Id, budgetId, YnabSyncType.TransactionPush, cancellationToken);
 
 				// Build sub-transactions
@@ -208,6 +209,13 @@ public class PushYnabTransactionsCommandHandler(
 			}
 			catch (Exception ex)
 			{
+				// Mark sync record as Failed if it was created (preserves original behavior)
+				if (syncRecord is not null)
+				{
+					await syncRecordService.UpdateStatusAsync(
+						syncRecord.Id, YnabSyncStatus.Failed, null, ex.Message, cancellationToken);
+				}
+
 				return new PushYnabTransactionsResult(false, pushedTransactions,
 					Error: $"Failed to push YNAB transaction for local transaction {localTx.Id}: {ex.Message}");
 			}

--- a/src/Application/Utilities/YnabImportId.cs
+++ b/src/Application/Utilities/YnabImportId.cs
@@ -3,12 +3,14 @@ namespace Application.Utilities;
 public static class YnabImportId
 {
 	private const int MaxLength = 36;
+	private const int ReceiptPrefixLength = 8;
 
-	public static string Generate(long milliunits, DateOnly date, int occurrence)
+	public static string Generate(long milliunits, DateOnly date, Guid receiptId, int occurrence)
 	{
 		ArgumentOutOfRangeException.ThrowIfLessThan(occurrence, 1);
 
-		string importId = $"YNAB:{milliunits}:{date:yyyy-MM-dd}:{occurrence}";
+		string receiptPrefix = receiptId.ToString("N")[..ReceiptPrefixLength];
+		string importId = $"YNAB:{milliunits}:{date:yyyy-MM-dd}:{receiptPrefix}:{occurrence}";
 
 		if (importId.Length > MaxLength)
 		{

--- a/src/Presentation/API/Validators/BulkPushYnabTransactionsRequestValidator.cs
+++ b/src/Presentation/API/Validators/BulkPushYnabTransactionsRequestValidator.cs
@@ -5,7 +5,9 @@ namespace API.Validators;
 
 public class BulkPushYnabTransactionsRequestValidator : AbstractValidator<BulkPushYnabTransactionsRequest>
 {
+	public const int MaxReceiptIds = 100;
 	public const string ReceiptIdsMustNotBeEmpty = "At least one receipt ID is required.";
+	public const string ReceiptIdsTooMany = "Cannot push more than 100 receipts at once.";
 	public const string ReceiptIdMustNotBeEmpty = "Each receipt ID must not be empty.";
 
 	public BulkPushYnabTransactionsRequestValidator()
@@ -13,6 +15,10 @@ public class BulkPushYnabTransactionsRequestValidator : AbstractValidator<BulkPu
 		RuleFor(x => x.ReceiptIds)
 			.NotEmpty()
 			.WithMessage(ReceiptIdsMustNotBeEmpty);
+
+		RuleFor(x => x.ReceiptIds)
+			.Must(ids => ids is null || ids.Count <= MaxReceiptIds)
+			.WithMessage(ReceiptIdsTooMany);
 
 		RuleForEach(x => x.ReceiptIds)
 			.NotEmpty()

--- a/tests/Application.Tests/Commands/Ynab/BulkPushYnabTransactionsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/BulkPushYnabTransactionsCommandHandlerTests.cs
@@ -83,7 +83,93 @@ public class BulkPushYnabTransactionsCommandHandlerTests
 		// Act
 		await _handler.Handle(command, CancellationToken.None);
 
-		// Assert — checks with 2 receipts * 2 estimated requests per receipt = 4
+		// Assert -- checks with 2 receipts * 2 estimated requests per receipt = 4
 		_rateLimitTrackerMock.Verify(r => r.CanMakeRequests(4), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_AllSucceed_ReturnsAllResults()
+	{
+		// Arrange
+		Guid receipt1 = Guid.NewGuid();
+		Guid receipt2 = Guid.NewGuid();
+		PushYnabTransactionsResult successResult1 = new(true, [new PushedTransactionInfo(Guid.NewGuid(), "ynab-1", -1000, 1)]);
+		PushYnabTransactionsResult successResult2 = new(true, [new PushedTransactionInfo(Guid.NewGuid(), "ynab-2", -2000, 1)]);
+
+		_mediatorMock.Setup(m => m.Send(It.Is<PushYnabTransactionsCommand>(c => c.ReceiptId == receipt1), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(successResult1);
+		_mediatorMock.Setup(m => m.Send(It.Is<PushYnabTransactionsCommand>(c => c.ReceiptId == receipt2), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(successResult2);
+
+		// Act
+		BulkPushYnabTransactionsResult result = await _handler.Handle(
+			new BulkPushYnabTransactionsCommand([receipt1, receipt2]), CancellationToken.None);
+
+		// Assert
+		result.Results.Should().HaveCount(2);
+		result.Results[0].ReceiptId.Should().Be(receipt1);
+		result.Results[0].Result.Success.Should().BeTrue();
+		result.Results[1].ReceiptId.Should().Be(receipt2);
+		result.Results[1].Result.Success.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Handle_ExceptionOnSecondReceipt_ContinuesAndReturnsAll()
+	{
+		// Bug 2: Exception on receipt N must not abort remaining receipts
+		Guid receipt1 = Guid.NewGuid();
+		Guid receipt2 = Guid.NewGuid();
+		Guid receipt3 = Guid.NewGuid();
+
+		PushYnabTransactionsResult successResult = new(true, [new PushedTransactionInfo(Guid.NewGuid(), "ynab-1", -1000, 1)]);
+
+		_mediatorMock.Setup(m => m.Send(It.Is<PushYnabTransactionsCommand>(c => c.ReceiptId == receipt1), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(successResult);
+		_mediatorMock.Setup(m => m.Send(It.Is<PushYnabTransactionsCommand>(c => c.ReceiptId == receipt2), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("DB connection lost"));
+		_mediatorMock.Setup(m => m.Send(It.Is<PushYnabTransactionsCommand>(c => c.ReceiptId == receipt3), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(successResult);
+
+		// Act
+		BulkPushYnabTransactionsResult result = await _handler.Handle(
+			new BulkPushYnabTransactionsCommand([receipt1, receipt2, receipt3]), CancellationToken.None);
+
+		// Assert: all 3 receipts have results, receipt2 has failure
+		result.Results.Should().HaveCount(3);
+		result.Results[0].Result.Success.Should().BeTrue();
+		result.Results[1].Result.Success.Should().BeFalse();
+		result.Results[1].Result.Error.Should().Contain("DB connection lost");
+		result.Results[2].Result.Success.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Handle_ExceptionResult_ContainsUnexpectedErrorPrefix()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		_mediatorMock.Setup(m => m.Send(It.IsAny<PushYnabTransactionsCommand>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("Network timeout"));
+
+		// Act
+		BulkPushYnabTransactionsResult result = await _handler.Handle(
+			new BulkPushYnabTransactionsCommand([receiptId]), CancellationToken.None);
+
+		// Assert
+		result.Results.Should().HaveCount(1);
+		result.Results[0].Result.Success.Should().BeFalse();
+		result.Results[0].Result.Error.Should().StartWith("Unexpected error:");
+		result.Results[0].Result.PushedTransactions.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Handle_EmptyReceiptIds_ReturnsEmptyResults()
+	{
+		// Act
+		BulkPushYnabTransactionsResult result = await _handler.Handle(
+			new BulkPushYnabTransactionsCommand([]), CancellationToken.None);
+
+		// Assert
+		result.Results.Should().BeEmpty();
+		_mediatorMock.Verify(m => m.Send(It.IsAny<PushYnabTransactionsCommand>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 }

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
@@ -200,7 +200,7 @@ public class PushYnabTransactionsCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task Handle_AlreadySynced_ReturnsError()
+	public async Task Handle_AlreadySynced_SkipsTransactionAndSucceeds()
 	{
 		SetupHappyPath();
 		_syncRecordServiceMock.Setup(s => s.GetByTransactionAndTypeAsync(_transactionId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
@@ -209,8 +209,64 @@ public class PushYnabTransactionsCommandHandlerTests
 		PushYnabTransactionsResult result = await _handler.Handle(
 			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
 
-		result.Success.Should().BeFalse();
-		result.Error.Should().Contain("already been synced");
+		// Bug 1 fix: already-synced transactions are skipped, not rejected
+		result.Success.Should().BeTrue();
+		result.PushedTransactions.Should().BeEmpty();
+		_ynabApiClientMock.Verify(s => s.CreateTransactionAsync(It.IsAny<string>(), It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_PartialSync_SkipsSyncedAndPushesRemaining()
+	{
+		SetupHappyPath();
+
+		// Set up two transactions: TX1 already synced, TX2 not synced
+		Guid transactionId2 = Guid.NewGuid();
+		Domain.Core.Transaction tx1 = new(_transactionId, new Money(11.00m), DateOnly.FromDateTime(DateTime.Today.AddDays(-1)));
+		tx1.AccountId = _accountId;
+		tx1.ReceiptId = _receiptId;
+		Domain.Core.Transaction tx2 = new(transactionId2, new Money(5.00m), DateOnly.FromDateTime(DateTime.Today.AddDays(-1)));
+		tx2.AccountId = _accountId;
+		tx2.ReceiptId = _receiptId;
+
+		Domain.Core.Account account = new(_accountId, "CHK001", "Checking", true);
+		_transactionServiceMock.Setup(s => s.GetTransactionAccountsByReceiptIdAsync(_receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([
+				new TransactionAccount { Transaction = tx1, Account = account },
+				new TransactionAccount { Transaction = tx2, Account = account },
+			]);
+
+		// TX1 is already synced
+		_syncRecordServiceMock.Setup(s => s.GetByTransactionAndTypeAsync(_transactionId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabSyncRecordDto(Guid.NewGuid(), _transactionId, "ynab-tx-old", _budgetId, null, YnabSyncType.TransactionPush, YnabSyncStatus.Synced, DateTimeOffset.UtcNow, null, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+		// TX2 is not synced
+		_syncRecordServiceMock.Setup(s => s.GetByTransactionAndTypeAsync(transactionId2, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((YnabSyncRecordDto?)null);
+
+		Guid syncRecordId2 = Guid.NewGuid();
+		_syncRecordServiceMock.Setup(s => s.CreateAsync(transactionId2, _budgetId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabSyncRecordDto(syncRecordId2, transactionId2, null, _budgetId, null, YnabSyncType.TransactionPush, YnabSyncStatus.Pending, null, null, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+
+		_splitCalculatorMock.Setup(s => s.ComputeWaterfallSplits(It.IsAny<ReceiptWithItems>(), It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Dictionary<string, string>>()))
+			.Returns(new YnabSplitResult([
+				new YnabTransactionSplit(_transactionId, -11000, [new YnabSubTransactionSplit("ynab-cat-1", -11000)]),
+				new YnabTransactionSplit(transactionId2, -5000, [new YnabSubTransactionSplit("ynab-cat-1", -5000)]),
+			]));
+
+		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabCreateTransactionResponse("ynab-tx-2"));
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		// TX1 skipped, TX2 pushed
+		result.Success.Should().BeTrue();
+		result.PushedTransactions.Should().HaveCount(1);
+		result.PushedTransactions[0].LocalTransactionId.Should().Be(transactionId2);
+
+		// CreateAsync only called for TX2
+		_syncRecordServiceMock.Verify(s => s.CreateAsync(_transactionId, It.IsAny<string>(), It.IsAny<YnabSyncType>(), It.IsAny<CancellationToken>()), Times.Never);
+		_syncRecordServiceMock.Verify(s => s.CreateAsync(transactionId2, _budgetId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()), Times.Once);
 	}
 
 	[Fact]
@@ -242,7 +298,7 @@ public class PushYnabTransactionsCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task Handle_YnabApiFailure_TracksSyncAsFailedAndReturnsError()
+	public async Task Handle_YnabApiFailure_ReturnsErrorWithMessage()
 	{
 		SetupHappyPath();
 		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
@@ -253,9 +309,42 @@ public class PushYnabTransactionsCommandHandlerTests
 
 		result.Success.Should().BeFalse();
 		result.Error.Should().Contain("YNAB API down");
-		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
-			It.IsAny<Guid>(), YnabSyncStatus.Failed, null, It.IsAny<string>(),
-			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_CreateAsyncFailure_ReturnsFalseWithoutCallingYnabApi()
+	{
+		// Bug 3: CreateAsync is now inside the try block, so DB failures are caught
+		SetupHappyPath();
+		_syncRecordServiceMock.Setup(s => s.CreateAsync(_transactionId, _budgetId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("DB connection lost"));
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.Error.Should().Contain("DB connection lost");
+		_ynabApiClientMock.Verify(s => s.CreateTransactionAsync(It.IsAny<string>(), It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_StatusUpdateFailsAfterYnabSuccess_ReturnsSuccessWithWarning()
+	{
+		// Bug 6: If UpdateStatusAsync(Synced) throws after YNAB TX created,
+		// the result should be Success=true with a warning, not Failed
+		SetupHappyPath();
+		_syncRecordServiceMock.Setup(s => s.UpdateStatusAsync(
+				It.IsAny<Guid>(), YnabSyncStatus.Synced, "ynab-tx-1", null,
+				It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("DB timeout on status update"));
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		result.PushedTransactions.Should().HaveCount(1);
+		result.Error.Should().Contain("sync record update failed");
+		result.Error.Should().Contain("DB timeout on status update");
 	}
 
 	[Fact]
@@ -275,7 +364,7 @@ public class PushYnabTransactionsCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task Handle_HappyPath_PassesImportIdToCreateTransaction()
+	public async Task Handle_HappyPath_PassesImportIdWithReceiptPrefixToCreateTransaction()
 	{
 		SetupHappyPath();
 		YnabCreateTransactionRequest? capturedRequest = null;
@@ -289,7 +378,10 @@ public class PushYnabTransactionsCommandHandlerTests
 		capturedRequest.Should().NotBeNull();
 		capturedRequest!.ImportId.Should().NotBeNullOrEmpty();
 		capturedRequest.ImportId.Should().StartWith("YNAB:");
-		string expected = $"YNAB:-11000:{DateTime.Today.AddDays(-1):yyyy-MM-dd}:1";
+
+		// Import ID should contain the receipt prefix (first 8 hex chars of receipt ID)
+		string receiptPrefix = _receiptId.ToString("N")[..8];
+		string expected = $"YNAB:-11000:{DateTime.Today.AddDays(-1):yyyy-MM-dd}:{receiptPrefix}:1";
 		capturedRequest.ImportId.Should().Be(expected);
 	}
 

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
@@ -298,7 +298,7 @@ public class PushYnabTransactionsCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task Handle_YnabApiFailure_ReturnsErrorWithMessage()
+	public async Task Handle_YnabApiFailure_MarksSyncRecordAsFailedAndReturnsError()
 	{
 		SetupHappyPath();
 		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
@@ -309,6 +309,9 @@ public class PushYnabTransactionsCommandHandlerTests
 
 		result.Success.Should().BeFalse();
 		result.Error.Should().Contain("YNAB API down");
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			It.IsAny<Guid>(), YnabSyncStatus.Failed, null, It.Is<string>(msg => msg.Contains("YNAB API down")),
+			It.IsAny<CancellationToken>()), Times.Once);
 	}
 
 	[Fact]

--- a/tests/Application.Tests/Utilities/YnabImportIdTests.cs
+++ b/tests/Application.Tests/Utilities/YnabImportIdTests.cs
@@ -5,6 +5,9 @@ namespace Application.Tests.Utilities;
 
 public class YnabImportIdTests
 {
+	private static readonly Guid TestReceiptId = Guid.Parse("abcdef01-2345-6789-abcd-ef0123456789");
+	private static readonly string TestReceiptPrefix = TestReceiptId.ToString("N")[..8]; // "abcdef01"
+
 	[Fact]
 	public void Generate_StandardInput_ReturnsExpectedFormat()
 	{
@@ -14,10 +17,10 @@ public class YnabImportIdTests
 		int occurrence = 1;
 
 		// Act
-		string actual = YnabImportId.Generate(milliunits, date, occurrence);
+		string actual = YnabImportId.Generate(milliunits, date, TestReceiptId, occurrence);
 
 		// Assert
-		string expected = "YNAB:-11000:2025-03-15:1";
+		string expected = $"YNAB:-11000:2025-03-15:{TestReceiptPrefix}:1";
 		actual.Should().Be(expected);
 	}
 
@@ -30,10 +33,10 @@ public class YnabImportIdTests
 		int occurrence = 1;
 
 		// Act
-		string actual = YnabImportId.Generate(milliunits, date, occurrence);
+		string actual = YnabImportId.Generate(milliunits, date, TestReceiptId, occurrence);
 
 		// Assert
-		string expected = "YNAB:-5500:2025-01-01:1";
+		string expected = $"YNAB:-5500:2025-01-01:{TestReceiptPrefix}:1";
 		actual.Should().Be(expected);
 	}
 
@@ -46,10 +49,10 @@ public class YnabImportIdTests
 		int occurrence = 1;
 
 		// Act
-		string actual = YnabImportId.Generate(milliunits, date, occurrence);
+		string actual = YnabImportId.Generate(milliunits, date, TestReceiptId, occurrence);
 
 		// Assert
-		string expected = "YNAB:3000:2025-12-31:1";
+		string expected = $"YNAB:3000:2025-12-31:{TestReceiptPrefix}:1";
 		actual.Should().Be(expected);
 	}
 
@@ -62,10 +65,10 @@ public class YnabImportIdTests
 		int occurrence = 1;
 
 		// Act
-		string actual = YnabImportId.Generate(milliunits, date, occurrence);
+		string actual = YnabImportId.Generate(milliunits, date, TestReceiptId, occurrence);
 
 		// Assert
-		string expected = "YNAB:0:2025-06-15:1";
+		string expected = $"YNAB:0:2025-06-15:{TestReceiptPrefix}:1";
 		actual.Should().Be(expected);
 	}
 
@@ -78,10 +81,10 @@ public class YnabImportIdTests
 		int occurrence = 3;
 
 		// Act
-		string actual = YnabImportId.Generate(milliunits, date, occurrence);
+		string actual = YnabImportId.Generate(milliunits, date, TestReceiptId, occurrence);
 
 		// Assert
-		string expected = "YNAB:-11000:2025-03-15:3";
+		string expected = $"YNAB:-11000:2025-03-15:{TestReceiptPrefix}:3";
 		actual.Should().Be(expected);
 	}
 
@@ -96,7 +99,7 @@ public class YnabImportIdTests
 		DateOnly date = new(2025, 3, 15);
 
 		// Act
-		Action act = () => YnabImportId.Generate(milliunits, date, occurrence);
+		Action act = () => YnabImportId.Generate(milliunits, date, TestReceiptId, occurrence);
 
 		// Assert
 		act.Should().Throw<ArgumentOutOfRangeException>();
@@ -106,16 +109,65 @@ public class YnabImportIdTests
 	public void Generate_ResultExceeds36Characters_ThrowsInvalidOperationException()
 	{
 		// Arrange — long.MaxValue (19 digits) pushes the string beyond 36 chars
-		// "YNAB:" (5) + 19-digit number + ":" (1) + "2025-03-15" (10) + ":" (1) + "1" (1) = 37
 		long milliunits = long.MaxValue;
 		DateOnly date = new(2025, 3, 15);
 		int occurrence = 1;
 
 		// Act
-		Action act = () => YnabImportId.Generate(milliunits, date, occurrence);
+		Action act = () => YnabImportId.Generate(milliunits, date, TestReceiptId, occurrence);
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>()
 			.WithMessage("*exceeds YNAB's 36-character limit*");
+	}
+
+	[Fact]
+	public void Generate_DifferentReceiptIds_ProduceDifferentImportIds()
+	{
+		// Arrange
+		long milliunits = -11000;
+		DateOnly date = new(2025, 3, 15);
+		int occurrence = 1;
+		Guid receiptId1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
+		Guid receiptId2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+		// Act
+		string id1 = YnabImportId.Generate(milliunits, date, receiptId1, occurrence);
+		string id2 = YnabImportId.Generate(milliunits, date, receiptId2, occurrence);
+
+		// Assert
+		id1.Should().NotBe(id2);
+	}
+
+	[Fact]
+	public void Generate_ReceiptPrefixIsFirst8HexCharsWithoutHyphens()
+	{
+		// Arrange
+		Guid receiptId = Guid.Parse("deadbeef-cafe-babe-dead-beefcafebabe");
+		long milliunits = -1000;
+		DateOnly date = new(2025, 1, 1);
+		int occurrence = 1;
+
+		// Act
+		string actual = YnabImportId.Generate(milliunits, date, receiptId, occurrence);
+
+		// Assert
+		actual.Should().Contain("deadbeef");
+		actual.Should().Be("YNAB:-1000:2025-01-01:deadbeef:1");
+	}
+
+	[Fact]
+	public void Generate_TypicalValues_StaysWithin36CharLimit()
+	{
+		// Arrange — typical receipt amount in milliunits and common date
+		long milliunits = -9999999;
+		DateOnly date = new(2025, 12, 31);
+		int occurrence = 1;
+
+		// Act
+		string actual = YnabImportId.Generate(milliunits, date, TestReceiptId, occurrence);
+
+		// Assert
+		actual.Length.Should().BeLessThanOrEqualTo(36);
 	}
 }

--- a/tests/Presentation.API.Tests/Validators/BulkPushYnabTransactionsRequestValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Validators/BulkPushYnabTransactionsRequestValidatorTests.cs
@@ -57,4 +57,39 @@ public class BulkPushYnabTransactionsRequestValidatorTests
 		// Assert
 		result.IsValid.Should().BeFalse();
 	}
+
+	[Fact]
+	public void ReceiptIds_ExceedingMaxCount_Fails()
+	{
+		// Arrange
+		List<Guid> ids = Enumerable.Range(0, 101).Select(_ => Guid.NewGuid()).ToList();
+		BulkPushYnabTransactionsRequest request = new()
+		{
+			ReceiptIds = ids,
+		};
+
+		// Act
+		ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.ErrorMessage == BulkPushYnabTransactionsRequestValidator.ReceiptIdsTooMany);
+	}
+
+	[Fact]
+	public void ReceiptIds_AtMaxCount_Passes()
+	{
+		// Arrange
+		List<Guid> ids = Enumerable.Range(0, 100).Select(_ => Guid.NewGuid()).ToList();
+		BulkPushYnabTransactionsRequest request = new()
+		{
+			ReceiptIds = ids,
+		};
+
+		// Act
+		ValidationResult result = _validator.Validate(request);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
 }


### PR DESCRIPTION
## Summary
- **Bug 1 (HIGH):** Fix retry deadlock -- skip already-synced transactions with `continue` instead of aborting
- **Bug 2 (HIGH):** Add try-catch isolation per receipt in BulkPush handler so infrastructure exceptions don't abort remaining receipts
- **Bug 3 (HIGH):** Move `syncRecordService.CreateAsync` inside try block to catch DB failures before YNAB API call
- **Bug 4 (MEDIUM):** Add receipt-scoped prefix (8 hex chars) to import IDs to prevent cross-receipt collision
- **Bug 5 (LOW):** Add `minItems: 1` / `maxItems: 100` to bulk push request (FluentValidation + OpenAPI spec)
- **Bug 6 (MEDIUM):** Separate YNAB API error handling from sync status update -- don't mark Failed when TX already exists in YNAB

## Test plan
- [x] `Handle_AlreadySynced_SkipsTransactionAndSucceeds` -- verifies synced TXs are skipped
- [x] `Handle_PartialSync_SkipsSyncedAndPushesRemaining` -- verifies retry pushes only un-synced TXs
- [x] `Handle_ExceptionOnSecondReceipt_ContinuesAndReturnsAll` -- verifies bulk isolation
- [x] `Handle_CreateAsyncFailure_ReturnsFalseWithoutCallingYnabApi` -- verifies CreateAsync inside try
- [x] `Handle_StatusUpdateFailsAfterYnabSuccess_ReturnsSuccessWithWarning` -- verifies Bug 6 fix
- [x] `Handle_YnabApiFailure_MarksSyncRecordAsFailedAndReturnsError` -- verifies sync record marked Failed
- [x] `Generate_DifferentReceiptIds_ProduceDifferentImportIds` -- verifies import ID uniqueness
- [x] `ReceiptIds_ExceedingMaxCount_Fails` / `ReceiptIds_AtMaxCount_Passes` -- verifies maxItems validation
- [x] All 1980 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)