### PR TITLE
feat: surface logical Accounts in wizard, reports, search (RECEIPTS-546)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -137,6 +137,36 @@ paths:
                   - message
                   - cardCount
 
+  /api/accounts/{id}/cards:
+    get:
+      operationId: GetCardsForAccount
+      tags: [Accounts]
+      summary: Get cards for an account
+      description: >
+        Returns the physical Cards (aliases) that belong to the given logical
+        Account. Returns 404 if the account does not exist.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CardResponse"
+        "404":
+          description: Not Found
+
   /api/accounts:
     get:
       operationId: GetAllAccounts

--- a/src/Application/Interfaces/Services/ICardService.cs
+++ b/src/Application/Interfaces/Services/ICardService.cs
@@ -7,6 +7,7 @@ public interface ICardService : IService<Card>
 {
 	Task<PagedResult<Card>> GetAllAsync(int offset, int limit, SortParams sort, bool? isActive, CancellationToken cancellationToken);
 	Task<Card?> GetByTransactionIdAsync(Guid transactionId, CancellationToken cancellationToken);
+	Task<List<Card>> GetByAccountIdAsync(Guid accountId, CancellationToken cancellationToken);
 	Task<List<Card>> CreateAsync(List<Card> models, CancellationToken cancellationToken);
 	Task UpdateAsync(List<Card> models, CancellationToken cancellationToken);
 	Task DeleteAsync(Guid id, CancellationToken cancellationToken);

--- a/src/Application/Queries/Core/Card/GetCardsByAccountIdQuery.cs
+++ b/src/Application/Queries/Core/Card/GetCardsByAccountIdQuery.cs
@@ -1,0 +1,19 @@
+using Application.Interfaces;
+
+namespace Application.Queries.Core.Card;
+
+public record GetCardsByAccountIdQuery : IQuery<List<Domain.Core.Card>>
+{
+	public Guid AccountId { get; }
+	public const string AccountIdCannotBeEmptyExceptionMessage = "Account Id cannot be empty.";
+
+	public GetCardsByAccountIdQuery(Guid accountId)
+	{
+		if (accountId == Guid.Empty)
+		{
+			throw new ArgumentException(AccountIdCannotBeEmptyExceptionMessage, nameof(accountId));
+		}
+
+		AccountId = accountId;
+	}
+}

--- a/src/Application/Queries/Core/Card/GetCardsByAccountIdQueryHandler.cs
+++ b/src/Application/Queries/Core/Card/GetCardsByAccountIdQueryHandler.cs
@@ -1,0 +1,12 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Queries.Core.Card;
+
+public class GetCardsByAccountIdQueryHandler(ICardService cardService) : IRequestHandler<GetCardsByAccountIdQuery, List<Domain.Core.Card>>
+{
+	public async Task<List<Domain.Core.Card>> Handle(GetCardsByAccountIdQuery request, CancellationToken cancellationToken)
+	{
+		return await cardService.GetByAccountIdAsync(request.AccountId, cancellationToken);
+	}
+}

--- a/src/Infrastructure/Interfaces/Repositories/ICardRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/ICardRepository.cs
@@ -7,6 +7,7 @@ public interface ICardRepository
 {
 	Task<CardEntity?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 	Task<CardEntity?> GetByTransactionIdAsync(Guid transactionId, CancellationToken cancellationToken);
+	Task<List<CardEntity>> GetByAccountIdAsync(Guid accountId, CancellationToken cancellationToken);
 	Task<List<CardEntity>> GetAllAsync(int offset, int limit, SortParams sort, CancellationToken cancellationToken, bool? isActive = null);
 	Task<List<CardEntity>> CreateAsync(List<CardEntity> entities, CancellationToken cancellationToken);
 	Task UpdateAsync(List<CardEntity> entities, CancellationToken cancellationToken);

--- a/src/Infrastructure/Repositories/CardRepository.cs
+++ b/src/Infrastructure/Repositories/CardRepository.cs
@@ -40,6 +40,16 @@ public class CardRepository(IDbContextFactory<ApplicationDbContext> contextFacto
 			.FirstOrDefaultAsync(cancellationToken);
 	}
 
+	public async Task<List<CardEntity>> GetByAccountIdAsync(Guid accountId, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		return await context.Cards
+			.AsNoTracking()
+			.Where(c => c.AccountId == accountId)
+			.OrderBy(c => c.Name)
+			.ToListAsync(cancellationToken);
+	}
+
 	public async Task<List<CardEntity>> GetAllAsync(int offset, int limit, SortParams sort, CancellationToken cancellationToken, bool? isActive = null)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();

--- a/src/Infrastructure/Services/CardService.cs
+++ b/src/Infrastructure/Services/CardService.cs
@@ -49,6 +49,12 @@ public class CardService(ICardRepository repository, CardMapper mapper) : ICardS
 		return cardEntity == null ? null : mapper.ToDomain(cardEntity);
 	}
 
+	public async Task<List<Card>> GetByAccountIdAsync(Guid accountId, CancellationToken cancellationToken)
+	{
+		List<CardEntity> entities = await repository.GetByAccountIdAsync(accountId, cancellationToken);
+		return [.. entities.Select(mapper.ToDomain)];
+	}
+
 	public async Task<int> GetCountAsync(CancellationToken cancellationToken)
 	{
 		return await repository.GetCountAsync(cancellationToken);

--- a/src/Infrastructure/Services/DashboardService.cs
+++ b/src/Infrastructure/Services/DashboardService.cs
@@ -188,9 +188,12 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 
 		decimal total = accountSpending.Sum(a => a.Amount);
 
-		// Fetch account names in a single query
+		// Fetch account names in a single query. Transactions.AccountId references
+		// the logical Accounts table (RECEIPTS-543 Stage 2), so we look up names
+		// there — Cards joined coincidentally when seeded 1:1, but breaks once
+		// Cards get merged and their source Accounts are deleted.
 		List<Guid> accountIds = accountSpending.Select(a => a.AccountId).ToList();
-		Dictionary<Guid, string> accountNames = await context.Cards
+		Dictionary<Guid, string> accountNames = await context.Accounts
 			.AsNoTracking()
 			.Where(a => accountIds.Contains(a.Id))
 			.ToDictionaryAsync(a => a.Id, a => a.Name, cancellationToken);

--- a/src/Presentation/API/Controllers/Core/AccountsController.cs
+++ b/src/Presentation/API/Controllers/Core/AccountsController.cs
@@ -7,6 +7,7 @@ using Application.Commands.Account.Update;
 using Application.Interfaces.Services;
 using Application.Models;
 using Application.Queries.Core.Account;
+using Application.Queries.Core.Card;
 using Asp.Versioning;
 using Domain.Core;
 using MediatR;
@@ -21,10 +22,11 @@ namespace API.Controllers.Core;
 [Route("api/accounts")]
 [Produces("application/json")]
 [Authorize]
-public class AccountsController(IMediator mediator, AccountMapper mapper, ILogger<AccountsController> logger, IEntityChangeNotifier notifier, IAccountService accountService) : ControllerBase
+public class AccountsController(IMediator mediator, AccountMapper mapper, CardMapper cardMapper, ILogger<AccountsController> logger, IEntityChangeNotifier notifier, IAccountService accountService) : ControllerBase
 {
 	public const string RouteGetById = "{id}";
 	public const string RouteGetAll = "";
+	public const string RouteGetCards = "{id}/cards";
 	public const string RouteCreate = "";
 	public const string RouteCreateBatch = "batch";
 	public const string RouteUpdate = "{id}";
@@ -84,6 +86,22 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, ILogge
 			Offset = result.Offset,
 			Limit = result.Limit,
 		});
+	}
+
+	[HttpGet(RouteGetCards)]
+	[EndpointSummary("Get cards for an account")]
+	[EndpointDescription("Returns the physical Cards (aliases) that belong to the given logical Account. Returns 404 if the account does not exist.")]
+	public async Task<Results<Ok<List<CardResponse>>, NotFound>> GetCardsForAccount([FromRoute] Guid id)
+	{
+		if (!await accountService.ExistsAsync(id, HttpContext.RequestAborted))
+		{
+			logger.LogWarning("Account {Id} not found when fetching cards", id);
+			return TypedResults.NotFound();
+		}
+
+		GetCardsByAccountIdQuery query = new(id);
+		List<Card> cards = await mediator.Send(query);
+		return TypedResults.Ok(cards.Select(cardMapper.ToResponse).ToList());
 	}
 
 	[HttpPost(RouteCreate)]

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -7,6 +7,7 @@ import Dashboard from "@/pages/Dashboard";
 import Login from "@/pages/Login";
 import ChangePassword from "@/pages/ChangePassword";
 import ApiKeys from "@/pages/ApiKeys";
+import Accounts from "@/pages/Accounts";
 import Cards from "@/pages/Cards";
 import Categories from "@/pages/Categories";
 import Subcategories from "@/pages/Subcategories";
