### PR TITLE
fix(infra): skip OpenAPI doc generation during Docker publish to unblock arm64 (RECEIPTS-540)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,8 @@ RUN case ${TARGETARCH} in \
     esac && \
     dotnet publish src/Presentation/API/API.csproj \
       -c Release -o /app/publish --no-restore \
-      -p:PublishReadyToRun=true -r linux-${DOTNET_ARCH} && \
+      -p:PublishReadyToRun=true -p:OpenApiGenerateDocumentsOnBuild=false \
+      -r linux-${DOTNET_ARCH} && \
     dotnet publish src/Tools/DbMigrator/DbMigrator.csproj \
       -c Release -o /app/tools/DbMigrator --no-restore \
       -r linux-${DOTNET_ARCH} && \


### PR DESCRIPTION
## Summary

Tiny Dockerfile fix: add `-p:OpenApiGenerateDocumentsOnBuild=false` to the API's `dotnet publish` command. This prevents `Microsoft.Extensions.ApiDescription.Server`'s `GenerateOpenApiDocuments` MSBuild target from running `dotnet-getdocument.dll` during the Docker build — which is what currently segfaults under QEMU arm64 emulation because `dotnet-getdocument` loads the API assembly, which initializes ONNX Runtime's native library, which fails the CPU-feature probe in QEMU.

Resolves RECEIPTS-540.

## Context

v0.1.39's Docker Publish pipeline succeeded for amd64 but failed for arm64 (retried twice — not a flake). The failure mode is well-understood: QEMU's CPU emulation is not a full substitute for native silicon, and heavy native-code workloads like ONNX Runtime can crash inside it. We hit that here because the `dotnet publish` invocation has a dependency on `dotnet-getdocument` which transitively loads ONNX — a dependency we don't actually need inside the Docker build because:

1. `openapi/spec.yaml` is the source of truth (checked into git per RECEIPTS-534)
2. It's regenerated by the pre-commit hook whenever anything changes
3. The build time check `generate:types:check` already guards against drift
4. The runtime API doesn't need the regenerated JSON artifact — it serves OpenAPI from source at runtime via its own middleware

Setting `OpenApiGenerateDocumentsOnBuild=false` is the documented way to skip this target (see `Microsoft.Extensions.ApiDescription.Server.targets:12-13`). It disables `dotnet-getdocument` invocation during `dotnet publish` without affecting anything else.

## Why only the API publish needs the flag

The DbMigrator and DbSeeder tool publishes don't reference `Microsoft.Extensions.ApiDescription.Server` at all, so they never triggered the problem.

## Alternatives considered

1. **Switch arm64 to a native `ubuntu-24.04-arm` runner** — cleaner long-term but a bigger workflow change. Worth a separate issue as future-proofing.
2. **Retry the build** — already tried twice on v0.1.39, both failed. Not a flake.
3. **Remove ONNX from startup DI** — moving `OnnxEmbeddingService` off the critical path would help, but has broader implications for the OCR pipeline.

## Test plan

- [ ] Docker Build Check CI job passes on this PR (amd64-only local build)
- [ ] After merge and release, the `Docker Publish` workflow succeeds for both amd64 AND arm64
- [ ] Smoke check: the amd64 runtime image still serves OpenAPI via its runtime middleware (nothing changed there — the spec is served from source at runtime)

## Rollout

Bundled with RECEIPTS-537 and RECEIPTS-539 into v0.1.40 so arm64 users can skip v0.1.39 entirely and get the UI/backend fixes at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)