### PR TITLE
fix(client): palette navigate+dispatch race on New X commands (RECEIPTS-569)

### DIFF
--- a/src/client/src/hooks/useOpenNewItem.test.tsx
+++ b/src/client/src/hooks/useOpenNewItem.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { useOpenNewItem } from "./useOpenNewItem";
+
+type InitialEntry = string | { pathname: string; state?: unknown };
+
+function createWrapper(initialEntry: InitialEntry = "/test") {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={[initialEntry]}>{children}</MemoryRouter>
+    );
+  };
+}
+
+describe("useOpenNewItem", () => {
+  it("calls open when the shortcut:new-item event fires", () => {
+    const open = vi.fn();
+    renderHook(() => useOpenNewItem(open), { wrapper: createWrapper() });
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("shortcut:new-item"));
+    });
+
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes the listener on unmount", () => {
+    const open = vi.fn();
+    const { unmount } = renderHook(() => useOpenNewItem(open), {
+      wrapper: createWrapper(),
+    });
+
+    unmount();
+
+    window.dispatchEvent(new CustomEvent("shortcut:new-item"));
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("resubscribes when the open callback changes", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ open }: { open: () => void }) => useOpenNewItem(open),
+      { wrapper: createWrapper(), initialProps: { open: first } },
+    );
+
+    rerender({ open: second });
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("shortcut:new-item"));
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens when mounted with openNew navigation state", () => {
+    const open = vi.fn();
+    renderHook(() => useOpenNewItem(open), {
+      wrapper: createWrapper({
+        pathname: "/accounts",
+        state: { openNew: true },
+      }),
+    });
+
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears navigation state after consuming it", () => {
+    const open = vi.fn();
+
+    function HookAndLocation() {
+      useOpenNewItem(open);
+      const location = useLocation();
+      return location.state as { openNew?: boolean } | null;
+    }
+
+    const { result } = renderHook(() => HookAndLocation(), {
+      wrapper: createWrapper({
+        pathname: "/accounts",
+        state: { openNew: true },
+      }),
+    });
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(result.current).toBeNull();
+  });
+
+  it("does nothing when mounted without openNew state", () => {
+    const open = vi.fn();
+    renderHook(() => useOpenNewItem(open), {
+      wrapper: createWrapper("/accounts"),
+    });
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("does not re-trigger on subsequent renders once state is cleared", () => {
+    const open = vi.fn();
+    const { rerender } = renderHook(() => useOpenNewItem(open), {
+      wrapper: createWrapper({
+        pathname: "/accounts",
+        state: { openNew: true },
+      }),
+    });
+
+    rerender();
+    rerender();
+
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/client/src/hooks/useOpenNewItem.test.tsx
+++ b/src/client/src/hooks/useOpenNewItem.test.tsx
@@ -88,6 +88,31 @@ describe("useOpenNewItem", () => {
     expect(result.current).toBeNull();
   });
 
+  it("preserves pathname, search, and hash when clearing state", () => {
+    const open = vi.fn();
+
+    function HookAndLocation() {
+      useOpenNewItem(open);
+      const location = useLocation();
+      return location;
+    }
+
+    const { result } = renderHook(() => HookAndLocation(), {
+      wrapper: createWrapper({
+        pathname: "/accounts",
+        search: "?foo=bar",
+        hash: "#section",
+        state: { openNew: true },
+      } as unknown as Parameters<typeof createWrapper>[0]),
+    });
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(result.current.pathname).toBe("/accounts");
+    expect(result.current.search).toBe("?foo=bar");
+    expect(result.current.hash).toBe("#section");
+    expect(result.current.state).toBeNull();
+  });
+
   it("does nothing when mounted without openNew state", () => {
     const open = vi.fn();
     renderHook(() => useOpenNewItem(open), {

--- a/src/client/src/hooks/useOpenNewItem.ts
+++ b/src/client/src/hooks/useOpenNewItem.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+// Navigation-state shape used by the command palette's "New X" commands to ask
+// a target list page to open its create dialog on mount. Using state instead
+// of a post-navigate setTimeout avoids a race: the listener doesn't need to
+// already be mounted when the command fires.
+interface OpenNewItemState {
+  openNew?: boolean;
+}
+
+/**
+ * Wire a list page's create dialog to both the Shift+N global shortcut and
+ * the command palette's cross-page "New X" action.
+ *
+ * - Subscribes to the `shortcut:new-item` window event (Shift+N, same-page
+ *   palette actions).
+ * - Reads `location.state.openNew` on mount/navigation; if true, calls `open`
+ *   and strips the flag so browser back/forward won't re-trigger.
+ *
+ * Pass a stable callback (e.g. a `useCallback` that closes over a
+ * `useState` setter) so the subscription effect doesn't resubscribe.
+ */
+export function useOpenNewItem(open: () => void) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    window.addEventListener("shortcut:new-item", open);
+    return () => window.removeEventListener("shortcut:new-item", open);
+  }, [open]);
+
+  useEffect(() => {
+    const state = location.state as OpenNewItemState | null;
+    if (state?.openNew) {
+      open();
+      navigate(location.pathname + location.search, {
+        replace: true,
+        state: null,
+      });
+    }
+  }, [location, navigate, open]);
+}

--- a/src/client/src/hooks/useOpenNewItem.ts
+++ b/src/client/src/hooks/useOpenNewItem.ts
@@ -34,7 +34,7 @@ export function useOpenNewItem(open: () => void) {
     const state = location.state as OpenNewItemState | null;
     if (state?.openNew) {
       open();
-      navigate(location.pathname + location.search, {
+      navigate(location.pathname + location.search + location.hash, {
         replace: true,
         state: null,
       });

--- a/src/client/src/lib/command-palette/commands.test.ts
+++ b/src/client/src/lib/command-palette/commands.test.ts
@@ -135,25 +135,30 @@ describe("command registry", () => {
     dispatchSpy.mockRestore();
   });
 
-  it("create:account navigates then dispatches when on a different page", () => {
-    vi.useFakeTimers();
+  it("create:account navigates with openNew state when on a different page", () => {
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
     const ctx = makeCtx({ currentPath: "/" });
     COMMANDS.find((c) => c.id === "create:account")!.run(ctx);
-    expect(ctx.navigate).toHaveBeenCalledWith("/accounts");
+    expect(ctx.close).toHaveBeenCalled();
+    expect(ctx.navigate).toHaveBeenCalledWith("/accounts", {
+      state: { openNew: true },
+    });
     expect(
       dispatchSpy.mock.calls.some(
         ([e]) => (e as CustomEvent).type === "shortcut:new-item",
       ),
     ).toBe(false);
-    vi.advanceTimersByTime(100);
-    expect(
-      dispatchSpy.mock.calls.some(
-        ([e]) => (e as CustomEvent).type === "shortcut:new-item",
-      ),
-    ).toBe(true);
     dispatchSpy.mockRestore();
-    vi.useRealTimers();
+  });
+
+  it("create:user navigates to /admin/users with openNew state", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+    const ctx = makeCtx({ currentPath: "/" });
+    COMMANDS.find((c) => c.id === "create:user")!.run(ctx);
+    expect(ctx.navigate).toHaveBeenCalledWith("/admin/users", {
+      state: { openNew: true },
+    });
+    dispatchSpy.mockRestore();
   });
 
   it("create:receipt navigates directly (no event dispatch)", () => {

--- a/src/client/src/lib/command-palette/commands.ts
+++ b/src/client/src/lib/command-palette/commands.ts
@@ -30,35 +30,27 @@ import {
   UserPlus,
   Users,
 } from "lucide-react";
-import type { Command } from "./types";
+import type { Command, CommandContext } from "./types";
 
 /**
- * Dispatches the app's existing per-page "open new-item dialog" handler.
- * If already on the target page, dispatch immediately; otherwise navigate
- * first and dispatch after a short delay so the target page's effect has
- * mounted and registered its listener.
+ * Open a list page's create dialog from the command palette.
+ *
+ * Same-page: dispatch the `shortcut:new-item` event — the page's listener is
+ * already mounted. Cross-page: navigate with `state.openNew` so the target
+ * page's `useOpenNewItem` hook opens the dialog on mount. The earlier
+ * dispatch-after-setTimeout approach raced with the listener's mount and
+ * silently dropped the event on slow devices or under StrictMode.
  */
 function runNewItem(
   targetPath: string,
-  {
-    navigate,
-    close,
-    currentPath,
-  }: {
-    navigate: (path: string) => void;
-    close: () => void;
-    currentPath: string;
-  },
+  { navigate, close, currentPath }: CommandContext,
 ) {
   close();
   if (currentPath === targetPath) {
     window.dispatchEvent(new CustomEvent("shortcut:new-item"));
     return;
   }
-  navigate(targetPath);
-  setTimeout(() => {
-    window.dispatchEvent(new CustomEvent("shortcut:new-item"));
-  }, 50);
+  navigate(targetPath, { state: { openNew: true } });
 }
 
 function goTo(path: string) {

--- a/src/client/src/pages/Accounts.test.tsx
+++ b/src/client/src/pages/Accounts.test.tsx
@@ -193,4 +193,29 @@ describe("Accounts", () => {
 
     expect(await screen.findByText(/no cards linked/i)).toBeInTheDocument();
   });
+
+  it("opens create dialog on shortcut:new-item event", async () => {
+    const { act } = await import("@testing-library/react");
+    renderWithProviders(<Accounts />);
+
+    act(() => {
+      window.dispatchEvent(new Event("shortcut:new-item"));
+    });
+
+    await screen.findByRole("heading", { name: /create account/i });
+    expect(
+      screen.getByRole("heading", { name: /create account/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithProviders(<Accounts />, {
+      route: { pathname: "/accounts", state: { openNew: true } },
+    });
+
+    await screen.findByRole("heading", { name: /create account/i });
+    expect(
+      screen.getByRole("heading", { name: /create account/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useMemo, useEffect, useCallback } from "react";
+import { Fragment, useState, useMemo, useCallback } from "react";
 import { Link } from "react-router";
 import {
   useAccounts,
@@ -10,6 +10,7 @@ import {
 import { usePermission } from "@/hooks/usePermission";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useEntityLinkParams } from "@/hooks/useEntityLinkParams";
+import { useOpenNewItem } from "@/hooks/useOpenNewItem";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useServerPagination } from "@/hooks/useServerPagination";
 import { useServerSort } from "@/hooks/useServerSort";
@@ -139,13 +140,8 @@ function Accounts() {
     });
   }, []);
 
-  useEffect(() => {
-    function onNewItem() {
-      setCreateOpen(true);
-    }
-    window.addEventListener("shortcut:new-item", onNewItem);
-    return () => window.removeEventListener("shortcut:new-item", onNewItem);
-  }, []);
+  const openCreate = useCallback(() => setCreateOpen(true), []);
+  useOpenNewItem(openCreate);
 
   const handleSort = useCallback((column: string) => {
     toggleSort(column);

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -653,4 +653,29 @@ describe("AdminUsers", () => {
     const roleBadge = screen.getByText("User", { selector: "[data-slot='badge']" });
     expect(roleBadge).toBeInTheDocument();
   });
+
+  it("opens create dialog on shortcut:new-item event", async () => {
+    const { act } = await import("@testing-library/react");
+    renderWithProviders(<AdminUsers />);
+
+    act(() => {
+      window.dispatchEvent(new Event("shortcut:new-item"));
+    });
+
+    await screen.findByRole("heading", { name: /create user/i });
+    expect(
+      screen.getByRole("heading", { name: /create user/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithProviders(<AdminUsers />, {
+      route: { pathname: "/admin/users", state: { openNew: true } },
+    });
+
+    await screen.findByRole("heading", { name: /create user/i });
+    expect(
+      screen.getByRole("heading", { name: /create user/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/hooks/useUsers";
 import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useOpenNewItem } from "@/hooks/useOpenNewItem";
 import { useServerPagination } from "@/hooks/useServerPagination";
 import { useServerSort } from "@/hooks/useServerSort";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
@@ -123,6 +124,9 @@ function AdminUsers() {
     id: string;
     email: string;
   } | null>(null);
+
+  const openCreate = useCallback(() => setCreateOpen(true), []);
+  useOpenNewItem(openCreate);
 
   const items = usersData ?? [];
 

--- a/src/client/src/pages/ApiKeys.test.tsx
+++ b/src/client/src/pages/ApiKeys.test.tsx
@@ -248,6 +248,17 @@ describe("ApiKeys", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithQueryClient(<ApiKeys />, {
+      route: { pathname: "/api-keys", state: { openNew: true } },
+    });
+
+    await screen.findByRole("heading", { name: /create api key/i });
+    expect(
+      screen.getByRole("heading", { name: /create api key/i }),
+    ).toBeInTheDocument();
+  });
+
   it("shows loading skeleton when data is loading", async () => {
     const { useQuery } = await import("@tanstack/react-query");
     vi.mocked(useQuery).mockReturnValue(mockQueryResult({

--- a/src/client/src/pages/ApiKeys.tsx
+++ b/src/client/src/pages/ApiKeys.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { usePermission } from "@/hooks/usePermission";
+import { useOpenNewItem } from "@/hooks/useOpenNewItem";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -152,13 +153,7 @@ function ApiKeys() {
     setCreateOpen(true);
   }, [createForm]);
 
-  useEffect(() => {
-    function onNewItem() {
-      handleCreateOpen();
-    }
-    window.addEventListener("shortcut:new-item", onNewItem);
-    return () => window.removeEventListener("shortcut:new-item", onNewItem);
-  }, [handleCreateOpen]);
+  useOpenNewItem(handleCreateOpen);
 
   function handleCreateSubmit(values: CreateKeyFormValues) {
     createMutation.mutate(values);

--- a/src/client/src/pages/Cards.integration.test.tsx
+++ b/src/client/src/pages/Cards.integration.test.tsx
@@ -205,4 +205,16 @@ describe("Cards (integration)", () => {
       expect(screen.getByRole("heading", { name: /create card/i })).toBeInTheDocument();
     });
   });
+
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithQueryClient(<Cards />, {
+      route: { pathname: "/cards", state: { openNew: true } },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /create card/i }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/client/src/pages/Cards.test.tsx
+++ b/src/client/src/pages/Cards.test.tsx
@@ -273,6 +273,17 @@ describe("Cards", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithProviders(<Cards />, {
+      route: { pathname: "/cards", state: { openNew: true } },
+    });
+
+    await screen.findByRole("heading", { name: /create card/i });
+    expect(
+      screen.getByRole("heading", { name: /create card/i }),
+    ).toBeInTheDocument();
+  });
+
   it("submits create form and calls createCard.mutate", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const mockMutate = vi.fn();

--- a/src/client/src/pages/Cards.tsx
+++ b/src/client/src/pages/Cards.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { Link } from "react-router";
 import {
   useCards,
@@ -10,6 +10,7 @@ import { useAccounts } from "@/hooks/useAccounts";
 import { usePermission } from "@/hooks/usePermission";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useEntityLinkParams } from "@/hooks/useEntityLinkParams";
+import { useOpenNewItem } from "@/hooks/useOpenNewItem";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useServerPagination } from "@/hooks/useServerPagination";
 import { useServerSort } from "@/hooks/useServerSort";
@@ -121,13 +122,8 @@ function Cards() {
 
   const handleMergeComplete = useCallback(() => setSelectedIds(new Set()), []);
 
-  useEffect(() => {
-    function onNewItem() {
-      setCreateOpen(true);
-    }
-    window.addEventListener("shortcut:new-item", onNewItem);
-    return () => window.removeEventListener("shortcut:new-item", onNewItem);
-  }, []);
+  const openCreate = useCallback(() => setCreateOpen(true), []);
+  useOpenNewItem(openCreate);
 
   const handleSort = useCallback((column: string) => {
     toggleSort(column);

--- a/src/client/src/pages/Categories.integration.test.tsx
+++ b/src/client/src/pages/Categories.integration.test.tsx
@@ -217,4 +217,16 @@ describe("Categories (integration)", () => {
       expect(screen.getByRole("heading", { name: /create category/i })).toBeInTheDocument();
     });
   });
+
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithQueryClient(<Categories />, {
+      route: { pathname: "/categories", state: { openNew: true } },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /create category/i }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/client/src/pages/Categories.test.tsx
+++ b/src/client/src/pages/Categories.test.tsx
@@ -350,4 +350,15 @@ describe("Categories", () => {
       screen.getByRole("heading", { name: /create category/i }),
     ).toBeInTheDocument();
   });
+
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithProviders(<Categories />, {
+      route: { pathname: "/categories", state: { openNew: true } },
+    });
+
+    await screen.findByRole("heading", { name: /create category/i });
+    expect(
+      screen.getByRole("heading", { name: /create category/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { Link } from "react-router";
 import {
   useCategories,
@@ -9,6 +9,7 @@ import {
 import { usePermission } from "@/hooks/usePermission";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useEntityLinkParams } from "@/hooks/useEntityLinkParams";
+import { useOpenNewItem } from "@/hooks/useOpenNewItem";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
 import { useServerPagination } from "@/hooks/useServerPagination";
@@ -95,13 +96,8 @@ function Categories() {
 
   const anyDialogOpen = createOpen || editCategory !== null;
 
-  useEffect(() => {
-    function onNewItem() {
-      setCreateOpen(true);
-    }
-    window.addEventListener("shortcut:new-item", onNewItem);
-    return () => window.removeEventListener("shortcut:new-item", onNewItem);
-  }, []);
+  const openCreate = useCallback(() => setCreateOpen(true), []);
+  useOpenNewItem(openCreate);
 
   const handleSort = useCallback((column: string) => {
     toggleSort(column);

--- a/src/client/src/pages/ItemTemplates.integration.test.tsx
+++ b/src/client/src/pages/ItemTemplates.integration.test.tsx
@@ -271,4 +271,16 @@ describe("ItemTemplates (integration)", () => {
       expect(screen.getByRole("heading", { name: /create item template/i })).toBeInTheDocument();
     });
   });
+
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithQueryClient(<ItemTemplates />, {
+      route: { pathname: "/item-templates", state: { openNew: true } },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /create item template/i }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/client/src/pages/ItemTemplates.test.tsx
+++ b/src/client/src/pages/ItemTemplates.test.tsx
@@ -454,6 +454,17 @@ describe("ItemTemplates", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithProviders(<ItemTemplates />, {
+      route: { pathname: "/item-templates", state: { openNew: true } },
+    });
+
+    await screen.findByRole("heading", { name: /create item template/i });
+    expect(
+      screen.getByRole("heading", { name: /create item template/i }),
+    ).toBeInTheDocument();
+  });
+
   it("shows Hide button in edit modal when user is admin", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const items = [

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useCallback } from "react";
 import {
   useItemTemplates,
   useCreateItemTemplate,
@@ -8,6 +8,7 @@ import {
 } from "@/hooks/useItemTemplates";
 import { usePermission } from "@/hooks/usePermission";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useOpenNewItem } from "@/hooks/useOpenNewItem";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
 import { useServerPagination } from "@/hooks/useServerPagination";
@@ -82,13 +83,8 @@ function ItemTemplates() {
 
   const anyDialogOpen = createOpen || editTemplate !== null || deleteOpen;
 
-  useEffect(() => {
-    function onNewItem() {
-      setCreateOpen(true);
-    }
-    window.addEventListener("shortcut:new-item", onNewItem);
-    return () => window.removeEventListener("shortcut:new-item", onNewItem);
-  }, []);
+  const openCreate = useCallback(() => setCreateOpen(true), []);
+  useOpenNewItem(openCreate);
 
   const handleSort = useCallback((column: string) => {
     toggleSort(column);

--- a/src/client/src/pages/Subcategories.integration.test.tsx
+++ b/src/client/src/pages/Subcategories.integration.test.tsx
@@ -299,4 +299,16 @@ describe("Subcategories (integration)", () => {
       expect(screen.getByRole("heading", { name: /create subcategory/i })).toBeInTheDocument();
     });
   });
+
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithQueryClient(<Subcategories />, {
+      route: { pathname: "/subcategories", state: { openNew: true } },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /create subcategory/i }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -372,6 +372,17 @@ describe("Subcategories", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens create dialog when navigated with openNew state", async () => {
+    renderWithProviders(<Subcategories />, {
+      route: { pathname: "/subcategories", state: { openNew: true } },
+    });
+
+    await screen.findByRole("heading", { name: /create subcategory/i });
+    expect(
+      screen.getByRole("heading", { name: /create subcategory/i }),
+    ).toBeInTheDocument();
+  });
+
   it("does not render receipt-items links in expanded rows", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     await setupWithData();

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useMemo, useEffect, useCallback } from "react";
+import { Fragment, useState, useMemo, useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { Link } from "react-router";
 import {
@@ -13,6 +13,7 @@ import { usePermission } from "@/hooks/usePermission";
 import { useCategories } from "@/hooks/useCategories";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useEntityLinkParams } from "@/hooks/useEntityLinkParams";
+import { useOpenNewItem } from "@/hooks/useOpenNewItem";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 import { useSavedFilters } from "@/hooks/useSavedFilters";
 import { useServerPagination } from "@/hooks/useServerPagination";
@@ -125,13 +126,8 @@ function Subcategories() {
 
   const anyDialogOpen = createOpen || editSubcategory !== null || conflictData !== null;
 
-  useEffect(() => {
-    function onNewItem() {
-      setCreateOpen(true);
-    }
-    window.addEventListener("shortcut:new-item", onNewItem);
-    return () => window.removeEventListener("shortcut:new-item", onNewItem);
-  }, []);
+  const openCreate = useCallback(() => setCreateOpen(true), []);
+  useOpenNewItem(openCreate);
 
   const handleSort = useCallback((column: string) => {
     toggleSort(column);

--- a/src/client/src/test/test-utils.tsx
+++ b/src/client/src/test/test-utils.tsx
@@ -14,9 +14,11 @@ const defaultAuth: AuthContextValue = {
   changePassword: async () => {},
 };
 
+type RouteEntry = string | { pathname: string; search?: string; state?: unknown };
+
 interface WrapperOptions {
   auth?: Partial<AuthContextValue>;
-  route?: string;
+  route?: RouteEntry;
 }
 
 export function createWrapper({ auth, route = "/" }: WrapperOptions = {}) {


### PR DESCRIPTION
## Summary

- Replaces the `setTimeout(dispatchEvent, 50)` race in `runNewItem` with navigation state: `navigate(path, { state: { openNew: true } })`. The dispatch would silently drop on slow devices or under React StrictMode when the target page's listener hadn't mounted in time.
- New shared hook `useOpenNewItem(open)` consolidates the two pathways (Shift+N window event + palette navigation state) and clears the state after consuming so browser back/forward doesn't re-open the dialog.
- 7 list pages now use the hook: `Accounts`, `Cards`, `Categories`, `Subcategories`, `ItemTemplates`, `ApiKeys`, `AdminUsers`. `AdminUsers` had no `shortcut:new-item` listener at all before this PR — palette "New User" never actually worked on a fresh navigation; it does now.

Resolves RECEIPTS-569

## Test plan

- [x] `npm test` — all 1832 unit tests pass, including 7 new `useOpenNewItem` tests and 9 new "opens create dialog when navigated with openNew state" tests across the 7 pages.
- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean.
- [x] `npm run lint` — no new warnings.
- [x] `npm run test:integration -- src/pages/Cards.integration.test.tsx src/pages/Categories.integration.test.tsx src/pages/Subcategories.integration.test.tsx src/pages/ItemTemplates.integration.test.tsx` — new integration-test cases pass. (The 8 pre-existing failures are unrelated — confirmed to fail on clean `origin/develop` too.)
- [ ] Manual smoke: open palette on `/`, click **New Account** → Accounts page loads with create dialog open. Click browser back → state cleared, dialog does not re-open. On `/accounts`, "New Account" uses the event path and opens instantly.
- [ ] Manual smoke: admin user on `/`, palette → **New User** → AdminUsers page loads with create dialog open (this was broken before).