@@ -43,6 +44,7 @@ export const routeConfig = [
         ),
         children: [
           { path: "/", element: <Dashboard /> },
+          { path: "/accounts", element: <Accounts /> },
           { path: "/cards", element: <Cards /> },
           { path: "/categories", element: <Categories /> },
           { path: "/subcategories", element: <Subcategories /> },

--- a/src/client/src/components/AccountForm.test.tsx
+++ b/src/client/src/components/AccountForm.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AccountForm } from "./AccountForm";
+
+vi.mock("@/hooks/useFormShortcuts", () => ({
+  useFormShortcuts: vi.fn(),
+}));
+
+describe("AccountForm", () => {
+  const defaultProps = {
+    mode: "create" as const,
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders in create mode with empty fields and correct submit button text", () => {
+    render(<AccountForm {...defaultProps} />);
+
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("");
+    expect(screen.getByRole("button", { name: /create account/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it("renders in edit mode with pre-populated fields and correct submit button text", () => {
+    render(
+      <AccountForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Apple Card", isActive: false }}
+      />,
+    );
+
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("Apple Card");
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(screen.getByRole("button", { name: /update account/i })).toBeInTheDocument();
+  });
+
+  it("calls onSubmit with correct data when form is valid", async () => {
+    const user = userEvent.setup();
+    render(<AccountForm {...defaultProps} />);
+
+    await user.type(screen.getByLabelText(/^Name/), "Chase Sapphire");
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+        { name: "Chase Sapphire", isActive: true },
+        expect.anything(),
+      );
+    });
+  });
+
+  it("shows validation error when name is empty", async () => {
+    const user = userEvent.setup();
+    render(<AccountForm {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Name is required")).toBeInTheDocument();
+    });
+    expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("calls onCancel when cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<AccountForm {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables submit button and shows loading label when isSubmitting is true", () => {
+    render(<AccountForm {...defaultProps} isSubmitting={true} />);
+
+    const submitButton = screen.getByRole("button", { name: /saving/i });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("renders the Active checkbox checked by default in create mode", () => {
+    render(<AccountForm {...defaultProps} />);
+
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
+
+  it("shows delete button in edit mode for admin users only", () => {
+    const { rerender } = render(
+      <AccountForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Apple Card", isActive: true }}
+        isAdmin={false}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /delete/i }),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <AccountForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Apple Card", isActive: true }}
+        isAdmin={true}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it("calls onDelete when delete is confirmed", async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AccountForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{ name: "Apple Card", isActive: true }}
+        isAdmin={true}
+        onDelete={onDelete}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete Account?")).toBeInTheDocument();
+    });
+
+    const confirmButtons = screen.getAllByRole("button", { name: /delete/i });
+    const confirmButton = confirmButtons[confirmButtons.length - 1];
+    await user.click(confirmButton);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/client/src/components/AccountForm.tsx
+++ b/src/client/src/components/AccountForm.tsx
@@ -1,0 +1,156 @@
+import { useRef } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod/v4";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useFormShortcuts } from "@/hooks/useFormShortcuts";
+import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
+import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Trash2 } from "lucide-react";
+
+const accountSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  isActive: z.boolean(),
+});
+
+type AccountFormValues = z.infer<typeof accountSchema>;
+
+interface AccountFormProps {
+  mode: "create" | "edit";
+  defaultValues?: AccountFormValues;
+  onSubmit: (values: AccountFormValues) => void;
+  onCancel: () => void;
+  isSubmitting?: boolean;
+  onDelete?: () => void;
+  isDeleting?: boolean;
+  isAdmin?: boolean;
+}
+
+export function AccountForm({
+  mode,
+  defaultValues,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  onDelete,
+  isDeleting,
+  isAdmin,
+}: AccountFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  useFormShortcuts({ formRef });
+
+  const form = useForm<AccountFormValues>({
+    resolver: zodResolver(accountSchema),
+    defaultValues: defaultValues ?? {
+      name: "",
+      isActive: true,
+    },
+  });
+
+  return (
+    <Form {...form}>
+      <form ref={formRef} onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel required>Name</FormLabel>
+              <FormControl>
+                <Input aria-required="true" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="isActive"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center gap-2">
+                <FormControl>
+                  <input
+                    type="checkbox"
+                    checked={field.value}
+                    onChange={field.onChange}
+                    className="h-4 w-4 rounded border-gray-300"
+                  />
+                </FormControl>
+                <FormLabel>Active</FormLabel>
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex items-center pt-4">
+          {mode === "edit" && isAdmin && onDelete && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  disabled={isDeleting}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  {isDeleting ? "Deleting..." : "Delete"}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete Account?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently delete this logical account. Any cards
+                    that currently point at it will be unlinked. This action
+                    cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    variant="destructive"
+                    onClick={onDelete}
+                  >
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+            <SubmitButton
+              isSubmitting={isSubmitting ?? false}
+              label={mode === "create" ? "Create Account" : "Update Account"}
+              loadingLabel="Saving..."
+            />
+          </div>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/client/src/components/GlobalSearchDialog.test.tsx
+++ b/src/client/src/components/GlobalSearchDialog.test.tsx
@@ -19,6 +19,10 @@ vi.mock("@/hooks/useKeyboardShortcut", () => ({
   useKeyboardShortcut: vi.fn(),
 }));
 
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() => ({ data: undefined })),
+}));
+
 vi.mock("@/hooks/useCards", () => ({
   useCards: vi.fn(() => ({ data: undefined })),
 }));
@@ -60,8 +64,44 @@ describe("GlobalSearchDialog", () => {
     );
     expect(screen.getByText("Navigation")).toBeInTheDocument();
     expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("Accounts")).toBeInTheDocument();
     expect(screen.getByText("Cards")).toBeInTheDocument();
     expect(screen.getByText("Receipts")).toBeInTheDocument();
+  });
+
+  it("renders account items when accounts data is available", async () => {
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+      data: [
+        { id: "acct-1", name: "Apple Card", isActive: true },
+        { id: "acct-2", name: "Chase Sapphire", isActive: true },
+      ],
+      total: 2,
+    }));
+
+    renderWithQueryClient(
+      <GlobalSearchDialog open={true} onOpenChange={vi.fn()} />,
+    );
+    // "Accounts" appears both as a nav item and a group heading; the group items
+    // are the logical account names.
+    expect(screen.getByText("Apple Card")).toBeInTheDocument();
+    expect(screen.getByText("Chase Sapphire")).toBeInTheDocument();
+  });
+
+  it("selecting an account item navigates to /accounts and closes the dialog", async () => {
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(mockQueryResult({
+      data: [{ id: "acct-1", name: "Apple Card", isActive: true }],
+      total: 1,
+    }));
+
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderWithQueryClient(
+      <GlobalSearchDialog open={true} onOpenChange={onOpenChange} />,
+    );
+    await user.click(screen.getByText("Apple Card"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("renders card items when cards data is available", async () => {

--- a/src/client/src/components/GlobalSearchDialog.tsx
+++ b/src/client/src/components/GlobalSearchDialog.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/command";
 import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
 import { formatCurrency } from "@/lib/format";
+import { useAccounts } from "@/hooks/useAccounts";
 import { useCards } from "@/hooks/useCards";
 import { useReceipts } from "@/hooks/useReceipts";
 import { useReceiptItems } from "@/hooks/useReceiptItems";
@@ -30,6 +31,7 @@ interface GlobalSearchDialogProps {
 
 const navItems = [
   { label: "Home", path: "/", icon: Home },
+  { label: "Accounts", path: "/accounts", icon: Building2 },
   { label: "Cards", path: "/cards", icon: Building2 },
   { label: "Receipts", path: "/receipts", icon: FileText },
 ];
@@ -39,6 +41,7 @@ export function GlobalSearchDialog({
   onOpenChange,
 }: GlobalSearchDialogProps) {
   const navigate = useNavigate();
+  const { data: accounts } = useAccounts();
   const { data: cards } = useCards();
   const { data: receipts } = useReceipts();
   const { data: receiptItems } = useReceiptItems();
@@ -73,6 +76,24 @@ export function GlobalSearchDialog({
             </CommandItem>
           ))}
         </CommandGroup>
+
+        {accounts?.length ? (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Accounts">
+              {(accounts ?? []).slice(0, 8).map((a) => (
+                <CommandItem
+                  key={a.id}
+                  value={`account:${a.name}`}
+                  onSelect={() => select("/accounts")}
+                >
+                  <Building2 className="mr-2 h-4 w-4 text-muted-foreground" />
+                  <span className="font-medium">{a.name}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        ) : null}
 
         {cards?.length ? (
           <>

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -92,6 +92,11 @@ const navGroups: NavGroup[] = [
     label: "Manage",
     items: [
       {
+        to: "/accounts",
+        label: "Accounts",
+        description: "Manage logical accounts",
+      },
+      {
         to: "/cards",
         label: "Cards",
         description: "Manage payment cards",
@@ -205,6 +210,7 @@ export function Layout() {
 
   const navLinks = [
     { to: "/", label: "Dashboard" },
+    { to: "/accounts", label: "Accounts" },
     { to: "/cards", label: "Cards" },
     { to: "/categories", label: "Categories" },
     { to: "/subcategories", label: "Subcategories" },

--- a/src/client/src/components/ReceiptTransactionForm.tsx
+++ b/src/client/src/components/ReceiptTransactionForm.tsx
@@ -3,8 +3,8 @@ import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
-import { useCards } from "@/hooks/useCards";
-import { cardToOption } from "@/lib/combobox-options";
+import { useAccounts } from "@/hooks/useAccounts";
+import { accountToOption } from "@/lib/combobox-options";
 import { Button } from "@/components/ui/button";
 import { DateInput } from "@/components/ui/date-input";
 import { Combobox } from "@/components/ui/combobox";
@@ -49,16 +49,11 @@ export function ReceiptTransactionForm({
   const formRef = useRef<HTMLFormElement>(null);
   useFormShortcuts({ formRef });
 
-  const { data: cards, isLoading: accountsLoading } = useCards(0, 50, undefined, undefined, true);
+  const { data: accounts, isLoading: accountsLoading } = useAccounts(0, 50, undefined, undefined, true);
 
   const accountOptions = useMemo(
-    () =>
-      (
-        (cards as
-          | { id: string; name: string; cardCode: string }[]
-          | undefined) ?? []
-      ).map(cardToOption),
-    [cards],
+    () => (accounts ?? []).map(accountToOption),
+    [accounts],
   );
 
   const form = useForm<ReceiptTransactionFormValues>({

--- a/src/client/src/components/ReceiptTransactionsCard.test.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.test.tsx
@@ -5,11 +5,11 @@ import { ReceiptTransactionsCard } from "./ReceiptTransactionsCard";
 import { renderWithQueryClient } from "@/test/test-utils";
 import { mockMutationResult } from "@/test/mock-hooks";
 
-vi.mock("@/hooks/useCards", () => ({
-  useCards: vi.fn(() => ({
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() => ({
     data: [
-      { id: "acc-1", name: "Checking", cardCode: "1001" },
-      { id: "acc-2", name: "Savings", cardCode: "2001" },
+      { id: "acc-1", name: "Checking", isActive: true },
+      { id: "acc-2", name: "Savings", isActive: false },
     ],
     isLoading: false,
   })),

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -60,6 +60,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/accounts/{id}/cards": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get cards for an account
+         * @description Returns the physical Cards (aliases) that belong to the given logical Account. Returns 404 if the account does not exist.
+         */
+        get: operations["GetCardsForAccount"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/accounts": {
         parameters: {
             query?: never;
@@ -3551,6 +3571,35 @@ export interface operations {
                         cardCount: number;
                     };
                 };
+            };
+        };
+    };
+    GetCardsForAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardResponse"][];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/src/client/src/hooks/useAccounts.test.ts
+++ b/src/client/src/hooks/useAccounts.test.ts
@@ -112,8 +112,7 @@ describe("useAccountCards", () => {
       wrapper: createWrapper(),
     });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual(cards);
+    await waitFor(() => expect(result.current.data).toEqual(cards));
     expect(client.GET).toHaveBeenCalledWith("/api/accounts/{id}/cards", {
       params: { path: { id: "a1" } },
     });

--- a/src/client/src/hooks/useAccounts.test.ts
+++ b/src/client/src/hooks/useAccounts.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import client from "@/lib/api-client";
+import { toast } from "sonner";
+import {
+  useAccounts,
+  useAccount,
+  useAccountCards,
+  useCreateAccount,
+  useUpdateAccount,
+  useDeleteAccount,
+} from "./useAccounts";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useAccounts", () => {
+  it("list query returns data on success", async () => {
+    const accounts = [{ id: "a1", name: "Apple Card", isActive: true }];
+    (client.GET as Mock).mockResolvedValue({
+      data: { data: accounts, total: 1, offset: 0, limit: 50 },
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useAccounts(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(accounts);
+    expect(client.GET).toHaveBeenCalledWith("/api/accounts", {
+      params: { query: { offset: 0, limit: 50 } },
+    });
+  });
+
+  it("list query passes isActive filter", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: { data: [], total: 0, offset: 0, limit: 50 }, error: undefined });
+
+    const { result } = renderHook(() => useAccounts(0, 50, null, null, true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.GET).toHaveBeenCalledWith("/api/accounts", {
+      params: { query: { offset: 0, limit: 50, isActive: true } },
+    });
+  });
+
+  it("list query throws when API returns error", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "boom" } });
+
+    const { result } = renderHook(() => useAccounts(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useAccount", () => {
+  it("fetches a single account by id", async () => {
+    const account = { id: "a1", name: "Apple Card", isActive: true };
+    (client.GET as Mock).mockResolvedValue({ data: account, error: undefined });
+
+    const { result } = renderHook(() => useAccount("a1"), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(account);
+    expect(client.GET).toHaveBeenCalledWith("/api/accounts/{id}", {
+      params: { path: { id: "a1" } },
+    });
+  });
+
+  it("does not fire query when id is null", () => {
+    renderHook(() => useAccount(null), { wrapper: createWrapper() });
+
+    expect(client.GET).not.toHaveBeenCalled();
+  });
+});
+
+describe("useAccountCards", () => {
+  it("fetches cards for the given account", async () => {
+    const cards = [
+      { id: "c1", cardCode: "VISA1", name: "Physical A", isActive: true },
+      { id: "c2", cardCode: "VISA2", name: "Physical B", isActive: true },
+    ];
+    (client.GET as Mock).mockResolvedValue({ data: cards, error: undefined });
+
+    const { result } = renderHook(() => useAccountCards("a1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(cards);
+    expect(client.GET).toHaveBeenCalledWith("/api/accounts/{id}/cards", {
+      params: { path: { id: "a1" } },
+    });
+  });
+
+  it("does not fire query when accountId is null", () => {
+    renderHook(() => useAccountCards(null), { wrapper: createWrapper() });
+
+    expect(client.GET).not.toHaveBeenCalled();
+  });
+
+  it("throws when API returns error", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: { message: "not found" } });
+
+    const { result } = renderHook(() => useAccountCards("a1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useCreateAccount", () => {
+  it("creates an account and toasts success", async () => {
+    const created = { id: "a1", name: "Apple Card", isActive: true };
+    (client.POST as Mock).mockResolvedValue({ data: created, error: undefined });
+
+    const { result } = renderHook(() => useCreateAccount(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({ name: "Apple Card", isActive: true });
+
+    expect(client.POST).toHaveBeenCalledWith("/api/accounts", {
+      body: { name: "Apple Card", isActive: true },
+    });
+    expect(toast.success).toHaveBeenCalledWith("Account created");
+  });
+
+  it("toasts error on failure", async () => {
+    (client.POST as Mock).mockResolvedValue({ data: undefined, error: { message: "boom" } });
+
+    const { result } = renderHook(() => useCreateAccount(), {
+      wrapper: createWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({ name: "Apple Card", isActive: true }),
+    ).rejects.toBeDefined();
+    expect(toast.error).toHaveBeenCalledWith("Failed to create account");
+  });
+});
+
+describe("useUpdateAccount", () => {
+  it("updates an account and toasts success", async () => {
+    (client.PUT as Mock).mockResolvedValue({ data: undefined, error: undefined });
+
+    const { result } = renderHook(() => useUpdateAccount(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({ id: "a1", name: "Apple", isActive: false });
+
+    expect(client.PUT).toHaveBeenCalledWith("/api/accounts/{id}", {
+      params: { path: { id: "a1" } },
+      body: { id: "a1", name: "Apple", isActive: false },
+    });
+    expect(toast.success).toHaveBeenCalledWith("Account updated");
+  });
+});
+
+describe("useDeleteAccount", () => {
+  it("deletes an account and toasts success", async () => {
+    (client.DELETE as Mock).mockResolvedValue({
+      data: undefined,
+      error: undefined,
+      response: { status: 204 },
+    });
+
+    const { result } = renderHook(() => useDeleteAccount(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync("a1");
+
+    expect(client.DELETE).toHaveBeenCalledWith("/api/accounts/{id}", {
+      params: { path: { id: "a1" } },
+    });
+    expect(toast.success).toHaveBeenCalledWith("Account deleted");
+  });
+
+  it("surfaces 409 card-count conflict message", async () => {
+    (client.DELETE as Mock).mockResolvedValue({
+      data: undefined,
+      error: { message: "Cannot delete — 3 card(s) reference this account", cardCount: 3 },
+      response: { status: 409 },
+    });
+
+    const { result } = renderHook(() => useDeleteAccount(), {
+      wrapper: createWrapper(),
+    });
+
+    await expect(result.current.mutateAsync("a1")).rejects.toMatchObject({
+      conflict: true,
+      cardCount: 3,
+    });
+    expect(toast.error).toHaveBeenCalledWith(
+      "Cannot delete — 3 card(s) reference this account",
+    );
+  });
+});

--- a/src/client/src/hooks/useAccounts.ts
+++ b/src/client/src/hooks/useAccounts.ts
@@ -32,8 +32,11 @@ export function useAccount(id: string | null) {
 }
 
 export function useAccountCards(accountId: string | null) {
-  return useQuery({
-    queryKey: ["accounts", accountId, "cards"],
+  // Keyed under "cards" so mutations in useCards (useUpdateCard, useDeleteCard,
+  // useMergeCards) that invalidate ["cards"] also invalidate these per-account
+  // card lists via React Query's prefix matching.
+  const query = useQuery({
+    queryKey: ["cards", "byAccount", accountId],
     enabled: !!accountId,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/accounts/{id}/cards", {
@@ -43,6 +46,15 @@ export function useAccountCards(accountId: string | null) {
       return data;
     },
   });
+  return useMemo(
+    () => ({
+      data: query.data,
+      isLoading: query.isLoading,
+      isError: query.isError,
+      error: query.error,
+    }),
+    [query.data, query.isLoading, query.isError, query.error],
+  );
 }
 
 export function useCreateAccount() {

--- a/src/client/src/hooks/useAccounts.ts
+++ b/src/client/src/hooks/useAccounts.ts
@@ -31,6 +31,20 @@ export function useAccount(id: string | null) {
   });
 }
 
+export function useAccountCards(accountId: string | null) {
+  return useQuery({
+    queryKey: ["accounts", accountId, "cards"],
+    enabled: !!accountId,
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/accounts/{id}/cards", {
+        params: { path: { id: accountId! } },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
 export function useCreateAccount() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/client/src/lib/combobox-options.ts
+++ b/src/client/src/lib/combobox-options.ts
@@ -6,6 +6,11 @@ interface CardLike {
   cardCode: string;
 }
 
+interface AccountLike {
+  id: string;
+  name: string;
+}
+
 interface ReceiptLike {
   id: string;
   location: string;
@@ -17,6 +22,13 @@ export function cardToOption(card: CardLike): ComboboxOption {
     value: card.id,
     label: card.name,
     sublabel: card.cardCode,
+  };
+}
+
+export function accountToOption(account: AccountLike): ComboboxOption {
+  return {
+    value: account.id,
+    label: account.name,
   };
 }
 

--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -1,0 +1,196 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { mockQueryResult } from "@/test/mock-hooks";
+import { mockAccountResponse, mockCardResponse } from "@/test/mock-api";
+import Accounts from "./Accounts";
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+  useAccountCards: vi.fn(() => ({ data: [], isLoading: false })),
+  useCreateAccount: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useUpdateAccount: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDeleteAccount: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/hooks/usePermission", () => ({
+  usePermission: vi.fn(() => ({
+    roles: ["User"],
+    hasRole: (role: string) => role === "User",
+    isAdmin: () => false,
+  })),
+}));
+
+vi.mock("@/hooks/useFuzzySearch", () => ({
+  useFuzzySearch: vi.fn(() => ({
+    search: "",
+    setSearch: vi.fn(),
+    results: [],
+    totalCount: 0,
+    isSearching: false,
+    clearSearch: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/useServerPagination", () => ({
+  useServerPagination: vi.fn(() => ({
+    offset: 0,
+    limit: 25,
+    currentPage: 1,
+    pageSize: 25,
+    totalPages: vi.fn(() => 1),
+    setPage: vi.fn(),
+    setPageSize: vi.fn(),
+    resetPage: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/useServerSort", () => ({
+  useServerSort: vi.fn(() => ({
+    sortBy: "name",
+    sortDirection: "asc",
+    toggleSort: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/useListKeyboardNav", () => ({
+  useListKeyboardNav: vi.fn(() => ({
+    focusedId: null,
+    setFocusedIndex: vi.fn(),
+    tableRef: { current: null },
+  })),
+}));
+
+describe("Accounts", () => {
+  beforeEach(() => {
+    localStorage.removeItem("accounts-status-filter");
+  });
+
+  it("renders the page heading", () => {
+    renderWithProviders(<Accounts />);
+    expect(screen.getByRole("heading", { name: /accounts/i })).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton when data is loading", async () => {
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(
+      mockQueryResult({ data: undefined, isLoading: true }),
+    );
+
+    const { container } = renderWithProviders(<Accounts />);
+    expect(container.querySelector("[data-slot='skeleton']")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no accounts exist", async () => {
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(
+      mockQueryResult({ data: [], total: 0, isLoading: false }),
+    );
+
+    renderWithProviders(<Accounts />);
+    expect(screen.getByText(/no accounts yet/i)).toBeInTheDocument();
+  });
+
+  it("renders the New Account button", () => {
+    renderWithProviders(<Accounts />);
+    expect(screen.getByRole("button", { name: /new account/i })).toBeInTheDocument();
+  });
+
+  it("renders the search input", () => {
+    renderWithProviders(<Accounts />);
+    expect(screen.getByPlaceholderText(/search accounts/i)).toBeInTheDocument();
+  });
+
+  it("renders table with accounts when data exists", async () => {
+    const items = [
+      mockAccountResponse({ id: "1", name: "Apple Card" }),
+      mockAccountResponse({ id: "2", name: "Chase Sapphire" }),
+    ];
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(
+      mockQueryResult({ data: items, total: items.length, isLoading: false }),
+    );
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [] as never })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+      // satisfy any extra fields returned by hook
+    } as unknown as ReturnType<typeof useFuzzySearch>);
+
+    renderWithProviders(<Accounts />);
+
+    expect(screen.getByText("Apple Card")).toBeInTheDocument();
+    expect(screen.getByText("Chase Sapphire")).toBeInTheDocument();
+  });
+
+  it("expands an account row and lazy-loads its cards", async () => {
+    const items = [mockAccountResponse({ id: "a1", name: "Apple Card" })];
+    const { useAccounts, useAccountCards } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(
+      mockQueryResult({ data: items, total: 1, isLoading: false }),
+    );
+
+    const cards = [
+      mockCardResponse({ id: "c1", cardCode: "VISA1", name: "Physical 1" }),
+      mockCardResponse({ id: "c2", cardCode: "VISA2", name: "Physical 2" }),
+    ];
+    vi.mocked(useAccountCards).mockReturnValue(
+      mockQueryResult({ data: cards, isLoading: false }),
+    );
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [] as never })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    } as unknown as ReturnType<typeof useFuzzySearch>);
+
+    const user = userEvent.setup();
+    renderWithProviders(<Accounts />);
+
+    await user.click(screen.getByRole("button", { name: /expand cards/i }));
+
+    expect(await screen.findByText("Physical 1")).toBeInTheDocument();
+    expect(screen.getByText("Physical 2")).toBeInTheDocument();
+    expect(screen.getByText("VISA1")).toBeInTheDocument();
+  });
+
+  it("shows 'No cards linked' when expanded account has no cards", async () => {
+    const items = [mockAccountResponse({ id: "a1", name: "Apple Card" })];
+    const { useAccounts, useAccountCards } = await import("@/hooks/useAccounts");
+    vi.mocked(useAccounts).mockReturnValue(
+      mockQueryResult({ data: items, total: 1, isLoading: false }),
+    );
+    vi.mocked(useAccountCards).mockReturnValue(
+      mockQueryResult({ data: [], isLoading: false }),
+    );
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [] as never })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    } as unknown as ReturnType<typeof useFuzzySearch>);
+
+    const user = userEvent.setup();
+    renderWithProviders(<Accounts />);
+
+    await user.click(screen.getByRole("button", { name: /expand cards/i }));
+
+    expect(await screen.findByText(/no cards linked/i)).toBeInTheDocument();
+  });
+});

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -58,6 +58,8 @@ type StatusFilter = "all" | "true" | "false";
 
 const HIGHLIGHT_PARAMS = ["highlight"] as const;
 
+const getAccountId = (a: AccountRow) => a.id;
+
 function AccountCardsRow({ accountId }: { accountId: string }) {
   const { data, isLoading } = useAccountCards(accountId);
 
@@ -115,6 +117,7 @@ function Accounts() {
   const { data: accountsData, total: serverTotal, isLoading } = useAccounts(offset, limit, sortBy, sortDirection, isActiveParam);
   const createAccount = useCreateAccount();
   const updateAccount = useUpdateAccount();
+  const { mutate: mutateUpdateAccount } = updateAccount;
   const deleteAccount = useDeleteAccount();
   const { isAdmin } = usePermission();
   const [createOpen, setCreateOpen] = useState(false);
@@ -149,12 +152,14 @@ function Accounts() {
   }, [toggleSort, resetPage]);
 
   const handleToggleActive = useCallback((account: AccountRow, checked: boolean) => {
-    updateAccount.mutate({
+    mutateUpdateAccount({
       id: account.id,
       name: account.name,
       isActive: checked,
     });
-  }, [updateAccount]);
+  }, [mutateUpdateAccount]);
+
+  const handleOpen = useCallback((a: AccountRow) => setEditAccount(a), []);
 
   const data = useMemo(() => (accountsData as AccountRow[] | undefined) ?? [], [accountsData]);
 
@@ -185,9 +190,9 @@ function Accounts() {
 
   const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
     items: filteredResults,
-    getId: (a) => a.id,
+    getId: getAccountId,
     enabled: !anyDialogOpen,
-    onOpen: (a) => setEditAccount(a),
+    onOpen: handleOpen,
   });
 
   if (isLoading) {

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -1,0 +1,407 @@
+import { Fragment, useState, useMemo, useEffect, useCallback } from "react";
+import {
+  useAccounts,
+  useAccountCards,
+  useCreateAccount,
+  useUpdateAccount,
+  useDeleteAccount,
+} from "@/hooks/useAccounts";
+import { usePermission } from "@/hooks/usePermission";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { useEntityLinkParams } from "@/hooks/useEntityLinkParams";
+import { useFuzzySearch } from "@/hooks/useFuzzySearch";
+import { useServerPagination } from "@/hooks/useServerPagination";
+import { useServerSort } from "@/hooks/useServerSort";
+import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
+import type { FuseSearchConfig } from "@/lib/search";
+import { AccountForm } from "@/components/AccountForm";
+import { FuzzySearchInput } from "@/components/FuzzySearchInput";
+import { SearchHighlight } from "@/components/SearchHighlight";
+import { getMatchIndices } from "@/lib/search-highlight";
+import { SortableTableHead } from "@/components/SortableTableHead";
+import { NoResults } from "@/components/NoResults";
+import { Pagination } from "@/components/Pagination";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TableSkeleton } from "@/components/ui/table-skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { ChevronDown, ChevronRight, Info, Pencil } from "lucide-react";
+
+interface AccountRow {
+  id: string;
+  name: string;
+  isActive: boolean;
+}
+
+const SEARCH_CONFIG: FuseSearchConfig<AccountRow> = {
+  keys: [{ name: "name", weight: 1 }],
+};
+
+const STATUS_STORAGE_KEY = "accounts-status-filter";
+type StatusFilter = "all" | "true" | "false";
+
+const HIGHLIGHT_PARAMS = ["highlight"] as const;
+
+function AccountCardsRow({ accountId }: { accountId: string }) {
+  const { data, isLoading } = useAccountCards(accountId);
+
+  if (isLoading) {
+    return (
+      <div className="text-sm text-muted-foreground">Loading cards…</div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground italic">
+        No cards linked to this account yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="text-xs font-medium text-muted-foreground">
+        Cards ({data.length})
+      </div>
+      <ul className="space-y-1">
+        {data.map((card) => (
+          <li
+            key={card.id}
+            className="flex items-center gap-3 rounded border px-3 py-1.5 text-sm"
+          >
+            <span className="font-mono text-xs text-muted-foreground">
+              {card.cardCode}
+            </span>
+            <span>{card.name}</span>
+            {!card.isActive && (
+              <Badge variant="secondary" className="ml-auto">
+                Inactive
+              </Badge>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Accounts() {
+  usePageTitle("Accounts");
+  const { params: linkParams } = useEntityLinkParams(HIGHLIGHT_PARAMS);
+  const { sortBy, sortDirection, toggleSort } = useServerSort({ defaultSortBy: "name", defaultSortDirection: "asc" });
+  const { offset, limit, currentPage, pageSize, totalPages, setPage, setPageSize, resetPage } = useServerPagination({ sortBy, sortDirection });
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => {
+    const saved = localStorage.getItem(STATUS_STORAGE_KEY);
+    return saved === "all" || saved === "true" || saved === "false" ? saved : "true";
+  });
+  const isActiveParam = statusFilter === "all" ? undefined : statusFilter === "true";
+  const { data: accountsData, total: serverTotal, isLoading } = useAccounts(offset, limit, sortBy, sortDirection, isActiveParam);
+  const createAccount = useCreateAccount();
+  const updateAccount = useUpdateAccount();
+  const deleteAccount = useDeleteAccount();
+  const { isAdmin } = usePermission();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editAccount, setEditAccount] = useState<AccountRow | null>(null);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const anyDialogOpen = createOpen || editAccount !== null;
+
+  const toggleExpanded = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    function onNewItem() {
+      setCreateOpen(true);
+    }
+    window.addEventListener("shortcut:new-item", onNewItem);
+    return () => window.removeEventListener("shortcut:new-item", onNewItem);
+  }, []);
+
+  const handleSort = useCallback((column: string) => {
+    toggleSort(column);
+    resetPage();
+  }, [toggleSort, resetPage]);
+
+  const handleToggleActive = useCallback((account: AccountRow, checked: boolean) => {
+    updateAccount.mutate({
+      id: account.id,
+      name: account.name,
+      isActive: checked,
+    });
+  }, [updateAccount]);
+
+  const data = useMemo(() => (accountsData as AccountRow[] | undefined) ?? [], [accountsData]);
+
+  const { search, setSearch, results, totalCount, clearSearch } =
+    useFuzzySearch({ data, config: SEARCH_CONFIG });
+
+  function handleStatusChange(value: string) {
+    const v = value as StatusFilter;
+    setStatusFilter(v);
+    localStorage.setItem(STATUS_STORAGE_KEY, v);
+    resetPage();
+  }
+
+  const filteredResults = useMemo(() => {
+    return results.map((r) => r.item);
+  }, [results]);
+
+  const matchMap = useMemo(() => {
+    const map = new Map<string, (typeof results)[number]>();
+    for (const r of results) {
+      map.set(r.item.id, r);
+    }
+    return map;
+  }, [results]);
+
+  const highlightMissing =
+    linkParams.highlight && data.length > 0 && !data.some((a) => a.id === linkParams.highlight);
+
+  const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
+    items: filteredResults,
+    getId: (a) => a.id,
+    enabled: !anyDialogOpen,
+    onOpen: (a) => setEditAccount(a),
+  });
+
+  if (isLoading) {
+    return <TableSkeleton columns={4} />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Accounts</h1>
+      <div className="flex items-center justify-between">
+        <FuzzySearchInput
+          aria-label="Search accounts"
+          value={search}
+          onChange={setSearch}
+          placeholder="Search accounts..."
+          resultCount={filteredResults.length}
+          totalCount={totalCount}
+          className="max-w-sm"
+        />
+        <Button onClick={() => setCreateOpen(true)}>New Account</Button>
+      </div>
+
+      <Tabs value={statusFilter} onValueChange={handleStatusChange}>
+        <TabsList>
+          <TabsTrigger value="true">Active</TabsTrigger>
+          <TabsTrigger value="false">Inactive</TabsTrigger>
+          <TabsTrigger value="all">All</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {highlightMissing && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription>The highlighted item is not on this page.</AlertDescription>
+        </Alert>
+      )}
+
+      {filteredResults.length === 0 ? (
+        search ? (
+          <NoResults
+            searchTerm={search}
+            onClearSearch={clearSearch}
+            onSelectSuggestion={setSearch}
+            entityName="accounts"
+          />
+        ) : (
+          <div className="py-12 text-center text-muted-foreground">
+            No accounts yet. Create one to get started.
+          </div>
+        )
+      ) : (
+        <>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
+          <div className="rounded-md border" ref={tableRef}>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-10" />
+                  <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
+                  <SortableTableHead column="isActive" label="Status" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
+                  <TableHead className="w-24">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredResults.map((account, index) => {
+                  const result = matchMap.get(account.id);
+                  const matches = result?.matches;
+                  const isExpanded = expandedIds.has(account.id);
+                  return (
+                    <Fragment key={account.id}>
+                      <TableRow
+                        className={`cursor-pointer ${focusedId === account.id ? "bg-accent" : ""} ${linkParams.highlight === account.id ? "ring-2 ring-primary" : ""}`}
+                        onClick={(e) => {
+                          if ((e.target as HTMLElement).closest("button, input, a, [role='button']")) return;
+                          setFocusedIndex(index);
+                        }}
+                      >
+                        <TableCell>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            aria-label={isExpanded ? "Collapse cards" : "Expand cards"}
+                            aria-expanded={isExpanded}
+                            onClick={() => toggleExpanded(account.id)}
+                          >
+                            {isExpanded ? (
+                              <ChevronDown className="h-4 w-4" />
+                            ) : (
+                              <ChevronRight className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </TableCell>
+                        <TableCell>
+                          <SearchHighlight
+                            text={account.name}
+                            indices={getMatchIndices(matches, "name")}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <Switch
+                              checked={account.isActive}
+                              onCheckedChange={(checked) => handleToggleActive(account, checked)}
+                              aria-label={`Toggle ${account.name} active status`}
+                            />
+                            <Badge
+                              variant={account.isActive ? "default" : "secondary"}
+                            >
+                              {account.isActive ? "Active" : "Inactive"}
+                            </Badge>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            aria-label="Edit"
+                            onClick={() => setEditAccount(account)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                      {isExpanded && (
+                        <TableRow
+                          className="bg-muted/30 hover:bg-muted/30"
+                        >
+                          <TableCell />
+                          <TableCell colSpan={3} className="py-3">
+                            <AccountCardsRow accountId={account.id} />
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={serverTotal}
+            pageSize={pageSize}
+            totalPages={totalPages(serverTotal)}
+            onPageChange={(page) => setPage(page, serverTotal)}
+            onPageSizeChange={setPageSize}
+          />
+        </>
+      )}
+
+      {/* Create Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Account</DialogTitle>
+          </DialogHeader>
+          <AccountForm
+            mode="create"
+            isSubmitting={createAccount.isPending}
+            onCancel={() => setCreateOpen(false)}
+            onSubmit={(values) => {
+              createAccount.mutate(values, {
+                onSuccess: () => setCreateOpen(false),
+              });
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog
+        open={editAccount !== null}
+        onOpenChange={(open) => !open && setEditAccount(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Account</DialogTitle>
+          </DialogHeader>
+          {editAccount && (
+            <AccountForm
+              mode="edit"
+              defaultValues={{
+                name: editAccount.name,
+                isActive: editAccount.isActive,
+              }}
+              isSubmitting={updateAccount.isPending}
+              onCancel={() => setEditAccount(null)}
+              onSubmit={(values) => {
+                updateAccount.mutate(
+                  { id: editAccount.id, ...values },
+                  { onSuccess: () => setEditAccount(null) },
+                );
+              }}
+              isAdmin={isAdmin()}
+              isDeleting={deleteAccount.isPending}
+              onDelete={() => {
+                deleteAccount.mutate(editAccount.id, {
+                  onSuccess: () => setEditAccount(null),
+                });
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+    </div>
+  );
+}
+
+export default Accounts;

--- a/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
@@ -9,12 +9,12 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
   useFormShortcuts: vi.fn(),
 }));
 
-vi.mock("@/hooks/useCards", () => ({
-  useCards: vi.fn(() =>
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() =>
     mockQueryResult({
       data: [
-        { id: "acct-1", name: "Checking", cardCode: "CHK" },
-        { id: "acct-2", name: "Credit Card", cardCode: "CC" },
+        { id: "acct-1", name: "Checking", isActive: true },
+        { id: "acct-2", name: "Credit Card", isActive: true },
       ],
       total: 2,
       isLoading: false,

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -4,8 +4,8 @@ import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
-import { useCards } from "@/hooks/useCards";
-import { cardToOption } from "@/lib/combobox-options";
+import { useAccounts } from "@/hooks/useAccounts";
+import { accountToOption } from "@/lib/combobox-options";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -58,17 +58,12 @@ export function TransactionsSection({
 }: TransactionsSectionProps) {
   const formRef = useRef<HTMLFormElement>(null);
   const accountRef = useRef<HTMLButtonElement>(null);
-  const { data: cards } = useCards(0, 50, undefined, undefined, true);
+  const { data: accounts } = useAccounts(0, 50, undefined, undefined, true);
   useFormShortcuts({ formRef });
 
   const accountOptions = useMemo(
-    () =>
-      (
-        (cards as
-          | { id: string; name: string; cardCode: string }[]
-          | undefined) ?? []
-      ).map(cardToOption),
-    [cards],
+    () => (accounts ?? []).map(accountToOption),
+    [accounts],
   );
 
   const accountNameMap = useMemo(() => {

--- a/src/client/src/pages/settings/YnabSettings.test.tsx
+++ b/src/client/src/pages/settings/YnabSettings.test.tsx
@@ -7,8 +7,8 @@ vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
 }));
 
-vi.mock("@/hooks/useCards", () => ({
-  useCards: vi.fn(() =>
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() =>
     mockQueryResult({ data: [], isLoading: false }),
   ),
 }));

--- a/src/client/src/pages/settings/YnabSettings.tsx
+++ b/src/client/src/pages/settings/YnabSettings.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { useCards } from "@/hooks/useCards";
+import { useAccounts } from "@/hooks/useAccounts";
 import {
   useYnabConnectionStatus,
   useYnabBudgets,
@@ -77,7 +77,7 @@ export default function YnabSettings() {
   // Only fetch YNAB data when configured (budgets query succeeded)
   const ynabReady = !budgetsLoading && !budgetsError;
 
-  const { data: receiptsAccounts, isLoading: accountsLoading } = useCards(0, 200);
+  const { data: receiptsAccounts, isLoading: accountsLoading } = useAccounts(0, 200);
   const { accounts: ynabAccounts, isLoading: ynabAccountsLoading } = useYnabAccounts(ynabReady);
   const { mappings: accountMappings, isLoading: accountMappingsLoading } = useYnabAccountMappings(ynabReady);
   const createAccountMapping = useCreateYnabAccountMapping();

--- a/src/client/src/pages/wizard/Step2Transactions.test.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.test.tsx
@@ -8,12 +8,12 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
   useFormShortcuts: vi.fn(),
 }));
 
-vi.mock("@/hooks/useCards", () => ({
-  useCards: vi.fn(() =>
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() =>
     mockQueryResult({
       data: [
-        { id: "acct-1", name: "Checking", cardCode: "CHK" },
-        { id: "acct-2", name: "Credit Card", cardCode: "CC" },
+        { id: "acct-1", name: "Checking", isActive: true },
+        { id: "acct-2", name: "Credit Card", isActive: true },
       ],
       total: 2,
       isLoading: false,

--- a/src/client/src/pages/wizard/Step2Transactions.tsx
+++ b/src/client/src/pages/wizard/Step2Transactions.tsx
@@ -4,8 +4,8 @@ import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
-import { useCards } from "@/hooks/useCards";
-import { cardToOption } from "@/lib/combobox-options";
+import { useAccounts } from "@/hooks/useAccounts";
+import { accountToOption } from "@/lib/combobox-options";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -59,17 +59,12 @@ export function Step2Transactions({
   const [transactions, setTransactions] = useState<WizardTransaction[]>(data);
   const formRef = useRef<HTMLFormElement>(null);
   const accountRef = useRef<HTMLButtonElement>(null);
-  const { data: cards } = useCards(0, 50, undefined, undefined, true);
+  const { data: accounts } = useAccounts(0, 50, undefined, undefined, true);
   useFormShortcuts({ formRef });
 
   const accountOptions = useMemo(
-    () =>
-      (
-        (cards as
-          | { id: string; name: string; cardCode: string }[]
-          | undefined) ?? []
-      ).map(cardToOption),
-    [cards],
+    () => (accounts ?? []).map(accountToOption),
+    [accounts],
   );
 
   const accountNameMap = useMemo(() => {

--- a/src/client/src/pages/wizard/Step4Review.test.tsx
+++ b/src/client/src/pages/wizard/Step4Review.test.tsx
@@ -5,8 +5,8 @@ import "@/test/setup-combobox-polyfills";
 import { Step4Review } from "./Step4Review";
 import type { WizardState } from "./wizardReducer";
 
-vi.mock("@/hooks/useCards", () => ({
-  useCards: vi.fn(() =>
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() =>
     mockQueryResult({
       data: [
         { id: "acct-1", name: "Checking" },

--- a/src/client/src/pages/wizard/Step4Review.tsx
+++ b/src/client/src/pages/wizard/Step4Review.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useCards } from "@/hooks/useCards";
+import { useAccounts } from "@/hooks/useAccounts";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -36,15 +36,15 @@ export function Step4Review({
   onSubmit,
   isSubmitting,
 }: Step4Props) {
-  const { data: cards } = useCards();
+  const { data: accounts } = useAccounts();
 
   const accountNameMap = useMemo(() => {
     const map = new Map<string, string>();
-    for (const card of (cards as { id: string; name: string }[] | undefined) ?? []) {
-      map.set(card.id, card.name);
+    for (const account of accounts ?? []) {
+      map.set(account.id, account.name);
     }
     return map;
-  }, [cards]);
+  }, [accounts]);
 
   const subtotal = useMemo(
     () =>

--- a/src/client/src/test/mock-api.ts
+++ b/src/client/src/test/mock-api.ts
@@ -16,6 +16,7 @@ import type { components } from "@/generated/api";
 // ---------------------------------------------------------------------------
 // Type aliases for readability
 // ---------------------------------------------------------------------------
+type AccountResponse = components["schemas"]["AccountResponse"];
 type CardResponse = components["schemas"]["CardResponse"];
 type CategoryResponse = components["schemas"]["CategoryResponse"];
 type SubcategoryResponse = components["schemas"]["SubcategoryResponse"];
@@ -97,6 +98,18 @@ export function mockCardResponse(
     id: nextId(),
     cardCode: "CARD-001",
     name: "Test Card",
+    isActive: true,
+    ...overrides,
+  };
+}
+
+/** Creates a single `AccountResponse` with sensible defaults. */
+export function mockAccountResponse(
+  overrides?: Partial<AccountResponse>,
+): AccountResponse {
+  return {
+    id: nextId(),
+    name: "Test Account",
     isActive: true,
     ...overrides,
   };

--- a/tests/Application.Tests/Queries/Core/Card/GetCardsByAccountIdQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Core/Card/GetCardsByAccountIdQueryHandlerTests.cs
@@ -1,0 +1,41 @@
+using Application.Interfaces.Services;
+using Application.Queries.Core.Card;
+using FluentAssertions;
+using Moq;
+using SampleData.Domain.Core;
+
+namespace Application.Tests.Queries.Core.Card;
+
+public class GetCardsByAccountIdQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ShouldReturnCards_WhenAccountHasCards()
+	{
+		Guid accountId = Guid.NewGuid();
+		List<Domain.Core.Card> expected = CardGenerator.GenerateList(3);
+
+		Mock<ICardService> mockService = new();
+		mockService.Setup(s => s.GetByAccountIdAsync(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+
+		GetCardsByAccountIdQueryHandler handler = new(mockService.Object);
+		GetCardsByAccountIdQuery query = new(accountId);
+		List<Domain.Core.Card> result = await handler.Handle(query, CancellationToken.None);
+
+		result.Should().BeEquivalentTo(expected);
+	}
+
+	[Fact]
+	public async Task Handle_ShouldReturnEmptyList_WhenAccountHasNoCards()
+	{
+		Guid accountId = Guid.NewGuid();
+
+		Mock<ICardService> mockService = new();
+		mockService.Setup(s => s.GetByAccountIdAsync(accountId, It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+		GetCardsByAccountIdQueryHandler handler = new(mockService.Object);
+		GetCardsByAccountIdQuery query = new(accountId);
+		List<Domain.Core.Card> result = await handler.Handle(query, CancellationToken.None);
+
+		result.Should().BeEmpty();
+	}
+}

--- a/tests/Application.Tests/Queries/Core/Card/GetCardsByAccountIdQueryTests.cs
+++ b/tests/Application.Tests/Queries/Core/Card/GetCardsByAccountIdQueryTests.cs
@@ -1,0 +1,22 @@
+using Application.Queries.Core.Card;
+
+namespace Application.Tests.Queries.Core.Card;
+
+public class GetCardsByAccountIdQueryTests : IQueryTests
+{
+	[Fact]
+	public void Query_CanBeCreated()
+	{
+		Guid accountId = Guid.NewGuid();
+		GetCardsByAccountIdQuery query = new(accountId);
+		Assert.Equal(accountId, query.AccountId);
+	}
+
+	[Fact]
+	public void Query_WithEmptyAccountId_ThrowsArgumentException()
+	{
+		ArgumentException exception = Assert.Throws<ArgumentException>(() => new GetCardsByAccountIdQuery(Guid.Empty));
+		Assert.StartsWith(GetCardsByAccountIdQuery.AccountIdCannotBeEmptyExceptionMessage, exception.Message);
+		Assert.Equal("accountId", exception.ParamName);
+	}
+}

--- a/tests/Infrastructure.Tests/Repositories/CardRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Repositories/CardRepositoryTests.cs
@@ -314,4 +314,54 @@ public class CardRepositoryTests
 
 		_contextFactory.ResetDatabase();
 	}
+
+	[Fact]
+	public async Task GetByAccountIdAsync_ReturnsOnlyCardsForAccount()
+	{
+		// Arrange
+		using ApplicationDbContext context = _contextFactory.CreateDbContext();
+		AccountEntity parent = AccountEntityGenerator.Generate();
+		AccountEntity otherParent = AccountEntityGenerator.Generate();
+		await context.Accounts.AddRangeAsync(parent, otherParent);
+
+		CardEntity c1 = CardEntityGenerator.Generate();
+		c1.AccountId = parent.Id;
+		CardEntity c2 = CardEntityGenerator.Generate();
+		c2.AccountId = parent.Id;
+		CardEntity c3 = CardEntityGenerator.Generate();
+		c3.AccountId = otherParent.Id;
+		await context.Cards.AddRangeAsync(c1, c2, c3);
+		await context.SaveChangesAsync(CancellationToken.None);
+
+		CardRepository repository = new(_contextFactory);
+
+		// Act
+		List<CardEntity> result = await repository.GetByAccountIdAsync(parent.Id, CancellationToken.None);
+
+		// Assert
+		result.Should().HaveCount(2);
+		result.Select(c => c.Id).Should().BeEquivalentTo([c1.Id, c2.Id]);
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetByAccountIdAsync_ReturnsEmptyList_WhenAccountHasNoCards()
+	{
+		// Arrange
+		using ApplicationDbContext context = _contextFactory.CreateDbContext();
+		AccountEntity parent = AccountEntityGenerator.Generate();
+		await context.Accounts.AddAsync(parent);
+		await context.SaveChangesAsync(CancellationToken.None);
+
+		CardRepository repository = new(_contextFactory);
+
+		// Act
+		List<CardEntity> result = await repository.GetByAccountIdAsync(parent.Id, CancellationToken.None);
+
+		// Assert
+		result.Should().BeEmpty();
+
+		_contextFactory.ResetDatabase();
+	}
 }

--- a/tests/Infrastructure.Tests/Services/CardServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/CardServiceTests.cs
@@ -210,4 +210,35 @@ public class CardServiceTests
 		// Assert
 		Assert.Equal(expected, actual);
 	}
+
+	[Fact]
+	public async Task GetByAccountIdAsync_ReturnsMappedCards()
+	{
+		// Arrange
+		Guid accountId = Guid.NewGuid();
+		List<CardEntity> entities = CardEntityGenerator.GenerateList(2);
+		_mockRepository.Setup(r => r.GetByAccountIdAsync(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(entities);
+
+		// Act
+		List<Card> actual = await _service.GetByAccountIdAsync(accountId, CancellationToken.None);
+
+		// Assert
+		actual.Should().HaveCount(entities.Count);
+		actual.Select(c => c.Id).Should().BeEquivalentTo(entities.Select(e => e.Id));
+		_mockRepository.Verify(r => r.GetByAccountIdAsync(accountId, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetByAccountIdAsync_ReturnsEmptyList_WhenNoCards()
+	{
+		// Arrange
+		Guid accountId = Guid.NewGuid();
+		_mockRepository.Setup(r => r.GetByAccountIdAsync(accountId, It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+		// Act
+		List<Card> actual = await _service.GetByAccountIdAsync(accountId, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeEmpty();
+	}
 }

--- a/tests/Infrastructure.Tests/Services/DashboardServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/DashboardServiceTests.cs
@@ -399,4 +399,131 @@ public class DashboardServiceTests
 
 		contextFactory.ResetDatabase();
 	}
+
+	[Fact]
+	public async Task GetSpendingByAccountAsync_ResolvesNamesFromAccountsTable_NotCards()
+	{
+		// Regression test for RECEIPTS-546: the service used to resolve names by
+		// joining Transactions.AccountId against the Cards table. Transactions
+		// reference the logical Accounts table (RECEIPTS-543 Stage 2), and this
+		// join silently breaks once a card has been merged into another account
+		// and its 1:1 account row has been deleted.
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid receiptId = Guid.NewGuid();
+		Guid accountId = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Accounts.Add(new AccountEntity
+			{
+				Id = accountId,
+				Name = "Chase Sapphire",
+				IsActive = true,
+			});
+
+			context.Receipts.Add(new ReceiptEntity
+			{
+				Id = receiptId,
+				Location = "Costco",
+				Date = new DateOnly(2025, 5, 1),
+				TaxAmount = 0,
+			});
+
+			context.Transactions.Add(new TransactionEntity
+			{
+				Id = Guid.NewGuid(),
+				ReceiptId = receiptId,
+				AccountId = accountId,
+				Amount = 42.00m,
+				Date = new DateOnly(2025, 5, 1),
+			});
+
+			await context.SaveChangesAsync();
+		}
+
+		DashboardService service = new(contextFactory);
+
+		// Act
+		SpendingByAccountResult result = await service.GetSpendingByAccountAsync(
+			new DateOnly(2025, 5, 1),
+			new DateOnly(2025, 5, 31),
+			CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		result.Items[0].AccountId.Should().Be(accountId);
+		result.Items[0].AccountName.Should().Be("Chase Sapphire");
+		result.Items[0].Amount.Should().Be(42.00m);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByAccountAsync_MergedAccount_RollsUpTransactionsFromAllCards()
+	{
+		// Simulates the Stage 3 post-merge state: two Cards have been merged
+		// into a single Account, so all of their transactions reference the
+		// surviving account. The widget should show a single row.
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		Guid survivingAccountId = Guid.NewGuid();
+		Guid receiptId1 = Guid.NewGuid();
+		Guid receiptId2 = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Accounts.Add(new AccountEntity
+			{
+				Id = survivingAccountId,
+				Name = "Apple Card",
+				IsActive = true,
+			});
+
+			context.Receipts.AddRange(
+				new ReceiptEntity { Id = receiptId1, Location = "Store A", Date = new DateOnly(2025, 6, 1), TaxAmount = 0 },
+				new ReceiptEntity { Id = receiptId2, Location = "Store B", Date = new DateOnly(2025, 6, 2), TaxAmount = 0 });
+
+			context.Transactions.AddRange(
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId1, AccountId = survivingAccountId, Amount = 10.00m, Date = new DateOnly(2025, 6, 1) },
+				new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId2, AccountId = survivingAccountId, Amount = 20.00m, Date = new DateOnly(2025, 6, 2) });
+
+			await context.SaveChangesAsync();
+		}
+
+		DashboardService service = new(contextFactory);
+
+		// Act
+		SpendingByAccountResult result = await service.GetSpendingByAccountAsync(
+			new DateOnly(2025, 6, 1),
+			new DateOnly(2025, 6, 30),
+			CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		result.Items[0].AccountName.Should().Be("Apple Card");
+		result.Items[0].Amount.Should().Be(30.00m);
+		result.Items[0].Percentage.Should().Be(100m);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByAccountAsync_EmptyRange_ReturnsEmptyItems()
+	{
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+
+		DashboardService service = new(contextFactory);
+
+		// Act
+		SpendingByAccountResult result = await service.GetSpendingByAccountAsync(
+			new DateOnly(2025, 1, 1),
+			new DateOnly(2025, 1, 31),
+			CancellationToken.None);
+
+		// Assert
+		result.Items.Should().BeEmpty();
+
+		contextFactory.ResetDatabase();
+	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Core/AccountsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/AccountsControllerTests.cs
@@ -8,6 +8,7 @@ using Application.Commands.Account.Update;
 using Application.Interfaces.Services;
 using Application.Models;
 using Application.Queries.Core.Account;
+using Application.Queries.Core.Card;
 using Domain.Core;
 using FluentAssertions;
 using MediatR;
@@ -24,6 +25,7 @@ namespace Presentation.API.Tests.Controllers.Core;
 public class AccountsControllerTests
 {
 	private readonly AccountMapper _mapper;
+	private readonly CardMapper _cardMapper;
 	private readonly Mock<IMediator> _mediatorMock;
 	private readonly Mock<ILogger<AccountsController>> _loggerMock;
 	private readonly Mock<IEntityChangeNotifier> _notifierMock;
@@ -34,10 +36,11 @@ public class AccountsControllerTests
 	{
 		_mediatorMock = new Mock<IMediator>();
 		_mapper = new AccountMapper();
+		_cardMapper = new CardMapper();
 		_loggerMock = ControllerTestHelpers.GetLoggerMock<AccountsController>();
 		_notifierMock = new Mock<IEntityChangeNotifier>();
 		_accountServiceMock = new Mock<IAccountService>();
-		_controller = new AccountsController(_mediatorMock.Object, _mapper, _loggerMock.Object, _notifierMock.Object, _accountServiceMock.Object);
+		_controller = new AccountsController(_mediatorMock.Object, _mapper, _cardMapper, _loggerMock.Object, _notifierMock.Object, _accountServiceMock.Object);
 		_controller.ControllerContext = new ControllerContext
 		{
 			HttpContext = new DefaultHttpContext()
@@ -457,5 +460,76 @@ public class AccountsControllerTests
 
 		// Assert
 		await act.Should().ThrowAsync<Exception>();
+	}
+
+	[Fact]
+	public async Task GetCardsForAccount_ReturnsOk_WithCards_WhenAccountExists()
+	{
+		// Arrange
+		Guid accountId = Guid.NewGuid();
+		List<Card> cards = CardGenerator.GenerateList(3);
+
+		_accountServiceMock
+			.Setup(s => s.ExistsAsync(accountId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<GetCardsByAccountIdQuery>(q => q.AccountId == accountId),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(cards);
+
+		// Act
+		Results<Ok<List<CardResponse>>, NotFound> result = await _controller.GetCardsForAccount(accountId);
+
+		// Assert
+		Ok<List<CardResponse>> ok = Assert.IsType<Ok<List<CardResponse>>>(result.Result);
+		List<CardResponse> responses = Assert.IsType<List<CardResponse>>(ok.Value);
+		responses.Should().HaveCount(3);
+		responses.Select(r => r.Id).Should().BeEquivalentTo(cards.Select(c => c.Id));
+	}
+
+	[Fact]
+	public async Task GetCardsForAccount_ReturnsNotFound_WhenAccountDoesNotExist()
+	{
+		// Arrange
+		Guid missingId = Guid.NewGuid();
+
+		_accountServiceMock
+			.Setup(s => s.ExistsAsync(missingId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		// Act
+		Results<Ok<List<CardResponse>>, NotFound> result = await _controller.GetCardsForAccount(missingId);
+
+		// Assert
+		Assert.IsType<NotFound>(result.Result);
+		_mediatorMock.Verify(
+			m => m.Send(It.IsAny<GetCardsByAccountIdQuery>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task GetCardsForAccount_ReturnsEmptyList_WhenAccountHasNoCards()
+	{
+		// Arrange
+		Guid accountId = Guid.NewGuid();
+
+		_accountServiceMock
+			.Setup(s => s.ExistsAsync(accountId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<GetCardsByAccountIdQuery>(q => q.AccountId == accountId),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+
+		// Act
+		Results<Ok<List<CardResponse>>, NotFound> result = await _controller.GetCardsForAccount(accountId);
+
+		// Assert
+		Ok<List<CardResponse>> ok = Assert.IsType<Ok<List<CardResponse>>>(result.Result);
+		ok.Value.Should().BeEmpty();
 	}
 }


### PR DESCRIPTION
## Summary

Stage 4 of RECEIPTS-543. Flips the UX so the logical `Account` (the aggregate above physical `Card`s introduced in Stage 2) is what users pick, see, and search for by default.

- **Wizard & receipt entry**: Step 2, `TransactionsSection`, `ReceiptTransactionForm`, and `Step4Review` now source the "Account" dropdown from `useAccounts` instead of `useCards`. Fixes a latent bug where picking a card that had been merged would write `Transaction.AccountId = Card.Id` and violate the FK (which, as of Stage 2, points at `Accounts`). YnabSettings mapping UI switched for the same reason.
- **New `/accounts` page**: server-paginated CRUD list with per-row expand that lazy-loads the physical Cards under each logical Account via a new `GET /api/accounts/{id}/cards` endpoint. Adds `AccountForm`, Accounts to the Manage nav group, and a first-class Accounts section to the Ctrl/⌘-K palette (Cards remain searchable, shown after Accounts).
- **Dashboard fix**: `DashboardService.GetSpendingByAccountAsync` was resolving names from the Cards table — coincidentally correct because of the 1:1 seed but broken once Cards get merged and their source Account rows are deleted. Now joins `Accounts`.

Audit-log entity-type filter already included both `Account` and `Card` via `EnumLabels.EntityTypes`, so no change was required there. Accepts Stage 4's acceptance criteria.

Resolves RECEIPTS-546.

## Test plan

- [x] `dotnet test Receipts.slnx --filter "Category!=Integration&FullyQualifiedName!~BackupImportService"` — all 2203 tests pass. (7 `BackupImportServiceTests` currently fail on Windows with `IOException … used by another process`; they also fail on pristine `origin/develop` and are unrelated to this change.)
- [x] `(cd src/client && npx vitest run)` — 1782 frontend tests pass.
- [x] `npx tsc -b tsconfig.json --noEmit` and `npx eslint src` clean (only 2 pre-existing warnings).
- [x] `Jwt__Key=… dotnet build Receipts.slnx -p:TreatWarningsAsErrors=true --no-restore` clean.
- [x] `node scripts/check-drift.mjs` — no drift between `openapi/spec.yaml` and generated DTOs.
- [ ] Manual smoke:
  - [ ] Wizard → Step 2 → "Account" dropdown lists logical Accounts; submit wizard saves a receipt bound to the logical Account.
  - [ ] `/accounts` list renders; expand a row shows the Cards under it; create / edit / delete flows work; delete with cards returns the 409 cardCount toast.
  - [ ] Ctrl/⌘-K shows an "Accounts" group above "Cards".
  - [ ] `/audit` Entity Type dropdown includes Account and Card.
  - [ ] Dashboard "Spending by Account" rolls up merged Cards correctly.