### PR TITLE
fix(application): harden YNAB push-transactions against timeout/retry duplication and failed-row retries (RECEIPTS-535)

### DIFF
--- a/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
+++ b/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
@@ -99,15 +99,15 @@ public class PushYnabTransactionsCommandHandler(
 			return new PushYnabTransactionsResult(false, [], Error: "Some transaction accounts are not mapped to YNAB accounts.");
 		}
 
-		// 5. Skip already-synced transactions (allows retry after partial push)
-		HashSet<Guid> alreadySyncedIds = [];
+		// 5. Pre-load existing sync records (Synced → skip; Failed/Pending → reuse on retry)
+		Dictionary<Guid, YnabSyncRecordDto> existingSyncRecords = [];
 		foreach (Domain.Core.Transaction tx in transactions)
 		{
 			YnabSyncRecordDto? existingSync = await syncRecordService.GetByTransactionAndTypeAsync(
 				tx.Id, YnabSyncType.TransactionPush, cancellationToken);
-			if (existingSync is not null && existingSync.SyncStatus == YnabSyncStatus.Synced)
+			if (existingSync is not null)
 			{
-				alreadySyncedIds.Add(tx.Id);
+				existingSyncRecords[tx.Id] = existingSync;
 			}
 		}
 
@@ -139,8 +139,10 @@ public class PushYnabTransactionsCommandHandler(
 		{
 			Domain.Core.Transaction localTx = transactions.First(t => t.Id == txSplit.LocalTransactionId);
 
-			// Skip already-synced transactions (Bug 1: allows retry after partial push)
-			if (alreadySyncedIds.Contains(localTx.Id))
+			existingSyncRecords.TryGetValue(localTx.Id, out YnabSyncRecordDto? existingRecord);
+
+			// Skip already-synced transactions (allows retry after partial push)
+			if (existingRecord?.SyncStatus == YnabSyncStatus.Synced)
 			{
 				continue;
 			}
@@ -156,9 +158,19 @@ public class PushYnabTransactionsCommandHandler(
 			YnabSyncRecordDto? syncRecord = null;
 			try
 			{
-				// Create sync record (Pending) — inside try so DB failure is caught (Bug 3)
-				syncRecord = await syncRecordService.CreateAsync(
-					localTx.Id, budgetId, YnabSyncType.TransactionPush, cancellationToken);
+				if (existingRecord is not null)
+				{
+					// Reuse existing Failed/Pending row to avoid unique-constraint violation
+					await syncRecordService.UpdateStatusAsync(
+						existingRecord.Id, YnabSyncStatus.Pending, null, null, cancellationToken);
+					syncRecord = existingRecord;
+				}
+				else
+				{
+					// Create sync record (Pending) — inside try so DB failure is caught
+					syncRecord = await syncRecordService.CreateAsync(
+						localTx.Id, budgetId, YnabSyncType.TransactionPush, cancellationToken);
+				}
 
 				// Build sub-transactions
 				List<YnabSubTransaction>? subTransactions = null;
@@ -187,8 +199,33 @@ public class PushYnabTransactionsCommandHandler(
 					SubTransactions: subTransactions,
 					ImportId: importId);
 
-				YnabCreateTransactionResponse ynabResponse = await ynabApiClient.CreateTransactionAsync(
-					budgetId, ynabRequest, cancellationToken);
+				YnabCreateTransactionResponse ynabResponse;
+				try
+				{
+					ynabResponse = await ynabApiClient.CreateTransactionAsync(
+						budgetId, ynabRequest, cancellationToken);
+				}
+				catch (HttpRequestException conflictEx) when (conflictEx.StatusCode == System.Net.HttpStatusCode.Conflict)
+				{
+					string? recoveredId = await ynabApiClient.FindTransactionByImportIdAsync(
+						budgetId, ynabAccountId, importId, localTx.Date.AddDays(-1), cancellationToken);
+
+					if (recoveredId is null)
+					{
+						throw;
+					}
+
+					await syncRecordService.UpdateStatusAsync(
+						syncRecord!.Id, YnabSyncStatus.Synced, recoveredId, null, cancellationToken);
+
+					pushedTransactions.Add(new PushedTransactionInfo(
+						localTx.Id,
+						recoveredId,
+						txSplit.TotalMilliunits,
+						txSplit.SubTransactions.Count));
+
+					continue;
+				}
 
 				// Update sync record to Synced — separate error handling (Bug 6)
 				try

--- a/src/Application/Interfaces/Services/IYnabApiClient.cs
+++ b/src/Application/Interfaces/Services/IYnabApiClient.cs
@@ -10,6 +10,7 @@ public interface IYnabApiClient
 	Task<YnabTransaction?> GetTransactionAsync(string budgetId, string transactionId, CancellationToken cancellationToken);
 	Task<YnabCreateTransactionResponse> CreateTransactionAsync(string budgetId, YnabCreateTransactionRequest request, CancellationToken cancellationToken);
 	Task<YnabTransactionsResult> GetTransactionsByDateAsync(string budgetId, DateOnly sinceDate, long? lastKnowledgeOfServer = null, CancellationToken cancellationToken = default);
+	Task<string?> FindTransactionByImportIdAsync(string budgetId, string accountId, string importId, DateOnly sinceDate, CancellationToken cancellationToken);
 	Task UpdateTransactionMemoAsync(string budgetId, string transactionId, string memo, CancellationToken cancellationToken);
 	bool IsConfigured { get; }
 }

--- a/src/Infrastructure/Services/YnabApiClient.cs
+++ b/src/Infrastructure/Services/YnabApiClient.cs
@@ -219,6 +219,28 @@ public class YnabApiClient(
 		return new YnabTransactionsResult(transactions, envelope.Data.ServerKnowledge);
 	}
 
+	public async Task<string?> FindTransactionByImportIdAsync(string budgetId, string accountId, string importId, DateOnly sinceDate, CancellationToken cancellationToken)
+	{
+		string encodedBudgetId = Uri.EscapeDataString(budgetId);
+		string formattedDate = sinceDate.ToString("yyyy-MM-dd");
+		string url = $"budgets/{encodedBudgetId}/transactions?since_date={formattedDate}";
+
+		YnabTransactionsListResponseEnvelope envelope;
+		try
+		{
+			envelope = await GetAsync<YnabTransactionsListResponseEnvelope>(url, cancellationToken);
+		}
+		catch (YnabNotFoundException)
+		{
+			return null;
+		}
+
+		YnabTransactionDto? match = envelope.Data.Transactions
+			.FirstOrDefault(t => !t.Deleted && t.AccountId == accountId && t.ImportId == importId);
+
+		return match?.Id;
+	}
+
 	public async Task UpdateTransactionMemoAsync(string budgetId, string transactionId, string memo, CancellationToken cancellationToken)
 	{
 		string encodedBudgetId = Uri.EscapeDataString(budgetId);

--- a/src/Infrastructure/Ynab/Models/YnabTransactionResponse.cs
+++ b/src/Infrastructure/Ynab/Models/YnabTransactionResponse.cs
@@ -79,6 +79,9 @@ internal sealed class YnabTransactionDto
 	[JsonPropertyName("payee_name")]
 	public string? PayeeName { get; set; }
 
+	[JsonPropertyName("import_id")]
+	public string? ImportId { get; set; }
+
 	[JsonPropertyName("deleted")]
 	public bool Deleted { get; set; }
 }

--- a/src/Receipts.ServiceDefaults/Extensions.cs
+++ b/src/Receipts.ServiceDefaults/Extensions.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ServiceDiscovery;
 using OpenTelemetry;
@@ -29,7 +30,13 @@ public static class Extensions
 		builder.Services.ConfigureHttpClientDefaults(http =>
 		{
 			// Turn on resilience by default
-			http.AddStandardResilienceHandler();
+			http.AddStandardResilienceHandler(options =>
+			{
+				options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(30);
+				options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(90);
+				options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(60);
+				options.Retry.ShouldHandle = _ => ValueTask.FromResult(false);
+			});
 
 			// Turn on service discovery by default
 			http.AddServiceDiscovery();

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactions409ReconcileTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactions409ReconcileTests.cs
@@ -1,0 +1,168 @@
+using System.Net;
+using Application.Commands.Ynab.PushTransactions;
+using Application.Interfaces.Services;
+using Application.Models;
+using Application.Models.Ynab;
+using Common;
+using Domain;
+using Domain.Aggregates;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.Ynab;
+
+public class PushYnabTransactions409ReconcileTests
+{
+	private readonly Mock<IReceiptService> _receiptServiceMock = new();
+	private readonly Mock<IReceiptItemService> _receiptItemServiceMock = new();
+	private readonly Mock<IAdjustmentService> _adjustmentServiceMock = new();
+	private readonly Mock<ITransactionService> _transactionServiceMock = new();
+	private readonly Mock<IYnabCategoryMappingService> _categoryMappingServiceMock = new();
+	private readonly Mock<IYnabAccountMappingService> _accountMappingServiceMock = new();
+	private readonly Mock<IYnabBudgetSelectionService> _budgetSelectionServiceMock = new();
+	private readonly Mock<IYnabSyncRecordService> _syncRecordServiceMock = new();
+	private readonly Mock<IYnabApiClient> _ynabApiClientMock = new();
+	private readonly Mock<IYnabSplitCalculator> _splitCalculatorMock = new();
+	private readonly PushYnabTransactionsCommandHandler _handler;
+
+	private readonly Guid _receiptId = Guid.NewGuid();
+	private readonly Guid _accountId = Guid.NewGuid();
+	private readonly Guid _transactionId = Guid.NewGuid();
+	private readonly Guid _syncRecordId = Guid.NewGuid();
+	private readonly string _budgetId = "budget-123";
+	private readonly string _ynabAccountId = "ynab-acc-1";
+
+	public PushYnabTransactions409ReconcileTests()
+	{
+		_handler = new PushYnabTransactionsCommandHandler(
+			_receiptServiceMock.Object,
+			_receiptItemServiceMock.Object,
+			_adjustmentServiceMock.Object,
+			_transactionServiceMock.Object,
+			_categoryMappingServiceMock.Object,
+			_accountMappingServiceMock.Object,
+			_budgetSelectionServiceMock.Object,
+			_syncRecordServiceMock.Object,
+			_ynabApiClientMock.Object,
+			_splitCalculatorMock.Object);
+	}
+
+	private void SetupHappyPath()
+	{
+		Domain.Core.Receipt receipt = new(_receiptId, "Store", DateOnly.FromDateTime(DateTime.Today.AddDays(-1)), new Money(1.00m));
+		_receiptServiceMock.Setup(s => s.GetByIdAsync(_receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(receipt);
+
+		List<Domain.Core.ReceiptItem> items =
+		[
+			new(Guid.NewGuid(), null, "Item1", 1, new Money(10.00m), new Money(10.00m), "Groceries", null),
+		];
+		_receiptItemServiceMock.Setup(s => s.GetByReceiptIdAsync(_receiptId, 0, 10000, It.IsAny<SortParams>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Domain.Core.ReceiptItem>(items, items.Count, 0, 10000));
+
+		_adjustmentServiceMock.Setup(s => s.GetByReceiptIdAsync(_receiptId, 0, 10000, It.IsAny<SortParams>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Domain.Core.Adjustment>([], 0, 0, 10000));
+
+		Domain.Core.Transaction tx = new(_transactionId, new Money(11.00m), DateOnly.FromDateTime(DateTime.Today.AddDays(-1)));
+		tx.AccountId = _accountId;
+		tx.ReceiptId = _receiptId;
+
+		Domain.Core.Account account = new(_accountId, "CHK001", "Checking", true);
+		List<TransactionAccount> txAccounts =
+		[
+			new() { Transaction = tx, Account = account },
+		];
+		_transactionServiceMock.Setup(s => s.GetTransactionAccountsByReceiptIdAsync(_receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(txAccounts);
+
+		_categoryMappingServiceMock.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync([
+				new YnabCategoryMappingDto(Guid.NewGuid(), "Groceries", "ynab-cat-1", "Groceries", "Food", _budgetId, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+			]);
+
+		_budgetSelectionServiceMock.Setup(s => s.GetSelectedBudgetIdAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(_budgetId);
+
+		_accountMappingServiceMock.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync([
+				new YnabAccountMappingDto(Guid.NewGuid(), _accountId, _ynabAccountId, "Checking", _budgetId, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+			]);
+
+		_syncRecordServiceMock.Setup(s => s.GetByTransactionAndTypeAsync(_transactionId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((YnabSyncRecordDto?)null);
+
+		_syncRecordServiceMock.Setup(s => s.CreateAsync(_transactionId, _budgetId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabSyncRecordDto(_syncRecordId, _transactionId, null, _budgetId, null, YnabSyncType.TransactionPush, YnabSyncStatus.Pending, null, null, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+
+		_splitCalculatorMock.Setup(s => s.ComputeWaterfallSplits(It.IsAny<ReceiptWithItems>(), It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Dictionary<string, string>>()))
+			.Returns(new YnabSplitResult([
+				new YnabTransactionSplit(_transactionId, -11000, [new YnabSubTransactionSplit("ynab-cat-1", -11000)]),
+			]));
+	}
+
+	[Fact]
+	public async Task Handle_CreateTransaction409_ImportIdFound_ReconcilesToSuccess()
+	{
+		SetupHappyPath();
+
+		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("conflict", null, HttpStatusCode.Conflict));
+
+		_ynabApiClientMock.Setup(s => s.FindTransactionByImportIdAsync(
+				_budgetId, _ynabAccountId, It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync("ynab-tx-recovered");
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		result.PushedTransactions.Should().HaveCount(1);
+		result.PushedTransactions[0].YnabTransactionId.Should().Be("ynab-tx-recovered");
+		result.PushedTransactions[0].LocalTransactionId.Should().Be(_transactionId);
+		result.Error.Should().BeNull();
+
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_syncRecordId, YnabSyncStatus.Synced, "ynab-tx-recovered", null, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_CreateTransaction409_ImportIdNotFound_ReturnsFailure()
+	{
+		SetupHappyPath();
+
+		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("conflict", null, HttpStatusCode.Conflict));
+
+		_ynabApiClientMock.Setup(s => s.FindTransactionByImportIdAsync(
+				_budgetId, _ynabAccountId, It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((string?)null);
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_syncRecordId, YnabSyncStatus.Failed, null, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_CreateTransaction409_LookupThrows_ReturnsFailure()
+	{
+		SetupHappyPath();
+
+		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("conflict", null, HttpStatusCode.Conflict));
+
+		_ynabApiClientMock.Setup(s => s.FindTransactionByImportIdAsync(
+				_budgetId, _ynabAccountId, It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("lookup failed"));
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.Error.Should().Contain("lookup failed");
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_syncRecordId, YnabSyncStatus.Failed, null, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsFailedRetryTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsFailedRetryTests.cs
@@ -1,0 +1,186 @@
+using Application.Commands.Ynab.PushTransactions;
+using Application.Interfaces.Services;
+using Application.Models;
+using Application.Models.Ynab;
+using Common;
+using Domain;
+using Domain.Aggregates;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.Ynab;
+
+public class PushYnabTransactionsFailedRetryTests
+{
+	private readonly Mock<IReceiptService> _receiptServiceMock = new();
+	private readonly Mock<IReceiptItemService> _receiptItemServiceMock = new();
+	private readonly Mock<IAdjustmentService> _adjustmentServiceMock = new();
+	private readonly Mock<ITransactionService> _transactionServiceMock = new();
+	private readonly Mock<IYnabCategoryMappingService> _categoryMappingServiceMock = new();
+	private readonly Mock<IYnabAccountMappingService> _accountMappingServiceMock = new();
+	private readonly Mock<IYnabBudgetSelectionService> _budgetSelectionServiceMock = new();
+	private readonly Mock<IYnabSyncRecordService> _syncRecordServiceMock = new();
+	private readonly Mock<IYnabApiClient> _ynabApiClientMock = new();
+	private readonly Mock<IYnabSplitCalculator> _splitCalculatorMock = new();
+	private readonly PushYnabTransactionsCommandHandler _handler;
+
+	private readonly Guid _receiptId = Guid.NewGuid();
+	private readonly Guid _accountId = Guid.NewGuid();
+	private readonly Guid _transactionId = Guid.NewGuid();
+	private readonly Guid _existingSyncRecordId = Guid.NewGuid();
+	private readonly string _budgetId = "budget-123";
+	private readonly string _ynabAccountId = "ynab-acc-1";
+
+	public PushYnabTransactionsFailedRetryTests()
+	{
+		_handler = new PushYnabTransactionsCommandHandler(
+			_receiptServiceMock.Object,
+			_receiptItemServiceMock.Object,
+			_adjustmentServiceMock.Object,
+			_transactionServiceMock.Object,
+			_categoryMappingServiceMock.Object,
+			_accountMappingServiceMock.Object,
+			_budgetSelectionServiceMock.Object,
+			_syncRecordServiceMock.Object,
+			_ynabApiClientMock.Object,
+			_splitCalculatorMock.Object);
+	}
+
+	private void SetupHappyPathPipeline()
+	{
+		Domain.Core.Receipt receipt = new(_receiptId, "Store", DateOnly.FromDateTime(DateTime.Today.AddDays(-1)), new Money(1.00m));
+		_receiptServiceMock.Setup(s => s.GetByIdAsync(_receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(receipt);
+
+		List<Domain.Core.ReceiptItem> items =
+		[
+			new(Guid.NewGuid(), null, "Item1", 1, new Money(10.00m), new Money(10.00m), "Groceries", null),
+		];
+		_receiptItemServiceMock.Setup(s => s.GetByReceiptIdAsync(_receiptId, 0, 10000, It.IsAny<SortParams>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Domain.Core.ReceiptItem>(items, items.Count, 0, 10000));
+
+		_adjustmentServiceMock.Setup(s => s.GetByReceiptIdAsync(_receiptId, 0, 10000, It.IsAny<SortParams>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Domain.Core.Adjustment>([], 0, 0, 10000));
+
+		Domain.Core.Transaction tx = new(_transactionId, new Money(11.00m), DateOnly.FromDateTime(DateTime.Today.AddDays(-1)));
+		tx.AccountId = _accountId;
+		tx.ReceiptId = _receiptId;
+
+		Domain.Core.Account account = new(_accountId, "CHK001", "Checking", true);
+		_transactionServiceMock.Setup(s => s.GetTransactionAccountsByReceiptIdAsync(_receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([new TransactionAccount { Transaction = tx, Account = account }]);
+
+		_categoryMappingServiceMock.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync([
+				new YnabCategoryMappingDto(Guid.NewGuid(), "Groceries", "ynab-cat-1", "Groceries", "Food", _budgetId, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+			]);
+
+		_budgetSelectionServiceMock.Setup(s => s.GetSelectedBudgetIdAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(_budgetId);
+
+		_accountMappingServiceMock.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync([
+				new YnabAccountMappingDto(Guid.NewGuid(), _accountId, _ynabAccountId, "Checking", _budgetId, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+			]);
+
+		_splitCalculatorMock.Setup(s => s.ComputeWaterfallSplits(It.IsAny<ReceiptWithItems>(), It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Dictionary<string, string>>()))
+			.Returns(new YnabSplitResult([
+				new YnabTransactionSplit(_transactionId, -11000, [new YnabSubTransactionSplit("ynab-cat-1", -11000)]),
+			]));
+	}
+
+	private YnabSyncRecordDto MakeExistingRecord(YnabSyncStatus status)
+	{
+		return new YnabSyncRecordDto(
+			_existingSyncRecordId,
+			_transactionId,
+			null,
+			_budgetId,
+			null,
+			YnabSyncType.TransactionPush,
+			status,
+			null,
+			status == YnabSyncStatus.Failed ? "previous failure" : null,
+			DateTimeOffset.UtcNow.AddMinutes(-5),
+			DateTimeOffset.UtcNow.AddMinutes(-5));
+	}
+
+	[Fact]
+	public async Task Handle_ExistingFailedSyncRecord_ReusesRowAndSucceeds()
+	{
+		SetupHappyPathPipeline();
+
+		_syncRecordServiceMock.Setup(s => s.GetByTransactionAndTypeAsync(_transactionId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(MakeExistingRecord(YnabSyncStatus.Failed));
+
+		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabCreateTransactionResponse("ynab-tx-1"));
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		result.PushedTransactions.Should().HaveCount(1);
+		result.PushedTransactions[0].YnabTransactionId.Should().Be("ynab-tx-1");
+
+		_syncRecordServiceMock.Verify(s => s.CreateAsync(
+			It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<YnabSyncType>(), It.IsAny<CancellationToken>()), Times.Never);
+
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_existingSyncRecordId, YnabSyncStatus.Pending, null, null, It.IsAny<CancellationToken>()), Times.Once);
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_existingSyncRecordId, YnabSyncStatus.Synced, "ynab-tx-1", null, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ExistingPendingSyncRecord_ReusesRowAndSucceeds()
+	{
+		SetupHappyPathPipeline();
+
+		_syncRecordServiceMock.Setup(s => s.GetByTransactionAndTypeAsync(_transactionId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(MakeExistingRecord(YnabSyncStatus.Pending));
+
+		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabCreateTransactionResponse("ynab-tx-1"));
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		result.PushedTransactions.Should().HaveCount(1);
+
+		_syncRecordServiceMock.Verify(s => s.CreateAsync(
+			It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<YnabSyncType>(), It.IsAny<CancellationToken>()), Times.Never);
+
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_existingSyncRecordId, YnabSyncStatus.Pending, null, null, It.IsAny<CancellationToken>()), Times.Once);
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_existingSyncRecordId, YnabSyncStatus.Synced, "ynab-tx-1", null, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ExistingFailedSyncRecord_YnabApiFails_MarksRowFailedAgain()
+	{
+		SetupHappyPathPipeline();
+
+		_syncRecordServiceMock.Setup(s => s.GetByTransactionAndTypeAsync(_transactionId, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(MakeExistingRecord(YnabSyncStatus.Failed));
+
+		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("network timeout"));
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.Error.Should().Contain("network timeout");
+
+		_syncRecordServiceMock.Verify(s => s.CreateAsync(
+			It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<YnabSyncType>(), It.IsAny<CancellationToken>()), Times.Never);
+
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_existingSyncRecordId, YnabSyncStatus.Pending, null, null, It.IsAny<CancellationToken>()), Times.Once);
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_existingSyncRecordId, YnabSyncStatus.Failed, null, It.Is<string>(msg => msg.Contains("network timeout")), It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Infrastructure.Tests/Services/YnabApiClientFindByImportIdTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabApiClientFindByImportIdTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Text.Json;
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Infrastructure.Services;
+using Infrastructure.Ynab;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+namespace Infrastructure.Tests.Services;
+
+public class YnabApiClientFindByImportIdTests
+{
+	private static YnabApiClient CreateClient(
+		HttpMessageHandler handler,
+		string? pat = "test-pat",
+		IMemoryCache? cache = null,
+		IYnabRateLimitTracker? rateLimitTracker = null)
+	{
+		HttpClient httpClient = new(handler) { BaseAddress = new Uri("https://api.ynab.com/v1/") };
+		cache ??= new MemoryCache(new MemoryCacheOptions());
+		rateLimitTracker ??= new Mock<IYnabRateLimitTracker>().Object;
+
+		Dictionary<string, string?> configValues = new();
+		if (pat is not null)
+		{
+			configValues["YNAB_PAT"] = pat;
+		}
+
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(configValues)
+			.Build();
+
+		Mock<ILogger<YnabApiClient>> logger = new();
+		return new YnabApiClient(httpClient, cache, configuration, rateLimitTracker, logger.Object);
+	}
+
+	private static HttpMessageHandler CreateHandler(HttpStatusCode statusCode, string content)
+	{
+		Mock<HttpMessageHandler> handlerMock = new();
+		handlerMock.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.ReturnsAsync(new HttpResponseMessage
+			{
+				StatusCode = statusCode,
+				Content = new StringContent(content, System.Text.Encoding.UTF8, "application/json"),
+			});
+		return handlerMock.Object;
+	}
+
+	private static string TransactionsListJson(params object[] transactions)
+	{
+		return JsonSerializer.Serialize(new
+		{
+			data = new
+			{
+				transactions,
+				server_knowledge = 1L,
+			}
+		});
+	}
+
+	[Fact]
+	public async Task MatchFound_ReturnsTransactionId()
+	{
+		string json = TransactionsListJson(
+			new { id = "tx-1", date = "2026-04-01", amount = -10000L, memo = (string?)null, cleared = "cleared", approved = true, account_id = "acc-1", category_id = "cat-1", payee_name = "Store", import_id = "YNAB:-10000:2026-04-01:abc123:1", deleted = false });
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		string? result = await client.FindTransactionByImportIdAsync(
+			"budget-1", "acc-1", "YNAB:-10000:2026-04-01:abc123:1", new DateOnly(2026, 4, 1), CancellationToken.None);
+
+		result.Should().Be("tx-1");
+	}
+
+	[Fact]
+	public async Task NoMatch_WrongImportId_ReturnsNull()
+	{
+		string json = TransactionsListJson(
+			new { id = "tx-1", date = "2026-04-01", amount = -10000L, memo = (string?)null, cleared = "cleared", approved = true, account_id = "acc-1", category_id = "cat-1", payee_name = "Store", import_id = "YNAB:-10000:2026-04-01:other:1", deleted = false });
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		string? result = await client.FindTransactionByImportIdAsync(
+			"budget-1", "acc-1", "YNAB:-10000:2026-04-01:abc123:1", new DateOnly(2026, 4, 1), CancellationToken.None);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task NoMatch_WrongAccountId_ReturnsNull()
+	{
+		string json = TransactionsListJson(
+			new { id = "tx-1", date = "2026-04-01", amount = -10000L, memo = (string?)null, cleared = "cleared", approved = true, account_id = "acc-2", category_id = "cat-1", payee_name = "Store", import_id = "YNAB:-10000:2026-04-01:abc123:1", deleted = false });
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		string? result = await client.FindTransactionByImportIdAsync(
+			"budget-1", "acc-1", "YNAB:-10000:2026-04-01:abc123:1", new DateOnly(2026, 4, 1), CancellationToken.None);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task DeletedTransactionIgnored_ReturnsNull()
+	{
+		string json = TransactionsListJson(
+			new { id = "tx-1", date = "2026-04-01", amount = -10000L, memo = (string?)null, cleared = "cleared", approved = true, account_id = "acc-1", category_id = "cat-1", payee_name = "Store", import_id = "YNAB:-10000:2026-04-01:abc123:1", deleted = true });
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		string? result = await client.FindTransactionByImportIdAsync(
+			"budget-1", "acc-1", "YNAB:-10000:2026-04-01:abc123:1", new DateOnly(2026, 4, 1), CancellationToken.None);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task EmptyList_ReturnsNull()
+	{
+		string json = TransactionsListJson();
+
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.OK, json));
+
+		string? result = await client.FindTransactionByImportIdAsync(
+			"budget-1", "acc-1", "YNAB:-10000:2026-04-01:abc123:1", new DateOnly(2026, 4, 1), CancellationToken.None);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task NotFoundFromYnab_ReturnsNull()
+	{
+		YnabApiClient client = CreateClient(CreateHandler(HttpStatusCode.NotFound, "{}"));
+
+		string? result = await client.FindTransactionByImportIdAsync(
+			"budget-1", "acc-1", "YNAB:-10000:2026-04-01:abc123:1", new DateOnly(2026, 4, 1), CancellationToken.None);
+
+		result.Should().BeNull();
+	}
+}


### PR DESCRIPTION
## Summary

Fixes three stacked bugs in `POST /api/ynab/push-transactions` surfaced on 0.1.38:

- **Bug A** — global 10s HTTP attempt timeout killed the YNAB POST mid-response
- **Bug B** — Polly retried the non-idempotent POST; YNAB had already created the transaction, retry got 409, handler misreported it as failure
- **Bug C** — the Failed sync record left behind by Bug B made every retry crash on `IX_YnabSyncRecords_LocalTransactionId_SyncType` before ever talking to YNAB

### Changes

- **`Receipts.ServiceDefaults/Extensions.cs`** — pass options to `AddStandardResilienceHandler`: 30s attempt timeout, 90s total, CB sampling 60s, standard-layer retry disabled via `ShouldHandle = _ => ValueTask.FromResult(false)` (validator rejects `MaxRetryAttempts = 0`)
- **`IYnabApiClient` + `YnabApiClient`** — new `FindTransactionByImportIdAsync` that calls the private `GetAsync<YnabTransactionsListResponseEnvelope>` directly so it can access raw `YnabTransactionDto.ImportId` before mapping strips it
- **`YnabTransactionResponse.cs`** — `[JsonPropertyName("import_id")]` added to `YnabTransactionDto`
- **`PushYnabTransactionsCommandHandler.cs`**:
  - Step 5 now pre-loads **all** existing `YnabSyncRecord` rows, not just Synced ones
  - Per-tx loop reuses Failed/Pending rows via `UpdateStatusAsync(Pending)` instead of blind `CreateAsync`
  - New inner catch on `HttpRequestException when StatusCode == Conflict` calls `FindTransactionByImportIdAsync` and marks the sync record Synced with the recovered YNAB transaction id if found; rethrows otherwise

### Tests (12 new, all passing)

- `PushYnabTransactions409ReconcileTests` (3) — 409 with matching import_id → success; no match → failure; lookup throws → failure
- `PushYnabTransactionsFailedRetryTests` (3) — Failed row reuse; Pending row reuse; Failed + YNAB fails again
- `YnabApiClientFindByImportIdTests` (6) — match / wrong import_id / wrong account / deleted / empty list / 404

**Total suite:** 2076 passed / 0 failed / 0 skipped.

### Notes

- Two minor deviations from the original plan (documented in the SDLC state file before cleanup): `ShouldHandle=false` in lieu of `MaxRetryAttempts=0` (validator rejected 0), and CB `SamplingDuration` bumped to 60s to satisfy the `>= 2 × AttemptTimeout` validator constraint. Both equivalent in intent.
- The custom `"ynab"` resilience handler (in `InfrastructureService.cs`) is unchanged. It still retries 429/503/504 and `HttpRequestException`. Transport-level retries on POST can still occur there, but Fix B's 409 reconciliation composes correctly with that path — any resulting YNAB duplicate is now recovered rather than crashing the handler.

## Test plan

- [x] `dotnet build Receipts.slnx` — 0 errors
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2076/0/0
- [ ] Manual repro: trigger Push to YNAB and click twice; verify second click does not 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)