### PR TITLE
fix(client): default category trends report to 1M date range

### DIFF
--- a/src/client/src/components/reports/CategoryTrends.test.tsx
+++ b/src/client/src/components/reports/CategoryTrends.test.tsx
@@ -1,0 +1,153 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "@/test/test-utils";
+import CategoryTrends from "./CategoryTrends";
+
+vi.mock("@/hooks/useCategoryTrendsReport", () => ({
+  useCategoryTrendsReport: vi.fn(),
+}));
+
+vi.mock("@/components/dashboard/DateRangeSelector", () => ({
+  DateRangeSelector: ({
+    onChange,
+  }: {
+    value: { startDate?: string; endDate?: string };
+    onChange: (range: { startDate?: string; endDate?: string }) => void;
+  }) => (
+    <button
+      data-testid="date-range-selector"
+      onClick={() =>
+        onChange({ startDate: "2020-01-01", endDate: "2024-12-31" })
+      }
+    >
+      DateRangeSelector
+    </button>
+  ),
+}));
+
+vi.mock("@/components/charts", () => ({
+  ChartCard: ({
+    children,
+    title,
+    action,
+  }: {
+    children: React.ReactNode;
+    title: string;
+    action?: React.ReactNode;
+  }) => (
+    <div data-testid="chart-card">
+      <h3>{title}</h3>
+      <div data-testid="chart-card-action">{action}</div>
+      {children}
+    </div>
+  ),
+  StackedAreaChart: () => <div data-testid="stacked-area-chart" />,
+}));
+
+import { useCategoryTrendsReport } from "@/hooks/useCategoryTrendsReport";
+const mockHook = vi.mocked(useCategoryTrendsReport);
+
+function setupMock(overrides: Record<string, unknown> = {}) {
+  mockHook.mockReturnValue({
+    data: {
+      categories: ["Groceries", "Dining"],
+      buckets: [
+        { period: "2025-01", amounts: [100, 50] },
+        { period: "2025-02", amounts: [120, 75] },
+      ],
+    },
+    isLoading: false,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+describe("CategoryTrends", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes with a 1-month default date range (regression guard for RECEIPTS-558)", () => {
+    setupMock();
+    renderWithQueryClient(<CategoryTrends />);
+
+    const params = mockHook.mock.calls[0]?.[0];
+    expect(params?.startDate).toBeTypeOf("string");
+    expect(params?.endDate).toBeTypeOf("string");
+    expect(params?.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(params?.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("derives daily granularity from the 1-month default range", () => {
+    setupMock();
+    renderWithQueryClient(<CategoryTrends />);
+
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({ granularity: "daily" }),
+    );
+  });
+
+  it("defaults topN to 5", () => {
+    setupMock();
+    renderWithQueryClient(<CategoryTrends />);
+
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({ topN: 5 }),
+    );
+  });
+
+  it("renders the stacked area chart with data", () => {
+    setupMock();
+    renderWithQueryClient(<CategoryTrends />);
+
+    expect(screen.getByTestId("stacked-area-chart")).toBeInTheDocument();
+    expect(screen.getByText("Category Trends")).toBeInTheDocument();
+  });
+
+  it("updates the hook when the date range changes", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<CategoryTrends />);
+
+    await user.click(screen.getByTestId("date-range-selector"));
+
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startDate: "2020-01-01",
+        endDate: "2024-12-31",
+      }),
+    );
+  });
+
+  it("resets granularity override when date range changes", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<CategoryTrends />);
+
+    await user.click(screen.getByRole("button", { name: "Month" }));
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({ granularity: "monthly" }),
+    );
+
+    await user.click(screen.getByTestId("date-range-selector"));
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startDate: "2020-01-01",
+        endDate: "2024-12-31",
+        granularity: "yearly",
+      }),
+    );
+  });
+
+  it("applies granularity override when a granularity button is clicked", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<CategoryTrends />);
+
+    await user.click(screen.getByRole("button", { name: "Quarter" }));
+
+    expect(mockHook).toHaveBeenLastCalledWith(
+      expect.objectContaining({ granularity: "quarterly" }),
+    );
+  });
+});

--- a/src/client/src/components/reports/CategoryTrends.tsx
+++ b/src/client/src/components/reports/CategoryTrends.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
-import { differenceInDays, parseISO } from "date-fns";
+import { differenceInDays, format, parseISO, subMonths } from "date-fns";
 import { ChartCard, StackedAreaChart } from "@/components/charts";
 import { DateRangeSelector } from "@/components/dashboard/DateRangeSelector";
 import type { DateRange } from "@/hooks/useDashboard";
@@ -14,6 +14,14 @@ import {
 } from "@/components/ui/select";
 
 type Granularity = "daily" | "monthly" | "quarterly" | "yearly";
+
+function getDefaultRange(): DateRange {
+  const now = new Date();
+  return {
+    startDate: format(subMonths(now, 1), "yyyy-MM-dd"),
+    endDate: format(now, "yyyy-MM-dd"),
+  };
+}
 
 const granularityOptions: { value: Granularity; label: string }[] = [
   { value: "daily", label: "Day" },
@@ -47,10 +55,7 @@ function formatCompactCurrency(value: number): string {
 }
 
 export default function CategoryTrends() {
-  const [dateRange, setDateRange] = useState<DateRange>(() => ({
-    startDate: undefined,
-    endDate: undefined,
-  }));
+  const [dateRange, setDateRange] = useState<DateRange>(getDefaultRange);
   const [granularityOverride, setGranularityOverride] =
     useState<Granularity | null>(null);
   const [topN, setTopN] = useState(5);


### PR DESCRIPTION
## Summary
- The Category Trends report's \`DateRangeSelector\` showed **1M** as the active preset on mount, but the parent \`dateRange\` state was initialized to \`{ undefined, undefined }\`. The API was called without date filters, so the graph rendered a full century of years on the X-axis despite the 1M button being highlighted.
- Seed \`dateRange\` via \`getDefaultRange()\` returning the last 30 days, mirroring the pattern already used in \`Dashboard.tsx\` and \`SpendingByLocation.tsx\`.
- Add a new \`CategoryTrends.test.tsx\` suite including a regression guard that asserts the hook is called with defined \`startDate\`/\`endDate\` on mount.

Resolves RECEIPTS-558

## Follow-up
\`ItemCostOverTime.tsx\` has the same latent bug (also initializes \`dateRange\` to \`undefined\`), but the chart is gated on \`selectedItem\` so the century-of-years symptom isn't visible until a user picks an item. Not bundled here to keep the fix scoped — worth filing a follow-up issue.

## Test plan
- [x] \`npm test -- CategoryTrends --run\` — 7 new tests pass
- [x] \`npm run lint\` — no new warnings
- [x] Pre-commit hook full suite — passes
- [ ] Manual: open Reports → Category Trends; confirm the X-axis shows ~30 days of daily buckets instead of a century; click 3M/1Y/5Y and verify the axis updates; click "All" to confirm full-history still works