### PR TITLE
fix(api): accept camelCase matchOn in duplicates report

### DIFF
--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -308,14 +308,14 @@ public class ReportsController(IMediator mediator) : ControllerBase
 		[FromQuery] double? totalTolerance,
 		CancellationToken cancellationToken)
 	{
-		string match = matchOn ?? "DateAndLocation";
+		string match = matchOn ?? "dateAndLocation";
 		string locTol = locationTolerance ?? "exact";
 		decimal totTol = (decimal)(totalTolerance ?? 0);
 
-		string[] validMatchOn = ["DateAndLocation", "DateAndTotal", "DateAndLocationAndTotal"];
-		if (!validMatchOn.Contains(match))
+		string[] validMatchOn = ["dateAndLocation", "dateAndTotal", "dateAndLocationAndTotal"];
+		if (!validMatchOn.Contains(match, StringComparer.OrdinalIgnoreCase))
 		{
-			return TypedResults.BadRequest($"Invalid matchOn '{match}'. Allowed: DateAndLocation, DateAndTotal, DateAndLocationAndTotal");
+			return TypedResults.BadRequest($"Invalid matchOn '{match}'. Allowed: dateAndLocation, dateAndTotal, dateAndLocationAndTotal");
 		}
 
 		string[] validLocTolerance = ["exact", "normalized"];

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
@@ -546,4 +546,178 @@ public class ReportsControllerTests
 				q.StartDate == start && q.EndDate == end && q.Granularity == "quarterly" && q.TopN == 5),
 			It.IsAny<CancellationToken>()), Times.Once);
 	}
