### PR TITLE
fix(infrastructure): disable SQLite pooling in BackupImportService tests (RECEIPTS-551)

### DIFF
--- a/tests/Infrastructure.Tests/Services/BackupImportServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/BackupImportServiceTests.cs
@@ -248,7 +248,7 @@ public class BackupImportServiceTests : IDisposable
 	private string CreateEmptySqliteDatabase()
 	{
 		string path = Path.Combine(_tempDir, $"{Guid.NewGuid():N}.sqlite");
-		using SqliteConnection conn = new($"Data Source={path}");
+		using SqliteConnection conn = new($"Data Source={path};Pooling=False");
 		conn.Open();
 		// Force SQLite to write the file header by creating and dropping a dummy table
 		using SqliteCommand cmd = conn.CreateCommand();
@@ -260,7 +260,7 @@ public class BackupImportServiceTests : IDisposable
 	private string CreateSqliteDatabaseWithAccounts(params (Guid Id, string CardCode, string Name, bool IsActive)[] accounts)
 	{
 		string path = Path.Combine(_tempDir, $"{Guid.NewGuid():N}.sqlite");
-		using SqliteConnection conn = new($"Data Source={path}");
+		using SqliteConnection conn = new($"Data Source={path};Pooling=False");
 		conn.Open();
 
 		using SqliteCommand createCmd = conn.CreateCommand();
@@ -290,7 +290,7 @@ public class BackupImportServiceTests : IDisposable
 	private string CreateSqliteDatabaseWithCategories(params (Guid Id, string Name, string? Description, bool IsActive)[] categories)
 	{
 		string path = Path.Combine(_tempDir, $"{Guid.NewGuid():N}.sqlite");
-		using SqliteConnection conn = new($"Data Source={path}");
+		using SqliteConnection conn = new($"Data Source={path};Pooling=False");
 		conn.Open();
 
 		using SqliteCommand createCmd = conn.CreateCommand();
@@ -320,7 +320,7 @@ public class BackupImportServiceTests : IDisposable
 	private string CreateSqliteDatabaseWithReceipts(params (Guid Id, string Location, string Date, decimal TaxAmount, string TaxAmountCurrency)[] receipts)
 	{
 		string path = Path.Combine(_tempDir, $"{Guid.NewGuid():N}.sqlite");
-		using SqliteConnection conn = new($"Data Source={path}");
+		using SqliteConnection conn = new($"Data Source={path};Pooling=False");
 		conn.Open();
 
 		using SqliteCommand createCmd = conn.CreateCommand();


### PR DESCRIPTION
## Summary

- On Windows, `BackupImportServiceTests` failed 7/8 with `System.IO.IOException : ... file ... being used by another process.` because Microsoft.Data.Sqlite's default connection pooling kept the file handle alive past `using`-block `Dispose()`, racing the subsequent `File.OpenRead(sqlitePath)`.
- Added `;Pooling=False` to the four test helper connection strings (`CreateEmptySqliteDatabase`, `CreateSqliteDatabaseWithAccounts`, `CreateSqliteDatabaseWithCategories`, `CreateSqliteDatabaseWithReceipts`) so `Dispose()` fully releases the handle before the test re-opens the file.
- No production code changes. Preferred over `ClearAllPools()` (process-wide hammer), `DisableParallelization` (masks root cause; each test already uses unique GUIDs for its DB + temp dir), and retry-with-backoff (papers over the race).

Resolves RECEIPTS-551

## Test plan

- [x] `dotnet test tests/Infrastructure.Tests/Infrastructure.Tests.csproj --filter "FullyQualifiedName~BackupImportServiceTests"` — 8/8 pass on Windows
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2211/2211 pass, no regressions
- [x] Pre-commit hook (full mode, without `PRECOMMIT_QUICK=1`) passes