### PR TITLE
fix(api): guard exhausted allocations in waterfall split calculator (RECEIPTS-512)

### DIFF
--- a/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
+++ b/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
@@ -120,8 +120,16 @@ public class PushYnabTransactionsCommandHandler(
 		};
 
 		// 7. Compute waterfall splits
-		YnabSplitResult splitResult = splitCalculator.ComputeWaterfallSplits(
-			receiptWithItems, transactions, categoryToYnabId);
+		YnabSplitResult splitResult;
+		try
+		{
+			splitResult = splitCalculator.ComputeWaterfallSplits(
+				receiptWithItems, transactions, categoryToYnabId);
+		}
+		catch (InvalidOperationException ex)
+		{
+			return new PushYnabTransactionsResult(false, [], Error: ex.Message);
+		}
 
 		// 8. Create YNAB transactions and track sync
 		List<PushedTransactionInfo> pushedTransactions = [];

--- a/src/Infrastructure/Services/YnabSplitCalculator.cs
+++ b/src/Infrastructure/Services/YnabSplitCalculator.cs
@@ -196,6 +196,17 @@ public class YnabSplitCalculator : IYnabSplitCalculator
 				}
 			}
 
+			// Guard: every non-zero transaction must have at least one category allocation.
+			// If subs is empty, category allocations were exhausted by earlier transactions,
+			// which means transaction totals exceed category totals — a data inconsistency.
+			if (subs.Count == 0 && txMilliunits != 0)
+			{
+				throw new InvalidOperationException(
+					$"Transaction {tx.Id} ({txMilliunits} milliunits) could not be categorized. " +
+					$"All category allocations were exhausted by earlier transactions. " +
+					$"This indicates transaction totals exceed the receipt category totals.");
+			}
+
 			// Apply largest-remainder correction for this transaction independently
 			if (subs.Count > 0)
 			{

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
@@ -432,4 +432,27 @@ public class PushYnabTransactionsCommandHandlerTests
 		capturedRequests[0].ImportId.Should().EndWith(":1");
 		capturedRequests[1].ImportId.Should().EndWith(":2");
 	}
+
+	[Fact]
+	public async Task Handle_SplitCalculatorThrowsExhaustedAllocations_ReturnsError()
+	{
+		SetupHappyPath();
+		_splitCalculatorMock
+			.Setup(s => s.ComputeWaterfallSplits(It.IsAny<ReceiptWithItems>(), It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Dictionary<string, string>>()))
+			.Throws(new InvalidOperationException(
+				"Transaction abc (−5000 milliunits) could not be categorized. " +
+				"All category allocations were exhausted by earlier transactions."));
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.Error.Should().Contain("could not be categorized");
+		result.Error.Should().Contain("exhausted");
+
+		// No sync record should be created since the error occurs before the push loop
+		_syncRecordServiceMock.Verify(s => s.CreateAsync(
+			It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<YnabSyncType>(),
+			It.IsAny<CancellationToken>()), Times.Never);
+	}
 }

--- a/tests/Infrastructure.Tests/Services/YnabSplitCalculatorTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabSplitCalculatorTests.cs
@@ -596,4 +596,27 @@ public class YnabSplitCalculatorTests
 		YnabTransactionSplit split = result.TransactionSplits[0];
 		split.SubTransactions.Sum(s => s.Milliunits).Should().Be(-30);
 	}
+
+	[Fact]
+	public void ComputeWaterfallSplits_ExhaustedAllocations_ThrowsInvalidOperationException()
+	{
+		// Arrange: categories total $10, but transactions total $15.
+		// tx1 ($10) exhausts all category allocations, tx2 ($5) gets empty subs.
+		Transaction tx1 = MakeTransaction(10.00m);
+		Transaction tx2 = MakeTransaction(5.00m);
+		ReceiptWithItems rwi = new()
+		{
+			Receipt = MakeReceipt(0.00m),
+			Items = [MakeItem("A", 10.00m)],
+			Adjustments = [],
+		};
+		Dictionary<string, string> mappings = MakeMappings("A");
+
+		// Act & Assert
+		Action act = () => _calculator.ComputeWaterfallSplits(rwi, [tx1, tx2], mappings);
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*could not be categorized*")
+			.WithMessage("*exhausted*");
+	}
+
 }


### PR DESCRIPTION
## Summary

- Add guard in `YnabSplitCalculator.ComputeWaterfallSplits()` that throws `InvalidOperationException` when a non-zero transaction gets zero category allocations (all exhausted by earlier transactions)
- Wrap `ComputeWaterfallSplits` call in the push handler with try/catch to return a failure result instead of propagating unhandled
- Add 2 new unit tests: one for the calculator guard, one for handler error propagation

Fixes RECEIPTS-512.

## Test plan

- [x] New test `ComputeWaterfallSplits_ExhaustedAllocations_ThrowsInvalidOperationException` validates the guard
- [x] New test `Handle_SplitCalculatorThrowsExhaustedAllocations_ReturnsError` validates handler catches the error
- [x] All 1956 existing + new unit tests pass
- [x] Pre-commit hooks pass (build, test, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)