### PR TITLE
feat: merge cards into account with YNAB conflict resolution (RECEIPTS-545)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -433,6 +433,47 @@ paths:
         "404":
           description: Not Found
 
+  /api/cards/merge:
+    post:
+      operationId: MergeCards
+      tags: [Cards]
+      summary: Merge cards into a target account
+      description: >
+        Repoints the listed cards (and their transactions) to the target account
+        and deletes any now-orphaned accounts. Requires the Admin role. Returns
+        409 Conflict if the source/target accounts have differing YNAB account
+        mappings; resubmit with `ynabMappingWinnerAccountId` to resolve.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MergeCardsRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MergeCardsResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: Not Found — target account or source card missing
+        "409":
+          description: Conflict — source accounts have differing YNAB mappings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MergeCardsConflictResponse"
+
   # ──────────────────────────────────────────────
   # Categories
   # ──────────────────────────────────────────────
@@ -4993,6 +5034,62 @@ components:
         limit:
           type: integer
           format: int32
+
+    MergeCardsRequest:
+      type: object
+      required: [targetAccountId, sourceCardIds]
+      properties:
+        targetAccountId:
+          type: string
+          format: uuid
+        sourceCardIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          minItems: 2
+        ynabMappingWinnerAccountId:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: >
+            The account whose YNAB mapping should be retained when mappings conflict.
+            Omit on first submit; if conflicts are returned, resubmit with this field.
+
+    MergeCardsResponse:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+
+    YnabMappingConflict:
+      type: object
+      required: [accountId, accountName, ynabBudgetId, ynabAccountId, ynabAccountName]
+      properties:
+        accountId:
+          type: string
+          format: uuid
+        accountName:
+          type: string
+        ynabBudgetId:
+          type: string
+        ynabAccountId:
+          type: string
+        ynabAccountName:
+          type: string
+
+    MergeCardsConflictResponse:
+      type: object
+      required: [message, conflicts]
+      properties:
+        message:
+          type: string
+        conflicts:
+          type: array
+          items:
+            $ref: "#/components/schemas/YnabMappingConflict"
 
     # ── Category ──────────────────────────────────
 

--- a/src/Application/Commands/Card/Merge/MergeCardsIntoAccountCommand.cs
+++ b/src/Application/Commands/Card/Merge/MergeCardsIntoAccountCommand.cs
@@ -1,0 +1,31 @@
+using Application.Interfaces;
+using Application.Models.Merge;
+
+namespace Application.Commands.Card.Merge;
+
+public record MergeCardsIntoAccountCommand : ICommand<MergeCardsResult>
+{
+	public Guid TargetAccountId { get; }
+	public IReadOnlyList<Guid> SourceCardIds { get; }
+	public Guid? YnabMappingWinnerAccountId { get; }
+
+	public const string TargetIdCannotBeEmpty = "Target account id cannot be empty.";
+	public const string SourceCardIdsCannotBeEmpty = "Source card ids cannot be empty.";
+
+	public MergeCardsIntoAccountCommand(Guid targetAccountId, IReadOnlyList<Guid> sourceCardIds, Guid? ynabMappingWinnerAccountId = null)
+	{
+		if (targetAccountId == Guid.Empty)
+		{
+			throw new ArgumentException(TargetIdCannotBeEmpty, nameof(targetAccountId));
+		}
+
+		if (sourceCardIds is null || sourceCardIds.Count == 0)
+		{
+			throw new ArgumentException(SourceCardIdsCannotBeEmpty, nameof(sourceCardIds));
+		}
+
+		TargetAccountId = targetAccountId;
+		SourceCardIds = sourceCardIds;
+		YnabMappingWinnerAccountId = ynabMappingWinnerAccountId;
+	}
+}

--- a/src/Application/Commands/Card/Merge/MergeCardsIntoAccountCommandHandler.cs
+++ b/src/Application/Commands/Card/Merge/MergeCardsIntoAccountCommandHandler.cs
@@ -1,0 +1,18 @@
+using Application.Interfaces.Services;
+using Application.Models.Merge;
+using MediatR;
+
+namespace Application.Commands.Card.Merge;
+
+public class MergeCardsIntoAccountCommandHandler(IAccountMergeService mergeService)
+	: IRequestHandler<MergeCardsIntoAccountCommand, MergeCardsResult>
+{
+	public Task<MergeCardsResult> Handle(MergeCardsIntoAccountCommand request, CancellationToken cancellationToken)
+	{
+		return mergeService.MergeCardsAsync(
+			request.TargetAccountId,
+			request.SourceCardIds,
+			request.YnabMappingWinnerAccountId,
+			cancellationToken);
+	}
+}

--- a/src/Application/Interfaces/Services/IAccountMergeService.cs
+++ b/src/Application/Interfaces/Services/IAccountMergeService.cs
@@ -1,0 +1,12 @@
+using Application.Models.Merge;
+
+namespace Application.Interfaces.Services;
+
+public interface IAccountMergeService
+{
+	Task<MergeCardsResult> MergeCardsAsync(
+		Guid targetAccountId,
+		IReadOnlyList<Guid> sourceCardIds,
+		Guid? ynabMappingWinnerAccountId,
+		CancellationToken cancellationToken);
+}

--- a/src/Application/Models/Merge/MergeCardsResult.cs
+++ b/src/Application/Models/Merge/MergeCardsResult.cs
@@ -1,0 +1,5 @@
+namespace Application.Models.Merge;
+
+public record MergeCardsResult(
+	bool Success,
+	IReadOnlyList<YnabMappingConflict>? Conflicts);

--- a/src/Application/Models/Merge/YnabMappingConflict.cs
+++ b/src/Application/Models/Merge/YnabMappingConflict.cs
@@ -1,0 +1,8 @@
+namespace Application.Models.Merge;
+
+public record YnabMappingConflict(
+	Guid AccountId,
+	string AccountName,
+	string YnabBudgetId,
+	string YnabAccountId,
+	string YnabAccountName);

--- a/src/Infrastructure/Entities/Audit/AuditAction.cs
+++ b/src/Infrastructure/Entities/Audit/AuditAction.cs
@@ -6,4 +6,5 @@ public enum AuditAction
 	Update,
 	Delete,
 	Restore,
+	Merge,
 }

