### PR TITLE
fix(api): thread CancellationToken through mediator.Send across controllers (RECEIPTS-550)

### DIFF
--- a/src/Presentation/API/Controllers/Aggregates/ReceiptWithItemsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReceiptWithItemsController.cs
@@ -22,10 +22,10 @@ public class ReceiptWithItemsController(IMediator mediator, ReceiptWithItemsMapp
 	[HttpGet(RouteByReceiptId)]
 	[EndpointSummary("Get a receipt with its items")]
 	[EndpointDescription("Returns a receipt and all its associated line items as a single aggregate, looked up by receipt ID.")]
-	public async Task<Results<Ok<ReceiptWithItemsResponse>, NotFound>> GetReceiptWithItemsByReceiptId([FromQuery] Guid receiptId)
+	public async Task<Results<Ok<ReceiptWithItemsResponse>, NotFound>> GetReceiptWithItemsByReceiptId([FromQuery] Guid receiptId, CancellationToken cancellationToken = default)
 	{
 		GetReceiptWithItemsByReceiptIdQuery query = new(receiptId);
-		ReceiptWithItems? result = await mediator.Send(query);
+		ReceiptWithItems? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{

--- a/src/Presentation/API/Controllers/Aggregates/TransactionAccountController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/TransactionAccountController.cs
@@ -20,7 +20,7 @@ public class TransactionAccountController(IMediator mediator, TransactionAccount
 	[HttpGet("")]
 	[EndpointSummary("Get transaction accounts")]
 	[EndpointDescription("Returns transaction accounts filtered by transaction ID or receipt ID.")]
-	public async Task<Results<Ok<List<TransactionAccountResponse>>, BadRequest<string>>> GetTransactionAccounts([FromQuery] Guid? transactionId = null, [FromQuery] Guid? receiptId = null)
+	public async Task<Results<Ok<List<TransactionAccountResponse>>, BadRequest<string>>> GetTransactionAccounts([FromQuery] Guid? transactionId = null, [FromQuery] Guid? receiptId = null, CancellationToken cancellationToken = default)
 	{
 		if (transactionId.HasValue && receiptId.HasValue)
 		{
@@ -30,7 +30,7 @@ public class TransactionAccountController(IMediator mediator, TransactionAccount
 		if (transactionId.HasValue)
 		{
 			GetTransactionAccountByTransactionIdQuery query = new(transactionId.Value);
-			TransactionAccount? result = await mediator.Send(query);
+			TransactionAccount? result = await mediator.Send(query, cancellationToken);
 
 			List<TransactionAccountResponse> model = result != null
 				? [mapper.ToResponse(result)]
@@ -41,7 +41,7 @@ public class TransactionAccountController(IMediator mediator, TransactionAccount
 		if (receiptId.HasValue)
 		{
 			GetTransactionAccountsByReceiptIdQuery query = new(receiptId.Value);
-			List<TransactionAccount>? result = await mediator.Send(query);
+			List<TransactionAccount>? result = await mediator.Send(query, cancellationToken);
 
 			List<TransactionAccountResponse> model = [.. (result ?? []).Select(mapper.ToResponse)];
 			return TypedResults.Ok(model);

--- a/src/Presentation/API/Controllers/Aggregates/TripController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/TripController.cs
@@ -22,10 +22,10 @@ public class TripController(IMediator mediator, TripMapper mapper, ILogger<TripC
 	[HttpGet(RouteByReceiptId)]
 	[EndpointSummary("Get a trip by receipt ID")]
 	[EndpointDescription("Returns the full trip aggregate for a receipt, including the receipt, its items, transactions, and associated accounts.")]
-	public async Task<Results<Ok<TripResponse>, NotFound>> GetTripByReceiptId([FromQuery] Guid receiptId)
+	public async Task<Results<Ok<TripResponse>, NotFound>> GetTripByReceiptId([FromQuery] Guid receiptId, CancellationToken cancellationToken = default)
 	{
 		GetTripByReceiptIdQuery query = new(receiptId);
-		Trip? result = await mediator.Send(query);
+		Trip? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{

--- a/src/Presentation/API/Controllers/Core/AdjustmentsController.cs
+++ b/src/Presentation/API/Controllers/Core/AdjustmentsController.cs
@@ -34,10 +34,10 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get an adjustment by ID")]
 	[EndpointDescription("Returns a single adjustment matching the provided GUID.")]
-	public async Task<Results<Ok<AdjustmentResponse>, NotFound>> GetAdjustmentById([FromRoute] Guid id)
+	public async Task<Results<Ok<AdjustmentResponse>, NotFound>> GetAdjustmentById([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		GetAdjustmentByIdQuery query = new(id);
-		Adjustment? result = await mediator.Send(query);
+		Adjustment? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{
@@ -51,7 +51,7 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all adjustments")]
-	public async Task<Results<Ok<AdjustmentListResponse>, BadRequest<string>>> GetAllAdjustments([FromQuery] Guid? receiptId = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<AdjustmentListResponse>, BadRequest<string>>> GetAllAdjustments([FromQuery] Guid? receiptId = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -78,7 +78,7 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 		if (receiptId.HasValue)
 		{
 			GetAdjustmentsByReceiptIdQuery byReceiptQuery = new(receiptId.Value, offset, limit, sort);
-			PagedResult<Adjustment> byReceiptResult = await mediator.Send(byReceiptQuery);
+			PagedResult<Adjustment> byReceiptResult = await mediator.Send(byReceiptQuery, cancellationToken);
 
 			return TypedResults.Ok(new AdjustmentListResponse
 			{
@@ -90,7 +90,7 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 		}
 
 		GetAllAdjustmentsQuery query = new(offset, limit, sort);
-		PagedResult<Adjustment> result = await mediator.Send(query);
+		PagedResult<Adjustment> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new AdjustmentListResponse
 		{
@@ -104,7 +104,7 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted adjustments")]
 	[EndpointDescription("Returns all adjustments that have been soft-deleted.")]
-	public async Task<Results<Ok<AdjustmentListResponse>, BadRequest<string>>> GetDeletedAdjustments([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<AdjustmentListResponse>, BadRequest<string>>> GetDeletedAdjustments([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -128,7 +128,7 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetDeletedAdjustmentsQuery query = new(offset, limit, sort);
-		PagedResult<Adjustment> result = await mediator.Send(query);
+		PagedResult<Adjustment> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new AdjustmentListResponse
 		{
@@ -141,20 +141,20 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single adjustment")]
-	public async Task<Ok<AdjustmentResponse>> CreateAdjustment([FromBody] CreateAdjustmentRequest model, [FromRoute] Guid receiptId)
+	public async Task<Ok<AdjustmentResponse>> CreateAdjustment([FromBody] CreateAdjustmentRequest model, [FromRoute] Guid receiptId, CancellationToken cancellationToken = default)
 	{
 		CreateAdjustmentCommand command = new([mapper.ToDomain(model)], receiptId);
-		List<Adjustment> adjustments = await mediator.Send(command);
+		List<Adjustment> adjustments = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyCreated("adjustment", adjustments[0].Id);
 		return TypedResults.Ok(mapper.ToResponse(adjustments[0]));
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single adjustment")]
-	public async Task<Results<NoContent, NotFound>> UpdateAdjustment([FromBody] UpdateAdjustmentRequest model, [FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> UpdateAdjustment([FromBody] UpdateAdjustmentRequest model, [FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		UpdateAdjustmentCommand command = new([mapper.ToDomain(model)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -169,10 +169,10 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 	[HttpDelete(RouteDelete)]
 	[EndpointSummary("Delete adjustments")]
 	[EndpointDescription("Deletes one or more adjustments by their IDs. Returns 404 if any adjustment is not found.")]
-	public async Task<Results<NoContent, NotFound>> DeleteAdjustments([FromBody] List<Guid> ids)
+	public async Task<Results<NoContent, NotFound>> DeleteAdjustments([FromBody] List<Guid> ids, CancellationToken cancellationToken = default)
 	{
 		DeleteAdjustmentCommand command = new(ids);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -187,10 +187,10 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 	[HttpPost(RouteRestore)]
 	[EndpointSummary("Restore a soft-deleted adjustment")]
 	[EndpointDescription("Restores a previously soft-deleted adjustment by clearing its DeletedAt timestamp.")]
-	public async Task<Results<NoContent, NotFound>> RestoreAdjustment([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> RestoreAdjustment([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		RestoreAdjustmentCommand command = new(id);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{

--- a/src/Presentation/API/Controllers/Core/CardsController.cs
+++ b/src/Presentation/API/Controllers/Core/CardsController.cs
@@ -37,10 +37,10 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get a card by ID")]
 	[EndpointDescription("Returns a single card matching the provided GUID.")]
-	public async Task<Results<Ok<CardResponse>, NotFound>> GetCardById([FromRoute] Guid id)
+	public async Task<Results<Ok<CardResponse>, NotFound>> GetCardById([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		GetCardByIdQuery query = new(id);
-		Card? result = await mediator.Send(query);
+		Card? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{
@@ -54,7 +54,7 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all cards")]
-	public async Task<Results<Ok<CardListResponse>, BadRequest<string>>> GetAllCards([FromQuery] bool? isActive = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<CardListResponse>, BadRequest<string>>> GetAllCards([FromQuery] bool? isActive = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -78,7 +78,7 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetAllCardsQuery query = new(offset, limit, sort, isActive);
-		PagedResult<Card> result = await mediator.Send(query);
+		PagedResult<Card> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new CardListResponse
 		{
@@ -91,25 +91,25 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single card")]
-	public async Task<Results<Ok<CardResponse>, BadRequest<string>>> CreateCard([FromBody] CreateCardRequest model)
+	public async Task<Results<Ok<CardResponse>, BadRequest<string>>> CreateCard([FromBody] CreateCardRequest model, CancellationToken cancellationToken = default)
 	{
-		if (await MissingAccountIdAsync(model.AccountId, HttpContext.RequestAborted))
+		if (await MissingAccountIdAsync(model.AccountId, cancellationToken))
 		{
 			logger.LogWarning("Card create rejected — parent account {AccountId} not found", model.AccountId);
 			return TypedResults.BadRequest($"Account {model.AccountId} does not exist.");
 		}
 
 		CreateCardCommand command = new([mapper.ToDomain(model)]);
-		List<Card> cards = await mediator.Send(command);
+		List<Card> cards = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyCreated("card", cards[0].Id);
 		return TypedResults.Ok(mapper.ToResponse(cards[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create cards in batch")]
-	public async Task<Results<Ok<List<CardResponse>>, BadRequest<string>>> CreateCards([FromBody] List<CreateCardRequest> models)
+	public async Task<Results<Ok<List<CardResponse>>, BadRequest<string>>> CreateCards([FromBody] List<CreateCardRequest> models, CancellationToken cancellationToken = default)
 	{
-		Guid? missing = await FirstMissingAccountIdAsync(models.Select(m => m.AccountId), HttpContext.RequestAborted);
+		Guid? missing = await FirstMissingAccountIdAsync(models.Select(m => m.AccountId), cancellationToken);
 		if (missing.HasValue)
 		{
 			logger.LogWarning("Cards batch create rejected — parent account {AccountId} not found", missing.Value);
@@ -117,23 +117,23 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 		}
 
 		CreateCardCommand command = new([.. models.Select(mapper.ToDomain)]);
-		List<Card> cards = await mediator.Send(command);
+		List<Card> cards = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyBulkChanged("card", "created", cards.Select(a => a.Id));
 		return TypedResults.Ok(cards.Select(mapper.ToResponse).ToList());
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single card")]
-	public async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateCard([FromRoute] Guid id, [FromBody] UpdateCardRequest model)
+	public async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateCard([FromRoute] Guid id, [FromBody] UpdateCardRequest model, CancellationToken cancellationToken = default)
 	{
-		if (await MissingAccountIdAsync(model.AccountId, HttpContext.RequestAborted))
+		if (await MissingAccountIdAsync(model.AccountId, cancellationToken))
 		{
 			logger.LogWarning("Card {Id} update rejected — parent account {AccountId} not found", id, model.AccountId);
 			return TypedResults.BadRequest($"Account {model.AccountId} does not exist.");
 		}
 
 		UpdateCardCommand command = new([mapper.ToDomain(model)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -147,9 +147,9 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update cards in batch")]
-	public async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateCards([FromBody] List<UpdateCardRequest> models)
+	public async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateCards([FromBody] List<UpdateCardRequest> models, CancellationToken cancellationToken = default)
 	{
-		Guid? missing = await FirstMissingAccountIdAsync(models.Select(m => m.AccountId), HttpContext.RequestAborted);
+		Guid? missing = await FirstMissingAccountIdAsync(models.Select(m => m.AccountId), cancellationToken);
 		if (missing.HasValue)
 		{
 			logger.LogWarning("Cards batch update rejected — parent account {AccountId} not found", missing.Value);
@@ -157,7 +157,7 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 		}
 
 		UpdateCardCommand command = new([.. models.Select(mapper.ToDomain)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -191,9 +191,9 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 	[Authorize(Policy = "RequireAdmin")]
 	[EndpointSummary("Hard-delete a card")]
 	[EndpointDescription("Permanently deletes a card. Requires the Admin role. Returns 409 Conflict if transactions reference this card.")]
-	public async Task<Results<NoContent, NotFound, Conflict<object>>> DeleteCard([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound, Conflict<object>>> DeleteCard([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
-		int transactionCount = await cardService.GetTransactionCountByCardIdAsync(id, HttpContext.RequestAborted);
+		int transactionCount = await cardService.GetTransactionCountByCardIdAsync(id, cancellationToken);
 		if (transactionCount > 0)
 		{
 			logger.LogWarning("Card {Id} cannot be deleted — {Count} transactions reference it", id, transactionCount);
@@ -201,7 +201,7 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 		}
 
 		DeleteCardCommand command = new(id);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -217,7 +217,7 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 	[Authorize(Policy = "RequireAdmin")]
 	[EndpointSummary("Merge cards into a target account")]
 	[EndpointDescription("Repoints the listed cards (and their transactions) to the target account and deletes any now-orphaned accounts. Requires the Admin role. Returns 409 Conflict if the source/target accounts have differing YNAB account mappings; resubmit with ynabMappingWinnerAccountId to resolve.")]
-	public async Task<Results<Ok<MergeCardsResponse>, BadRequest<string>, NotFound, Conflict<MergeCardsConflictResponse>>> MergeCards([FromBody] MergeCardsRequest model)
+	public async Task<Results<Ok<MergeCardsResponse>, BadRequest<string>, NotFound, Conflict<MergeCardsConflictResponse>>> MergeCards([FromBody] MergeCardsRequest model, CancellationToken cancellationToken = default)
 	{
 		if (model.SourceCardIds is null || model.SourceCardIds.Count < 2)
 		{
@@ -240,7 +240,7 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 		MergeCardsResult result;
 		try
 		{
-			result = await mediator.Send(command, HttpContext.RequestAborted);
+			result = await mediator.Send(command, cancellationToken);
 		}
 		catch (KeyNotFoundException ex)
 		{

--- a/src/Presentation/API/Controllers/Core/CategoriesController.cs
+++ b/src/Presentation/API/Controllers/Core/CategoriesController.cs
@@ -37,10 +37,10 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get a category by ID")]
 	[EndpointDescription("Returns a single category matching the provided GUID.")]
-	public async Task<Results<Ok<CategoryResponse>, NotFound>> GetCategoryById([FromRoute] Guid id)
+	public async Task<Results<Ok<CategoryResponse>, NotFound>> GetCategoryById([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		GetCategoryByIdQuery query = new(id);
-		Category? result = await mediator.Send(query);
+		Category? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{
@@ -54,7 +54,7 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all categories")]
-	public async Task<Results<Ok<CategoryListResponse>, BadRequest<string>>> GetAllCategories([FromQuery] bool? isActive = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<CategoryListResponse>, BadRequest<string>>> GetAllCategories([FromQuery] bool? isActive = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -78,7 +78,7 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetAllCategoriesQuery query = new(offset, limit, sort, isActive);
-		PagedResult<Category> result = await mediator.Send(query);
+		PagedResult<Category> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new CategoryListResponse
 		{
@@ -92,7 +92,7 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted categories")]
 	[EndpointDescription("Returns all categories that have been soft-deleted.")]
-	public async Task<Results<Ok<CategoryListResponse>, BadRequest<string>>> GetDeletedCategories([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<CategoryListResponse>, BadRequest<string>>> GetDeletedCategories([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -116,7 +116,7 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetDeletedCategoriesQuery query = new(offset, limit, sort);
-		PagedResult<Category> result = await mediator.Send(query);
+		PagedResult<Category> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new CategoryListResponse
 		{
@@ -129,30 +129,30 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single category")]
-	public async Task<Ok<CategoryResponse>> CreateCategory([FromBody] CreateCategoryRequest model)
+	public async Task<Ok<CategoryResponse>> CreateCategory([FromBody] CreateCategoryRequest model, CancellationToken cancellationToken = default)
 	{
 		CreateCategoryCommand command = new([mapper.ToDomain(model)]);
-		List<Category> categories = await mediator.Send(command);
+		List<Category> categories = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyCreated("category", categories[0].Id);
 		return TypedResults.Ok(mapper.ToResponse(categories[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create categories in batch")]
-	public async Task<Ok<List<CategoryResponse>>> CreateCategories([FromBody] List<CreateCategoryRequest> models)
+	public async Task<Ok<List<CategoryResponse>>> CreateCategories([FromBody] List<CreateCategoryRequest> models, CancellationToken cancellationToken = default)
 	{
 		CreateCategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
-		List<Category> categories = await mediator.Send(command);
+		List<Category> categories = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyBulkChanged("category", "created", categories.Select(c => c.Id));
 		return TypedResults.Ok(categories.Select(mapper.ToResponse).ToList());
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single category")]
-	public async Task<Results<NoContent, NotFound>> UpdateCategory([FromRoute] Guid id, [FromBody] UpdateCategoryRequest model)
+	public async Task<Results<NoContent, NotFound>> UpdateCategory([FromRoute] Guid id, [FromBody] UpdateCategoryRequest model, CancellationToken cancellationToken = default)
 	{
 		UpdateCategoryCommand command = new([mapper.ToDomain(model)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -166,10 +166,10 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update categories in batch")]
-	public async Task<Results<NoContent, NotFound>> UpdateCategories([FromBody] List<UpdateCategoryRequest> models)
+	public async Task<Results<NoContent, NotFound>> UpdateCategories([FromBody] List<UpdateCategoryRequest> models, CancellationToken cancellationToken = default)
 	{
 		UpdateCategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -184,24 +184,24 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	[HttpDelete(RouteDelete)]
 	[EndpointSummary("Soft-delete a category")]
 	[EndpointDescription("Soft-deletes a category and cascade soft-deletes its subcategories. Returns 409 Conflict if receipt items reference this category or any of its subcategories.")]
-	public async Task<Results<NoContent, NotFound, Conflict<object>>> DeleteCategory([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound, Conflict<object>>> DeleteCategory([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
-		Category? category = await mediator.Send(new GetCategoryByIdQuery(id));
+		Category? category = await mediator.Send(new GetCategoryByIdQuery(id), cancellationToken);
 		if (category == null)
 		{
 			logger.LogWarning("Category {Id} not found for deletion", id);
 			return TypedResults.NotFound();
 		}
 
-		int receiptItemCount = await categoryService.GetReceiptItemCountByCategoryNameAsync(category.Name, HttpContext.RequestAborted);
+		int receiptItemCount = await categoryService.GetReceiptItemCountByCategoryNameAsync(category.Name, cancellationToken);
 		if (receiptItemCount > 0)
 		{
 			logger.LogWarning("Category {Id} cannot be deleted — {Count} receipt items reference its category name", id, receiptItemCount);
 			return TypedResults.Conflict<object>(new { message = $"Cannot delete — {receiptItemCount} receipt item(s) use this category", receiptItemCount });
 		}
 
-		List<string> subcategoryNames = await categoryService.GetSubcategoryNamesAsync(id, HttpContext.RequestAborted);
-		int subReceiptItemCount = await categoryService.GetReceiptItemCountBySubcategoryNamesAsync(subcategoryNames, HttpContext.RequestAborted);
+		List<string> subcategoryNames = await categoryService.GetSubcategoryNamesAsync(id, cancellationToken);
+		int subReceiptItemCount = await categoryService.GetReceiptItemCountBySubcategoryNamesAsync(subcategoryNames, cancellationToken);
 		if (subReceiptItemCount > 0)
 		{
 			logger.LogWarning("Category {Id} cannot be deleted — {Count} receipt items reference its subcategories", id, subReceiptItemCount);
@@ -209,7 +209,7 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 		}
 
 		DeleteCategoryCommand command = new([id]);
-		await mediator.Send(command);
+		await mediator.Send(command, cancellationToken);
 
 		await notifier.NotifyDeleted("category", id);
 		return TypedResults.NoContent();
@@ -218,10 +218,10 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	[HttpPost(RouteRestore)]
 	[EndpointSummary("Restore a soft-deleted category")]
 	[EndpointDescription("Restores a previously soft-deleted category and its cascade-deleted subcategories.")]
-	public async Task<Results<NoContent, NotFound>> RestoreCategory([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> RestoreCategory([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		RestoreCategoryCommand command = new(id);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{

--- a/src/Presentation/API/Controllers/Core/ItemTemplatesController.cs
+++ b/src/Presentation/API/Controllers/Core/ItemTemplatesController.cs
@@ -38,10 +38,10 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get an item template by ID")]
 	[EndpointDescription("Returns a single item template matching the provided GUID.")]
-	public async Task<Results<Ok<ItemTemplateResponse>, NotFound>> GetItemTemplateById([FromRoute] Guid id)
+	public async Task<Results<Ok<ItemTemplateResponse>, NotFound>> GetItemTemplateById([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		GetItemTemplateByIdQuery query = new(id);
-		ItemTemplate? result = await mediator.Send(query);
+		ItemTemplate? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{
@@ -55,7 +55,7 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all item templates")]
-	public async Task<Results<Ok<ItemTemplateListResponse>, BadRequest<string>>> GetAllItemTemplates([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<ItemTemplateListResponse>, BadRequest<string>>> GetAllItemTemplates([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -79,7 +79,7 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetAllItemTemplatesQuery query = new(offset, limit, sort);
-		PagedResult<ItemTemplate> result = await mediator.Send(query);
+		PagedResult<ItemTemplate> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new ItemTemplateListResponse
 		{
@@ -93,7 +93,7 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted item templates")]
 	[EndpointDescription("Returns all item templates that have been soft-deleted.")]
-	public async Task<Results<Ok<ItemTemplateListResponse>, BadRequest<string>>> GetDeletedItemTemplates([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<ItemTemplateListResponse>, BadRequest<string>>> GetDeletedItemTemplates([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -117,7 +117,7 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetDeletedItemTemplatesQuery query = new(offset, limit, sort);
-		PagedResult<ItemTemplate> result = await mediator.Send(query);
+		PagedResult<ItemTemplate> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new ItemTemplateListResponse
 		{
@@ -130,20 +130,20 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single item template")]
-	public async Task<Ok<ItemTemplateResponse>> CreateItemTemplate([FromBody] CreateItemTemplateRequest model)
+	public async Task<Ok<ItemTemplateResponse>> CreateItemTemplate([FromBody] CreateItemTemplateRequest model, CancellationToken cancellationToken = default)
 	{
 		CreateItemTemplateCommand command = new([mapper.ToDomain(model)]);
-		List<ItemTemplate> itemTemplates = await mediator.Send(command);
+		List<ItemTemplate> itemTemplates = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyCreated("item-template", itemTemplates[0].Id);
 		return TypedResults.Ok(mapper.ToResponse(itemTemplates[0]));
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single item template")]
-	public async Task<Results<NoContent, NotFound>> UpdateItemTemplate([FromRoute] Guid id, [FromBody] UpdateItemTemplateRequest model)
+	public async Task<Results<NoContent, NotFound>> UpdateItemTemplate([FromRoute] Guid id, [FromBody] UpdateItemTemplateRequest model, CancellationToken cancellationToken = default)
 	{
 		UpdateItemTemplateCommand command = new([mapper.ToDomain(model)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -158,10 +158,10 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[HttpDelete(RouteDelete)]
 	[EndpointSummary("Delete item templates")]
 	[EndpointDescription("Deletes one or more item templates by their IDs. Returns 404 if any item template is not found.")]
-	public async Task<Results<NoContent, NotFound>> DeleteItemTemplates([FromBody] List<Guid> ids)
+	public async Task<Results<NoContent, NotFound>> DeleteItemTemplates([FromBody] List<Guid> ids, CancellationToken cancellationToken = default)
 	{
 		DeleteItemTemplateCommand command = new(ids);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -176,10 +176,10 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[HttpPost(RouteRestore)]
 	[EndpointSummary("Restore a soft-deleted item template")]
 	[EndpointDescription("Restores a previously soft-deleted item template by clearing its DeletedAt timestamp.")]
-	public async Task<Results<NoContent, NotFound>> RestoreItemTemplate([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> RestoreItemTemplate([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		RestoreItemTemplateCommand command = new(id);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -194,10 +194,10 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[HttpGet(RouteGetSimilar)]
 	[EndpointSummary("Find similar items by hybrid similarity")]
 	[EndpointDescription("Returns items from templates and receipt history that are similar to the provided search text, ranked by a weighted combination of trigram and semantic (embedding) similarity.")]
-	public async Task<Ok<List<SimilarItemResponse>>> GetSimilarItems([FromQuery] string q, [FromQuery] int limit = 5, [FromQuery] double threshold = 0.3, [FromQuery] bool semantic = true)
+	public async Task<Ok<List<SimilarItemResponse>>> GetSimilarItems([FromQuery] string q, [FromQuery] int limit = 5, [FromQuery] double threshold = 0.3, [FromQuery] bool semantic = true, CancellationToken cancellationToken = default)
 	{
 		GetSimilarItemsQuery query = new(q, limit, threshold, semantic);
-		IEnumerable<SimilarItemResult> results = await mediator.Send(query);
+		IEnumerable<SimilarItemResult> results = await mediator.Send(query, cancellationToken);
 
 		List<SimilarItemResponse> response = [.. results.Select(r => new SimilarItemResponse
 		{
@@ -219,10 +219,10 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[HttpGet(RouteGetCategorySuggestions)]
 	[EndpointSummary("Get category/subcategory recommendations")]
 	[EndpointDescription("Returns ranked category and subcategory suggestions based on semantic and trigram similarity to existing items and receipt history.")]
-	public async Task<Ok<List<CategoryRecommendationResponse>>> GetCategorySuggestions([FromQuery] string q, [FromQuery] int limit = 5)
+	public async Task<Ok<List<CategoryRecommendationResponse>>> GetCategorySuggestions([FromQuery] string q, [FromQuery] int limit = 5, CancellationToken cancellationToken = default)
 	{
 		GetCategoryRecommendationsQuery query = new(q, limit);
-		IEnumerable<CategoryRecommendation> results = await mediator.Send(query);
+		IEnumerable<CategoryRecommendation> results = await mediator.Send(query, cancellationToken);
 
 		List<CategoryRecommendationResponse> response = [.. results.Select(r => new CategoryRecommendationResponse
 		{

--- a/src/Presentation/API/Controllers/Core/ReceiptImageController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptImageController.cs
@@ -30,7 +30,8 @@ public class ReceiptImageController(
 	[EndpointDescription("Accepts a JPEG or PNG image, saves the original, runs preprocessing (grayscale, adaptive threshold, deskew), and returns both image paths.")]
 	public async Task<Results<Ok<UploadReceiptImageResponse>, NotFound, BadRequest<string>, StatusCodeHttpResult>> UploadImage(
 		[FromRoute] Guid receiptId,
-		IFormFile? file)
+		IFormFile? file,
+		CancellationToken cancellationToken = default)
 	{
 		if (file is null || file.Length == 0)
 		{
@@ -56,7 +57,7 @@ public class ReceiptImageController(
 		byte[] imageBytes;
 		using (MemoryStream ms = new())
 		{
-			await file.CopyToAsync(ms);
+			await file.CopyToAsync(ms, cancellationToken);
 			imageBytes = ms.ToArray();
 		}
 
@@ -73,7 +74,7 @@ public class ReceiptImageController(
 		UploadReceiptImageResult result;
 		try
 		{
-			result = await mediator.Send(command);
+			result = await mediator.Send(command, cancellationToken);
 		}
 		catch (KeyNotFoundException)
 		{

--- a/src/Presentation/API/Controllers/Core/ReceiptItemsController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptItemsController.cs
@@ -40,10 +40,10 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get a receipt item by ID")]
 	[EndpointDescription("Returns a single receipt item matching the provided GUID.")]
-	public async Task<Results<Ok<ReceiptItemResponse>, NotFound>> GetReceiptItemById([FromRoute] Guid id)
+	public async Task<Results<Ok<ReceiptItemResponse>, NotFound>> GetReceiptItemById([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		GetReceiptItemByIdQuery query = new(id);
-		ReceiptItem? result = await mediator.Send(query);
+		ReceiptItem? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{
@@ -57,7 +57,7 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all receipt items")]
-	public async Task<Results<Ok<ReceiptItemListResponse>, BadRequest<string>>> GetAllReceiptItems([FromQuery] Guid? receiptId = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<ReceiptItemListResponse>, BadRequest<string>>> GetAllReceiptItems([FromQuery] Guid? receiptId = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -84,7 +84,7 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 		if (receiptId.HasValue)
 		{
 			GetReceiptItemsByReceiptIdQuery byReceiptQuery = new(receiptId.Value, offset, limit, sort);
-			PagedResult<ReceiptItem> byReceiptResult = await mediator.Send(byReceiptQuery);
+			PagedResult<ReceiptItem> byReceiptResult = await mediator.Send(byReceiptQuery, cancellationToken);
 
 			return TypedResults.Ok(new ReceiptItemListResponse
 			{
@@ -96,7 +96,7 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 		}
 
 		GetAllReceiptItemsQuery query = new(offset, limit, sort);
-		PagedResult<ReceiptItem> result = await mediator.Send(query);
+		PagedResult<ReceiptItem> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new ReceiptItemListResponse
 		{
@@ -110,7 +110,7 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted receipt items")]
 	[EndpointDescription("Returns all receipt items that have been soft-deleted.")]
-	public async Task<Results<Ok<ReceiptItemListResponse>, BadRequest<string>>> GetDeletedReceiptItems([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<ReceiptItemListResponse>, BadRequest<string>>> GetDeletedReceiptItems([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -134,7 +134,7 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetDeletedReceiptItemsQuery query = new(offset, limit, sort);
-		PagedResult<ReceiptItem> result = await mediator.Send(query);
+		PagedResult<ReceiptItem> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new ReceiptItemListResponse
 		{
@@ -147,30 +147,30 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single receipt item")]
-	public async Task<Ok<ReceiptItemResponse>> CreateReceiptItem([FromBody] CreateReceiptItemRequest model, [FromRoute] Guid receiptId)
+	public async Task<Ok<ReceiptItemResponse>> CreateReceiptItem([FromBody] CreateReceiptItemRequest model, [FromRoute] Guid receiptId, CancellationToken cancellationToken = default)
 	{
 		CreateReceiptItemCommand command = new([mapper.ToDomain(model)], receiptId);
-		List<ReceiptItem> receiptItems = await mediator.Send(command);
+		List<ReceiptItem> receiptItems = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyCreated("receipt-item", receiptItems[0].Id);
 		return TypedResults.Ok(mapper.ToResponse(receiptItems[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create receipt items in batch")]
-	public async Task<Ok<List<ReceiptItemResponse>>> CreateReceiptItems([FromBody] List<CreateReceiptItemRequest> models, [FromRoute] Guid receiptId)
+	public async Task<Ok<List<ReceiptItemResponse>>> CreateReceiptItems([FromBody] List<CreateReceiptItemRequest> models, [FromRoute] Guid receiptId, CancellationToken cancellationToken = default)
 	{
 		CreateReceiptItemCommand command = new([.. models.Select(mapper.ToDomain)], receiptId);
-		List<ReceiptItem> receiptItems = await mediator.Send(command);
+		List<ReceiptItem> receiptItems = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyBulkChanged("receipt-item", "created", receiptItems.Select(ri => ri.Id));
 		return TypedResults.Ok(receiptItems.Select(mapper.ToResponse).ToList());
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single receipt item")]
-	public async Task<Results<NoContent, NotFound>> UpdateReceiptItem([FromBody] UpdateReceiptItemRequest model, [FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> UpdateReceiptItem([FromBody] UpdateReceiptItemRequest model, [FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		UpdateReceiptItemCommand command = new([mapper.ToDomain(model)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -184,10 +184,10 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update receipt items in batch")]
-	public async Task<Results<NoContent, NotFound>> UpdateReceiptItems([FromBody] List<UpdateReceiptItemRequest> models)
+	public async Task<Results<NoContent, NotFound>> UpdateReceiptItems([FromBody] List<UpdateReceiptItemRequest> models, CancellationToken cancellationToken = default)
 	{
 		UpdateReceiptItemCommand command = new([.. models.Select(mapper.ToDomain)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -202,10 +202,10 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	[HttpDelete(RouteDelete)]
 	[EndpointSummary("Delete receipt items")]
 	[EndpointDescription("Deletes one or more receipt items by their IDs. Returns 404 if any item is not found.")]
-	public async Task<Results<NoContent, NotFound>> DeleteReceiptItems([FromBody] List<Guid> ids)
+	public async Task<Results<NoContent, NotFound>> DeleteReceiptItems([FromBody] List<Guid> ids, CancellationToken cancellationToken = default)
 	{
 		DeleteReceiptItemCommand command = new(ids);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -220,10 +220,10 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	[HttpPost(RouteRestore)]
 	[EndpointSummary("Restore a soft-deleted receipt item")]
 	[EndpointDescription("Restores a previously soft-deleted receipt item by clearing its DeletedAt timestamp.")]
-	public async Task<Results<NoContent, NotFound>> RestoreReceiptItem([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> RestoreReceiptItem([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		RestoreReceiptItemCommand command = new(id);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -238,10 +238,10 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	[HttpGet(RouteGetSuggestions)]
 	[EndpointSummary("Get item code suggestions from receipt history")]
 	[EndpointDescription("Returns suggestions for receipt item entry based on historical receipt items, grouped by itemCode and optionally filtered by location.")]
-	public async Task<Ok<List<ReceiptItemSuggestionResponse>>> GetSuggestions([FromQuery] string itemCode, [FromQuery] string? location = null, [FromQuery] int limit = 10)
+	public async Task<Ok<List<ReceiptItemSuggestionResponse>>> GetSuggestions([FromQuery] string itemCode, [FromQuery] string? location = null, [FromQuery] int limit = 10, CancellationToken cancellationToken = default)
 	{
 		GetReceiptItemSuggestionsQuery query = new(itemCode, location, limit);
-		IEnumerable<ReceiptItemSuggestion> results = await mediator.Send(query);
+		IEnumerable<ReceiptItemSuggestion> results = await mediator.Send(query, cancellationToken);
 
 		List<ReceiptItemSuggestionResponse> response = [.. results.Select(r => new ReceiptItemSuggestionResponse
 		{

--- a/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
@@ -35,7 +35,8 @@ public class ReceiptScanController(
 	[EndpointDescription("Accepts a JPEG or PNG image, or a PDF document. For images, runs preprocessing, OCR, and parsing. For PDFs, extracts text from the text layer or renders pages for OCR. Returns a proposed receipt with per-field confidence scores. The proposal is NOT persisted.")]
 	[ProducesResponseType(StatusCodes.Status415UnsupportedMediaType)]
 	public async Task<Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>>> ScanReceipt(
-		IFormFile? file)
+		IFormFile? file,
+		CancellationToken cancellationToken = default)
 	{
 		if (file is null || file.Length == 0)
 		{
@@ -55,7 +56,7 @@ public class ReceiptScanController(
 		byte[] imageBytes;
 		using (MemoryStream ms = new())
 		{
-			await file.CopyToAsync(ms);
+			await file.CopyToAsync(ms, cancellationToken);
 			imageBytes = ms.ToArray();
 		}
 
@@ -72,7 +73,7 @@ public class ReceiptScanController(
 		ScanReceiptResult result;
 		try
 		{
-			result = await mediator.Send(command);
+			result = await mediator.Send(command, cancellationToken);
 		}
 		catch (OcrNoTextException ex)
 		{

--- a/src/Presentation/API/Controllers/Core/ReceiptsController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptsController.cs
@@ -45,10 +45,10 @@ public class ReceiptsController(
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get a receipt by ID")]
 	[EndpointDescription("Returns a single receipt matching the provided GUID.")]
-	public async Task<Results<Ok<ReceiptResponse>, NotFound>> GetReceiptById([FromRoute] Guid id)
+	public async Task<Results<Ok<ReceiptResponse>, NotFound>> GetReceiptById([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		GetReceiptByIdQuery query = new(id);
-		Receipt? result = await mediator.Send(query);
+		Receipt? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{
@@ -62,7 +62,7 @@ public class ReceiptsController(
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all receipts")]
-	public async Task<Results<Ok<ReceiptListResponse>, BadRequest<string>>> GetAllReceipts([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, [FromQuery] Guid? accountId = null, [FromQuery] Guid? cardId = null)
+	public async Task<Results<Ok<ReceiptListResponse>, BadRequest<string>>> GetAllReceipts([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, [FromQuery] Guid? accountId = null, [FromQuery] Guid? cardId = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -86,7 +86,7 @@ public class ReceiptsController(
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetAllReceiptsQuery query = new(offset, limit, sort, accountId, cardId);
-		PagedResult<Receipt> result = await mediator.Send(query);
+		PagedResult<Receipt> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new ReceiptListResponse
 		{
@@ -100,7 +100,7 @@ public class ReceiptsController(
 	[HttpGet(RouteGetLocations)]
 	[EndpointSummary("Get distinct receipt locations sorted by frequency")]
 	[EndpointDescription("Returns distinct location strings from existing receipts, ordered by usage frequency (most-used first). Supports optional prefix filtering.")]
-	public async Task<Results<Ok<LocationSuggestionsResponse>, BadRequest<string>>> GetLocations([FromQuery] string? q = null, [FromQuery] int limit = 20)
+	public async Task<Results<Ok<LocationSuggestionsResponse>, BadRequest<string>>> GetLocations([FromQuery] string? q = null, [FromQuery] int limit = 20, CancellationToken cancellationToken = default)
 	{
 		if (limit <= 0 || limit > 100)
 		{
@@ -108,7 +108,7 @@ public class ReceiptsController(
 		}
 
 		GetDistinctLocationsQuery query = new(q, limit);
-		List<string> locations = await mediator.Send(query);
+		List<string> locations = await mediator.Send(query, cancellationToken);
 
 		LocationSuggestionsResponse response = new()
 		{
@@ -121,7 +121,7 @@ public class ReceiptsController(
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted receipts")]
 	[EndpointDescription("Returns all receipts that have been soft-deleted.")]
-	public async Task<Results<Ok<ReceiptListResponse>, BadRequest<string>>> GetDeletedReceipts([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<ReceiptListResponse>, BadRequest<string>>> GetDeletedReceipts([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -145,7 +145,7 @@ public class ReceiptsController(
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetDeletedReceiptsQuery query = new(offset, limit, sort);
-		PagedResult<Receipt> result = await mediator.Send(query);
+		PagedResult<Receipt> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new ReceiptListResponse
 		{
@@ -158,10 +158,10 @@ public class ReceiptsController(
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single receipt")]
-	public async Task<Ok<ReceiptResponse>> CreateReceipt([FromBody] CreateReceiptRequest model)
+	public async Task<Ok<ReceiptResponse>> CreateReceipt([FromBody] CreateReceiptRequest model, CancellationToken cancellationToken = default)
 	{
 		CreateReceiptCommand command = new([mapper.ToDomain(model)]);
-		List<Receipt> receipts = await mediator.Send(command);
+		List<Receipt> receipts = await mediator.Send(command, cancellationToken);
 		ReceiptResponse response = mapper.ToResponse(receipts[0]);
 		await notifier.NotifyCreated("receipt", receipts[0].Id);
 		return TypedResults.Ok(response);
@@ -170,7 +170,7 @@ public class ReceiptsController(
 	[HttpPost(RouteCreateComplete)]
 	[EndpointSummary("Create a receipt with transactions and items atomically")]
 	[EndpointDescription("Creates a receipt along with its transactions and items in a single atomic operation. If any part fails, nothing is persisted.")]
-	public async Task<Ok<CompleteReceiptResponse>> CreateCompleteReceipt([FromBody] CreateCompleteReceiptRequest model)
+	public async Task<Ok<CompleteReceiptResponse>> CreateCompleteReceipt([FromBody] CreateCompleteReceiptRequest model, CancellationToken cancellationToken = default)
 	{
 		Receipt receipt = mapper.ToDomain(model.Receipt);
 
@@ -184,7 +184,7 @@ public class ReceiptsController(
 		List<ReceiptItem> items = [.. model.Items.Select(receiptItemMapper.ToDomain)];
 
 		CreateCompleteReceiptCommand command = new(receipt, transactions, items);
-		CreateCompleteReceiptResult result = await mediator.Send(command);
+		CreateCompleteReceiptResult result = await mediator.Send(command, cancellationToken);
 
 		CompleteReceiptResponse response = new()
 		{
@@ -199,10 +199,10 @@ public class ReceiptsController(
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create receipts in batch")]
-	public async Task<Ok<List<ReceiptResponse>>> CreateReceipts([FromBody] List<CreateReceiptRequest> models)
+	public async Task<Ok<List<ReceiptResponse>>> CreateReceipts([FromBody] List<CreateReceiptRequest> models, CancellationToken cancellationToken = default)
 	{
 		CreateReceiptCommand command = new([.. models.Select(mapper.ToDomain)]);
-		List<Receipt> receipts = await mediator.Send(command);
+		List<Receipt> receipts = await mediator.Send(command, cancellationToken);
 		List<ReceiptResponse> responses = receipts.Select(mapper.ToResponse).ToList();
 		await notifier.NotifyBulkChanged("receipt", "created", receipts.Select(r => r.Id));
 		return TypedResults.Ok(responses);
@@ -210,10 +210,10 @@ public class ReceiptsController(
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single receipt")]
-	public async Task<Results<NoContent, NotFound>> UpdateReceipt([FromRoute] Guid id, [FromBody] UpdateReceiptRequest model)
+	public async Task<Results<NoContent, NotFound>> UpdateReceipt([FromRoute] Guid id, [FromBody] UpdateReceiptRequest model, CancellationToken cancellationToken = default)
 	{
 		UpdateReceiptCommand command = new([mapper.ToDomain(model)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -227,10 +227,10 @@ public class ReceiptsController(
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update receipts in batch")]
-	public async Task<Results<NoContent, NotFound>> UpdateReceipts([FromBody] List<UpdateReceiptRequest> models)
+	public async Task<Results<NoContent, NotFound>> UpdateReceipts([FromBody] List<UpdateReceiptRequest> models, CancellationToken cancellationToken = default)
 	{
 		UpdateReceiptCommand command = new([.. models.Select(mapper.ToDomain)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -245,10 +245,10 @@ public class ReceiptsController(
 	[HttpDelete(RouteDelete)]
 	[EndpointSummary("Delete receipts")]
 	[EndpointDescription("Deletes one or more receipts by their IDs. Returns 404 if any receipt is not found.")]
-	public async Task<Results<NoContent, NotFound>> DeleteReceipts([FromBody] List<Guid> ids)
+	public async Task<Results<NoContent, NotFound>> DeleteReceipts([FromBody] List<Guid> ids, CancellationToken cancellationToken = default)
 	{
 		DeleteReceiptCommand command = new(ids);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -263,10 +263,10 @@ public class ReceiptsController(
 	[HttpPost(RouteRestore)]
 	[EndpointSummary("Restore a soft-deleted receipt")]
 	[EndpointDescription("Restores a previously soft-deleted receipt and its associated items and transactions.")]
-	public async Task<Results<NoContent, NotFound>> RestoreReceipt([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> RestoreReceipt([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		RestoreReceiptCommand command = new(id);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{

--- a/src/Presentation/API/Controllers/Core/SubcategoriesController.cs
+++ b/src/Presentation/API/Controllers/Core/SubcategoriesController.cs
@@ -37,10 +37,10 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get a subcategory by ID")]
 	[EndpointDescription("Returns a single subcategory matching the provided GUID.")]
-	public async Task<Results<Ok<SubcategoryResponse>, NotFound>> GetSubcategoryById([FromRoute] Guid id)
+	public async Task<Results<Ok<SubcategoryResponse>, NotFound>> GetSubcategoryById([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		GetSubcategoryByIdQuery query = new(id);
-		Subcategory? result = await mediator.Send(query);
+		Subcategory? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{
@@ -54,7 +54,7 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all subcategories")]
-	public async Task<Results<Ok<SubcategoryListResponse>, BadRequest<string>>> GetAllSubcategories([FromQuery] Guid? categoryId = null, [FromQuery] bool? isActive = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<SubcategoryListResponse>, BadRequest<string>>> GetAllSubcategories([FromQuery] Guid? categoryId = null, [FromQuery] bool? isActive = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -81,7 +81,7 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 		if (categoryId.HasValue)
 		{
 			GetSubcategoriesByCategoryIdQuery byCategoryQuery = new(categoryId.Value, offset, limit, sort, isActive);
-			PagedResult<Subcategory> byCategoryResult = await mediator.Send(byCategoryQuery);
+			PagedResult<Subcategory> byCategoryResult = await mediator.Send(byCategoryQuery, cancellationToken);
 
 			return TypedResults.Ok(new SubcategoryListResponse
 			{
@@ -93,7 +93,7 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 		}
 
 		GetAllSubcategoriesQuery query = new(offset, limit, sort, isActive);
-		PagedResult<Subcategory> result = await mediator.Send(query);
+		PagedResult<Subcategory> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new SubcategoryListResponse
 		{
@@ -107,7 +107,7 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted subcategories")]
 	[EndpointDescription("Returns all subcategories that have been soft-deleted.")]
-	public async Task<Results<Ok<SubcategoryListResponse>, BadRequest<string>>> GetDeletedSubcategories([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<SubcategoryListResponse>, BadRequest<string>>> GetDeletedSubcategories([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -131,7 +131,7 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetDeletedSubcategoriesQuery query = new(offset, limit, sort);
-		PagedResult<Subcategory> result = await mediator.Send(query);
+		PagedResult<Subcategory> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new SubcategoryListResponse
 		{
@@ -144,30 +144,30 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single subcategory")]
-	public async Task<Ok<SubcategoryResponse>> CreateSubcategory([FromBody] CreateSubcategoryRequest model)
+	public async Task<Ok<SubcategoryResponse>> CreateSubcategory([FromBody] CreateSubcategoryRequest model, CancellationToken cancellationToken = default)
 	{
 		CreateSubcategoryCommand command = new([mapper.ToDomain(model)]);
-		List<Subcategory> subcategories = await mediator.Send(command);
+		List<Subcategory> subcategories = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyCreated("subcategory", subcategories[0].Id);
 		return TypedResults.Ok(mapper.ToResponse(subcategories[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create subcategories in batch")]
-	public async Task<Ok<List<SubcategoryResponse>>> CreateSubcategories([FromBody] List<CreateSubcategoryRequest> models)
+	public async Task<Ok<List<SubcategoryResponse>>> CreateSubcategories([FromBody] List<CreateSubcategoryRequest> models, CancellationToken cancellationToken = default)
 	{
 		CreateSubcategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
-		List<Subcategory> subcategories = await mediator.Send(command);
+		List<Subcategory> subcategories = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyBulkChanged("subcategory", "created", subcategories.Select(s => s.Id));
 		return TypedResults.Ok(subcategories.Select(mapper.ToResponse).ToList());
 	}
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single subcategory")]
-	public async Task<Results<NoContent, NotFound>> UpdateSubcategory([FromRoute] Guid id, [FromBody] UpdateSubcategoryRequest model)
+	public async Task<Results<NoContent, NotFound>> UpdateSubcategory([FromRoute] Guid id, [FromBody] UpdateSubcategoryRequest model, CancellationToken cancellationToken = default)
 	{
 		UpdateSubcategoryCommand command = new([mapper.ToDomain(model)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -181,10 +181,10 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update subcategories in batch")]
-	public async Task<Results<NoContent, NotFound>> UpdateSubcategories([FromBody] List<UpdateSubcategoryRequest> models)
+	public async Task<Results<NoContent, NotFound>> UpdateSubcategories([FromBody] List<UpdateSubcategoryRequest> models, CancellationToken cancellationToken = default)
 	{
 		UpdateSubcategoryCommand command = new([.. models.Select(mapper.ToDomain)]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -199,20 +199,20 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 	[HttpDelete(RouteDelete)]
 	[EndpointSummary("Soft-delete a subcategory")]
 	[EndpointDescription("Soft-deletes a subcategory. Returns 409 Conflict if receipt items reference this subcategory.")]
-	public async Task<Results<NoContent, NotFound, Conflict<object>>> DeleteSubcategory([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound, Conflict<object>>> DeleteSubcategory([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
-		Subcategory? subcategory = await mediator.Send(new GetSubcategoryByIdQuery(id));
+		Subcategory? subcategory = await mediator.Send(new GetSubcategoryByIdQuery(id), cancellationToken);
 		if (subcategory == null)
 		{
 			logger.LogWarning("Subcategory {Id} not found for deletion", id);
 			return TypedResults.NotFound();
 		}
 
-		int receiptItemCount = await subcategoryService.GetReceiptItemCountBySubcategoryNameAsync(subcategory.Name, HttpContext.RequestAborted);
+		int receiptItemCount = await subcategoryService.GetReceiptItemCountBySubcategoryNameAsync(subcategory.Name, cancellationToken);
 		if (receiptItemCount > 0)
 		{
 			logger.LogWarning("Subcategory {Id} cannot be deleted — {Count} receipt items reference it", id, receiptItemCount);
-			List<(Guid ReceiptId, DateOnly Date, string Location)> affected = await subcategoryService.GetAffectedReceiptsBySubcategoryNameAsync(subcategory.Name, 20, HttpContext.RequestAborted);
+			List<(Guid ReceiptId, DateOnly Date, string Location)> affected = await subcategoryService.GetAffectedReceiptsBySubcategoryNameAsync(subcategory.Name, 20, cancellationToken);
 			return TypedResults.Conflict<object>(new
 			{
 				message = $"Cannot delete — {receiptItemCount} receipt item(s) use this subcategory",
@@ -222,7 +222,7 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 		}
 
 		DeleteSubcategoryCommand command = new([id]);
-		await mediator.Send(command);
+		await mediator.Send(command, cancellationToken);
 
 		await notifier.NotifyDeleted("subcategory", id);
 		return TypedResults.NoContent();
@@ -231,10 +231,10 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 	[HttpPost(RouteRestore)]
 	[EndpointSummary("Restore a soft-deleted subcategory")]
 	[EndpointDescription("Restores a previously soft-deleted subcategory by clearing its DeletedAt timestamp.")]
-	public async Task<Results<NoContent, NotFound>> RestoreSubcategory([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> RestoreSubcategory([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		RestoreSubcategoryCommand command = new(id);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{

--- a/src/Presentation/API/Controllers/Core/TransactionsController.cs
+++ b/src/Presentation/API/Controllers/Core/TransactionsController.cs
@@ -36,10 +36,10 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 	[HttpGet(RouteGetById)]
 	[EndpointSummary("Get a transaction by ID")]
 	[EndpointDescription("Returns a single transaction matching the provided GUID.")]
-	public async Task<Results<Ok<TransactionResponse>, NotFound>> GetTransactionById([FromRoute] Guid id)
+	public async Task<Results<Ok<TransactionResponse>, NotFound>> GetTransactionById([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		GetTransactionByIdQuery query = new(id);
-		Transaction? result = await mediator.Send(query);
+		Transaction? result = await mediator.Send(query, cancellationToken);
 
 		if (result == null)
 		{
@@ -53,7 +53,7 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 
 	[HttpGet(RouteGetAll)]
 	[EndpointSummary("Get all transactions")]
-	public async Task<Results<Ok<TransactionListResponse>, BadRequest<string>>> GetAllTransactions([FromQuery] Guid? receiptId = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<TransactionListResponse>, BadRequest<string>>> GetAllTransactions([FromQuery] Guid? receiptId = null, [FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -80,7 +80,7 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 		if (receiptId.HasValue)
 		{
 			GetTransactionsByReceiptIdQuery byReceiptQuery = new(receiptId.Value, offset, limit, sort);
-			PagedResult<Transaction> byReceiptResult = await mediator.Send(byReceiptQuery);
+			PagedResult<Transaction> byReceiptResult = await mediator.Send(byReceiptQuery, cancellationToken);
 
 			return TypedResults.Ok(new TransactionListResponse
 			{
@@ -92,7 +92,7 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 		}
 
 		GetAllTransactionsQuery query = new(offset, limit, sort);
-		PagedResult<Transaction> result = await mediator.Send(query);
+		PagedResult<Transaction> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new TransactionListResponse
 		{
@@ -106,7 +106,7 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 	[HttpGet(RouteGetDeleted)]
 	[EndpointSummary("Get all soft-deleted transactions")]
 	[EndpointDescription("Returns all transactions that have been soft-deleted.")]
-	public async Task<Results<Ok<TransactionListResponse>, BadRequest<string>>> GetDeletedTransactions([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null)
+	public async Task<Results<Ok<TransactionListResponse>, BadRequest<string>>> GetDeletedTransactions([FromQuery] int offset = 0, [FromQuery] int limit = 50, [FromQuery] string? sortBy = null, [FromQuery] string? sortDirection = null, CancellationToken cancellationToken = default)
 	{
 		if (offset < 0)
 		{
@@ -130,7 +130,7 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 
 		SortParams sort = new(sortBy, sortDirection);
 		GetDeletedTransactionsQuery query = new(offset, limit, sort);
-		PagedResult<Transaction> result = await mediator.Send(query);
+		PagedResult<Transaction> result = await mediator.Send(query, cancellationToken);
 
 		return TypedResults.Ok(new TransactionListResponse
 		{
@@ -143,19 +143,19 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 
 	[HttpPost(RouteCreate)]
 	[EndpointSummary("Create a single transaction")]
-	public async Task<Ok<TransactionResponse>> CreateTransaction([FromBody] CreateTransactionRequest model, [FromRoute] Guid receiptId)
+	public async Task<Ok<TransactionResponse>> CreateTransaction([FromBody] CreateTransactionRequest model, [FromRoute] Guid receiptId, CancellationToken cancellationToken = default)
 	{
 		Transaction transaction = mapper.ToDomain(model);
 		transaction.AccountId = model.AccountId;
 		CreateTransactionCommand command = new([transaction], receiptId);
-		List<Transaction> transactions = await mediator.Send(command);
+		List<Transaction> transactions = await mediator.Send(command, cancellationToken);
 		await notifier.NotifyCreated("transaction", transactions[0].Id);
 		return TypedResults.Ok(mapper.ToResponse(transactions[0]));
 	}
 
 	[HttpPost(RouteCreateBatch)]
 	[EndpointSummary("Create transactions in batch")]
-	public async Task<Ok<List<TransactionResponse>>> CreateTransactions([FromBody] List<CreateTransactionRequest> models, [FromRoute] Guid receiptId)
+	public async Task<Ok<List<TransactionResponse>>> CreateTransactions([FromBody] List<CreateTransactionRequest> models, [FromRoute] Guid receiptId, CancellationToken cancellationToken = default)
 	{
 		List<Transaction> transactions = [.. models.Select(m =>
 		{
@@ -165,7 +165,7 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 		})];
 
 		CreateTransactionCommand command = new(transactions, receiptId);
-		List<Transaction> result = await mediator.Send(command);
+		List<Transaction> result = await mediator.Send(command, cancellationToken);
 
 		List<TransactionResponse> results = [.. result.Select(mapper.ToResponse)];
 		await notifier.NotifyBulkChanged("transaction", "created", result.Select(t => t.Id));
@@ -174,12 +174,12 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 
 	[HttpPut(RouteUpdate)]
 	[EndpointSummary("Update a single transaction")]
-	public async Task<Results<NoContent, NotFound>> UpdateTransaction([FromBody] UpdateTransactionRequest model, [FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> UpdateTransaction([FromBody] UpdateTransactionRequest model, [FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		Transaction transaction = mapper.ToDomain(model);
 		transaction.AccountId = model.AccountId;
 		UpdateTransactionCommand command = new([transaction]);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -193,7 +193,7 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 
 	[HttpPut(RouteUpdateBatch)]
 	[EndpointSummary("Update transactions in batch")]
-	public async Task<Results<NoContent, NotFound>> UpdateTransactions([FromBody] List<UpdateTransactionRequest> models)
+	public async Task<Results<NoContent, NotFound>> UpdateTransactions([FromBody] List<UpdateTransactionRequest> models, CancellationToken cancellationToken = default)
 	{
 		List<Transaction> transactions = [.. models.Select(m =>
 		{
@@ -203,7 +203,7 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 		})];
 
 		UpdateTransactionCommand command = new(transactions);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -218,10 +218,10 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 	[HttpDelete(RouteDelete)]
 	[EndpointSummary("Delete transactions")]
 	[EndpointDescription("Deletes one or more transactions by their IDs. Returns 404 if any transaction is not found.")]
-	public async Task<Results<NoContent, NotFound>> DeleteTransactions([FromBody] List<Guid> ids)
+	public async Task<Results<NoContent, NotFound>> DeleteTransactions([FromBody] List<Guid> ids, CancellationToken cancellationToken = default)
 	{
 		DeleteTransactionCommand command = new(ids);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{
@@ -236,10 +236,10 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 	[HttpPost(RouteRestore)]
 	[EndpointSummary("Restore a soft-deleted transaction")]
 	[EndpointDescription("Restores a previously soft-deleted transaction by clearing its DeletedAt timestamp.")]
-	public async Task<Results<NoContent, NotFound>> RestoreTransaction([FromRoute] Guid id)
+	public async Task<Results<NoContent, NotFound>> RestoreTransaction([FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
 		RestoreTransactionCommand command = new(id);
-		bool result = await mediator.Send(command);
+		bool result = await mediator.Send(command, cancellationToken);
 
 		if (!result)
 		{

--- a/src/Presentation/API/Controllers/Core/TrashController.cs
+++ b/src/Presentation/API/Controllers/Core/TrashController.cs
@@ -17,11 +17,11 @@ public class TrashController(IMediator mediator, ILogger<TrashController> logger
 {
 	[HttpPost("purge")]
 	[EndpointSummary("Permanently delete all soft-deleted items")]
-	public async Task<NoContent> PurgeTrash()
+	public async Task<NoContent> PurgeTrash(CancellationToken cancellationToken = default)
 	{
 		logger.LogWarning("PurgeTrash called — permanently deleting all soft-deleted items");
 		PurgeTrashCommand command = new();
-		await mediator.Send(command);
+		await mediator.Send(command, cancellationToken);
 
 		string[] entityTypes = ["receipt", "receipt-item", "transaction", "adjustment", "account", "category", "subcategory", "item-template"];
 		foreach (string entityType in entityTypes)


### PR DESCRIPTION
## Summary

- Adds `CancellationToken cancellationToken = default` to every endpoint across 13 controllers flagged in RECEIPTS-549's audit, plus `CardsController` (added to the codebase after the audit was recorded).
- Threads the token through every `mediator.Send` call and to downstream service methods that already accept a `CancellationToken` (`accountService.ExistsAsync`, `categoryService.*`, `subcategoryService.*`, `cardService.GetTransactionCountByCardIdAsync`).
- Leaves `IEntityChangeNotifier.Notify*` calls alone on purpose — that interface does not accept a token and notifications should fire regardless of client disconnect.

Matches the pattern used in `DashboardController` / `YnabController` / `ReportsController` (the "already correct" reference controllers). `= default` uniformly avoids test churn; no test changes were required.

Resolves RECEIPTS-550.

## Test plan

- [x] `dotnet build Receipts.slnx` — succeeds
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2,240/2,240 green (Common 18, Domain 123, Application 535, Infrastructure 604, Presentation.API 960)
- [x] Pre-commit hook full gauntlet (format check, build-with-warnings-as-errors, spec drift, client tests 1796/1796) — all green
- [x] Grep verification: the only remaining `mediator.Send(x)` calls without a token are in `AccountsController` (out of scope — uses `HttpContext.RequestAborted` from RECEIPTS-549)