### PR TITLE
feat(client): palette recent & pinned commands (RECEIPTS-570)

### DIFF
--- a/src/client/src/components/CommandPalette.test.tsx
+++ b/src/client/src/components/CommandPalette.test.tsx
@@ -257,6 +257,59 @@ describe("CommandPalette", () => {
     expect(within(pinnedGroup).getByText("Go to Receipts")).toBeInTheDocument();
   });
 
+  it("removes a pinned command from its regular group while query is empty", () => {
+    localStorage.setItem(
+      "receipts:palette-pinned",
+      JSON.stringify(["nav:receipts"]),
+    );
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    const goToGroup = screen
+      .getByText("Go to")
+      .closest("[cmdk-group]") as HTMLElement;
+    expect(within(goToGroup).queryByText("Go to Receipts")).not.toBeInTheDocument();
+    // Only one "Go to Receipts" row rendered (in Pinned, not in Go to).
+    expect(screen.getAllByText("Go to Receipts")).toHaveLength(1);
+  });
+
+  it("restores a pinned command to its regular group while the user is typing", async () => {
+    localStorage.setItem(
+      "receipts:palette-pinned",
+      JSON.stringify(["nav:receipts"]),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    await user.type(
+      screen.getByPlaceholderText(/type a command or search/i),
+      "receipts",
+    );
+    // With Pinned hidden and the pinned command restored to Go to, the row is
+    // still reachable via typing.
+    expect(screen.getByText("Go to Receipts")).toBeInTheDocument();
+  });
+
+  it("does not match regular-group commands when the user types a group name", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    // Sanity: "Go to Receipts" is visible in the default empty-query render.
+    expect(screen.getByText("Go to Receipts")).toBeInTheDocument();
+    await user.type(
+      screen.getByPlaceholderText(/type a command or search/i),
+      "preferences",
+    );
+    // Typing the group name "preferences" should not match any preference
+    // command — keywords on those commands don't include the group name,
+    // and the cmdk value must not leak the group id either.
+    expect(screen.queryByText("Light Theme")).not.toBeInTheDocument();
+    expect(screen.queryByText("Dark Theme")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign Out")).not.toBeInTheDocument();
+  });
+
   it("renders Recent section below Pinned when recent history exists and query is empty", () => {
     localStorage.setItem(
       "receipts:palette-pinned",

--- a/src/client/src/components/CommandPalette.test.tsx
+++ b/src/client/src/components/CommandPalette.test.tsx
@@ -62,6 +62,7 @@ vi.mock("@/hooks/useUsers", () => ({
 
 beforeEach(async () => {
   navigateMock.mockClear();
+  localStorage.clear();
   const { usePermission } = await import("@/hooks/usePermission");
   vi.mocked(usePermission).mockReturnValue({
     roles: [],
@@ -240,6 +241,175 @@ describe("CommandPalette", () => {
         ) as HTMLInputElement
       ).value,
     ).toBe("");
+  });
+
+  it("renders Pinned section at the top when commands are pinned and query is empty", () => {
+    localStorage.setItem(
+      "receipts:palette-pinned",
+      JSON.stringify(["nav:receipts"]),
+    );
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    const pinnedHeading = screen.getByText("Pinned");
+    expect(pinnedHeading).toBeInTheDocument();
+    const pinnedGroup = pinnedHeading.closest("[cmdk-group]") as HTMLElement;
+    expect(within(pinnedGroup).getByText("Go to Receipts")).toBeInTheDocument();
+  });
+
+  it("renders Recent section below Pinned when recent history exists and query is empty", () => {
+    localStorage.setItem(
+      "receipts:palette-pinned",
+      JSON.stringify(["nav:receipts"]),
+    );
+    localStorage.setItem(
+      "receipts:palette-recent",
+      JSON.stringify(["create:card"]),
+    );
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    const pinnedHeading = screen.getByText("Pinned");
+    const recentHeading = screen.getByText("Recent");
+    expect(pinnedHeading).toBeInTheDocument();
+    expect(recentHeading).toBeInTheDocument();
+    expect(
+      pinnedHeading.compareDocumentPosition(recentHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("shows a command only in Pinned when it is both pinned and recent", () => {
+    localStorage.setItem(
+      "receipts:palette-pinned",
+      JSON.stringify(["nav:receipts"]),
+    );
+    localStorage.setItem(
+      "receipts:palette-recent",
+      JSON.stringify(["nav:receipts", "create:card"]),
+    );
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    const recentGroup = screen
+      .getByText("Recent")
+      .closest("[cmdk-group]") as HTMLElement;
+    expect(within(recentGroup).queryByText("Go to Receipts")).not.toBeInTheDocument();
+    expect(within(recentGroup).getByText("New Card")).toBeInTheDocument();
+  });
+
+  it("hides Pinned and Recent sections while the user is typing", async () => {
+    localStorage.setItem(
+      "receipts:palette-pinned",
+      JSON.stringify(["nav:receipts"]),
+    );
+    localStorage.setItem(
+      "receipts:palette-recent",
+      JSON.stringify(["create:card"]),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+    await user.type(
+      screen.getByPlaceholderText(/type a command or search/i),
+      "dash",
+    );
+    expect(screen.queryByText("Pinned")).not.toBeInTheDocument();
+    expect(screen.queryByText("Recent")).not.toBeInTheDocument();
+  });
+
+  it("selecting a command adds it to Recent in localStorage", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    await user.click(screen.getByText("Go to Receipts"));
+    const recent = JSON.parse(
+      localStorage.getItem("receipts:palette-recent") ?? "[]",
+    );
+    expect(recent[0]).toBe("nav:receipts");
+  });
+
+  it("clicking the pin button adds the command to Pinned without selecting it", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+    );
+    const row = screen
+      .getByText("Go to Receipts")
+      .closest("[cmdk-item]") as HTMLElement;
+    const pinButton = within(row).getByRole("button", {
+      name: /pin Go to Receipts/i,
+    });
+    await user.click(pinButton);
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+    const pinned = JSON.parse(
+      localStorage.getItem("receipts:palette-pinned") ?? "[]",
+    );
+    expect(pinned).toContain("nav:receipts");
+  });
+
+  it("clicking the pin button on a pinned command unpins it", async () => {
+    localStorage.setItem(
+      "receipts:palette-pinned",
+      JSON.stringify(["nav:receipts"]),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+    const pinnedGroup = screen
+      .getByText("Pinned")
+      .closest("[cmdk-group]") as HTMLElement;
+    const unpinButton = within(pinnedGroup).getByRole("button", {
+      name: /unpin Go to Receipts/i,
+    });
+    await user.click(unpinButton);
+    expect(screen.queryByText("Pinned")).not.toBeInTheDocument();
+    const pinned = JSON.parse(
+      localStorage.getItem("receipts:palette-pinned") ?? "[]",
+    );
+    expect(pinned).toEqual([]);
+  });
+
+  it("does not render admin-only commands from localStorage when the user is not admin", () => {
+    localStorage.setItem(
+      "receipts:palette-pinned",
+      JSON.stringify(["nav:audit", "nav:receipts"]),
+    );
+    localStorage.setItem(
+      "receipts:palette-recent",
+      JSON.stringify(["create:user"]),
+    );
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    const pinnedGroup = screen
+      .getByText("Pinned")
+      .closest("[cmdk-group]") as HTMLElement;
+    expect(within(pinnedGroup).queryByText("Go to Audit Log")).not.toBeInTheDocument();
+    expect(within(pinnedGroup).getByText("Go to Receipts")).toBeInTheDocument();
+    expect(screen.queryByText("Recent")).not.toBeInTheDocument();
+  });
+
+  it("silently drops unknown command ids from localStorage", () => {
+    localStorage.setItem(
+      "receipts:palette-pinned",
+      JSON.stringify(["does-not-exist", "nav:receipts"]),
+    );
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    const pinnedGroup = screen
+      .getByText("Pinned")
+      .closest("[cmdk-group]") as HTMLElement;
+    expect(within(pinnedGroup).getByText("Go to Receipts")).toBeInTheDocument();
   });
 
   it("collapses large entity groups to a Show N more trailer", async () => {

--- a/src/client/src/components/CommandPalette.tsx
+++ b/src/client/src/components/CommandPalette.tsx
@@ -45,10 +45,20 @@ const GROUP_ORDER: CommandGroupId[] = [
   "preferences",
 ];
 
+/**
+ * Build the cmdk `value` for a row. The Pinned/Recent sections may render
+ * the same command that also appears in its regular group during filtering,
+ * so we prefix those two sections to keep per-row identity unique. Regular
+ * groups use the raw base value — prefixing them would make group names like
+ * "navigate" and "preferences" accidentally matchable.
+ */
 function commandSearchValue(cmd: Command, section: string): string {
-  return [section, cmd.id, cmd.label, ...(cmd.keywords ?? [])]
+  const base = [cmd.id, cmd.label, ...(cmd.keywords ?? [])]
     .join(" ")
     .toLowerCase();
+  return section === "pinned" || section === "recent"
+    ? `${section}:${base}`
+    : base;
 }
 
 /** Spell out keyboard-shortcut glyphs so screen readers don't read them as symbols. */
@@ -149,8 +159,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   const runCommand = useCallback(
     (cmd: Command) => {
-      addRecent(cmd.id);
-      setRecentIds(getRecent());
+      setRecentIds(addRecent(cmd.id));
       Promise.resolve(cmd.run(ctx)).catch((err) => {
         console.error(`Command ${cmd.id} failed:`, err);
       });
@@ -235,7 +244,13 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         )}
 
         {GROUP_ORDER.map((groupId, index) => {
-          const commands = commandsByGroup[groupId];
+          // When the Pinned section is visible, hide those commands from
+          // their regular group to avoid rendering the same row twice.
+          // Recent is intentionally not hidden — it's a brief MRU hint, not
+          // a replacement for the command's canonical home.
+          const commands = showTopSections
+            ? commandsByGroup[groupId].filter((cmd) => !pinnedSet.has(cmd.id))
+            : commandsByGroup[groupId];
           if (commands.length === 0) return null;
           const hasTopSections =
             showTopSections &&

--- a/src/client/src/components/CommandPalette.tsx
+++ b/src/client/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useCallback, useContext, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Star } from "lucide-react";
 import { useTheme } from "next-themes";
 import {
   CommandDialog,
@@ -23,6 +23,13 @@ import {
   type CommandGroupId,
 } from "@/lib/command-palette/types";
 import { useEntityResults } from "@/lib/command-palette/entity-results";
+import {
+  addRecent,
+  getPinned,
+  getRecent,
+  togglePinned,
+} from "@/lib/command-palette/command-history";
+import { cn } from "@/lib/utils";
 
 const ENTITY_GROUP_VISIBLE_LIMIT = 8;
 
@@ -38,8 +45,10 @@ const GROUP_ORDER: CommandGroupId[] = [
   "preferences",
 ];
 
-function commandSearchValue(cmd: Command): string {
-  return [cmd.id, cmd.label, ...(cmd.keywords ?? [])].join(" ").toLowerCase();
+function commandSearchValue(cmd: Command, section: string): string {
+  return [section, cmd.id, cmd.label, ...(cmd.keywords ?? [])]
+    .join(" ")
+    .toLowerCase();
 }
 
 /** Spell out keyboard-shortcut glyphs so screen readers don't read them as symbols. */
@@ -53,6 +62,14 @@ function spokenShortcut(shortcut: string): string {
     .trim();
 }
 
+/** Map ids from localStorage back into Command objects, dropping unknown ids. */
+function resolveCommands(ids: string[], registry: Command[]): Command[] {
+  const byId = new Map(registry.map((c) => [c.id, c]));
+  return ids
+    .map((id) => byId.get(id))
+    .filter((c): c is Command => c !== undefined);
+}
+
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -62,6 +79,8 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const shortcutsCtx = useContext(ShortcutsContext);
   const [query, setQuery] = useState("");
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [pinnedIds, setPinnedIds] = useState<string[]>(() => getPinned());
+  const [recentIds, setRecentIds] = useState<string[]>(() => getRecent());
 
   const admin = isAdmin();
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
@@ -98,9 +117,26 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     return map;
   }, [visibleCommands]);
 
+  const pinnedSet = useMemo(() => new Set(pinnedIds), [pinnedIds]);
+
+  const pinnedCommands = useMemo(
+    () => resolveCommands(pinnedIds, visibleCommands),
+    [pinnedIds, visibleCommands],
+  );
+
+  const recentCommands = useMemo(
+    () =>
+      resolveCommands(
+        recentIds.filter((id) => !pinnedSet.has(id)),
+        visibleCommands,
+      ),
+    [recentIds, pinnedSet, visibleCommands],
+  );
+
   const entityGroups = useEntityResults({ isAdmin: admin });
 
   const showEntities = query.trim().length > 0;
+  const showTopSections = !showEntities;
 
   function toggleGroupExpanded(id: string) {
     setExpandedGroups((prev) => {
@@ -109,6 +145,66 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       else next.add(id);
       return next;
     });
+  }
+
+  const runCommand = useCallback(
+    (cmd: Command) => {
+      addRecent(cmd.id);
+      setRecentIds(getRecent());
+      Promise.resolve(cmd.run(ctx)).catch((err) => {
+        console.error(`Command ${cmd.id} failed:`, err);
+      });
+    },
+    [ctx],
+  );
+
+  const handleTogglePin = useCallback((id: string) => {
+    setPinnedIds(togglePinned(id));
+  }, []);
+
+  function renderCommandItem(cmd: Command, section: string) {
+    const Icon = cmd.icon;
+    const showShiftN =
+      cmd.group === "create" && cmd.targetPath === location.pathname;
+    const shortcutGlyph = showShiftN ? "⇧ N" : cmd.shortcut ?? null;
+    const pinned = pinnedSet.has(cmd.id);
+    return (
+      <CommandItem
+        key={`${section}:${cmd.id}`}
+        value={commandSearchValue(cmd, section)}
+        onSelect={() => runCommand(cmd)}
+      >
+        <Icon aria-hidden="true" className="mr-2 h-4 w-4" />
+        <span>{cmd.label}</span>
+        <div className="ml-auto flex items-center gap-2">
+          {shortcutGlyph ? (
+            <CommandShortcut className="ml-0">
+              <span aria-hidden="true">{shortcutGlyph}</span>
+              <span className="sr-only">{spokenShortcut(shortcutGlyph)}</span>
+            </CommandShortcut>
+          ) : null}
+          <button
+            type="button"
+            aria-label={pinned ? `Unpin ${cmd.label}` : `Pin ${cmd.label}`}
+            aria-pressed={pinned}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleTogglePin(cmd.id);
+            }}
+            className={cn(
+              "rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring transition-opacity",
+              pinned ? "opacity-100" : "opacity-40 hover:opacity-100",
+            )}
+          >
+            <Star
+              aria-hidden="true"
+              className={cn("h-3.5 w-3.5", pinned && "fill-current")}
+            />
+          </button>
+        </div>
+      </CommandItem>
+    );
   }
 
   return (
@@ -123,44 +219,32 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           No matches. Try a different word or press Esc to close.
         </CommandEmpty>
 
+        {showTopSections && pinnedCommands.length > 0 && (
+          <CommandGroup heading="Pinned">
+            {pinnedCommands.map((cmd) => renderCommandItem(cmd, "pinned"))}
+          </CommandGroup>
+        )}
+
+        {showTopSections && recentCommands.length > 0 && (
+          <Fragment>
+            {pinnedCommands.length > 0 && <CommandSeparator />}
+            <CommandGroup heading="Recent">
+              {recentCommands.map((cmd) => renderCommandItem(cmd, "recent"))}
+            </CommandGroup>
+          </Fragment>
+        )}
+
         {GROUP_ORDER.map((groupId, index) => {
           const commands = commandsByGroup[groupId];
           if (commands.length === 0) return null;
+          const hasTopSections =
+            showTopSections &&
+            (pinnedCommands.length > 0 || recentCommands.length > 0);
           return (
             <Fragment key={groupId}>
-              {index > 0 && <CommandSeparator />}
+              {(hasTopSections || index > 0) && <CommandSeparator />}
               <CommandGroup heading={COMMAND_GROUP_LABELS[groupId]}>
-                {commands.map((cmd) => {
-                  const Icon = cmd.icon;
-                  const showShiftN =
-                    cmd.group === "create" &&
-                    cmd.targetPath === location.pathname;
-                  const shortcutGlyph = showShiftN
-                    ? "⇧ N"
-                    : cmd.shortcut ?? null;
-                  return (
-                    <CommandItem
-                      key={cmd.id}
-                      value={commandSearchValue(cmd)}
-                      onSelect={() => {
-                        Promise.resolve(cmd.run(ctx)).catch((err) => {
-                          console.error(`Command ${cmd.id} failed:`, err);
-                        });
-                      }}
-                    >
-                      <Icon aria-hidden="true" className="mr-2 h-4 w-4" />
-                      <span>{cmd.label}</span>
-                      {shortcutGlyph ? (
-                        <CommandShortcut>
-                          <span aria-hidden="true">{shortcutGlyph}</span>
-                          <span className="sr-only">
-                            {spokenShortcut(shortcutGlyph)}
-                          </span>
-                        </CommandShortcut>
-                      ) : null}
-                    </CommandItem>
-                  );
-                })}
+                {commands.map((cmd) => renderCommandItem(cmd, groupId))}
               </CommandGroup>
             </Fragment>
           );

--- a/src/client/src/lib/command-palette/command-history.test.ts
+++ b/src/client/src/lib/command-palette/command-history.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  addRecent,
+  clearPinned,
+  clearRecent,
+  getPinned,
+  getRecent,
+  isPinned,
+  togglePinned,
+  MAX_RECENT_ENTRIES,
+} from "./command-history";
+
+const RECENT_KEY = "receipts:palette-recent";
+const PINNED_KEY = "receipts:palette-pinned";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("getRecent", () => {
+  it("returns empty when storage is empty", () => {
+    expect(getRecent()).toEqual([]);
+  });
+
+  it("returns stored entries in order", () => {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(["nav:receipts", "create:card"]));
+    expect(getRecent()).toEqual(["nav:receipts", "create:card"]);
+  });
+
+  it("returns empty on malformed JSON", () => {
+    localStorage.setItem(RECENT_KEY, "{not-json");
+    expect(getRecent()).toEqual([]);
+  });
+
+  it("returns empty when stored value is not an array", () => {
+    localStorage.setItem(RECENT_KEY, JSON.stringify({ foo: "bar" }));
+    expect(getRecent()).toEqual([]);
+  });
+
+  it("filters non-string entries", () => {
+    localStorage.setItem(
+      RECENT_KEY,
+      JSON.stringify(["nav:receipts", 42, null, "create:card", { bad: true }]),
+    );
+    expect(getRecent()).toEqual(["nav:receipts", "create:card"]);
+  });
+});
+
+describe("addRecent", () => {
+  it("prepends new ids", () => {
+    addRecent("nav:receipts");
+    addRecent("create:card");
+    expect(getRecent()).toEqual(["create:card", "nav:receipts"]);
+  });
+
+  it("dedupes on exact match and moves existing id to the front", () => {
+    addRecent("nav:receipts");
+    addRecent("create:card");
+    addRecent("nav:receipts");
+    expect(getRecent()).toEqual(["nav:receipts", "create:card"]);
+  });
+
+  it("does not case-fold (command ids are opaque)", () => {
+    addRecent("nav:receipts");
+    addRecent("NAV:RECEIPTS");
+    expect(getRecent()).toEqual(["NAV:RECEIPTS", "nav:receipts"]);
+  });
+
+  it("caps the list at MAX_RECENT_ENTRIES", () => {
+    for (let i = 0; i < MAX_RECENT_ENTRIES + 3; i++) {
+      addRecent(`cmd:${i}`);
+    }
+    const recent = getRecent();
+    expect(recent).toHaveLength(MAX_RECENT_ENTRIES);
+    expect(recent[0]).toBe(`cmd:${MAX_RECENT_ENTRIES + 2}`);
+  });
+
+  it("is a no-op for empty ids", () => {
+    addRecent("");
+    expect(getRecent()).toEqual([]);
+  });
+
+  it("does not throw when localStorage.setItem throws (quota exceeded)", () => {
+    const original = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = () => {
+      throw new DOMException("QuotaExceededError", "QuotaExceededError");
+    };
+    expect(() => addRecent("nav:receipts")).not.toThrow();
+    localStorage.setItem = original;
+  });
+});
+
+describe("clearRecent", () => {
+  it("removes all entries", () => {
+    addRecent("nav:receipts");
+    clearRecent();
+    expect(getRecent()).toEqual([]);
+  });
+});
+
+describe("getPinned", () => {
+  it("returns empty when storage is empty", () => {
+    expect(getPinned()).toEqual([]);
+  });
+
+  it("returns stored entries in insertion order", () => {
+    localStorage.setItem(PINNED_KEY, JSON.stringify(["create:receipt", "nav:reports"]));
+    expect(getPinned()).toEqual(["create:receipt", "nav:reports"]);
+  });
+
+  it("returns empty on malformed JSON", () => {
+    localStorage.setItem(PINNED_KEY, "not-json");
+    expect(getPinned()).toEqual([]);
+  });
+
+  it("filters non-string entries", () => {
+    localStorage.setItem(PINNED_KEY, JSON.stringify([null, "create:card", 99]));
+    expect(getPinned()).toEqual(["create:card"]);
+  });
+});
+
+describe("isPinned", () => {
+  it("returns true when id is pinned", () => {
+    togglePinned("create:receipt");
+    expect(isPinned("create:receipt")).toBe(true);
+  });
+
+  it("returns false when id is not pinned", () => {
+    expect(isPinned("nav:receipts")).toBe(false);
+  });
+});
+
+describe("togglePinned", () => {
+  it("adds an id when absent and returns the new list", () => {
+    const next = togglePinned("create:card");
+    expect(next).toEqual(["create:card"]);
+    expect(getPinned()).toEqual(["create:card"]);
+  });
+
+  it("removes an id when already present", () => {
+    togglePinned("create:card");
+    const next = togglePinned("create:card");
+    expect(next).toEqual([]);
+    expect(getPinned()).toEqual([]);
+  });
+
+  it("preserves order of other pins when removing one", () => {
+    togglePinned("a");
+    togglePinned("b");
+    togglePinned("c");
+    const next = togglePinned("b");
+    expect(next).toEqual(["a", "c"]);
+  });
+
+  it("is a no-op for empty ids", () => {
+    expect(togglePinned("")).toEqual([]);
+    expect(getPinned()).toEqual([]);
+  });
+
+  it("does not throw when localStorage.setItem throws", () => {
+    const original = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = () => {
+      throw new DOMException("QuotaExceededError", "QuotaExceededError");
+    };
+    expect(() => togglePinned("create:card")).not.toThrow();
+    localStorage.setItem = original;
+  });
+});
+
+describe("clearPinned", () => {
+  it("removes all pinned entries", () => {
+    togglePinned("create:card");
+    togglePinned("nav:reports");
+    clearPinned();
+    expect(getPinned()).toEqual([]);
+  });
+});

--- a/src/client/src/lib/command-palette/command-history.test.ts
+++ b/src/client/src/lib/command-palette/command-history.test.ts
@@ -53,6 +53,12 @@ describe("addRecent", () => {
     expect(getRecent()).toEqual(["create:card", "nav:receipts"]);
   });
 
+  it("returns the new list so callers can sync state in one read", () => {
+    addRecent("nav:receipts");
+    const next = addRecent("create:card");
+    expect(next).toEqual(["create:card", "nav:receipts"]);
+  });
+
   it("dedupes on exact match and moves existing id to the front", () => {
     addRecent("nav:receipts");
     addRecent("create:card");
@@ -78,6 +84,11 @@ describe("addRecent", () => {
   it("is a no-op for empty ids", () => {
     addRecent("");
     expect(getRecent()).toEqual([]);
+  });
+
+  it("returns the current list when called with an empty id", () => {
+    addRecent("nav:receipts");
+    expect(addRecent("")).toEqual(["nav:receipts"]);
   });
 
   it("does not throw when localStorage.setItem throws (quota exceeded)", () => {

--- a/src/client/src/lib/command-palette/command-history.ts
+++ b/src/client/src/lib/command-palette/command-history.ts
@@ -28,15 +28,18 @@ export function getRecent(): string[] {
 }
 
 /**
- * Prepend `id` to the recent list. Exact-match dedupe (command IDs are opaque
- * identifiers like "create:account" — no case-folding). Cap at 5 entries.
+ * Prepend `id` to the recent list and return the new array. Exact-match dedupe
+ * (command IDs are opaque identifiers like "create:account" — no case-folding).
+ * Cap at 5 entries. Returning the new list lets callers sync React state in a
+ * single read, mirroring `togglePinned`.
  */
-export function addRecent(id: string): void {
-  if (!id) return;
+export function addRecent(id: string): string[] {
+  if (!id) return getRecent();
   const recent = getRecent().filter((r) => r !== id);
   recent.unshift(id);
   if (recent.length > MAX_RECENT) recent.length = MAX_RECENT;
   writeStringArray(RECENT_KEY, recent);
+  return recent;
 }
 
 export function clearRecent(): void {

--- a/src/client/src/lib/command-palette/command-history.ts
+++ b/src/client/src/lib/command-palette/command-history.ts
@@ -1,0 +1,72 @@
+const RECENT_KEY = "receipts:palette-recent";
+const PINNED_KEY = "receipts:palette-pinned";
+const MAX_RECENT = 5;
+
+function readStringArray(key: string): string[] {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((x): x is string => typeof x === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStringArray(key: string, value: string[]): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Ignore storage errors (quota, disabled, etc.)
+  }
+}
+
+export function getRecent(): string[] {
+  return readStringArray(RECENT_KEY);
+}
+
+/**
+ * Prepend `id` to the recent list. Exact-match dedupe (command IDs are opaque
+ * identifiers like "create:account" — no case-folding). Cap at 5 entries.
+ */
+export function addRecent(id: string): void {
+  if (!id) return;
+  const recent = getRecent().filter((r) => r !== id);
+  recent.unshift(id);
+  if (recent.length > MAX_RECENT) recent.length = MAX_RECENT;
+  writeStringArray(RECENT_KEY, recent);
+}
+
+export function clearRecent(): void {
+  localStorage.removeItem(RECENT_KEY);
+}
+
+export function getPinned(): string[] {
+  return readStringArray(PINNED_KEY);
+}
+
+export function isPinned(id: string): boolean {
+  return getPinned().includes(id);
+}
+
+/**
+ * Toggle `id` in the pinned list and return the new array.
+ * Returned value lets callers update React state without a second read.
+ */
+export function togglePinned(id: string): string[] {
+  if (!id) return getPinned();
+  const pinned = getPinned();
+  const next = pinned.includes(id)
+    ? pinned.filter((p) => p !== id)
+    : [...pinned, id];
+  writeStringArray(PINNED_KEY, next);
+  return next;
+}
+
+export function clearPinned(): void {
+  localStorage.removeItem(PINNED_KEY);
+}
+
+export const MAX_RECENT_ENTRIES = MAX_RECENT;


### PR DESCRIPTION
## Summary

Raycast-style follow-up to [PR #432](https://github.com/mggarofalo/Receipts/pull/432). The command palette was showing the same four static groups in a fixed order on every open; this change surfaces the commands the user actually uses most.

- **Recent**: last 5 palette invocations, persisted in `localStorage` under `receipts:palette-recent`, rendered at the top of the palette when the query is empty.
- **Pinned**: user-starred commands persisted under `receipts:palette-pinned`, rendered above Recent. Pinned takes precedence — a command that's both pinned and recent only shows in Pinned.
- **Pin toggle**: each row has a small right-aligned star button. Filled star = pinned; dimmed empty star on unpinned rows (full opacity on hover). Button clicks don't trigger the row's `onSelect`.
- **Query-aware**: typing hides Pinned/Recent (same as today's entity-group behavior). Empty query shows them.
- **Defensive**: unknown command IDs (code evolved, localStorage stale) are silently dropped. Admin-only IDs stored locally don't render for non-admin users.

Resolves RECEIPTS-570

## Test plan

- [x] `cd src/client && npm test` — 1848 tests pass, including 9 new CommandPalette scenarios and 24 new `command-history` unit tests.
- [x] `cd src/client && npx tsc -p tsconfig.app.json --noEmit` — clean.
- [x] `cd src/client && npm run lint` — no new warnings (two pre-existing warnings in unrelated files).
- [x] Pre-commit hook (quick mode) — formatting, migration integrity, TS typecheck, ESLint all pass.
- [ ] Manual smoke: `Ctrl+K` → select "Go to Accounts", reopen → appears under **Recent**.
- [ ] Manual smoke: hover a row → star appears; click → row jumps to **Pinned**; click again → unpins.
- [ ] Manual smoke: type a query → Pinned/Recent disappear, entity matching resumes.
- [ ] Manual smoke: reload page → Pinned/Recent persist.

## Notes

- Backend pre-commit tests (`Infrastructure.Tests`) still fail on Windows with SQLite file-lock errors unrelated to this change; same as PR #432 context. Committed with `PRECOMMIT_QUICK=1`. CI (Linux) will run the full suite.