### PR TITLE
fix(api): fix rate limit tracker race condition and Polly retry (RECEIPTS-507)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -6534,7 +6534,7 @@ components:
 
     YnabRateLimitStatusResponse:
       type: object
-      required: [remainingRequests, maxRequests, requestsUsed, windowResetAt]
+      required: [remainingRequests, maxRequests, requestsUsed]
       properties:
         remainingRequests:
           type: integer
@@ -6549,9 +6549,11 @@ components:
           format: int32
           description: Number of requests made in the current window
         windowResetAt:
-          type: string
+          type:
+            - "null"
+            - string
           format: date-time
-          description: When the oldest request in the window expires
+          description: When the oldest request in the window expires, null if no requests tracked
         oldestRequestAt:
           type:
             - "null"

--- a/src/Application/Commands/Ynab/MemoSync/SyncYnabMemosBulkCommandHandler.cs
+++ b/src/Application/Commands/Ynab/MemoSync/SyncYnabMemosBulkCommandHandler.cs
@@ -16,7 +16,7 @@ public class SyncYnabMemosBulkCommandHandler(IYnabMemoSyncService memoSyncServic
 		if (!rateLimitTracker.CanMakeRequests(estimatedRequests))
 		{
 			YnabRateLimitStatus status = rateLimitTracker.GetStatus();
-			string error = $"YNAB API rate limit would be exceeded. {status.RemainingRequests}/{status.MaxRequests} requests remaining. Try again after {status.WindowResetAt:HH:mm:ss} UTC.";
+			string error = $"YNAB API rate limit would be exceeded. {status.RemainingRequests}/{status.MaxRequests} requests remaining.{(status.WindowResetAt.HasValue ? $" Try again after {status.WindowResetAt.Value:HH:mm:ss} UTC." : "")}";
 			return request.ReceiptIds
 				.Select(id => new YnabMemoSyncResult(Guid.Empty, id, YnabMemoSyncOutcome.Failed, null, error, null))
 				.ToList();

--- a/src/Application/Commands/Ynab/PushTransactions/BulkPushYnabTransactionsCommandHandler.cs
+++ b/src/Application/Commands/Ynab/PushTransactions/BulkPushYnabTransactionsCommandHandler.cs
@@ -17,7 +17,7 @@ public class BulkPushYnabTransactionsCommandHandler(IMediator mediator, IYnabRat
 			YnabRateLimitStatus status = rateLimitTracker.GetStatus();
 			List<ReceiptPushResult> failedResults = request.ReceiptIds
 				.Select(id => new ReceiptPushResult(id, PushYnabTransactionsResult.Failure(
-					$"YNAB API rate limit would be exceeded. {status.RemainingRequests}/{status.MaxRequests} requests remaining. Try again after {status.WindowResetAt:HH:mm:ss} UTC.")))
+					$"YNAB API rate limit would be exceeded. {status.RemainingRequests}/{status.MaxRequests} requests remaining.{(status.WindowResetAt.HasValue ? $" Try again after {status.WindowResetAt.Value:HH:mm:ss} UTC." : "")}")))
 				.ToList();
 			return new BulkPushYnabTransactionsResult(failedResults);
 		}

--- a/src/Application/Models/Ynab/YnabRateLimitStatus.cs
+++ b/src/Application/Models/Ynab/YnabRateLimitStatus.cs
@@ -4,5 +4,5 @@ public record YnabRateLimitStatus(
 	int RemainingRequests,
 	int MaxRequests,
 	int RequestsUsed,
-	DateTimeOffset WindowResetAt,
+	DateTimeOffset? WindowResetAt,
 	DateTimeOffset? OldestRequestAt);

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -179,7 +179,6 @@ public static class InfrastructureService
 				BackoffType = DelayBackoffType.Exponential,
 				UseJitter = true,
 				ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
-					.HandleResult(r => r.StatusCode == HttpStatusCode.TooManyRequests)
 					.Handle<HttpRequestException>(),
 			});
 			builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Application.Interfaces;
 using Application.Interfaces.Services;
 using Common;

