### PR TITLE
fix(api): pass HttpContext.RequestAborted to mediator.Send in AccountsController (RECEIPTS-549)

### DIFF
--- a/src/Presentation/API/Controllers/Core/AccountsController.cs
+++ b/src/Presentation/API/Controllers/Core/AccountsController.cs
@@ -39,7 +39,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, CardMa
 	public async Task<Results<Ok<AccountResponse>, NotFound>> GetAccountById([FromRoute] Guid id)
 	{
 		GetAccountByIdQuery query = new(id);
-		Account? result = await mediator.Send(query);
+		Account? result = await mediator.Send(query, HttpContext.RequestAborted);
 
 		if (result == null)
 		{
@@ -77,7 +77,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, CardMa
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetAllAccountsQuery query = new(offset, limit, sort, isActive);
-		PagedResult<Account> result = await mediator.Send(query);
+		PagedResult<Account> result = await mediator.Send(query, HttpContext.RequestAborted);
 
 		return TypedResults.Ok(new AccountListResponse
 		{
@@ -100,7 +100,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, CardMa
 		}
 
 		GetCardsByAccountIdQuery query = new(id);
-		List<Card> cards = await mediator.Send(query);
+		List<Card> cards = await mediator.Send(query, HttpContext.RequestAborted);
 		return TypedResults.Ok(cards.Select(cardMapper.ToResponse).ToList());
 	}
 
@@ -109,7 +109,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, CardMa
 	public async Task<Ok<AccountResponse>> CreateAccount([FromBody] CreateAccountRequest model)
 	{
 		CreateAccountCommand command = new([mapper.ToDomain(model)]);
-		List<Account> accounts = await mediator.Send(command);
+		List<Account> accounts = await mediator.Send(command, HttpContext.RequestAborted);
 		await notifier.NotifyCreated("account", accounts[0].Id);
 		return TypedResults.Ok(mapper.ToResponse(accounts[0]));
 	}
@@ -119,7 +119,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, CardMa
 	public async Task<Ok<List<AccountResponse>>> CreateAccounts([FromBody] List<CreateAccountRequest> models)
 	{
 		CreateAccountCommand command = new([.. models.Select(mapper.ToDomain)]);
-		List<Account> accounts = await mediator.Send(command);
+		List<Account> accounts = await mediator.Send(command, HttpContext.RequestAborted);
 		await notifier.NotifyBulkChanged("account", "created", accounts.Select(a => a.Id));
 		return TypedResults.Ok(accounts.Select(mapper.ToResponse).ToList());
 	}
@@ -129,7 +129,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, CardMa
 	public async Task<Results<NoContent, NotFound>> UpdateAccount([FromRoute] Guid id, [FromBody] UpdateAccountRequest model)
 	{
 		UpdateAccountCommand command = new([mapper.ToDomain(model)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, HttpContext.RequestAborted);
 
 		if (!result)
 		{
@@ -146,7 +146,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, CardMa
 	public async Task<Results<NoContent, NotFound>> UpdateAccounts([FromBody] List<UpdateAccountRequest> models)
 	{
 		UpdateAccountCommand command = new([.. models.Select(mapper.ToDomain)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, HttpContext.RequestAborted);
 
 		if (!result)
 		{
@@ -172,7 +172,7 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, CardMa
 		}
 
 		DeleteAccountCommand command = new(id);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, HttpContext.RequestAborted);
 
 		if (!result)
 		{


### PR DESCRIPTION
## Summary

- Every `mediator.Send(...)` call in [`AccountsController`](src/Presentation/API/Controllers/Core/AccountsController.cs) was omitting the cancellation token, while the surrounding service calls correctly passed `HttpContext.RequestAborted`. Client disconnects mid-request would keep the MediatR handler chain running until it eventually blocked on some token-aware I/O operation downstream.
- Adds `HttpContext.RequestAborted` to all 8 `mediator.Send` calls (including `GetCardsForAccount` added in RECEIPTS-546, which was the bug-finder's original example).
- Minimum-diff fix — matches the existing pattern already used for `accountService.GetCardCountByAccountIdAsync(id, HttpContext.RequestAborted)` in the same controller.

Resolves RECEIPTS-549

## Test plan

- [x] `dotnet build src/Presentation/API/API.csproj` — clean build.
- [x] `dotnet test tests/Presentation.API.Tests/Presentation.API.Tests.csproj --filter "FullyQualifiedName~AccountsControllerTests"` — 28/28 pass (existing Moq setups use `It.IsAny<CancellationToken>()` so no test changes needed).
- [x] Full `Presentation.API.Tests` suite — 893/893 pass.
- [x] Pre-commit hook (quick mode) — format, migrations, TypeScript, ESLint all pass. (Full-mode `.NET` tests skipped locally due to pre-existing Windows-only flake in `BackupImportServiceTests` — SQLite file-lock race. Will file a separate issue; CI runs on Ubuntu and is unaffected.)

## Follow-ups

Controller-wide audit — grep shows ~14 other controllers have the same omission pattern (`AdjustmentsController`, `CategoriesController`, `ItemTemplatesController`, `ReceiptImageController`, `ReceiptScanController`, `SubcategoriesController`, `ReceiptItemsController`, `TrashController`, `ReceiptsController`, `TransactionsController`, `ReceiptWithItemsController`, `TripController`, `TransactionAccountController`). Already-good: `DashboardController`, `YnabController`, `ReportsController` (use `CancellationToken` parameter). Follow-up Plane issue will be filed to fix these in a batch.