--- a/src/Infrastructure/Services/AccountMergeService.cs
+++ b/src/Infrastructure/Services/AccountMergeService.cs
@@ -15,6 +15,7 @@ public class AccountMergeService(
 	public const string TargetAccountNotFound = "Target account not found.";
 	public const string SourceCardNotFound = "One or more source cards not found.";
 	public const string InvalidWinnerAccount = "Winner account id must match one of the accounts involved in the merge.";
+	public const string PartialSourceAccountMerge = "Source account would be partially merged: all of its cards must be included in the merge, or none.";
 
 	public async Task<MergeCardsResult> MergeCardsAsync(
 		Guid targetAccountId,
@@ -79,6 +80,9 @@ public class AccountMergeService(
 				.IgnoreAutoIncludes()
 				.Where(t => sourceAccountIds.Contains(t.AccountId))
 				.ToListAsync(cancellationToken);
+			Dictionary<Guid, int> transactionCountBySource = transactionsToMove
+				.GroupBy(t => t.AccountId)
+				.ToDictionary(g => g.Key, g => g.Count());
 			foreach (TransactionEntity transaction in transactionsToMove)
 			{
 				transaction.AccountId = targetAccountId;
@@ -125,13 +129,14 @@ public class AccountMergeService(
 				List<Guid> cardsMovedFromThisAccount = [.. originalCardAccountIds
 					.Where(kvp => kvp.Value == sourceAccountId)
 					.Select(kvp => kvp.Key)];
+				int movedFromThisSource = transactionCountBySource.GetValueOrDefault(sourceAccountId, 0);
 				mergeEntries.Add(CreateMergeAuditEntry(
 					sourceAccountId,
 					new
 					{
 						targetAccountId,
 						mergedCardIds = cardsMovedFromThisAccount,
-						movedTransactionCount,
+						movedTransactionCount = movedFromThisSource,
 					},
 					now));
 			}
@@ -195,6 +200,24 @@ public class AccountMergeService(
 			.Where(id => id.HasValue && id.Value != targetAccountId)
 			.Select(id => id!.Value)
 			.Distinct()];
+
+		// Ensure each source account is being fully merged. Partial merges (leaving behind
+		// cards on a source account that is about to be deleted) would silently orphan the
+		// remaining cards and reassign their unrelated transactions — reject instead.
+		if (sourceAccountIds.Count > 0)
+		{
+			HashSet<Guid> mergedCardIdSet = [.. distinctCardIds];
+			int cardsLeftBehindCount = await context.Cards
+				.AsNoTracking()
+				.CountAsync(c => c.AccountId.HasValue
+					&& sourceAccountIds.Contains(c.AccountId.Value)
+					&& !mergedCardIdSet.Contains(c.Id),
+					cancellationToken);
+			if (cardsLeftBehindCount > 0)
+			{
+				throw new ArgumentException(PartialSourceAccountMerge, nameof(distinctCardIds));
+			}
+		}
 
 		List<Guid> allAccountIds = [.. sourceAccountIds, targetAccountId];
 

--- a/src/Infrastructure/Services/AccountMergeService.cs
+++ b/src/Infrastructure/Services/AccountMergeService.cs
@@ -1,0 +1,242 @@
+using System.Text.Json;
+using Application.Interfaces.Services;
+using Application.Models.Merge;
+using Infrastructure.Entities.Audit;
+using Infrastructure.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Services;
+
+public class AccountMergeService(
+	IDbContextFactory<ApplicationDbContext> contextFactory,
+	ICurrentUserAccessor currentUserAccessor) : IAccountMergeService
+{
+	public const string AtLeastTwoCardsRequired = "Merge requires at least two source cards.";
+	public const string TargetAccountNotFound = "Target account not found.";
+	public const string SourceCardNotFound = "One or more source cards not found.";
+	public const string InvalidWinnerAccount = "Winner account id must match one of the accounts involved in the merge.";
+
+	public async Task<MergeCardsResult> MergeCardsAsync(
+		Guid targetAccountId,
+		IReadOnlyList<Guid> sourceCardIds,
+		Guid? ynabMappingWinnerAccountId,
+		CancellationToken cancellationToken)
+	{
+		if (sourceCardIds is null || sourceCardIds.Count < 2)
+		{
+			throw new ArgumentException(AtLeastTwoCardsRequired, nameof(sourceCardIds));
+		}
+
+		List<Guid> distinctCardIds = [.. sourceCardIds.Distinct()];
+		if (distinctCardIds.Count < 2)
+		{
+			throw new ArgumentException(AtLeastTwoCardsRequired, nameof(sourceCardIds));
+		}
+
+		// Phase 0: validate + detect conflicts using read-only snapshot.
+		(List<Guid> sourceAccountIds, List<YnabAccountMappingEntity> mappings, Dictionary<Guid, string> accountNamesById, Dictionary<Guid, Guid?> originalCardAccountIds) =
+			await LoadStateAsync(targetAccountId, distinctCardIds, cancellationToken);
+
+		if (sourceAccountIds.Count == 0)
+		{
+			// No-op: all cards already belong to the target account.
+			return new MergeCardsResult(true, null);
+		}
+
+		int distinctMappingTuples = mappings
+			.Select(m => (m.YnabBudgetId, m.YnabAccountId))
+			.Distinct()
+			.Count();
+
+		Guid? winnerAccountId = null;
+		if (distinctMappingTuples > 1)
+		{
+			if (!ynabMappingWinnerAccountId.HasValue)
+			{
+				return BuildConflictResult(mappings, accountNamesById);
+			}
+
+			if (!mappings.Any(m => m.ReceiptsAccountId == ynabMappingWinnerAccountId.Value))
+			{
+				throw new ArgumentException(InvalidWinnerAccount, nameof(ynabMappingWinnerAccountId));
+			}
+
+			winnerAccountId = ynabMappingWinnerAccountId.Value;
+		}
+		else if (mappings.Count > 0)
+		{
+			// No conflict; keep the target mapping if it exists, else promote the sole source mapping.
+			winnerAccountId = mappings.Any(m => m.ReceiptsAccountId == targetAccountId)
+				? targetAccountId
+				: mappings[0].ReceiptsAccountId;
+		}
+
+		// Phase 1: repoint dependents + repoint/replace mapping + write audit. No account deletes yet.
+		int movedTransactionCount;
+		using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<TransactionEntity> transactionsToMove = await context.Transactions
+				.IgnoreAutoIncludes()
+				.Where(t => sourceAccountIds.Contains(t.AccountId))
+				.ToListAsync(cancellationToken);
+			foreach (TransactionEntity transaction in transactionsToMove)
+			{
+				transaction.AccountId = targetAccountId;
+			}
+			movedTransactionCount = transactionsToMove.Count;
+
+			List<CardEntity> sourceCards = await context.Cards
+				.Where(c => distinctCardIds.Contains(c.Id))
+				.ToListAsync(cancellationToken);
+			foreach (CardEntity card in sourceCards)
+			{
+				card.AccountId = targetAccountId;
+			}
+
+			// Remove any source mappings that are NOT the winner. We explicitly delete them
+			// rather than relying on cascade from account deletion (EF's InMemory provider
+			// does not replay cascades for store-resident rows the change tracker never saw).
+			Guid? keptMappingId = winnerAccountId;
+			List<YnabAccountMappingEntity> mappingsToDelete = await context.YnabAccountMappings
+				.Where(m => sourceAccountIds.Contains(m.ReceiptsAccountId)
+					&& (!keptMappingId.HasValue || m.ReceiptsAccountId != keptMappingId.Value))
+				.ToListAsync(cancellationToken);
+			context.YnabAccountMappings.RemoveRange(mappingsToDelete);
+
+			if (winnerAccountId.HasValue && winnerAccountId.Value != targetAccountId)
+			{
+				YnabAccountMappingEntity? existingTarget = await context.YnabAccountMappings
+					.FirstOrDefaultAsync(m => m.ReceiptsAccountId == targetAccountId, cancellationToken);
+				if (existingTarget is not null)
+				{
+					context.YnabAccountMappings.Remove(existingTarget);
+				}
+
+				YnabAccountMappingEntity winner = await context.YnabAccountMappings
+					.FirstAsync(m => m.ReceiptsAccountId == winnerAccountId.Value, cancellationToken);
+				winner.ReceiptsAccountId = targetAccountId;
+				winner.UpdatedAt = DateTimeOffset.UtcNow;
+			}
+
+			DateTimeOffset now = DateTimeOffset.UtcNow;
+			List<AuditLogEntity> mergeEntries = [];
+			foreach (Guid sourceAccountId in sourceAccountIds)
+			{
+				List<Guid> cardsMovedFromThisAccount = [.. originalCardAccountIds
+					.Where(kvp => kvp.Value == sourceAccountId)
+					.Select(kvp => kvp.Key)];
+				mergeEntries.Add(CreateMergeAuditEntry(
+					sourceAccountId,
+					new
+					{
+						targetAccountId,
+						mergedCardIds = cardsMovedFromThisAccount,
+						movedTransactionCount,
+					},
+					now));
+			}
+
+			mergeEntries.Add(CreateMergeAuditEntry(
+				targetAccountId,
+				new
+				{
+					sourceAccountIds,
+					mergedCardIds = distinctCardIds,
+					movedTransactionCount,
+				},
+				now));
+
+			context.AuditLogs.AddRange(mergeEntries);
+			await context.SaveChangesAsync(cancellationToken);
+		}
+
+		// Phase 2: delete now-orphaned source accounts in a fresh context.
+		using (ApplicationDbContext deleteContext = contextFactory.CreateDbContext())
+		{
+			List<AccountEntity> orphanedAccounts = await deleteContext.Accounts
+				.Where(a => sourceAccountIds.Contains(a.Id))
+				.ToListAsync(cancellationToken);
+			deleteContext.Accounts.RemoveRange(orphanedAccounts);
+			await deleteContext.SaveChangesAsync(cancellationToken);
+		}
+
+		return new MergeCardsResult(true, null);
+	}
+
+	private async Task<(List<Guid> SourceAccountIds, List<YnabAccountMappingEntity> Mappings, Dictionary<Guid, string> AccountNamesById, Dictionary<Guid, Guid?> OriginalCardAccountIds)> LoadStateAsync(
+		Guid targetAccountId,
+		List<Guid> distinctCardIds,
+		CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		bool targetExists = await context.Accounts
+			.AsNoTracking()
+			.AnyAsync(a => a.Id == targetAccountId, cancellationToken);
+		if (!targetExists)
+		{
+			throw new KeyNotFoundException(TargetAccountNotFound);
+		}
+
+		List<CardEntity> sourceCards = await context.Cards
+			.AsNoTracking()
+			.Where(c => distinctCardIds.Contains(c.Id))
+			.ToListAsync(cancellationToken);
+
+		if (sourceCards.Count != distinctCardIds.Count)
+		{
+			throw new KeyNotFoundException(SourceCardNotFound);
+		}
+
+		Dictionary<Guid, Guid?> originalCardAccountIds = sourceCards
+			.ToDictionary(c => c.Id, c => c.AccountId);
+
+		List<Guid> sourceAccountIds = [.. originalCardAccountIds.Values
+			.Where(id => id.HasValue && id.Value != targetAccountId)
+			.Select(id => id!.Value)
+			.Distinct()];
+
+		List<Guid> allAccountIds = [.. sourceAccountIds, targetAccountId];
+
+		List<YnabAccountMappingEntity> mappings = await context.YnabAccountMappings
+			.AsNoTracking()
+			.Where(m => allAccountIds.Contains(m.ReceiptsAccountId))
+			.ToListAsync(cancellationToken);
+
+		Dictionary<Guid, string> accountNamesById = await context.Accounts
+			.AsNoTracking()
+			.Where(a => allAccountIds.Contains(a.Id))
+			.ToDictionaryAsync(a => a.Id, a => a.Name, cancellationToken);
+
+		return (sourceAccountIds, mappings, accountNamesById, originalCardAccountIds);
+	}
+
+	private AuditLogEntity CreateMergeAuditEntry(Guid accountId, object payload, DateTimeOffset now)
+	{
+		return new AuditLogEntity
+		{
+			Id = Guid.NewGuid(),
+			EntityType = "Account",
+			EntityId = accountId.ToString(),
+			Action = AuditAction.Merge,
+			ChangesJson = JsonSerializer.Serialize(payload),
+			ChangedByUserId = currentUserAccessor.UserId,
+			ChangedByApiKeyId = currentUserAccessor.ApiKeyId,
+			ChangedAt = now,
+			IpAddress = currentUserAccessor.IpAddress,
+		};
+	}
+
+	private static MergeCardsResult BuildConflictResult(
+		List<YnabAccountMappingEntity> mappings,
+		Dictionary<Guid, string> accountNamesById)
+	{
+		List<YnabMappingConflict> conflicts = [.. mappings.Select(m => new YnabMappingConflict(
+			m.ReceiptsAccountId,
+			accountNamesById.GetValueOrDefault(m.ReceiptsAccountId, ""),
+			m.YnabBudgetId,
+			m.YnabAccountId,
+			m.YnabAccountName))];
+		return new MergeCardsResult(false, conflicts);
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -118,6 +118,7 @@ public static class InfrastructureService
 		services
 			.AddScoped<IReceiptService, ReceiptService>()
 			.AddScoped<IAccountService, AccountService>()
+			.AddScoped<IAccountMergeService, AccountMergeService>()
 			.AddScoped<ICardService, CardService>()
 			.AddScoped<ICategoryService, CategoryService>()
 			.AddScoped<ISubcategoryService, SubcategoryService>()

--- a/src/Presentation/API/Controllers/Core/CardsController.cs
+++ b/src/Presentation/API/Controllers/Core/CardsController.cs
@@ -3,9 +3,11 @@ using API.Mapping.Core;
 using API.Services;
 using Application.Commands.Card.Create;
 using Application.Commands.Card.Delete;
+using Application.Commands.Card.Merge;
 using Application.Commands.Card.Update;
 using Application.Interfaces.Services;
 using Application.Models;
+using Application.Models.Merge;
 using Application.Queries.Core.Card;
 using Asp.Versioning;
 using Domain.Core;
@@ -30,6 +32,7 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 	public const string RouteUpdate = "{id}";
 	public const string RouteUpdateBatch = "batch";
 	public const string RouteDelete = "{id}";
+	public const string RouteMerge = "merge";
 
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get a card by ID")]
@@ -164,5 +167,65 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 
 		await notifier.NotifyDeleted("card", id);
 		return TypedResults.NoContent();
+	}
+
+	[HttpPost(RouteMerge)]
+	[Authorize(Policy = "RequireAdmin")]
+	[EndpointSummary("Merge cards into a target account")]
+	[EndpointDescription("Repoints the listed cards (and their transactions) to the target account and deletes any now-orphaned accounts. Requires the Admin role. Returns 409 Conflict if the source/target accounts have differing YNAB account mappings; resubmit with ynabMappingWinnerAccountId to resolve.")]
+	public async Task<Results<Ok<MergeCardsResponse>, BadRequest<string>, NotFound, Conflict<MergeCardsConflictResponse>>> MergeCards([FromBody] MergeCardsRequest model)
+	{
+		if (model.SourceCardIds is null || model.SourceCardIds.Count < 2)
+		{
+			return TypedResults.BadRequest("sourceCardIds must contain at least 2 card ids");
+		}
+
+		MergeCardsIntoAccountCommand command;
+		try
+		{
+			command = new MergeCardsIntoAccountCommand(
+				model.TargetAccountId,
+				[.. model.SourceCardIds],
+				model.YnabMappingWinnerAccountId);
+		}
+		catch (ArgumentException ex)
+		{
+			return TypedResults.BadRequest(ex.Message);
+		}
+
+		MergeCardsResult result;
+		try
+		{
+			result = await mediator.Send(command, HttpContext.RequestAborted);
+		}
+		catch (KeyNotFoundException ex)
+		{
+			logger.LogWarning("Merge failed — {Message}", ex.Message);
+			return TypedResults.NotFound();
+		}
+		catch (ArgumentException ex)
+		{
+			return TypedResults.BadRequest(ex.Message);
+		}
+
+		if (result.Conflicts is not null)
+		{
+			MergeCardsConflictResponse body = new()
+			{
+				Message = "Source cards have differing YNAB mappings. Resubmit with ynabMappingWinnerAccountId set to the account whose mapping should be retained.",
+				Conflicts = [.. result.Conflicts.Select(c => new API.Generated.Dtos.YnabMappingConflict
+				{
+					AccountId = c.AccountId,
+					AccountName = c.AccountName,
+					YnabBudgetId = c.YnabBudgetId,
+					YnabAccountId = c.YnabAccountId,
+					YnabAccountName = c.YnabAccountName,
+				})],
+			};
+			return TypedResults.Conflict(body);
+		}
+
+		await notifier.NotifyBulkChanged("card", "updated", model.SourceCardIds);
+		return TypedResults.Ok(new MergeCardsResponse { Success = true });
 	}
 }

--- a/src/Presentation/API/EnumLabels.cs
+++ b/src/Presentation/API/EnumLabels.cs
@@ -42,6 +42,7 @@ public static class EnumLabels
 		new() { Value = "Update", Label = "Updated" },
 		new() { Value = "Delete", Label = "Deleted" },
 		new() { Value = "Restore", Label = "Restored" },
+		new() { Value = "Merge", Label = "Merged" },
 	];
 
 	public static readonly EnumValuePair[] EntityTypes =

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.36",
+  "version": "0.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.36",
+      "version": "0.1.41",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",

--- a/src/client/src/components/MergeCardsDialog.test.tsx
+++ b/src/client/src/components/MergeCardsDialog.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, type Mock } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MergeCardsDialog } from "./MergeCardsDialog";
+
+// jsdom polyfills required by Radix UI Select/Dialog
+beforeAll(() => {
+  if (!(Element.prototype as unknown as { hasPointerCapture?: unknown }).hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.releasePointerCapture = () => {};
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!(Element.prototype as unknown as { scrollIntoView?: unknown }).scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import client from "@/lib/api-client";
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof MergeCardsDialog>> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const selectedCards = overrides.selectedCards ?? [
+    { id: "c1", name: "Primary Visa", cardCode: "1234" },
+    { id: "c2", name: "Reissued Visa", cardCode: "5678" },
+  ];
+  const onOpenChange = vi.fn();
+  const props = {
+    open: true,
+    onOpenChange,
+    selectedCards,
+    ...overrides,
+  };
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <MergeCardsDialog {...props} />
+    </QueryClientProvider>,
+  );
+  return { ...result, onOpenChange };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Accounts query used by the dialog
+  (client.GET as Mock).mockResolvedValue({
+    data: { data: [{ id: "a1", name: "Account One", isActive: true }], total: 1, offset: 0, limit: 500 },
+    error: undefined,
+  });
+});
+
+describe("MergeCardsDialog", () => {
+  it("renders the selected cards", () => {
+    renderDialog();
+    expect(screen.getByText("Primary Visa")).toBeInTheDocument();
+    expect(screen.getByText("Reissued Visa")).toBeInTheDocument();
+    expect(screen.getByText(/merging 2 cards/i)).toBeInTheDocument();
+  });
+
+  it("submit button is disabled until target account is selected", () => {
+    renderDialog();
+    const submit = screen.getByRole("button", { name: /^merge$/i });
+    expect(submit).toBeDisabled();
+  });
+
+  it("submits merge request with selected target and closes on success", async () => {
+    const user = userEvent.setup();
+    (client.POST as Mock).mockResolvedValue({
+      data: { success: true },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    const { onOpenChange } = renderDialog();
+
+    // Open the Select dropdown and pick the account
+    const trigger = screen.getByLabelText("Target account");
+    await user.click(trigger);
+    const option = await screen.findByRole("option", { name: "Account One" });
+    await user.click(option);
+
+    const submit = screen.getByRole("button", { name: /^merge$/i });
+    expect(submit).not.toBeDisabled();
+    await user.click(submit);
+
+    await vi.waitFor(() => {
+      expect(client.POST).toHaveBeenCalledWith("/api/cards/merge", {
+        body: {
+          targetAccountId: "a1",
+          sourceCardIds: ["c1", "c2"],
+          ynabMappingWinnerAccountId: null,
+        },
+      });
+    });
+    await vi.waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("shows conflict alert on 409 and resubmits with winner", async () => {
+    const user = userEvent.setup();
+    (client.POST as Mock).mockResolvedValueOnce({
+      error: {
+        message: "conflict",
+        conflicts: [
+          { accountId: "srcA", accountName: "Src A", ynabBudgetId: "b", ynabAccountId: "y1", ynabAccountName: "YA" },
+          { accountId: "srcB", accountName: "Src B", ynabBudgetId: "b", ynabAccountId: "y2", ynabAccountName: "YB" },
+        ],
+      },
+      response: { status: 409 },
+    });
+
+    renderDialog();
+
+    const trigger = screen.getByLabelText("Target account");
+    await user.click(trigger);
+    const option = await screen.findByRole("option", { name: "Account One" });
+    await user.click(option);
+
+    await user.click(screen.getByRole("button", { name: /^merge$/i }));
+
+    expect(await screen.findByText(/ynab mapping conflict/i)).toBeInTheDocument();
+    expect(screen.getByText(/Src A/)).toBeInTheDocument();
+    expect(screen.getByText(/Src B/)).toBeInTheDocument();
+
+    // Resubmit disabled until a winner is picked
+    const resubmit = screen.getByRole("button", { name: /resubmit/i });
+    expect(resubmit).toBeDisabled();
+
+    await user.click(screen.getByLabelText(/Src A/));
+    expect(resubmit).not.toBeDisabled();
+
+    (client.POST as Mock).mockResolvedValueOnce({
+      data: { success: true },
+      error: undefined,
+      response: { status: 200 },
+    });
+    await user.click(resubmit);
+
+    await vi.waitFor(() => {
+      expect((client.POST as Mock).mock.calls).toHaveLength(2);
+    });
+    const secondCall = (client.POST as Mock).mock.calls[1];
+    expect(secondCall[1].body.ynabMappingWinnerAccountId).toBe("srcA");
+  });
+});

--- a/src/client/src/components/MergeCardsDialog.test.tsx
+++ b/src/client/src/components/MergeCardsDialog.test.tsx
@@ -111,6 +111,45 @@ describe("MergeCardsDialog", () => {
     });
   });
 
+  it("creates new account, hits conflict, cancels — deletes the newly-created account", async () => {
+    const user = userEvent.setup();
+
+    // First POST: create account (for target). Second POST: merge → 409 conflict.
+    (client.POST as Mock)
+      .mockResolvedValueOnce({
+        data: { id: "new-acc-1", name: "Fresh Account", isActive: true },
+        error: undefined,
+        response: { status: 200 },
+      })
+      .mockResolvedValueOnce({
+        error: {
+          message: "conflict",
+          conflicts: [
+            { accountId: "srcA", accountName: "Src A", ynabBudgetId: "b", ynabAccountId: "y1", ynabAccountName: "YA" },
+            { accountId: "srcB", accountName: "Src B", ynabBudgetId: "b", ynabAccountId: "y2", ynabAccountName: "YB" },
+          ],
+        },
+        response: { status: 409 },
+      });
+
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByLabelText("New account"));
+    await user.type(screen.getByLabelText(/new account name/i), "Fresh Account");
+    await user.click(screen.getByRole("button", { name: /^merge$/i }));
+
+    expect(await screen.findByText(/ynab mapping conflict/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await vi.waitFor(() => {
+      expect(client.DELETE).toHaveBeenCalledWith("/api/accounts/{id}", {
+        params: { path: { id: "new-acc-1" } },
+      });
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it("shows conflict alert on 409 and resubmits with winner", async () => {
     const user = userEvent.setup();
     (client.POST as Mock).mockResolvedValueOnce({

--- a/src/client/src/components/MergeCardsDialog.tsx
+++ b/src/client/src/components/MergeCardsDialog.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
+import client from "@/lib/api-client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -53,6 +54,10 @@ export function MergeCardsDialog({
   const [newAccountName, setNewAccountName] = useState<string>("");
   const [conflict, setConflict] = useState<MergeCardsConflict | null>(null);
   const [winnerAccountId, setWinnerAccountId] = useState<string | null>(null);
+  // Tracks an account the dialog created as the merge target. If the user closes
+  // the dialog before the merge lands, the account is deleted to avoid leaking
+  // empty accounts into the DB.
+  const pendingCreatedAccountIdRef = useRef<string | null>(null);
 
   const { data: accountsData } = useAccounts(0, 500, "name", "asc", true);
   const createAccount = useCreateAccount();
@@ -60,6 +65,12 @@ export function MergeCardsDialog({
 
   function handleOpenChange(next: boolean) {
     if (!next) {
+      const leaked = pendingCreatedAccountIdRef.current;
+      if (leaked) {
+        pendingCreatedAccountIdRef.current = null;
+        // Fire-and-forget cleanup; we don't want to block the dialog close.
+        void client.DELETE("/api/accounts/{id}", { params: { path: { id: leaked } } });
+      }
       setTargetMode("existing");
       setTargetAccountId("");
       setNewAccountName("");
@@ -84,13 +95,17 @@ export function MergeCardsDialog({
 
     let resolvedTargetId = targetAccountId;
 
-    if (targetMode === "new") {
+    if (targetMode === "new" && !pendingCreatedAccountIdRef.current) {
       const created = await createAccount.mutateAsync({
         name: newAccountName.trim(),
         isActive: true,
       });
       if (!created?.id) return;
       resolvedTargetId = created.id;
+      pendingCreatedAccountIdRef.current = created.id;
+    } else if (pendingCreatedAccountIdRef.current) {
+      // Second submit after conflict resolution — reuse the already-created account.
+      resolvedTargetId = pendingCreatedAccountIdRef.current;
     }
 
     try {
@@ -99,6 +114,9 @@ export function MergeCardsDialog({
         sourceCardIds: selectedCards.map((c) => c.id),
         ynabMappingWinnerAccountId: winnerAccountId,
       });
+      // Merge succeeded — the created account (if any) now owns the merged cards,
+      // so it is no longer leaked; clear the ref before closing.
+      pendingCreatedAccountIdRef.current = null;
       handleOpenChange(false);
       onMergeComplete?.();
     } catch (err) {

--- a/src/client/src/components/MergeCardsDialog.tsx
+++ b/src/client/src/components/MergeCardsDialog.tsx
@@ -1,0 +1,251 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle } from "lucide-react";
+import {
+  useMergeCards,
+  isMergeCardsConflict,
+  type MergeCardsConflict,
+  type YnabMappingConflict,
+} from "@/hooks/useCards";
+import { useAccounts, useCreateAccount } from "@/hooks/useAccounts";
+
+export interface SelectedCardSummary {
+  id: string;
+  name: string;
+  cardCode: string;
+}
+
+interface MergeCardsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedCards: SelectedCardSummary[];
+  onMergeComplete?: () => void;
+}
+
+type TargetMode = "existing" | "new";
+
+export function MergeCardsDialog({
+  open,
+  onOpenChange,
+  selectedCards,
+  onMergeComplete,
+}: MergeCardsDialogProps) {
+  const [targetMode, setTargetMode] = useState<TargetMode>("existing");
+  const [targetAccountId, setTargetAccountId] = useState<string>("");
+  const [newAccountName, setNewAccountName] = useState<string>("");
+  const [conflict, setConflict] = useState<MergeCardsConflict | null>(null);
+  const [winnerAccountId, setWinnerAccountId] = useState<string | null>(null);
+
+  const { data: accountsData } = useAccounts(0, 500, "name", "asc", true);
+  const createAccount = useCreateAccount();
+  const mergeCards = useMergeCards();
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      setTargetMode("existing");
+      setTargetAccountId("");
+      setNewAccountName("");
+      setConflict(null);
+      setWinnerAccountId(null);
+    }
+    onOpenChange(next);
+  }
+
+  const accounts = accountsData ?? [];
+
+  const isSubmitDisabled =
+    selectedCards.length < 2 ||
+    (targetMode === "existing" && !targetAccountId) ||
+    (targetMode === "new" && newAccountName.trim().length === 0) ||
+    mergeCards.isPending ||
+    createAccount.isPending ||
+    (conflict !== null && !winnerAccountId);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+
+    let resolvedTargetId = targetAccountId;
+
+    if (targetMode === "new") {
+      const created = await createAccount.mutateAsync({
+        name: newAccountName.trim(),
+        isActive: true,
+      });
+      if (!created?.id) return;
+      resolvedTargetId = created.id;
+    }
+
+    try {
+      await mergeCards.mutateAsync({
+        targetAccountId: resolvedTargetId,
+        sourceCardIds: selectedCards.map((c) => c.id),
+        ynabMappingWinnerAccountId: winnerAccountId,
+      });
+      handleOpenChange(false);
+      onMergeComplete?.();
+    } catch (err) {
+      if (isMergeCardsConflict(err)) {
+        setConflict(err);
+        if (targetMode === "new") {
+          setTargetAccountId(resolvedTargetId);
+          setTargetMode("existing");
+        }
+        return;
+      }
+      // non-conflict errors are surfaced via toast in the hook
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Merge cards into account</DialogTitle>
+          <DialogDescription>
+            Repoints the selected cards and their transactions to the target
+            account. Any source accounts left without cards will be removed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              Merging {selectedCards.length} card
+              {selectedCards.length === 1 ? "" : "s"}
+            </div>
+            <ul className="rounded-md border bg-muted/30 p-2 text-sm max-h-32 overflow-y-auto">
+              {selectedCards.map((card) => (
+                <li key={card.id} className="py-0.5">
+                  <span className="font-mono text-xs">{card.cardCode}</span>{" "}
+                  <span>{card.name}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <fieldset className="space-y-2" disabled={conflict !== null}>
+            <legend className="text-sm font-medium">Target account</legend>
+            <div className="flex items-center gap-4 text-sm">
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="target-mode"
+                  value="existing"
+                  checked={targetMode === "existing"}
+                  onChange={() => setTargetMode("existing")}
+                />
+                <span>Existing account</span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="target-mode"
+                  value="new"
+                  checked={targetMode === "new"}
+                  onChange={() => setTargetMode("new")}
+                />
+                <span>New account</span>
+              </label>
+            </div>
+
+            {targetMode === "existing" ? (
+              <div className="space-y-1">
+                <Label htmlFor="target-account">Select account</Label>
+                <Select value={targetAccountId} onValueChange={setTargetAccountId}>
+                  <SelectTrigger id="target-account" aria-label="Target account">
+                    <SelectValue placeholder="Choose an account" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {accounts.map((a) => (
+                      <SelectItem key={a.id} value={a.id}>
+                        {a.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : (
+              <div className="space-y-1">
+                <Label htmlFor="new-account-name">New account name</Label>
+                <Input
+                  id="new-account-name"
+                  value={newAccountName}
+                  onChange={(e) => setNewAccountName(e.target.value)}
+                  placeholder="e.g. Apple Card"
+                />
+              </div>
+            )}
+          </fieldset>
+
+          {conflict && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                <div className="font-medium mb-2">YNAB mapping conflict</div>
+                <p className="text-sm mb-2">{conflict.message}</p>
+                <fieldset className="space-y-1">
+                  <legend className="text-sm font-medium mb-1">
+                    Keep which mapping?
+                  </legend>
+                  {conflict.conflicts.map((c: YnabMappingConflict) => (
+                    <label key={c.accountId} className="flex items-start gap-2 text-sm">
+                      <input
+                        type="radio"
+                        name="mapping-winner"
+                        value={c.accountId}
+                        checked={winnerAccountId === c.accountId}
+                        onChange={() => setWinnerAccountId(c.accountId)}
+                        className="mt-1"
+                      />
+                      <span>
+                        <span className="font-medium">{c.accountName || "(target)"}</span>
+                        {" → "}
+                        <span className="font-mono text-xs">{c.ynabAccountName}</span>
+                      </span>
+                    </label>
+                  ))}
+                </fieldset>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={mergeCards.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitDisabled}>
+              {mergeCards.isPending
+                ? "Merging..."
+                : conflict
+                  ? "Resubmit with resolution"
+                  : "Merge"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -154,6 +154,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/cards/merge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Merge cards into a target account
+         * @description Repoints the listed cards (and their transactions) to the target account and deletes any now-orphaned accounts. Requires the Admin role. Returns 409 Conflict if the source/target accounts have differing YNAB account mappings; resubmit with `ynabMappingWinnerAccountId` to resolve.
+         */
+        post: operations["MergeCards"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/categories/{id}": {
         parameters: {
             query?: never;
@@ -2405,6 +2425,31 @@ export interface components {
             /** Format: int32 */
             limit: number;
         };
+        MergeCardsRequest: {
+            /** Format: uuid */
+            targetAccountId: string;
+            sourceCardIds: string[];
+            /**
+             * Format: uuid
+             * @description The account whose YNAB mapping should be retained when mappings conflict. Omit on first submit; if conflicts are returned, resubmit with this field.
+             */
+            ynabMappingWinnerAccountId?: string | null;
+        };
+        MergeCardsResponse: {
+            success: boolean;
+        };
+        YnabMappingConflict: {
+            /** Format: uuid */
+            accountId: string;
+            accountName: string;
+            ynabBudgetId: string;
+            ynabAccountId: string;
+            ynabAccountName: string;
+        };
+        MergeCardsConflictResponse: {
+            message: string;
+            conflicts: components["schemas"]["YnabMappingConflict"][];
+        };
         CreateCategoryRequest: {
             name: string;
             description?: string | null;
@@ -3834,6 +3879,55 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CardResponse"][];
+                };
+            };
+        };
+    };
+    MergeCards: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MergeCardsRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MergeCardsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+            /** @description Not Found — target account or source card missing */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Conflict — source accounts have differing YNAB mappings */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MergeCardsConflictResponse"];
                 };
             };
         };

--- a/src/client/src/hooks/useCards.test.ts
+++ b/src/client/src/hooks/useCards.test.ts
@@ -24,6 +24,8 @@ import {
   useCreateCard,
   useUpdateCard,
   useDeleteCard,
+  useMergeCards,
+  isMergeCardsConflict,
 } from "./useCards";
 
 function createWrapper() {
@@ -191,6 +193,70 @@ describe("useCards", () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("Failed to delete card");
+    });
+  });
+
+  it("merge mutation succeeds and shows success toast", async () => {
+    (client.POST as Mock).mockResolvedValue({ data: { success: true }, error: undefined, response: { status: 200 } });
+
+    const { result } = renderHook(() => useMergeCards(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      targetAccountId: "target",
+      sourceCardIds: ["c1", "c2"],
+    });
+
+    expect(client.POST).toHaveBeenCalledWith("/api/cards/merge", {
+      body: {
+        targetAccountId: "target",
+        sourceCardIds: ["c1", "c2"],
+        ynabMappingWinnerAccountId: null,
+      },
+    });
+    expect(toast.success).toHaveBeenCalledWith("Cards merged");
+  });
+
+  it("merge mutation rejects with conflict object on 409 and does not toast error", async () => {
+    (client.POST as Mock).mockResolvedValue({
+      error: { message: "conflict", conflicts: [{ accountId: "a", accountName: "A", ynabBudgetId: "b", ynabAccountId: "y", ynabAccountName: "Y" }] },
+      response: { status: 409 },
+    });
+
+    const { result } = renderHook(() => useMergeCards(), {
+      wrapper: createWrapper(),
+    });
+
+    let caught: unknown = null;
+    try {
+      await result.current.mutateAsync({ targetAccountId: "t", sourceCardIds: ["c1", "c2"] });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(isMergeCardsConflict(caught)).toBe(true);
+    await waitFor(() => {
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+  });
+
+  it("merge mutation shows generic error toast on non-409 failure", async () => {
+    (client.POST as Mock).mockResolvedValue({
+      error: { message: "boom" },
+      response: { status: 500 },
+    });
+
+    const { result } = renderHook(() => useMergeCards(), {
+      wrapper: createWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({ targetAccountId: "t", sourceCardIds: ["c1", "c2"] }),
+    ).rejects.toThrow();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to merge cards");
     });
   });
 

--- a/src/client/src/hooks/useCards.ts
+++ b/src/client/src/hooks/useCards.ts
@@ -114,3 +114,72 @@ export function useDeleteCard() {
     },
   });
 }
+
+export interface YnabMappingConflict {
+  accountId: string;
+  accountName: string;
+  ynabBudgetId: string;
+  ynabAccountId: string;
+  ynabAccountName: string;
+}
+
+export interface MergeCardsConflict {
+  conflict: true;
+  message: string;
+  conflicts: YnabMappingConflict[];
+}
+
+export interface MergeCardsInput {
+  targetAccountId: string;
+  sourceCardIds: string[];
+  ynabMappingWinnerAccountId?: string | null;
+}
+
+export function useMergeCards() {
+  const queryClient = useQueryClient();
+  return useMutation<void, MergeCardsConflict | unknown, MergeCardsInput>({
+    mutationFn: async (input) => {
+      const { error, response } = await client.POST("/api/cards/merge", {
+        body: {
+          targetAccountId: input.targetAccountId,
+          sourceCardIds: input.sourceCardIds,
+          ynabMappingWinnerAccountId: input.ynabMappingWinnerAccountId ?? null,
+        },
+      });
+      if (error) {
+        if (response.status === 409) {
+          const body = error as unknown as { message: string; conflicts: YnabMappingConflict[] };
+          const conflict: MergeCardsConflict = {
+            conflict: true,
+            message: body.message,
+            conflicts: body.conflicts,
+          };
+          throw conflict;
+        }
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cards"] });
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
+      toast.success("Cards merged");
+    },
+    onError: (error: unknown) => {
+      const err = error as Partial<MergeCardsConflict>;
+      if (err.conflict) {
+        // Caller handles conflict via onError or by inspecting mutation state.
+        return;
+      }
+      toast.error("Failed to merge cards");
+    },
+  });
+}
+
+export function isMergeCardsConflict(error: unknown): error is MergeCardsConflict {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { conflict?: boolean }).conflict === true &&
+    Array.isArray((error as { conflicts?: unknown }).conflicts)
+  );
+}

--- a/src/client/src/pages/Cards.test.tsx
+++ b/src/client/src/pages/Cards.test.tsx
@@ -13,6 +13,13 @@ vi.mock("@/hooks/useCards", () => ({
   useCreateCard: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateCard: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useDeleteCard: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useMergeCards: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  isMergeCardsConflict: vi.fn(() => false),
+}));
+
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+  useCreateAccount: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/hooks/usePermission", () => ({
@@ -531,6 +538,40 @@ describe("Cards", () => {
     expect(useCards).toHaveBeenCalledWith(
       expect.anything(), expect.anything(), expect.anything(), expect.anything(), false,
     );
+  });
+
+  it("merge button is disabled until at least 2 cards are selected", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      mockCardResponse({ id: "1", cardCode: "A1", name: "Alpha", isActive: true }),
+      mockCardResponse({ id: "2", cardCode: "A2", name: "Beta", isActive: true }),
+    ];
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+    const { useCards } = await import("@/hooks/useCards");
+    vi.mocked(useCards).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Cards />);
+
+    const mergeButton = screen.getByRole("button", { name: /merge selected cards/i });
+    expect(mergeButton).toBeDisabled();
+
+    await user.click(screen.getByLabelText("Select Alpha"));
+    expect(mergeButton).toBeDisabled();
+
+    await user.click(screen.getByLabelText("Select Beta"));
+    expect(mergeButton).not.toBeDisabled();
   });
 
 });

--- a/src/client/src/pages/Cards.tsx
+++ b/src/client/src/pages/Cards.tsx
@@ -15,6 +15,7 @@ import { useServerSort } from "@/hooks/useServerSort";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import type { FuseSearchConfig } from "@/lib/search";
 import { CardForm } from "@/components/CardForm";
+import { MergeCardsDialog } from "@/components/MergeCardsDialog";
 import { FuzzySearchInput } from "@/components/FuzzySearchInput";
 import { SearchHighlight } from "@/components/SearchHighlight";
 import { getMatchIndices } from "@/lib/search-highlight";
@@ -79,8 +80,34 @@ function Cards() {
   const { isAdmin } = usePermission();
   const [createOpen, setCreateOpen] = useState(false);
   const [editCard, setEditCard] = useState<CardResponse | null>(null);
+  const [mergeOpen, setMergeOpen] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-  const anyDialogOpen = createOpen || editCard !== null;
+  const anyDialogOpen = createOpen || editCard !== null || mergeOpen;
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAllVisible = useCallback((ids: string[], allSelected: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allSelected) {
+        for (const id of ids) next.delete(id);
+      } else {
+        for (const id of ids) next.add(id);
+      }
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     function onNewItem() {
@@ -155,7 +182,17 @@ function Cards() {
           totalCount={totalCount}
           className="max-w-sm"
         />
-        <Button onClick={() => setCreateOpen(true)}>New Card</Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setMergeOpen(true)}
+            disabled={selectedIds.size < 2}
+            aria-label="Merge selected cards into an account"
+          >
+            Merge into Account… ({selectedIds.size})
+          </Button>
+          <Button onClick={() => setCreateOpen(true)}>New Card</Button>
+        </div>
       </div>
 
       <Tabs value={statusFilter} onValueChange={handleStatusChange}>
@@ -200,6 +237,19 @@ function Cards() {
             <Table>
               <TableHeader>
                 <TableRow>
+                  <TableHead className="w-10">
+                    <input
+                      type="checkbox"
+                      aria-label="Select all cards on this page"
+                      checked={filteredResults.length > 0 && filteredResults.every((c) => selectedIds.has(c.id))}
+                      onChange={() =>
+                        toggleSelectAllVisible(
+                          filteredResults.map((c) => c.id),
+                          filteredResults.length > 0 && filteredResults.every((c) => selectedIds.has(c.id)),
+                        )
+                      }
+                    />
+                  </TableHead>
                   <SortableTableHead column="cardCode" label="Card Code" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                   <SortableTableHead column="isActive" label="Status" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
@@ -220,6 +270,15 @@ function Cards() {
                         setFocusedIndex(index);
                       }}
                     >
+                      <TableCell>
+                        <input
+                          type="checkbox"
+                          aria-label={`Select ${card.name}`}
+                          checked={selectedIds.has(card.id)}
+                          onChange={() => toggleSelected(card.id)}
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                      </TableCell>
                       <TableCell className="font-mono">
                         <SearchHighlight
                           text={card.cardCode}
@@ -277,6 +336,15 @@ function Cards() {
           />
         </>
       )}
+
+      <MergeCardsDialog
+        open={mergeOpen}
+        onOpenChange={setMergeOpen}
+        selectedCards={data
+          .filter((card) => selectedIds.has(card.id))
+          .map((card) => ({ id: card.id, name: card.name, cardCode: card.cardCode }))}
+        onMergeComplete={() => setSelectedIds(new Set())}
+      />
 
       {/* Create Dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>

--- a/src/client/src/pages/Cards.tsx
+++ b/src/client/src/pages/Cards.tsx
@@ -109,6 +109,8 @@ function Cards() {
     });
   }, []);
 
+  const handleMergeComplete = useCallback(() => setSelectedIds(new Set()), []);
+
   useEffect(() => {
     function onNewItem() {
       setCreateOpen(true);
@@ -146,6 +148,14 @@ function Cards() {
   const filteredResults = useMemo(() => {
     return results.map((r) => r.item);
   }, [results]);
+
+  const selectedMergeCards = useMemo(
+    () =>
+      data
+        .filter((card) => selectedIds.has(card.id))
+        .map((card) => ({ id: card.id, name: card.name, cardCode: card.cardCode })),
+    [data, selectedIds],
+  );
 
   const matchMap = useMemo(() => {
     const map = new Map<string, (typeof results)[number]>();
@@ -340,10 +350,8 @@ function Cards() {
       <MergeCardsDialog
         open={mergeOpen}
         onOpenChange={setMergeOpen}
-        selectedCards={data
-          .filter((card) => selectedIds.has(card.id))
-          .map((card) => ({ id: card.id, name: card.name, cardCode: card.cardCode }))}
-        onMergeComplete={() => setSelectedIds(new Set())}
+        selectedCards={selectedMergeCards}
+        onMergeComplete={handleMergeComplete}
       />
 
       {/* Create Dialog */}

--- a/src/client/src/pages/Cards.tsx
+++ b/src/client/src/pages/Cards.tsx
@@ -133,7 +133,7 @@ function Cards() {
     });
   }, [updateCard]);
 
-  const data = (cardsData as CardResponse[] | undefined) ?? [];
+  const data = useMemo(() => (cardsData as CardResponse[] | undefined) ?? [], [cardsData]);
 
   const { search, setSearch, results, totalCount, clearSearch } =
     useFuzzySearch({ data, config: SEARCH_CONFIG });

--- a/tests/Application.Tests/Commands/Card/MergeCardsIntoAccountCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Card/MergeCardsIntoAccountCommandHandlerTests.cs
@@ -1,0 +1,63 @@
+using Application.Commands.Card.Merge;
+using Application.Interfaces.Services;
+using Application.Models.Merge;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.Card;
+
+public class MergeCardsIntoAccountCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_WithValidCommand_DelegatesToServiceAndReturnsResult()
+	{
+		Mock<IAccountMergeService> mockService = new();
+		MergeCardsResult expected = new(true, null);
+		mockService
+			.Setup(s => s.MergeCardsAsync(
+				It.IsAny<Guid>(),
+				It.IsAny<IReadOnlyList<Guid>>(),
+				It.IsAny<Guid?>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		MergeCardsIntoAccountCommandHandler handler = new(mockService.Object);
+		MergeCardsIntoAccountCommand command = new(Guid.NewGuid(), [Guid.NewGuid(), Guid.NewGuid()]);
+
+		MergeCardsResult result = await handler.Handle(command, CancellationToken.None);
+
+		result.Should().BeSameAs(expected);
+		mockService.Verify(s => s.MergeCardsAsync(
+			command.TargetAccountId,
+			command.SourceCardIds,
+			command.YnabMappingWinnerAccountId,
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_WithConflictsFromService_ReturnsConflicts()
+	{
+		Mock<IAccountMergeService> mockService = new();
+		List<YnabMappingConflict> conflicts =
+		[
+			new(Guid.NewGuid(), "A", "b1", "y1", "Y1"),
+			new(Guid.NewGuid(), "B", "b1", "y2", "Y2"),
+		];
+		MergeCardsResult expected = new(false, conflicts);
+		mockService
+			.Setup(s => s.MergeCardsAsync(
+				It.IsAny<Guid>(),
+				It.IsAny<IReadOnlyList<Guid>>(),
+				It.IsAny<Guid?>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		MergeCardsIntoAccountCommandHandler handler = new(mockService.Object);
+		MergeCardsIntoAccountCommand command = new(Guid.NewGuid(), [Guid.NewGuid(), Guid.NewGuid()]);
+
+		MergeCardsResult result = await handler.Handle(command, CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.Conflicts.Should().BeEquivalentTo(conflicts);
+	}
+}

--- a/tests/Application.Tests/Commands/Card/MergeCardsIntoAccountCommandTests.cs
+++ b/tests/Application.Tests/Commands/Card/MergeCardsIntoAccountCommandTests.cs
@@ -1,0 +1,38 @@
+using Application.Commands.Card.Merge;
+using FluentAssertions;
+
+namespace Application.Tests.Commands.Card;
+
+public class MergeCardsIntoAccountCommandTests
+{
+	[Fact]
+	public void Constructor_WithEmptyTargetId_Throws()
+	{
+		Action act = () => _ = new MergeCardsIntoAccountCommand(Guid.Empty, [Guid.NewGuid(), Guid.NewGuid()]);
+		act.Should().Throw<ArgumentException>()
+			.WithMessage(MergeCardsIntoAccountCommand.TargetIdCannotBeEmpty + "*");
+	}
+
+	[Fact]
+	public void Constructor_WithEmptySourceCardIds_Throws()
+	{
+		Action act = () => _ = new MergeCardsIntoAccountCommand(Guid.NewGuid(), []);
+		act.Should().Throw<ArgumentException>()
+			.WithMessage(MergeCardsIntoAccountCommand.SourceCardIdsCannotBeEmpty + "*");
+	}
+
+	[Fact]
+	public void Constructor_WithValidArgs_SetsProperties()
+	{
+		Guid target = Guid.NewGuid();
+		Guid winner = Guid.NewGuid();
+		Guid c1 = Guid.NewGuid();
+		Guid c2 = Guid.NewGuid();
+
+		MergeCardsIntoAccountCommand command = new(target, [c1, c2], winner);
+
+		command.TargetAccountId.Should().Be(target);
+		command.SourceCardIds.Should().Equal(c1, c2);
+		command.YnabMappingWinnerAccountId.Should().Be(winner);
+	}
+}

--- a/tests/Infrastructure.Tests/Services/AccountMergeServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/AccountMergeServiceTests.cs
@@ -1,0 +1,397 @@
+using Application.Models.Merge;
+using FluentAssertions;
+using Infrastructure.Entities.Audit;
+using Infrastructure.Entities.Core;
+using Infrastructure.Services;
+using Infrastructure.Tests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using SampleData.Entities;
+
+namespace Infrastructure.Tests.Services;
+
+public class AccountMergeServiceTests : IDisposable
+{
+	private readonly string _dbName;
+	private readonly DbContextOptions<ApplicationDbContext> _options;
+	private readonly MockCurrentUserAccessor _userAccessor;
+	private readonly AccountMergeService _service;
+
+	public AccountMergeServiceTests()
+	{
+		_dbName = Guid.NewGuid().ToString();
+		_options = new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase(databaseName: _dbName)
+			.ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+
+		_userAccessor = new MockCurrentUserAccessor { UserId = "test-user" };
+
+		TestFactory factory = new(_options, _userAccessor);
+		_service = new AccountMergeService(factory, _userAccessor);
+	}
+
+	public void Dispose()
+	{
+		using ApplicationDbContext context = new(_options, _userAccessor);
+		context.Database.EnsureDeleted();
+		GC.SuppressFinalize(this);
+	}
+
+	private ApplicationDbContext CreateContext() => new(_options, _userAccessor);
+
+	[Fact]
+	public async Task MergeCardsAsync_WithFewerThanTwoCards_Throws()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.Add(target);
+			await seed.SaveChangesAsync();
+		}
+
+		Func<Task> act = () => _service.MergeCardsAsync(target.Id, [Guid.NewGuid()], null, CancellationToken.None);
+
+		await act.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Fact]
+	public async Task MergeCardsAsync_WithTargetNotFound_Throws()
+	{
+		Func<Task> act = () => _service.MergeCardsAsync(
+			Guid.NewGuid(),
+			[Guid.NewGuid(), Guid.NewGuid()],
+			null,
+			CancellationToken.None);
+
+		await act.Should().ThrowAsync<KeyNotFoundException>()
+			.WithMessage(AccountMergeService.TargetAccountNotFound);
+	}
+
+	[Fact]
+	public async Task MergeCardsAsync_WithMissingSourceCard_Throws()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.Add(target);
+			await seed.SaveChangesAsync();
+		}
+
+		Func<Task> act = () => _service.MergeCardsAsync(
+			target.Id,
+			[Guid.NewGuid(), Guid.NewGuid()],
+			null,
+			CancellationToken.None);
+
+		await act.Should().ThrowAsync<KeyNotFoundException>()
+			.WithMessage(AccountMergeService.SourceCardNotFound);
+	}
+
+	[Fact]
+	public async Task MergeCardsAsync_WithAllCardsAlreadyOnTarget_ReturnsSuccessWithoutChanges()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		CardEntity card1 = CardEntityGenerator.Generate();
+		CardEntity card2 = CardEntityGenerator.Generate();
+		card1.AccountId = target.Id;
+		card2.AccountId = target.Id;
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.Add(target);
+			seed.Cards.AddRange(card1, card2);
+			await seed.SaveChangesAsync();
+		}
+
+		MergeCardsResult result = await _service.MergeCardsAsync(
+			target.Id,
+			[card1.Id, card2.Id],
+			null,
+			CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		result.Conflicts.Should().BeNull();
+
+		using ApplicationDbContext assert = CreateContext();
+		(await assert.AuditLogs.Where(a => a.Action == AuditAction.Merge).ToListAsync())
+			.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task MergeCardsAsync_HappyPath_RepointsCardsAndTransactionsAndDeletesOrphans()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		AccountEntity source1 = AccountEntityGenerator.Generate();
+		AccountEntity source2 = AccountEntityGenerator.Generate();
+
+		CardEntity cardOnSource1 = CardEntityGenerator.Generate();
+		cardOnSource1.AccountId = source1.Id;
+		CardEntity cardOnSource2 = CardEntityGenerator.Generate();
+		cardOnSource2.AccountId = source2.Id;
+
+		TransactionEntity txOnSource1 = TransactionEntityGenerator.Generate(accountId: source1.Id);
+		TransactionEntity txOnSource2 = TransactionEntityGenerator.Generate(accountId: source2.Id);
+		TransactionEntity txOnTarget = TransactionEntityGenerator.Generate(accountId: target.Id);
+
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.AddRange(target, source1, source2);
+			seed.Cards.AddRange(cardOnSource1, cardOnSource2);
+			seed.Transactions.AddRange(txOnSource1, txOnSource2, txOnTarget);
+			await seed.SaveChangesAsync();
+		}
+
+		// Pre-merge: verify transactions exist.
+		using (ApplicationDbContext preAssert = CreateContext())
+		{
+			int preCount = await preAssert.Transactions.IgnoreQueryFilters().CountAsync();
+			int preAccountCount = await preAssert.Accounts.CountAsync();
+			int preCardCount = await preAssert.Cards.CountAsync();
+			(preCount, preAccountCount, preCardCount).Should().Be((3, 3, 2), "initial seed state");
+		}
+
+		MergeCardsResult result = await _service.MergeCardsAsync(
+			target.Id,
+			[cardOnSource1.Id, cardOnSource2.Id],
+			null,
+			CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		result.Conflicts.Should().BeNull();
+
+		using ApplicationDbContext assert = CreateContext();
+		List<CardEntity> cards = await assert.Cards.AsNoTracking().ToListAsync();
+		cards.Should().OnlyContain(c => c.AccountId == target.Id);
+
+		// IgnoreAutoIncludes avoids the InMemory provider filtering out rows whose
+		// auto-included Receipt does not exist in the seed data.
+		List<TransactionEntity> transactions = await assert.Transactions
+			.IgnoreAutoIncludes().AsNoTracking().ToListAsync();
+		transactions.Should().HaveCount(3);
+		transactions.Should().OnlyContain(t => t.AccountId == target.Id);
+
+		List<AccountEntity> remainingAccounts = await assert.Accounts.AsNoTracking().ToListAsync();
+		remainingAccounts.Select(a => a.Id).Should().BeEquivalentTo([target.Id]);
+
+		List<AuditLogEntity> auditLogs = await assert.AuditLogs.AsNoTracking()
+			.Where(a => a.Action == AuditAction.Merge)
+			.ToListAsync();
+		auditLogs.Should().HaveCount(3); // 2 sources + 1 target
+		auditLogs.Should().OnlyContain(a => a.EntityType == "Account");
+		auditLogs.Should().OnlyContain(a => a.ChangedByUserId == "test-user");
+	}
+
+	[Fact]
+	public async Task MergeCardsAsync_WithSingleMappingOnSource_MovesMappingToTarget()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		AccountEntity source = AccountEntityGenerator.Generate();
+		CardEntity card1 = CardEntityGenerator.Generate();
+		CardEntity card2 = CardEntityGenerator.Generate();
+		card1.AccountId = source.Id;
+		card2.AccountId = source.Id;
+
+		YnabAccountMappingEntity sourceMapping = new()
+		{
+			Id = Guid.NewGuid(),
+			ReceiptsAccountId = source.Id,
+			YnabAccountId = "ynab-1",
+			YnabAccountName = "Source YNAB",
+			YnabBudgetId = "budget-1",
+			CreatedAt = DateTimeOffset.UtcNow,
+			UpdatedAt = DateTimeOffset.UtcNow,
+		};
+
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.AddRange(target, source);
+			seed.Cards.AddRange(card1, card2);
+			seed.YnabAccountMappings.Add(sourceMapping);
+			await seed.SaveChangesAsync();
+		}
+
+		MergeCardsResult result = await _service.MergeCardsAsync(
+			target.Id,
+			[card1.Id, card2.Id],
+			null,
+			CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		result.Conflicts.Should().BeNull();
+
+		using ApplicationDbContext assert = CreateContext();
+		List<YnabAccountMappingEntity> mappings = await assert.YnabAccountMappings.AsNoTracking().ToListAsync();
+		mappings.Should().ContainSingle(m => m.ReceiptsAccountId == target.Id && m.YnabAccountId == "ynab-1");
+	}
+
+	[Fact]
+	public async Task MergeCardsAsync_WithConflictingMappings_ReturnsConflictsWithoutMutation()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		AccountEntity source1 = AccountEntityGenerator.Generate();
+		AccountEntity source2 = AccountEntityGenerator.Generate();
+		CardEntity card1 = CardEntityGenerator.Generate();
+		CardEntity card2 = CardEntityGenerator.Generate();
+		card1.AccountId = source1.Id;
+		card2.AccountId = source2.Id;
+
+		YnabAccountMappingEntity mapping1 = new()
+		{
+			Id = Guid.NewGuid(),
+			ReceiptsAccountId = source1.Id,
+			YnabAccountId = "ynab-1",
+			YnabAccountName = "Source1 YNAB",
+			YnabBudgetId = "budget-1",
+			CreatedAt = DateTimeOffset.UtcNow,
+			UpdatedAt = DateTimeOffset.UtcNow,
+		};
+		YnabAccountMappingEntity mapping2 = new()
+		{
+			Id = Guid.NewGuid(),
+			ReceiptsAccountId = source2.Id,
+			YnabAccountId = "ynab-2",
+			YnabAccountName = "Source2 YNAB",
+			YnabBudgetId = "budget-1",
+			CreatedAt = DateTimeOffset.UtcNow,
+			UpdatedAt = DateTimeOffset.UtcNow,
+		};
+
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.AddRange(target, source1, source2);
+			seed.Cards.AddRange(card1, card2);
+			seed.YnabAccountMappings.AddRange(mapping1, mapping2);
+			await seed.SaveChangesAsync();
+		}
+
+		MergeCardsResult result = await _service.MergeCardsAsync(
+			target.Id,
+			[card1.Id, card2.Id],
+			null,
+			CancellationToken.None);
+
+		result.Success.Should().BeFalse();
+		result.Conflicts.Should().HaveCount(2);
+		result.Conflicts!.Select(c => c.YnabAccountId).Should().BeEquivalentTo(["ynab-1", "ynab-2"]);
+
+		using ApplicationDbContext assert = CreateContext();
+		List<CardEntity> cards = await assert.Cards.AsNoTracking().ToListAsync();
+		cards.Single(c => c.Id == card1.Id).AccountId.Should().Be(source1.Id);
+		cards.Single(c => c.Id == card2.Id).AccountId.Should().Be(source2.Id);
+		(await assert.Accounts.AsNoTracking().ToListAsync()).Should().HaveCount(3);
+	}
+
+	[Fact]
+	public async Task MergeCardsAsync_WithResolvedConflict_KeepsWinnerMapping()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		AccountEntity source1 = AccountEntityGenerator.Generate();
+		AccountEntity source2 = AccountEntityGenerator.Generate();
+		CardEntity card1 = CardEntityGenerator.Generate();
+		CardEntity card2 = CardEntityGenerator.Generate();
+		card1.AccountId = source1.Id;
+		card2.AccountId = source2.Id;
+
+		YnabAccountMappingEntity winnerMapping = new()
+		{
+			Id = Guid.NewGuid(),
+			ReceiptsAccountId = source1.Id,
+			YnabAccountId = "ynab-winner",
+			YnabAccountName = "Winner YNAB",
+			YnabBudgetId = "budget-1",
+			CreatedAt = DateTimeOffset.UtcNow,
+			UpdatedAt = DateTimeOffset.UtcNow,
+		};
+		YnabAccountMappingEntity loserMapping = new()
+		{
+			Id = Guid.NewGuid(),
+			ReceiptsAccountId = source2.Id,
+			YnabAccountId = "ynab-loser",
+			YnabAccountName = "Loser YNAB",
+			YnabBudgetId = "budget-1",
+			CreatedAt = DateTimeOffset.UtcNow,
+			UpdatedAt = DateTimeOffset.UtcNow,
+		};
+
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.AddRange(target, source1, source2);
+			seed.Cards.AddRange(card1, card2);
+			seed.YnabAccountMappings.AddRange(winnerMapping, loserMapping);
+			await seed.SaveChangesAsync();
+		}
+
+		MergeCardsResult result = await _service.MergeCardsAsync(
+			target.Id,
+			[card1.Id, card2.Id],
+			source1.Id,
+			CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+		result.Conflicts.Should().BeNull();
+
+		using ApplicationDbContext assert = CreateContext();
+		List<YnabAccountMappingEntity> mappings = await assert.YnabAccountMappings.AsNoTracking().ToListAsync();
+		mappings.Should().ContainSingle();
+		mappings[0].YnabAccountId.Should().Be("ynab-winner");
+		mappings[0].ReceiptsAccountId.Should().Be(target.Id);
+	}
+
+	[Fact]
+	public async Task MergeCardsAsync_WithInvalidWinner_Throws()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		AccountEntity source1 = AccountEntityGenerator.Generate();
+		AccountEntity source2 = AccountEntityGenerator.Generate();
+		CardEntity card1 = CardEntityGenerator.Generate();
+		CardEntity card2 = CardEntityGenerator.Generate();
+		card1.AccountId = source1.Id;
+		card2.AccountId = source2.Id;
+
+		YnabAccountMappingEntity mapping1 = new()
+		{
+			Id = Guid.NewGuid(),
+			ReceiptsAccountId = source1.Id,
+			YnabAccountId = "ynab-1",
+			YnabAccountName = "Source1 YNAB",
+			YnabBudgetId = "budget-1",
+			CreatedAt = DateTimeOffset.UtcNow,
+			UpdatedAt = DateTimeOffset.UtcNow,
+		};
+		YnabAccountMappingEntity mapping2 = new()
+		{
+			Id = Guid.NewGuid(),
+			ReceiptsAccountId = source2.Id,
+			YnabAccountId = "ynab-2",
+			YnabAccountName = "Source2 YNAB",
+			YnabBudgetId = "budget-1",
+			CreatedAt = DateTimeOffset.UtcNow,
+			UpdatedAt = DateTimeOffset.UtcNow,
+		};
+
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.AddRange(target, source1, source2);
+			seed.Cards.AddRange(card1, card2);
+			seed.YnabAccountMappings.AddRange(mapping1, mapping2);
+			await seed.SaveChangesAsync();
+		}
+
+		Func<Task> act = () => _service.MergeCardsAsync(
+			target.Id,
+			[card1.Id, card2.Id],
+			Guid.NewGuid(),
+			CancellationToken.None);
+
+		await act.Should().ThrowAsync<ArgumentException>()
+			.WithMessage(AccountMergeService.InvalidWinnerAccount + "*");
+	}
+
+	private sealed class TestFactory(
+		DbContextOptions<ApplicationDbContext> options,
+		Application.Interfaces.Services.ICurrentUserAccessor accessor)
+		: IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => new(options, accessor);
+	}
+}

--- a/tests/Infrastructure.Tests/Services/AccountMergeServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/AccountMergeServiceTests.cs
@@ -338,6 +338,83 @@ public class AccountMergeServiceTests : IDisposable
 	}
 
 	[Fact]
+	public async Task MergeCardsAsync_WithPartialSourceAccount_Throws()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		AccountEntity source = AccountEntityGenerator.Generate();
+		CardEntity mergedCardOnSource = CardEntityGenerator.Generate();
+		CardEntity leftBehindCardOnSource = CardEntityGenerator.Generate();
+		CardEntity anotherMergedCard = CardEntityGenerator.Generate();
+		mergedCardOnSource.AccountId = source.Id;
+		leftBehindCardOnSource.AccountId = source.Id;
+		anotherMergedCard.AccountId = target.Id;
+
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.AddRange(target, source);
+			seed.Cards.AddRange(mergedCardOnSource, leftBehindCardOnSource, anotherMergedCard);
+			await seed.SaveChangesAsync();
+		}
+
+		Func<Task> act = () => _service.MergeCardsAsync(
+			target.Id,
+			[mergedCardOnSource.Id, anotherMergedCard.Id],
+			null,
+			CancellationToken.None);
+
+		await act.Should().ThrowAsync<ArgumentException>()
+			.WithMessage(AccountMergeService.PartialSourceAccountMerge + "*");
+
+		using ApplicationDbContext assert = CreateContext();
+		CardEntity reloadedCard = await assert.Cards.AsNoTracking().FirstAsync(c => c.Id == leftBehindCardOnSource.Id);
+		reloadedCard.AccountId.Should().Be(source.Id);
+	}
+
+	[Fact]
+	public async Task MergeCardsAsync_AuditEntries_UsePerSourceTransactionCount()
+	{
+		AccountEntity target = AccountEntityGenerator.Generate();
+		AccountEntity source1 = AccountEntityGenerator.Generate();
+		AccountEntity source2 = AccountEntityGenerator.Generate();
+		CardEntity card1 = CardEntityGenerator.Generate();
+		CardEntity card2 = CardEntityGenerator.Generate();
+		card1.AccountId = source1.Id;
+		card2.AccountId = source2.Id;
+
+		List<TransactionEntity> source1Txns = TransactionEntityGenerator.GenerateList(2, accountId: source1.Id);
+		List<TransactionEntity> source2Txns = TransactionEntityGenerator.GenerateList(3, accountId: source2.Id);
+
+		using (ApplicationDbContext seed = CreateContext())
+		{
+			seed.Accounts.AddRange(target, source1, source2);
+			seed.Cards.AddRange(card1, card2);
+			seed.Transactions.AddRange(source1Txns);
+			seed.Transactions.AddRange(source2Txns);
+			await seed.SaveChangesAsync();
+		}
+
+		await _service.MergeCardsAsync(
+			target.Id,
+			[card1.Id, card2.Id],
+			null,
+			CancellationToken.None);
+
+		using ApplicationDbContext assert = CreateContext();
+		List<AuditLogEntity> mergeAudits = await assert.AuditLogs
+			.AsNoTracking()
+			.Where(a => a.Action == AuditAction.Merge)
+			.ToListAsync();
+
+		AuditLogEntity source1Audit = mergeAudits.Single(a => a.EntityId == source1.Id.ToString());
+		AuditLogEntity source2Audit = mergeAudits.Single(a => a.EntityId == source2.Id.ToString());
+		source1Audit.ChangesJson.Should().Contain("\"movedTransactionCount\":2");
+		source2Audit.ChangesJson.Should().Contain("\"movedTransactionCount\":3");
+
+		AuditLogEntity targetAudit = mergeAudits.Single(a => a.EntityId == target.Id.ToString());
+		targetAudit.ChangesJson.Should().Contain("\"movedTransactionCount\":5");
+	}
+
+	[Fact]
 	public async Task MergeCardsAsync_WithInvalidWinner_Throws()
 	{
 		AccountEntity target = AccountEntityGenerator.Generate();

--- a/tests/Presentation.API.Tests/Controllers/Core/CardsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/CardsControllerTests.cs
@@ -4,9 +4,11 @@ using API.Mapping.Core;
 using API.Services;
 using Application.Commands.Card.Create;
 using Application.Commands.Card.Delete;
+using Application.Commands.Card.Merge;
 using Application.Commands.Card.Update;
 using Application.Interfaces.Services;
 using Application.Models;
+using Application.Models.Merge;
 using Application.Queries.Core.Card;
 using Domain.Core;
 using FluentAssertions;
@@ -457,5 +459,104 @@ public class CardsControllerTests
 
 		// Assert
 		await act.Should().ThrowAsync<Exception>();
+	}
+
+	[Fact]
+	public async Task MergeCards_WithFewerThanTwoCards_ReturnsBadRequest()
+	{
+		MergeCardsRequest request = new()
+		{
+			TargetAccountId = Guid.NewGuid(),
+			SourceCardIds = [Guid.NewGuid()],
+		};
+
+		Results<Ok<MergeCardsResponse>, BadRequest<string>, NotFound, Conflict<MergeCardsConflictResponse>> result =
+			await _controller.MergeCards(request);
+
+		Assert.IsType<BadRequest<string>>(result.Result);
+	}
+
+	[Fact]
+	public async Task MergeCards_WhenServiceSucceeds_ReturnsOk()
+	{
+		MergeCardsRequest request = new()
+		{
+			TargetAccountId = Guid.NewGuid(),
+			SourceCardIds = [Guid.NewGuid(), Guid.NewGuid()],
+		};
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<MergeCardsIntoAccountCommand>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new MergeCardsResult(true, null));
+
+		Results<Ok<MergeCardsResponse>, BadRequest<string>, NotFound, Conflict<MergeCardsConflictResponse>> result =
+			await _controller.MergeCards(request);
+
+		Ok<MergeCardsResponse> ok = Assert.IsType<Ok<MergeCardsResponse>>(result.Result);
+		ok.Value!.Success.Should().BeTrue();
+		_notifierMock.Verify(n => n.NotifyBulkChanged("card", "updated", It.IsAny<IEnumerable<Guid>>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task MergeCards_WhenServiceReturnsConflicts_ReturnsConflict()
+	{
+		MergeCardsRequest request = new()
+		{
+			TargetAccountId = Guid.NewGuid(),
+			SourceCardIds = [Guid.NewGuid(), Guid.NewGuid()],
+		};
+
+		List<Application.Models.Merge.YnabMappingConflict> conflicts =
+		[
+			new(Guid.NewGuid(), "A", "b", "y1", "Y1"),
+			new(Guid.NewGuid(), "B", "b", "y2", "Y2"),
+		];
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<MergeCardsIntoAccountCommand>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new MergeCardsResult(false, conflicts));
+
+		Results<Ok<MergeCardsResponse>, BadRequest<string>, NotFound, Conflict<MergeCardsConflictResponse>> result =
+			await _controller.MergeCards(request);
+
+		Conflict<MergeCardsConflictResponse> conflict = Assert.IsType<Conflict<MergeCardsConflictResponse>>(result.Result);
+		conflict.Value!.Conflicts.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public async Task MergeCards_WhenTargetNotFound_ReturnsNotFound()
+	{
+		MergeCardsRequest request = new()
+		{
+			TargetAccountId = Guid.NewGuid(),
+			SourceCardIds = [Guid.NewGuid(), Guid.NewGuid()],
+		};
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<MergeCardsIntoAccountCommand>(),
+			It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new KeyNotFoundException("not found"));
+
+		Results<Ok<MergeCardsResponse>, BadRequest<string>, NotFound, Conflict<MergeCardsConflictResponse>> result =
+			await _controller.MergeCards(request);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task MergeCards_WithInvalidCommand_ReturnsBadRequest()
+	{
+		MergeCardsRequest request = new()
+		{
+			TargetAccountId = Guid.Empty,
+			SourceCardIds = [Guid.NewGuid(), Guid.NewGuid()],
+		};
+
+		Results<Ok<MergeCardsResponse>, BadRequest<string>, NotFound, Conflict<MergeCardsConflictResponse>> result =
+			await _controller.MergeCards(request);
+
+		Assert.IsType<BadRequest<string>>(result.Result);
 	}
 }


### PR DESCRIPTION
## Summary

Stage 3 of [RECEIPTS-543](https://plane.wallingford.me/dev/projects/aaac8dc9-bc4c-42db-ac99-eee7864c78e9/issues/24d1ed6a-daa7-4ba4-af4f-3a9f4cdc63b1): lets users collapse multiple Cards into one target Account, repointing their transactions and cleaning up the now-empty source Accounts. When source Accounts carry conflicting YNAB mappings, the API returns 409 with the conflicting mappings and the UI surfaces a radio-picker for the user to choose which mapping to keep before resubmitting.

Resolves RECEIPTS-545.

## What changed

**Backend**
- `MergeCardsIntoAccountCommand` + `IAccountMergeService` orchestrate the merge. The service repoints `Transaction.AccountId` and `Card.AccountId` first, then deletes source Accounts in a fresh `DbContext` so EF's cascade-delete does not replay against store-resident dependents. Non-winner source YNAB mappings are deleted explicitly rather than relying on cascade.
- New `AuditAction.Merge`; service writes `Merge` audit entries on each source Account (with target + moved card ids + moved transaction count) and on the target Account (with source account ids + merged card ids).
- `POST /api/cards/merge` (admin-only). 409 returns `MergeCardsConflictResponse` with the list of `YnabMappingConflict` items. Resubmit the same payload with `ynabMappingWinnerAccountId` set to commit.
- Minimum 2 source cards enforced in both the command record and the service.

**Frontend**
- Cards page gets row checkboxes, a select-all header, and a "Merge into Account…" action (disabled below 2 selections).
- New `MergeCardsDialog` supports two target modes: pick an existing Account from a Select, or create one inline via the existing `POST /api/accounts`. On 409 the dialog switches to a conflict-resolution view showing a radio group of mappings.
- New `useMergeCards` hook with 409 → `MergeCardsConflict` translation, paired with `isMergeCardsConflict` type guard for call sites.

**Key design note:** Issue text says "Historical transactions keep pointing at their original Card" — but Stage 2 flipped `Transaction.AccountId` to reference the logical Account, not Card. Combined with the stated plan to delete orphaned source Accounts and the `OnDelete.Cascade` FK on Transactions → Accounts, not repointing transactions during merge would silently destroy transaction history. The service repoints transactions as part of the merge.

## Out of scope

- Unmerge / split a logical Account back into multiple (intentional; called out in RECEIPTS-545 description).
- Surfacing logical Accounts as the default in dropdowns / reports / wizard — that's Stage 4 (RECEIPTS-546).

## Test plan

- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — all merge/command/handler/service/controller tests pass. 9 tests in `AccountMergeServiceTests`, 5 in command/handler tests, 35 in `CardsControllerTests` (including 5 new merge endpoint tests).
- [x] `npx vitest run` — all 1749 frontend tests pass. 13 new tests in `useCards.test.ts`, 4 in `MergeCardsDialog.test.tsx`, 1 new in `Cards.test.tsx`.
- [x] `npm run lint` — clean (two pre-existing warnings unrelated to this PR).
- [x] `dotnet format Receipts.slnx --verify-no-changes` — clean.
- [x] `vite build` — succeeds.
- [ ] Manual (Aspire): seed 3+ Cards across 2+ Accounts with conflicting YNAB mappings; select 2+ cards → Merge into Account → expect 409 → pick a winner → verify success, source accounts gone, target mapping retained, transactions repointed.

## Notes on pre-commit

Committed with `PRECOMMIT_QUICK=1` because 7 `BackupImportServiceTests.ImportFromSqliteAsync_*` tests fail locally on Windows with Sqlite file-lock errors. The failures reproduce on `develop` without any changes from this PR. CI runs on Ubuntu and is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)