--- a/src/Infrastructure/Services/YnabRateLimitTracker.cs
+++ b/src/Infrastructure/Services/YnabRateLimitTracker.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Application.Interfaces.Services;
 using Application.Models.Ynab;
 using Infrastructure.Ynab;
@@ -7,7 +6,8 @@ namespace Infrastructure.Services;
 
 public class YnabRateLimitTracker : IYnabRateLimitTracker
 {
-	private readonly ConcurrentQueue<DateTimeOffset> _requestTimestamps = new();
+	private readonly Queue<DateTimeOffset> _requestTimestamps = new();
+	private readonly object _lock = new();
 	private readonly YnabClientOptions _options;
 	private readonly TimeProvider _timeProvider;
 
@@ -19,41 +19,48 @@ public class YnabRateLimitTracker : IYnabRateLimitTracker
 
 	public void RecordRequest()
 	{
-		PruneExpired();
-		_requestTimestamps.Enqueue(_timeProvider.GetUtcNow());
+		lock (_lock)
+		{
+			PruneExpired();
+			_requestTimestamps.Enqueue(_timeProvider.GetUtcNow());
+		}
 	}
 
 	public YnabRateLimitStatus GetStatus()
 	{
-		PruneExpired();
-
-		int requestsUsed = _requestTimestamps.Count;
-		int remaining = Math.Max(0, _options.RateLimitMaxRequests - requestsUsed);
-
-		DateTimeOffset now = _timeProvider.GetUtcNow();
-		DateTimeOffset windowResetAt = now.Add(TimeSpan.FromSeconds(_options.RateLimitWindowSeconds));
-
-		DateTimeOffset? oldestRequestAt = null;
-		if (_requestTimestamps.TryPeek(out DateTimeOffset oldest))
+		lock (_lock)
 		{
-			oldestRequestAt = oldest;
-			// The window resets when the oldest request expires
-			windowResetAt = oldest.Add(TimeSpan.FromSeconds(_options.RateLimitWindowSeconds));
-		}
+			PruneExpired();
 
-		return new YnabRateLimitStatus(
-			remaining,
-			_options.RateLimitMaxRequests,
-			requestsUsed,
-			windowResetAt,
-			oldestRequestAt);
+			int requestsUsed = _requestTimestamps.Count;
+			int remaining = Math.Max(0, _options.RateLimitMaxRequests - requestsUsed);
+
+			DateTimeOffset? windowResetAt = null;
+			DateTimeOffset? oldestRequestAt = null;
+
+			if (_requestTimestamps.TryPeek(out DateTimeOffset oldest))
+			{
+				oldestRequestAt = oldest;
+				windowResetAt = oldest.Add(TimeSpan.FromSeconds(_options.RateLimitWindowSeconds));
+			}
+
+			return new YnabRateLimitStatus(
+				remaining,
+				_options.RateLimitMaxRequests,
+				requestsUsed,
+				windowResetAt,
+				oldestRequestAt);
+		}
 	}
 
 	public bool CanMakeRequests(int count)
 	{
-		PruneExpired();
-		int requestsUsed = _requestTimestamps.Count;
-		return requestsUsed + count <= _options.RateLimitMaxRequests;
+		lock (_lock)
+		{
+			PruneExpired();
+			int requestsUsed = _requestTimestamps.Count;
+			return requestsUsed + count <= _options.RateLimitMaxRequests;
+		}
 	}
 
 	private void PruneExpired()
@@ -62,7 +69,7 @@ public class YnabRateLimitTracker : IYnabRateLimitTracker
 
 		while (_requestTimestamps.TryPeek(out DateTimeOffset oldest) && oldest < cutoff)
 		{
-			_requestTimestamps.TryDequeue(out _);
+			_requestTimestamps.Dequeue();
 		}
 	}
 }

--- a/src/client/src/pages/settings/YnabSettings.tsx
+++ b/src/client/src/pages/settings/YnabSettings.tsx
@@ -434,7 +434,7 @@ export default function YnabSettings() {
                   }}
                 />
               </div>
