### PR TITLE
fix(client): darken muted-foreground to meet WCAG AA contrast (RECEIPTS-567)

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -61,7 +61,7 @@
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted-foreground: oklch(0.49 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);

--- a/src/client/src/test/theme-contrast.test.ts
+++ b/src/client/src/test/theme-contrast.test.ts
@@ -1,0 +1,93 @@
+/// <reference types="node" />
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+// Regression guard for RECEIPTS-567: `text-muted-foreground` must meet WCAG AA
+// (4.5:1 for normal text) against every surface it can plausibly render on,
+// in both light and dark themes. Bumping `--muted-foreground` lighter will fail
+// this test.
+//
+// Reads index.css from disk (rather than `?raw` import) because the vite
+// tailwindcss plugin transforms CSS imports through the vitest pipeline,
+// yielding an empty string for `?raw` queries.
+
+const CSS_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../index.css",
+);
+const CSS = readFileSync(CSS_PATH, "utf8");
+
+const WCAG_AA_NORMAL = 4.5;
+
+// Token neighborhoods a small-text caller might reasonably sit on.
+// Extend if new surface tokens are introduced.
+const BACKGROUND_TOKENS = [
+  "background",
+  "card",
+  "popover",
+  "muted",
+  "secondary",
+  "accent",
+  "sidebar",
+  "sidebar-accent",
+] as const;
+
+type ThemeBlock = ":root" | ".dark";
+
+function extractBlock(css: string, selector: ThemeBlock): string {
+  const start = css.indexOf(`${selector} {`);
+  if (start === -1) throw new Error(`Missing ${selector} block in index.css`);
+  const end = css.indexOf("}", start);
+  return css.slice(start, end);
+}
+
+function getTokenL(block: string, name: string): number {
+  // Match `--name: oklch(<L> 0 0);` — chroma must be 0 for the gray math below
+  // to hold. If a token introduces chroma, the test needs a proper OKLCH→sRGB
+  // conversion; the current shadcn theme is all-neutral for these tokens.
+  const re = new RegExp(
+    `--${name}:\\s*oklch\\(\\s*([0-9.]+)\\s+0\\s+0\\s*\\)`,
+  );
+  const match = block.match(re);
+  if (!match) {
+    throw new Error(
+      `Token --${name} not found or uses non-neutral OKLCH in block`,
+    );
+  }
+  return Number.parseFloat(match[1]);
+}
+
+// For neutral grays (chroma=0), OKLCH L cubed equals the WCAG relative
+// luminance: oklab.l = lin_R^(1/3), and for r=g=b the WCAG Y reduces to lin_R.
+function luminance(oklchL: number): number {
+  return oklchL ** 3;
+}
+
+function contrast(fgL: number, bgL: number): number {
+  const a = luminance(fgL);
+  const b = luminance(bgL);
+  const [lighter, darker] = a > b ? [a, b] : [b, a];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe("muted-foreground contrast meets WCAG AA", () => {
+  for (const theme of [":root", ".dark"] as const) {
+    describe(theme, () => {
+      const block = extractBlock(CSS, theme);
+      const fg = getTokenL(block, "muted-foreground");
+
+      for (const bgName of BACKGROUND_TOKENS) {
+        it(`on --${bgName}`, () => {
+          const bg = getTokenL(block, bgName);
+          const ratio = contrast(fg, bg);
+          expect(
+            ratio,
+            `muted-foreground on --${bgName} in ${theme}: ${ratio.toFixed(2)}:1`,
+          ).toBeGreaterThanOrEqual(WCAG_AA_NORMAL);
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes a WCAG AA contrast shortfall flagged by [RECEIPTS-542 PR #432](https://github.com/mggarofalo/receipts/pull/432): `text-muted-foreground` at small sizes was sitting below the 4.5:1 threshold on the "subtle gray" light-mode surfaces.

- **Measured** contrast for every plausible small-text pair using the WCAG formula (OKLCH L cubed equals linear sRGB for neutral grays):
  - Light `muted-fg (0.556)` on `muted`/`secondary`/`accent`/`sidebar-accent (0.97)` = **4.34:1 — FAIL AA normal**
  - Light `muted-fg` on `popover`/`card`/`background (1.0)` = 4.73:1 — borderline pass
  - Light `muted-fg` on `sidebar (0.985)` = 4.53:1 — borderline pass
  - Dark mode: minimum 5.83:1 on all backgrounds — comfortable pass, no change needed
- **Fix**: darken light `--muted-foreground` from `oklch(0.556 0 0)` (≈ `#737373`) to `oklch(0.49 0 0)` (≈ `#606060`). New ratios: 5.74:1 on muted/secondary/accent, 6.00:1 on sidebar, 6.26:1 on popover/card/background. All clear AA with headroom so a small theme tweak won't push the token back below threshold.
- **Regression test** (`src/client/src/test/theme-contrast.test.ts`) parses `index.css` and asserts AA on `muted-foreground` for every surface in both themes. Verified it fails at the old `0.556` value and passes at `0.49`.
- Rejected the issue's alternative suggestion of switching meta text to `text-foreground/80`: that pushes the work to 231 call sites and resolves to a non-muted color, breaking the visual hierarchy. Fixing the token is a one-line change with zero call-site churn.

Resolves RECEIPTS-567

## Test plan

- [x] `npx vitest run src/test/theme-contrast.test.ts` — 16/16 new assertions pass
- [x] `npx vitest run` — full client suite 1831/1831 pass
- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] `npm run lint` — 0 errors, 2 pre-existing warnings in unrelated files
- [x] Pre-commit hook suite passed
- [ ] Manual smoke: light-theme meta text (command palette labels, account card meta, breadcrumbs, form helpers) visibly darker but still reads as secondary; dark theme visually unchanged