+
+	// ── GetDuplicates ──────────────────────────────
+
+	[Fact]
+	public async Task GetDuplicates_ReturnsOkResult_WithDefaultParameters()
+	{
+		// Arrange
+		AppReports.DuplicateDetectionResult reportResult = new([], 0, 0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDuplicateDetectionReportQuery>(q =>
+				q.MatchOn == "dateAndLocation" && q.LocationTolerance == "exact" && q.TotalTolerance == 0m),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<DuplicatesResponse>, BadRequest<string>> result =
+			await _controller.GetDuplicates(null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<DuplicatesResponse> okResult = Assert.IsType<Ok<DuplicatesResponse>>(result.Result);
+		okResult.Value!.GroupCount.Should().Be(0);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetDuplicateDetectionReportQuery>(q =>
+				q.MatchOn == "dateAndLocation" && q.LocationTolerance == "exact" && q.TotalTolerance == 0m),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Theory]
+	[InlineData("dateAndLocation")]
+	[InlineData("dateAndTotal")]
+	[InlineData("dateAndLocationAndTotal")]
+	public async Task GetDuplicates_AcceptsValidMatchOnValues(string matchOn)
+	{
+		// Arrange
+		AppReports.DuplicateDetectionResult reportResult = new([], 0, 0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetDuplicateDetectionReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<DuplicatesResponse>, BadRequest<string>> result =
+			await _controller.GetDuplicates(matchOn, null, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<DuplicatesResponse>>(result.Result);
+	}
+
+	[Theory]
+	[InlineData("DateAndLocation")]
+	[InlineData("DATEANDLOCATION")]
+	[InlineData("DateAndTotal")]
+	[InlineData("DateAndLocationAndTotal")]
+	public async Task GetDuplicates_AcceptsMatchOnCaseInsensitively(string matchOn)
+	{
+		// Arrange
+		AppReports.DuplicateDetectionResult reportResult = new([], 0, 0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetDuplicateDetectionReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<DuplicatesResponse>, BadRequest<string>> result =
+			await _controller.GetDuplicates(matchOn, null, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<DuplicatesResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetDuplicates_ReturnsBadRequest_WhenInvalidMatchOn()
+	{
+		// Act
+		Results<Ok<DuplicatesResponse>, BadRequest<string>> result =
+			await _controller.GetDuplicates("bogus", null, null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid matchOn");
+		badResult.Value.Should().Contain("dateAndLocation");
+	}
+
+	[Fact]
+	public async Task GetDuplicates_ReturnsBadRequest_WhenInvalidLocationTolerance()
+	{
+		// Act
+		Results<Ok<DuplicatesResponse>, BadRequest<string>> result =
+			await _controller.GetDuplicates(null, "fuzzy", null, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("Invalid locationTolerance");
+	}
+
+	[Fact]
+	public async Task GetDuplicates_ReturnsBadRequest_WhenNegativeTotalTolerance()
+	{
+		// Act
+		Results<Ok<DuplicatesResponse>, BadRequest<string>> result =
+			await _controller.GetDuplicates(null, null, -0.01, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Be("totalTolerance must be >= 0");
+	}
+
+	[Fact]
+	public async Task GetDuplicates_PassesCustomParameters()
+	{
+		// Arrange
+		AppReports.DuplicateDetectionResult reportResult = new([], 0, 0);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetDuplicateDetectionReportQuery>(q =>
+				q.MatchOn == "dateAndLocationAndTotal" && q.LocationTolerance == "normalized" && q.TotalTolerance == 0.05m),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<DuplicatesResponse>, BadRequest<string>> result =
+			await _controller.GetDuplicates("dateAndLocationAndTotal", "normalized", 0.05, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<DuplicatesResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetDuplicateDetectionReportQuery>(q =>
+				q.MatchOn == "dateAndLocationAndTotal" && q.LocationTolerance == "normalized" && q.TotalTolerance == 0.05m),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetDuplicates_MapsResponseFieldsCorrectly()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		DateOnly date = new(2025, 7, 4);
+
+		AppReports.DuplicateDetectionResult reportResult = new(
+		[
+			new AppReports.DuplicateGroup(
+				"2025-07-04|Test Store",
+				[new AppReports.DuplicateReceiptSummary(receiptId, "Test Store", date, 42.99m)]),
+		], 1, 1);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetDuplicateDetectionReportQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<DuplicatesResponse>, BadRequest<string>> result =
+			await _controller.GetDuplicates(null, null, null, CancellationToken.None);
+
+		// Assert
+		Ok<DuplicatesResponse> okResult = Assert.IsType<Ok<DuplicatesResponse>>(result.Result);
+		DuplicatesResponse response = okResult.Value!;
+		response.GroupCount.Should().Be(1);
+		response.TotalDuplicateReceipts.Should().Be(1);
+		response.Groups.Should().ContainSingle();
+
+		DuplicateGroup group = response.Groups.First();
+		group.MatchKey.Should().Be("2025-07-04|Test Store");
+		group.Receipts.Should().ContainSingle();
+
+		DuplicateReceipt receipt = group.Receipts.First();
+		receipt.ReceiptId.Should().Be(receiptId);
+		receipt.Location.Should().Be("Test Store");
+		receipt.Date.Should().Be(date);
+		receipt.TransactionTotal.Should().Be(42.99);
+	}
 }


### PR DESCRIPTION
## Summary

The Duplicate Detection report page fails with `400 Bad Request`:
> Invalid matchOn 'dateAndLocation'. Allowed: DateAndLocation, DateAndTotal, DateAndLocationAndTotal

The OpenAPI spec declares `matchOn` as camelCase and the generated TS client sends camelCase, but the controller validated case-sensitively against a PascalCase allowlist, rejecting every spec-conformant request. The downstream `ReportService.GetDuplicatesAsync` already lowercases the value — only the controller gate was out of step.

- Align controller default + allowlist with the OpenAPI spec (camelCase)
- Use `StringComparer.OrdinalIgnoreCase` so any legacy PascalCase callers continue to work
- Add 13 tests for `GetDuplicates` (endpoint previously had zero coverage)

**Class-of-bug audit**: every other enum-style query parameter across `DashboardController` and `ReportsController` already normalizes case. `GetDuplicates.matchOn` was the sole offender.

Resolves RECEIPTS-559

## Test plan

- [x] `dotnet test tests/Presentation.API.Tests/Presentation.API.Tests.csproj --filter "FullyQualifiedName~GetDuplicates"` — 13 tests pass
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — full suite passes
- [x] Pre-commit hooks pass (format, build, drift, .NET tests, frontend tests)
- [ ] Aspire dev server → `/reports/duplicates` → toggle each of the three "Match On" values → each returns data without 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)