### PR TITLE
fix(api): resolve openapi spec drift on develop (RECEIPTS-564)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -3486,12 +3486,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RefreshItemSimilarityResponse"
-        "403":
-          description: Forbidden — admin role required.
-          content:
-            application/json:
-              schema:
-                type: string
 
   /api/reports/item-descriptions:
     get:
@@ -4678,9 +4672,8 @@ components:
           items:
             $ref: "#/components/schemas/ItemSimilarityGroup"
         computedAt:
-          type: string
+          type: [string, "null"]
           format: date-time
-          nullable: true
           description: Timestamp of the most recent edge-set refresh. Null when the background refresher has not yet populated edges.
 
     ItemSimilarityGroup:

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -7153,15 +7153,6 @@ export interface operations {
                     "application/json": components["schemas"]["RefreshItemSimilarityResponse"];
                 };
             };
-            /** @description Forbidden — admin role required. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": string;
-                };
-            };
         };
     };
     GetItemDescriptions: {


### PR DESCRIPTION
## Summary

Fixes two drift errors between `openapi/spec.yaml` and the build-time-generated `openapi/generated/API.json` that were blocking the pre-commit hook on every branch based on `develop`:

- **`ItemSimilarityResponse.computedAt` nullability** — converted `type: string` + `nullable: true` (OpenAPI 3.0 style) to `type: [string, "null"]` (3.1 style). The spec declares `openapi: 3.1.0`, which does not recognize the `nullable` keyword. `scripts/check-drift.mjs`'s `isNullable()` only inspects type-array / `oneOf` patterns and therefore silently failed to recognize the hand-authored nullability.
- **POST `/api/reports/item-similarity/refresh` `403` response** — removed the `"403"` response block from the spec. The controller has `[Authorize(Policy="RequireAdmin")]` and auth is correctly enforced at runtime, but ASP.NET's OpenAPI emitter does not auto-generate `403` from `[Authorize]`. No other admin endpoint in this codebase (BackupController, UsersController, UserRolesController, admin-only endpoints on Accounts/Cards) declares `403` in the spec either, so removing matches the established convention.

The C# source (`ItemSimilarityResult.ComputedAt` being `DateTimeOffset?`, the `[Authorize(Policy="RequireAdmin")]` attribute on the refresh endpoint) is correct — only the hand-authored spec was wrong.

Resolves RECEIPTS-564.

## Note on breaking-change detector

`scripts/check-breaking.mjs` flags the `computedAt` change (`string` → `null|string`). This is **not** a runtime behavior change — the API has always been able to return `null` here, and the generated TypeScript client (`src/client/src/generated/api.d.ts`) already typed the field as `string | null` before this PR (openapi-typescript respects `nullable: true` in 3.1 even though the keyword is formally deprecated). The PR carries the `breaking-changes-allowed` label on that basis.

## Test plan

- [x] `node scripts/check-drift.mjs` → "No drift detected"
- [x] `npm run lint:spec` → no Spectral warnings
- [x] `dotnet build Receipts.slnx` → 0 errors
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` → 2222 tests pass (Domain 123, App 535, API 960, Infra 604)
- [x] Pre-commit hook (11/11 steps, including 1796 client Vitest tests) → pass
- [ ] CI green on `develop` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- re-trigger CI after applying breaking-changes-allowed label -->