### PR TITLE
fix(infra): add OrderBy before Skip/Take in EF queries (RECEIPTS-552)

### DIFF
--- a/src/Infrastructure/Repositories/ReceiptItemRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptItemRepository.cs
@@ -213,6 +213,7 @@ public class ReceiptItemRepository(IDbContextFactory<ApplicationDbContext> conte
 				.Where(ri => ri.Receipt != null && ri.Receipt.Location.ToLower() == lowerLocation)
 				.Where(ri => ri.ReceiptItemCode!.ToLower().Contains(lowerItemCode))
 				.GroupBy(ri => ri.ReceiptItemCode!.ToLower())
+				.OrderByDescending(g => g.Count())
 				.Select(g => new ReceiptItemSuggestion
 				{
 					ItemCode = g.OrderByDescending(ri => ri.Id).First().ReceiptItemCode!,
@@ -237,6 +238,7 @@ public class ReceiptItemRepository(IDbContextFactory<ApplicationDbContext> conte
 			.Where(ri => ri.ReceiptItemCode != null && ri.ReceiptItemCode != "")
 			.Where(ri => ri.ReceiptItemCode!.ToLower().Contains(lowerItemCode))
 			.GroupBy(ri => ri.ReceiptItemCode!.ToLower())
+			.OrderByDescending(g => g.Count())
 			.Select(g => new ReceiptItemSuggestion
 			{
 				ItemCode = g.OrderByDescending(ri => ri.Id).First().ReceiptItemCode!,

--- a/src/Infrastructure/Services/EmbeddingGenerationService.cs
+++ b/src/Infrastructure/Services/EmbeddingGenerationService.cs
@@ -132,6 +132,7 @@ public class EmbeddingGenerationService(
 				x => x.Embeddings.DefaultIfEmpty(),
 				(x, e) => new { x.Template, Embedding = e })
 			.Where(x => x.Embedding == null || x.Embedding.EntityText != x.Template.Name)
+			.OrderBy(x => x.Template.Id)
 			.Select(x => new PendingItem("ItemTemplate", x.Template.Id, x.Template.Name))
 			.Take(BatchSize)
 			.ToListAsync(cancellationToken);
@@ -155,6 +156,7 @@ public class EmbeddingGenerationService(
 				x => x.Embeddings.DefaultIfEmpty(),
 				(x, e) => new { x.ReceiptItem, Embedding = e })
 			.Where(x => x.Embedding == null || x.Embedding.EntityText != x.ReceiptItem.Description)
+			.OrderBy(x => x.ReceiptItem.Id)
 			.Select(x => new PendingItem("ReceiptItem", x.ReceiptItem.Id, x.ReceiptItem.Description))
 			.Take(remaining)
 			.ToListAsync(cancellationToken);


### PR DESCRIPTION
## Summary

- Four EF Core queries used `Skip`/`Take` without an `OrderBy`, producing nondeterministic row selection and triggering the EF Core `RowLimitingOperationWithoutOrderByWarning`.
- `EmbeddingGenerationService`: order pending `ItemTemplate` / `ReceiptItem` batches by `Id` so embedding generation processes records in a stable order across runs.
- `ReceiptItemRepository.GetSuggestionsAsync`: order suggestion groups by occurrence count descending so the most-frequently-seen variants of a partial item code surface first to users.

Resolves RECEIPTS-552.

## Test plan

- [x] `dotnet build Receipts.slnx` clean (no new warnings).
- [x] `dotnet test --filter "Category!=Integration"` — only failures are the pre-existing `BackupImportServiceTests` SQLite Windows file-lock flakes (RECEIPTS-551), unrelated to this diff.
- [ ] Run the app, exercise embedding generation and receipt-item suggestions; confirm no `row limiting operator without OrderBy` warnings appear in the log.

## Notes

- Pre-commit hook was run in `PRECOMMIT_QUICK=1` mode to bypass the RECEIPTS-551 flake. All other checks (format, EF migration integrity, TypeScript, ESLint) passed. CI runs the full unit suite and may show the same flake.
- Out-of-scope `Skip`/`Take` audit results (already safe — no changes needed) are documented in the issue description.