### PR TITLE
fix(infrastructure): disable SQLite pooling in BackupImportService (RECEIPTS-560)

### DIFF
--- a/src/Infrastructure/Services/BackupImportService.cs
+++ b/src/Infrastructure/Services/BackupImportService.cs
@@ -61,7 +61,7 @@ public class BackupImportService(
 
 		try
 		{
-			await using SqliteConnection sqlite = new($"Data Source={sqlitePath};Mode=ReadOnly");
+			await using SqliteConnection sqlite = new($"Data Source={sqlitePath};Mode=ReadOnly;Pooling=False");
 			await sqlite.OpenAsync(cancellationToken);
 
 			int exportVersion = ReadExportVersion(sqlite);


### PR DESCRIPTION
## Summary

- Symmetric follow-up to [#419](https://github.com/mggarofalo/receipts/pull/419) (RECEIPTS-551). `BackupImportService.ImportFromFileAsync` opened the incoming temp SQLite file with a pooled connection, so Microsoft.Data.Sqlite kept the native file handle alive past `DisposeAsync()`. On Windows the `finally` block's `File.Delete(tempPath)` then threw `IOException` (silently swallowed), leaking one `Path.GetTempFileName()` file per import.
- Added `;Pooling=False` to the read-only connection string at [BackupImportService.cs:64](src/Infrastructure/Services/BackupImportService.cs:64). Single-line change.

Resolves RECEIPTS-560

## Test plan

- [x] `dotnet test tests/Infrastructure.Tests/Infrastructure.Tests.csproj --filter "FullyQualifiedName~BackupImportServiceTests"` — 8/8 pass
- [x] Pre-commit hook (full unit suite, 1782 frontend + 2211 backend tests) passes
- [x] No user-facing behavior change (same read-only SQLite access pattern; tests untouched)