### PR TITLE
fix(tests): stabilize DesignTimeDbContextFactoryTests env-var race

### DIFF
--- a/tests/Infrastructure.Tests/DateTimeOffsetUtcConverterTests.cs
+++ b/tests/Infrastructure.Tests/DateTimeOffsetUtcConverterTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Infrastructure.Tests;
 
+[Collection(PostgresConnectionStringEnvCollection.Name)]
 public class DateTimeOffsetUtcConverterTests
 {
 	[Fact]

--- a/tests/Infrastructure.Tests/DesignTimeDbContextFactory.cs
+++ b/tests/Infrastructure.Tests/DesignTimeDbContextFactory.cs
@@ -2,6 +2,19 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Tests;
 
+/// <summary>
+/// Serializes tests that mutate the process-global POSTGRES_CONNECTION_STRING
+/// environment variable. Without this, xUnit's default parallelism lets sibling
+/// tests race against each other: one test sets the variable to null while another
+/// sets it to a connection string, and the "throws when not set" assertion flakes.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class PostgresConnectionStringEnvCollection
+{
+	public const string Name = "PostgresConnectionStringEnv";
+}
+
+[Collection(PostgresConnectionStringEnvCollection.Name)]
 public class DesignTimeDbContextFactoryTests
 {
 	[Fact]


### PR DESCRIPTION
## Summary

Fixes the flaky `Infrastructure.Tests.DesignTimeDbContextFactoryTests.CreateDbContext_ThrowsWhenEnvironmentVariableNotSet` test that intermittently failed with "No exception was thrown".

## Root cause

Two test classes in `Infrastructure.Tests` mutate the process-global `POSTGRES_CONNECTION_STRING` environment variable:

- `DesignTimeDbContextFactoryTests` — four tests, three set it to a valid connection string and one sets it to `null` and asserts `InvalidOperationException`.
- `DateTimeOffsetUtcConverterTests` — two tests that set it to a valid connection string.

xUnit parallelizes across test classes by default, so the "throws when not set" assertion could race against any concurrent test that re-populates the variable between the `SetEnvironmentVariable(..., null)` call and the `CreateDbContext` call, silently turning the null back into a valid connection string and suppressing the expected exception.

## Fix

Introduces a shared xUnit collection `PostgresConnectionStringEnvCollection` with `DisableParallelization = true`, and places both affected classes in it. This serializes every test that touches the env var against the rest of the assembly without touching production code.

## Second test in the brief

The task also referenced `Presentation.API.Tests.Controllers.AuthControllerTests.Login_LockedOut_ReturnsOAuthErrorResponse` as "failing consistently". I could not reproduce any failure for this test on the current `origin/develop` — it passed in isolation, across the full `AuthControllerTests` class, across the full `Presentation.API.Tests` assembly, and across five consecutive full runs (890/890 each time). Either the failure was resolved by a recent merge or it was environment-specific. I have left this test untouched; if a reliable repro surfaces, we can address it in a follow-up.

## Test plan

- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — all 5 assemblies green (Common 18, Domain 117, Application 490, Presentation.API 890, Infrastructure 559 = 2074 tests)
- [x] `dotnet test tests/Infrastructure.Tests/Infrastructure.Tests.csproj --filter "Category!=Integration"` run 3 consecutive times — all 559/559 deterministic
- [x] `dotnet format Receipts.slnx --verify-no-changes` — clean
- [x] Pre-commit hook (format + full suite + client tests) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)