### PR TITLE
fix(infra): don't dispose borrowed DbContext connection in item-similarity (RECEIPTS-556)

### DIFF
--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -179,14 +179,16 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 
 		List<DescriptionSimilarityEdge> edges = [];
 
-		await using (NpgsqlConnection connection = (NpgsqlConnection)context.Database.GetDbConnection())
+		// The connection returned by GetDbConnection() is owned by the DbContext — do not dispose it.
+		// EF still needs this connection for the ReceiptItems query later in this method.
+		NpgsqlConnection connection = (NpgsqlConnection)context.Database.GetDbConnection();
+		await context.Database.OpenConnectionAsync(cancellationToken);
+
+		await using NpgsqlCommand command = new(sql, connection);
+		command.Parameters.AddWithValue("@threshold", threshold);
+
+		await using (NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken))
 		{
-			await connection.OpenAsync(cancellationToken);
-
-			await using NpgsqlCommand command = new(sql, connection);
-			command.Parameters.AddWithValue("@threshold", threshold);
-
-			await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
 			while (await reader.ReadAsync(cancellationToken))
 			{
 				edges.Add(new DescriptionSimilarityEdge(

--- a/tests/Infrastructure.IntegrationTests/Services/ReportServiceItemSimilarityTests.cs
+++ b/tests/Infrastructure.IntegrationTests/Services/ReportServiceItemSimilarityTests.cs
@@ -1,0 +1,116 @@
+using Application.Models.Reports;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests.Services;
+
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class ReportServiceItemSimilarityTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task GetItemSimilarityAsync_ReturnsClusters_WithoutDisposingBorrowedConnection()
+	{
+		// Regression test for RECEIPTS-556: before the fix, this threw
+		// ObjectDisposedException on the ReceiptItems follow-up query because the
+		// raw-SQL block disposed the DbContext's borrowed NpgsqlConnection.
+
+		// Arrange
+		await ResetItemTablesAsync();
+
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		List<ReceiptItemEntity> items =
+		[
+			WithDescription(receipt.Id, "COCA COLA"),
+			WithDescription(receipt.Id, "COCA-COLA"),
+			WithDescription(receipt.Id, "COCACOLA"),
+			WithDescription(receipt.Id, "MILK GALLON"),
+		];
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.Receipts.Add(receipt);
+			setup.ReceiptItems.AddRange(items);
+			await setup.SaveChangesAsync();
+		}
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		// Act
+		ItemSimilarityResult result = await service.GetItemSimilarityAsync(
+			threshold: 0.4,
+			sortBy: "occurrences",
+			sortDirection: "desc",
+			page: 1,
+			pageSize: 50,
+			CancellationToken.None);
+
+		// Assert — the call completes (no ObjectDisposedException) and returns the cola cluster
+		result.Groups.Should().NotBeEmpty();
+		ItemSimilarityGroup colaCluster = result.Groups
+			.Should().ContainSingle(g => g.Variants.Any(v => v.Contains("COLA", StringComparison.OrdinalIgnoreCase)))
+			.Subject;
+		colaCluster.Variants.Should().Contain(["COCA COLA", "COCA-COLA", "COCACOLA"]);
+		colaCluster.ItemIds.Should().HaveCount(3);
+	}
+
+	[Fact]
+	public async Task GetItemSimilarityAsync_ReturnsEmpty_WhenNoSimilarDescriptions()
+	{
+		// Arrange
+		await ResetItemTablesAsync();
+
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		List<ReceiptItemEntity> items =
+		[
+			WithDescription(receipt.Id, "BREAD"),
+			WithDescription(receipt.Id, "GASOLINE"),
+			WithDescription(receipt.Id, "NOTEBOOK"),
+		];
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.Receipts.Add(receipt);
+			setup.ReceiptItems.AddRange(items);
+			await setup.SaveChangesAsync();
+		}
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		// Act
+		ItemSimilarityResult result = await service.GetItemSimilarityAsync(
+			threshold: 0.4,
+			sortBy: "occurrences",
+			sortDirection: "desc",
+			page: 1,
+			pageSize: 50,
+			CancellationToken.None);
+
+		// Assert
+		result.Groups.Should().BeEmpty();
+		result.TotalCount.Should().Be(0);
+	}
+
+	private async Task ResetItemTablesAsync()
+	{
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		await context.Database.ExecuteSqlRawAsync(
+			"""TRUNCATE "ReceiptItems", "Receipts" RESTART IDENTITY CASCADE;""");
+	}
+
+	private static ReceiptItemEntity WithDescription(Guid receiptId, string description)
+	{
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receiptId);
+		item.Description = description;
+		return item;
+	}
+
+	private sealed class FixtureDbContextFactory(PostgresFixture fixture) : IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => fixture.CreateDbContext();
+	}
+}


### PR DESCRIPTION
## Summary

- Stops disposing the `DbContext`'s borrowed `NpgsqlConnection` in `ReportService.GetItemSimilarityAsync` — the `await using` wrapper was calling `DisposeAsync` on a connection still owned by the context, making the follow-up `ReceiptItems` query throw `ObjectDisposedException`.
- Open the connection via `context.Database.OpenConnectionAsync(ct)` so EF's ref-counted lifecycle stays consistent; keep `await using` on the command/reader we own.
- Adds Testcontainers-backed integration tests covering the fix (regression) and the empty-result path.

Resolves RECEIPTS-556.

## Test plan

- [x] `dotnet build Receipts.slnx` — 0 errors.
- [x] `dotnet test --filter "FullyQualifiedName~ReportService&Category!=Integration"` — 17/17 pass.
- [ ] `dotnet test tests/Infrastructure.IntegrationTests` — requires local Docker (Testcontainers). Not verified locally; please run if reviewing.
- [ ] Smoke: `GET /api/reports/item-similarity?threshold=0.4` returns 200 (perf still slow — tracked separately in RECEIPTS-557).

## Notes

- Pre-commit `.NET tests` skipped via `PRECOMMIT_QUICK=1`. Confirmed the 7 failing tests (`BackupImportServiceTests` — SQLite file-lock contention on Windows) reproduce on a clean `origin/develop` baseline with no other changes; unrelated to this PR. Will file a separate issue.
- Performance (~21s on prod data) is out of scope here — tracked in RECEIPTS-557 as a persisted edge-table refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)