### PR TITLE
feat(client): show persisted YNAB sync status on receipt load (RECEIPTS-538)

### DIFF
--- a/src/client/src/components/YnabPushButton.test.tsx
+++ b/src/client/src/components/YnabPushButton.test.tsx
@@ -1,0 +1,177 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { mockMutationResult } from "@/test/mock-hooks";
+import { YnabPushButton } from "./YnabPushButton";
+
+const mockPushMutate = vi.fn();
+
+vi.mock("@/hooks/useYnab", () => ({
+  usePushYnabTransactions: vi.fn(() =>
+    mockMutationResult({ mutate: mockPushMutate }),
+  ),
+}));
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const ynab = await import("@/hooks/useYnab");
+  vi.mocked(ynab.usePushYnabTransactions).mockReturnValue(
+    mockMutationResult({ mutate: mockPushMutate }),
+  );
+});
+
+describe("YnabPushButton", () => {
+  it("shows an enabled 'Push to YNAB' button and no badge when no persisted status and no mutation result", () => {
+    renderWithProviders(
+      <YnabPushButton receiptId="r1" hasTransactions={true} />,
+    );
+
+    const button = screen.getByRole("button", { name: /push to ynab/i });
+    expect(button).toBeEnabled();
+    expect(
+      screen.queryByLabelText(/YNAB sync status/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables the button when hasTransactions is false", () => {
+    renderWithProviders(
+      <YnabPushButton receiptId="r1" hasTransactions={false} />,
+    );
+
+    const button = screen.getByRole("button", { name: /push to ynab/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("calls the push mutation with the receipt id when clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <YnabPushButton receiptId="r-clicked" hasTransactions={true} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /push to ynab/i }));
+
+    expect(mockPushMutate).toHaveBeenCalledWith("r-clicked");
+  });
+
+  it("renders 'Already pushed' and disables the button when persisted status is Synced", () => {
+    renderWithProviders(
+      <YnabPushButton
+        receiptId="r1"
+        hasTransactions={true}
+        persistedSyncStatus="Synced"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /already pushed/i }),
+    ).toBeDisabled();
+    expect(screen.getByLabelText(/YNAB sync status: Synced/i)).toBeInTheDocument();
+  });
+
+  it("shows a 'Failed' badge but keeps the button enabled when persisted status is Failed (allows retry)", () => {
+    renderWithProviders(
+      <YnabPushButton
+        receiptId="r1"
+        hasTransactions={true}
+        persistedSyncStatus="Failed"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /push to ynab/i })).toBeEnabled();
+    expect(screen.getByLabelText(/YNAB sync status: Failed/i)).toBeInTheDocument();
+  });
+
+  it("shows a 'Not Synced' badge and enables the button when persisted status is NotSynced", () => {
+    renderWithProviders(
+      <YnabPushButton
+        receiptId="r1"
+        hasTransactions={true}
+        persistedSyncStatus="NotSynced"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /push to ynab/i })).toBeEnabled();
+    expect(
+      screen.getByLabelText(/YNAB sync status: Not Synced/i),
+    ).toBeInTheDocument();
+  });
+
+  it("a local mutation success overrides a NotSynced persisted status — button shows 'Pushed to YNAB' and is disabled", async () => {
+    const ynab = await import("@/hooks/useYnab");
+    vi.mocked(ynab.usePushYnabTransactions).mockReturnValue(
+      mockMutationResult({
+        mutate: mockPushMutate,
+        data: {
+          success: true,
+          pushedTransactions: [
+            {
+              localTransactionId: "tx-1",
+              ynabTransactionId: "ynab-tx-1",
+              amountMilliunits: -11000,
+              subTransactionCount: 1,
+            },
+          ],
+          error: null,
+          unmappedCategories: [],
+        },
+      }),
+    );
+
+    renderWithProviders(
+      <YnabPushButton
+        receiptId="r1"
+        hasTransactions={true}
+        persistedSyncStatus="NotSynced"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /pushed to ynab/i }),
+    ).toBeDisabled();
+    expect(screen.getByLabelText(/YNAB sync status: Synced/i)).toBeInTheDocument();
+  });
+
+  it("a local mutation failure overrides a Synced persisted status — shows Failed badge and re-enables the button for retry", async () => {
+    // If the server state was Synced but this session's push mutation returned
+    // a failure, we prefer the fresh (failure) result so the user knows the
+    // in-flight operation failed and can retry.
+    const ynab = await import("@/hooks/useYnab");
+    vi.mocked(ynab.usePushYnabTransactions).mockReturnValue(
+      mockMutationResult({
+        mutate: mockPushMutate,
+        data: {
+          success: false,
+          pushedTransactions: [],
+          error: "YNAB 500",
+          unmappedCategories: [],
+        },
+      }),
+    );
+
+    renderWithProviders(
+      <YnabPushButton
+        receiptId="r1"
+        hasTransactions={true}
+        persistedSyncStatus="Synced"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /push to ynab/i })).toBeEnabled();
+    expect(screen.getByLabelText(/YNAB sync status: Failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/YNAB 500/)).toBeInTheDocument();
+  });
+
+  it("shows a Pending spinner during an in-flight push mutation", async () => {
+    const ynab = await import("@/hooks/useYnab");
+    vi.mocked(ynab.usePushYnabTransactions).mockReturnValue(
+      mockMutationResult({ mutate: mockPushMutate, isPending: true }),
+    );
+
+    renderWithProviders(
+      <YnabPushButton receiptId="r1" hasTransactions={true} />,
+    );
+
+    expect(screen.getByText(/pushing to ynab/i)).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/src/client/src/components/YnabPushButton.test.tsx
+++ b/src/client/src/components/YnabPushButton.test.tsx
@@ -107,7 +107,7 @@ describe("YnabPushButton", () => {
             {
               localTransactionId: "tx-1",
               ynabTransactionId: "ynab-tx-1",
-              amountMilliunits: -11000,
+              milliunits: -11000,
               subTransactionCount: 1,
             },
           ],

--- a/src/client/src/components/YnabPushButton.tsx
+++ b/src/client/src/components/YnabPushButton.tsx
@@ -1,17 +1,22 @@
-import { usePushYnabTransactions } from "@/hooks/useYnab";
+import {
+  usePushYnabTransactions,
+  type ReceiptYnabSyncStatusValue,
+} from "@/hooks/useYnab";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { Badge } from "@/components/ui/badge";
+import { YnabSyncBadge } from "@/components/YnabSyncBadge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
 interface YnabPushButtonProps {
   receiptId: string;
   hasTransactions: boolean;
+  persistedSyncStatus?: ReceiptYnabSyncStatusValue;
 }
 
 export function YnabPushButton({
   receiptId,
   hasTransactions,
+  persistedSyncStatus,
 }: YnabPushButtonProps) {
   const pushMutation = usePushYnabTransactions();
 
@@ -20,7 +25,19 @@ export function YnabPushButton({
   };
 
   const result = pushMutation.data;
-  const hasSynced = result?.success === true;
+  const mutationSucceeded = result?.success === true;
+  const mutationFailed = result != null && result.success === false;
+
+  // Effective status: a fresh mutation result trumps whatever was persisted.
+  // Otherwise fall back to the status fetched on page load.
+  const effectiveStatus: ReceiptYnabSyncStatusValue | undefined =
+    mutationSucceeded
+      ? "Synced"
+      : mutationFailed
+        ? "Failed"
+        : persistedSyncStatus;
+
+  const isSynced = effectiveStatus === "Synced";
 
   return (
     <div className="space-y-3">
@@ -29,34 +46,23 @@ export function YnabPushButton({
           variant="outline"
           size="sm"
           onClick={handlePush}
-          disabled={pushMutation.isPending || hasSynced || !hasTransactions}
+          disabled={pushMutation.isPending || isSynced || !hasTransactions}
         >
           {pushMutation.isPending ? (
             <>
               <Spinner className="mr-2 h-3 w-3" />
               Pushing to YNAB...
             </>
-          ) : hasSynced ? (
+          ) : mutationSucceeded ? (
             "Pushed to YNAB"
+          ) : isSynced ? (
+            "Already pushed"
           ) : (
             "Push to YNAB"
           )}
         </Button>
 
-        {hasSynced && (
-          <Badge variant="outline" className="text-green-600 border-green-300">
-            Synced
-          </Badge>
-        )}
-
-        {result && !result.success && (
-          <Badge
-            variant="outline"
-            className="text-destructive border-destructive/50"
-          >
-            Failed
-          </Badge>
-        )}
+        <YnabSyncBadge status={effectiveStatus} />
       </div>
 
       {result && !result.success && result.error && (
@@ -81,7 +87,7 @@ export function YnabPushButton({
           </Alert>
         )}
 
-      {hasSynced && result.pushedTransactions.length > 0 && (
+      {mutationSucceeded && result != null && result.pushedTransactions.length > 0 && (
         <div className="text-sm text-muted-foreground">
           {result.pushedTransactions.length} transaction(s) pushed
           {result.pushedTransactions.some((t) => t.subTransactionCount > 1) &&

--- a/src/client/src/pages/ReceiptDetail.test.tsx
+++ b/src/client/src/pages/ReceiptDetail.test.tsx
@@ -65,6 +65,13 @@ vi.mock("@/components/ReceiptTransactionsCard", () => ({
   },
 }));
 
+vi.mock("@/hooks/useYnab", () => ({
+  useReceiptYnabSyncStatuses: vi.fn(() => ({
+    statusMap: new Map(),
+    isLoading: false,
+  })),
+}));
+
 vi.mock("@/components/YnabPushButton", () => ({
   YnabPushButton: function MockYnabPushButton() {
     return <div data-testid="ynab-push-button">Push to YNAB</div>;

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useParams, Navigate } from "react-router";
 import { useTripByReceiptId } from "@/hooks/useTrips";
 import { useUpdateReceipt } from "@/hooks/useReceipts";
+import { useReceiptYnabSyncStatuses } from "@/hooks/useYnab";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useEnumMetadata } from "@/hooks/useEnumMetadata";
 import {
@@ -55,6 +56,10 @@ function ReceiptDetail() {
 
   const { data: trip, isLoading, isError } = useTripByReceiptId(id ?? null);
   const updateReceipt = useUpdateReceipt();
+  const { statusMap: ynabStatusMap } = useReceiptYnabSyncStatuses(
+    id ? [id] : [],
+  );
+  const persistedYnabStatus = id ? ynabStatusMap.get(id) : undefined;
 
   const [editOpen, setEditOpen] = useState(false);
   const [serverErrors, setServerErrors] = useState<Record<string, string>>({});
@@ -273,6 +278,7 @@ function ReceiptDetail() {
               <YnabPushButton
                 receiptId={id}
                 hasTransactions={trip.transactions.length > 0}
+                persistedSyncStatus={persistedYnabStatus}
               />
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary

Wires the already-built `YnabSyncBadge` and `useReceiptYnabSyncStatuses` hook into the receipt detail page so the sync status is visible on load — not just after an in-session push.

Before: opening a receipt that was pushed earlier showed the "Push to YNAB" button with no indication it was already synced. You had to try pushing again just to see it was a no-op.

After: the YNAB Sync card shows the persisted status badge immediately. If it's `Synced`, the button is disabled and labeled "Already pushed". If it's `Failed`, the button stays enabled so you can retry. In-session mutation results (success or failure) still take precedence over the persisted state.

Resolves RECEIPTS-538.

## Implementation notes

- Everything the feature needs was already built: `GetReceiptYnabSyncStatusesQuery`, the `/api/ynab/receipt-sync-statuses` endpoint, `useReceiptYnabSyncStatuses` hook, and `YnabSyncBadge` component. The diff is pure wiring — zero backend changes.
- `YnabPushButton` now accepts an optional `persistedSyncStatus` prop. It computes an `effectiveStatus` where a fresh local mutation result (success/failure) trumps the persisted status, falling back to the persisted value when the mutation has not run yet.
- The two ad-hoc inline badges (the green "Synced" and destructive "Failed" ones) are replaced with the existing `YnabSyncBadge`, which already renders all four states (`NotSynced`, `Pending`, `Synced`, `Failed`) with consistent iconography and ARIA labels.
- `usePushYnabTransactions.onSuccess` already invalidates the `["ynab", "receipt-sync-statuses"]` query key, so the badge auto-refreshes after a successful push with no page reload.

## Tests

- **New file** `YnabPushButton.test.tsx` (9 tests): button was previously uncovered. Covers all 4 persisted-status branches, the mutation-result precedence (both success and failure overrides), disabled/enabled semantics, the in-flight pending spinner, and click → mutate wiring.
- `ReceiptDetail.test.tsx`: added a mock for `useReceiptYnabSyncStatuses` so the existing 12 tests continue to pass without needing a `QueryClientProvider`.
- Full frontend suite: **1741/0 passing** (up from 1732).

## Test plan

- [x] Unit tests
- [ ] Manual check: reload a receipt that was previously pushed to YNAB and verify the Synced badge is visible immediately without interaction
- [ ] Manual check: reload a receipt in Failed state and verify the badge + re-enabled Push button

🤖 Generated with [Claude Code](https://claude.com/claude-code)