### PR TITLE
fix(ci): trigger workflow on label changes (RECEIPTS-547)

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, labeled, unlabeled, reopened]
     branches: ["main", "develop"]
 
 env:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   source-branch-check:
     name: Source Branch Policy
-    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    if: github.event_name == 'pull_request' && github.base_ref == 'main' && github.event.action != 'labeled' && github.event.action != 'unlabeled'
     runs-on: ubuntu-latest
 
     steps:
@@ -79,7 +79,7 @@ jobs:
   build:
     name: Build & Test
     needs: [pr-title]
-    if: ${{ !cancelled() && (needs.pr-title.result == 'success' || needs.pr-title.result == 'skipped') }}
+    if: ${{ !cancelled() && (needs.pr-title.result == 'success' || needs.pr-title.result == 'skipped') && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -144,7 +144,7 @@ jobs:
   frontend-test:
     name: Frontend Test (Shard ${{ matrix.shard }}/2)
     needs: [pr-title]
-    if: ${{ !cancelled() && (needs.pr-title.result == 'success' || needs.pr-title.result == 'skipped') }}
+    if: ${{ !cancelled() && (needs.pr-title.result == 'success' || needs.pr-title.result == 'skipped') && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -187,7 +187,7 @@ jobs:
   frontend-test-report:
     name: Frontend Coverage Report
     needs: [pr-title, frontend-test]
-    if: ${{ !cancelled() && (needs.frontend-test.result == 'success' || needs.frontend-test.result == 'failure') }}
+    if: ${{ !cancelled() && (needs.frontend-test.result == 'success' || needs.frontend-test.result == 'failure') && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -238,7 +238,7 @@ jobs:
   lint:
     name: Code Formatting
     needs: [pr-title]
-    if: ${{ !cancelled() && (needs.pr-title.result == 'success' || needs.pr-title.result == 'skipped') }}
+    if: ${{ !cancelled() && (needs.pr-title.result == 'success' || needs.pr-title.result == 'skipped') && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -266,7 +266,7 @@ jobs:
   security:
     name: Vulnerability Scan
     needs: [pr-title]
-    if: ${{ !cancelled() && (needs.pr-title.result == 'success' || needs.pr-title.result == 'skipped') }}
+    if: ${{ !cancelled() && (needs.pr-title.result == 'success' || needs.pr-title.result == 'skipped') && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -291,7 +291,7 @@ jobs:
   docker-build:
     name: Docker Build Check
     needs: [pr-title]
-    if: ${{ needs.pr-title.result == 'success' }}
+    if: ${{ needs.pr-title.result == 'success' && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Add `labeled` and `unlabeled` to `pull_request.types` in `.github/workflows/github-ci.yml` so the `api-compat` job re-evaluates when the `breaking-changes-allowed` label is applied/removed on an open PR.
- Previous behavior: the label change did not fire a new workflow run, so applying the label required a close+reopen or an empty commit to clear the failing `API Breaking Changes` check.
- Add `github.event.action != 'labeled' && github.event.action != 'unlabeled'` guards to every non-label-aware job (`source-branch-check`, `build`, `frontend-test`, `frontend-test-report`, `lint`, `security`, `docker-build`) so only the label-aware jobs (`pr-title`, `api-compat`) re-run on label-only events. Skipped checks still satisfy branch protection, so this is compute-only savings.

Resolves RECEIPTS-547

## Test plan
- [ ] After merge, confirm on a follow-up PR that adding `breaking-changes-allowed` to a PR with a failing `api-compat` check fires a new workflow run and the job skips as expected.
- [ ] Confirm that removing the label fires another run and `api-compat` executes normally.
- [ ] Confirm that adding/removing any other label (e.g. a triage label) fires a run where only `pr-title` and `api-compat` execute — all other jobs should show as `Skipped`.