### PR TITLE
fix(infrastructure): correct YNAB subtransactions JSON field name (RECEIPTS-539)

### DIFF
--- a/src/Infrastructure/Ynab/Models/YnabTransactionResponse.cs
+++ b/src/Infrastructure/Ynab/Models/YnabTransactionResponse.cs
@@ -85,7 +85,7 @@ internal sealed class YnabTransactionDto
 	[JsonPropertyName("category_name")]
 	public string? CategoryName { get; set; }
 
-	[JsonPropertyName("sub_transactions")]
+	[JsonPropertyName("subtransactions")]
 	public List<YnabSubTransactionDto>? SubTransactions { get; set; }
 
 	[JsonPropertyName("deleted")]

--- a/tests/Infrastructure.Tests/Services/YnabApiClientSubTransactionsTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabApiClientSubTransactionsTests.cs
@@ -63,7 +63,7 @@ public class YnabApiClientSubTransactionsTests
 					category_name = (string?)null,
 					payee_name = "Walmart",
 					deleted = false,
-					sub_transactions = new[]
+					subtransactions = new[]
 					{
 						new
 						{
@@ -126,7 +126,7 @@ public class YnabApiClientSubTransactionsTests
 					category_name = (string?)null,
 					payee_name = (string?)null,
 					deleted = false,
-					sub_transactions = new[]
+					subtransactions = new[]
 					{
 						new { id = "sub-1", transaction_id = "tx-1", amount = -20000, memo = (string?)null, category_id = "cat-a", category_name = "A", deleted = false },
 						new { id = "sub-2", transaction_id = "tx-1", amount = -10000, memo = (string?)null, category_id = "cat-b", category_name = "B", deleted = true },
@@ -165,7 +165,7 @@ public class YnabApiClientSubTransactionsTests
 					category_name = "Groceries",
 					payee_name = "Store",
 					deleted = false,
-					sub_transactions = Array.Empty<object>(),
+					subtransactions = Array.Empty<object>(),
 				}
 			}
 		});
@@ -203,7 +203,7 @@ public class YnabApiClientSubTransactionsTests
 					category_name = (string?)null,
 					payee_name = (string?)null,
 					deleted = false,
-					sub_transactions = new[]
+					subtransactions = new[]
 					{
 						new { id = "sub-1", transaction_id = "tx-1", amount = -20000, memo = (string?)null, category_id = "cat-a", category_name = "A", deleted = true },
 						new { id = "sub-2", transaction_id = "tx-1", amount = -10000, memo = (string?)null, category_id = "cat-b", category_name = "B", deleted = true },


### PR DESCRIPTION
## Summary

One-character wire-format fix. YNAB's API uses `subtransactions` (no underscore), not `sub_transactions`. The read-side DTO introduced in RECEIPTS-536 had it wrong; our own write-side DTO has always been correct (which is why pushes work). As a result, every real YNAB split fetched via `GetTransactionAsync` returned `SubTransactions = null`, and the new Split Comparison card fell into the single-category branch and rendered the YNAB parent's "Split (Multiple Categories)..." label as a single actual row — visible drift on every pushed split receipt.

Resolves RECEIPTS-539.

## Why tests didn't catch it

`YnabApiClientSubTransactionsTests` used `sub_transactions` in its fake JSON — matching our broken DTO and verifying the round-trip against our own convention rather than YNAB's real wire format. All 4 test fixtures are updated to use `subtransactions`.

## Counterfactual verification

Ran the tests locally against the old (wrong) DTO with the new (correct) fixtures. Two tests fail on `SubTransactions.Should().NotBeNull()`, confirming the bug was real and not just a theoretical problem.

## Blast radius

- RECEIPTS-535 (push + 409 reconcile): unaffected — read path only checks top-level fields when filtering by import_id
- RECEIPTS-536 (split comparison card): broken for every real YNAB split until this ships
- Single-category pushed transactions: coincidentally still displayed correctly via the `else if (ynabTx.CategoryId is not null)` fallback branch

## Test plan

- [x] `dotnet test Infrastructure.Tests --filter YnabApiClientSubTransactionsTests` — 4/4 pass
- [x] Counterfactual: with the old DTO + new fixtures, 2 tests fail — confirming the regression
- [ ] Manual QA on the receipt detail page once PR 396 (dark-mode fix) and this PR are both merged: a pushed split receipt shows 3 actual rows matching the expected side (modulo legitimate drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)