-              {rateLimitStatus.oldestRequestAt && (
+              {rateLimitStatus.oldestRequestAt && rateLimitStatus.windowResetAt && (
                 <p className="text-xs text-muted-foreground">
                   Window resets at{" "}
                   {new Date(rateLimitStatus.windowResetAt).toLocaleTimeString()}

--- a/tests/Infrastructure.Tests/Services/YnabRateLimitTrackerTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabRateLimitTrackerTests.cs
@@ -22,7 +22,7 @@ public class YnabRateLimitTrackerTests
 	}
 
 	[Fact]
-	public void GetStatus_NoRequests_ReturnsFullQuota()
+	public void GetStatus_NoRequests_ReturnsFullQuotaWithNullWindowResetAt()
 	{
 		// Arrange
 		(YnabRateLimitTracker tracker, _) = CreateTracker();
@@ -34,6 +34,7 @@ public class YnabRateLimitTrackerTests
 		status.RemainingRequests.Should().Be(200);
 		status.MaxRequests.Should().Be(200);
 		status.RequestsUsed.Should().Be(0);
+		status.WindowResetAt.Should().BeNull();
 		status.OldestRequestAt.Should().BeNull();
 	}
 
@@ -180,5 +181,55 @@ public class YnabRateLimitTrackerTests
 		// Assert
 		status.RemainingRequests.Should().Be(0);
 		status.RequestsUsed.Should().Be(5);
+	}
+
+	[Fact]
+	public void WindowResetAt_IsNull_WhenAllRequestsExpired()
+	{
+		// Arrange
+		(YnabRateLimitTracker tracker, FakeTimeProvider timeProvider) = CreateTracker(windowSeconds: 3600);
+
+		tracker.RecordRequest();
+		tracker.GetStatus().WindowResetAt.Should().NotBeNull();
+
+		// Advance past the window so all requests expire
+		timeProvider.Advance(TimeSpan.FromSeconds(3601));
+
+		// Act
+		YnabRateLimitStatus status = tracker.GetStatus();
+
+		// Assert
+		status.WindowResetAt.Should().BeNull();
+		status.OldestRequestAt.Should().BeNull();
+		status.RequestsUsed.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task ConcurrentAccess_DoesNotCorruptState()
+	{
+		// Arrange — verify lock-based synchronization prevents data corruption
+		(YnabRateLimitTracker tracker, _) = CreateTracker(maxRequests: 10000);
+
+		const int threadCount = 10;
+		const int requestsPerThread = 100;
+
+		// Act — hammer the tracker from multiple threads simultaneously
+		Task[] tasks = Enumerable.Range(0, threadCount)
+			.Select(_ => Task.Run(() =>
+			{
+				for (int i = 0; i < requestsPerThread; i++)
+				{
+					tracker.RecordRequest();
+					tracker.GetStatus();
+					tracker.CanMakeRequests(1);
+				}
+			}))
+			.ToArray();
+
+		await Task.WhenAll(tasks);
+
+		// Assert — exactly threadCount * requestsPerThread requests should be recorded
+		YnabRateLimitStatus status = tracker.GetStatus();
+		status.RequestsUsed.Should().Be(threadCount * requestsPerThread);
 	}
 }


### PR DESCRIPTION
## Summary
- Replace `ConcurrentQueue` with `lock`-protected `Queue` in `YnabRateLimitTracker` to eliminate the `TryPeek`+`TryDequeue` race condition in `PruneExpired`
- Remove `TooManyRequests` from Polly retry predicate so 429 responses are surfaced immediately instead of silently retried (which caused request undercounting)
- Make `windowResetAt` nullable (`DateTimeOffset?`) and return `null` when no requests are tracked, instead of fabricating a meaningless future timestamp
- Update OpenAPI spec, bulk command handlers, and frontend to handle nullable `windowResetAt`

## Test plan
- [x] `GetStatus_NoRequests_ReturnsFullQuotaWithNullWindowResetAt` — verifies null when empty
- [x] `WindowResetAt_IsNull_WhenAllRequestsExpired` — verifies null after expiry
- [x] `ConcurrentAccess_DoesNotCorruptState` — verifies lock prevents corruption under concurrent load
- [x] All 1985 unit tests pass
- [x] OpenAPI spec lints cleanly
- [x] TypeScript types compile cleanly

Closes RECEIPTS-507

🤖 Generated with [Claude Code](https://claude.com/claude-code)