### PR TITLE
feat(client): palette direct-action commands (RECEIPTS-571)

### DIFF
--- a/src/client/src/components/CommandPalette.test.tsx
+++ b/src/client/src/components/CommandPalette.test.tsx
@@ -610,6 +610,32 @@ describe("CommandPalette", () => {
     });
   });
 
+  it("Empty Trash keeps the palette open when the purge mutation fails", async () => {
+    purgeTrashMutateAsync.mockRejectedValueOnce(new Error("network"));
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: () => true,
+      isAdmin: () => true,
+    });
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+    );
+    await user.click(screen.getByText("Empty Trash"));
+    const dialog = await screen.findByRole("alertdialog");
+    const confirm = within(dialog).getByRole("button", {
+      name: /empty trash/i,
+    });
+    await user.click(confirm);
+    await waitFor(() => {
+      expect(purgeTrashMutateAsync).toHaveBeenCalled();
+    });
+    // Palette must stay open so the user can retry.
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it("cancelling Empty Trash closes the dialog without calling purge", async () => {
     const { usePermission } = await import("@/hooks/usePermission");
     vi.mocked(usePermission).mockReturnValue({

--- a/src/client/src/components/CommandPalette.test.tsx
+++ b/src/client/src/components/CommandPalette.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
-import { screen, within } from "@testing-library/react";
+import { screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CommandPalette } from "./CommandPalette";
 import { renderWithQueryClient } from "@/test/test-utils";
@@ -60,8 +60,31 @@ vi.mock("@/hooks/useUsers", () => ({
   useUsers: vi.fn(() => mockQueryResult()),
 }));
 
+const bulkPushMutate = vi.fn();
+const backupExportMutate = vi.fn();
+const purgeTrashMutateAsync = vi.fn(async () => {});
+const fetchAllReceiptIdsMock = vi.fn(async () => ({ ids: ["r1", "r2"], total: 2 }));
+
+vi.mock("@/hooks/useYnab", () => ({
+  fetchAllReceiptIds: () => fetchAllReceiptIdsMock(),
+  useBulkPushYnabTransactions: () => ({ mutate: bulkPushMutate, isPending: false }),
+}));
+
+vi.mock("@/hooks/useBackup", () => ({
+  useBackupExport: () => ({ mutate: backupExportMutate, isPending: false }),
+}));
+
+vi.mock("@/hooks/useTrash", () => ({
+  usePurgeTrash: () => ({ mutateAsync: purgeTrashMutateAsync, isPending: false }),
+}));
+
 beforeEach(async () => {
   navigateMock.mockClear();
+  bulkPushMutate.mockClear();
+  backupExportMutate.mockClear();
+  purgeTrashMutateAsync.mockClear();
+  fetchAllReceiptIdsMock.mockClear();
+  fetchAllReceiptIdsMock.mockResolvedValue({ ids: ["r1", "r2"], total: 2 });
   localStorage.clear();
   const { usePermission } = await import("@/hooks/usePermission");
   vi.mocked(usePermission).mockReturnValue({
@@ -463,6 +486,148 @@ describe("CommandPalette", () => {
       .getByText("Pinned")
       .closest("[cmdk-group]") as HTMLElement;
     expect(within(pinnedGroup).getByText("Go to Receipts")).toBeInTheDocument();
+  });
+
+  it("renders the Actions group with Sync YNAB Now for every user", () => {
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+    expect(screen.getByText("Sync YNAB Now")).toBeInTheDocument();
+  });
+
+  it("hides admin-only action commands when user is not admin", () => {
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    expect(screen.queryByText("Export Backup")).not.toBeInTheDocument();
+    expect(screen.queryByText("Empty Trash")).not.toBeInTheDocument();
+  });
+
+  it("shows admin-only action commands for admins", async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: () => true,
+      isAdmin: () => true,
+    });
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    expect(screen.getByText("Export Backup")).toBeInTheDocument();
+    expect(screen.getByText("Empty Trash")).toBeInTheDocument();
+  });
+
+  it("Sync YNAB Now fetches receipt IDs, fires bulk push, and closes the palette", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+    );
+    await user.click(screen.getByText("Sync YNAB Now"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(fetchAllReceiptIdsMock).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(bulkPushMutate).toHaveBeenCalledWith(["r1", "r2"]);
+    });
+  });
+
+  it("Sync YNAB Now skips the push when there are no receipts", async () => {
+    fetchAllReceiptIdsMock.mockResolvedValueOnce({ ids: [], total: 0 });
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={vi.fn()} />,
+    );
+    await user.click(screen.getByText("Sync YNAB Now"));
+    await waitFor(() => {
+      expect(fetchAllReceiptIdsMock).toHaveBeenCalled();
+    });
+    expect(bulkPushMutate).not.toHaveBeenCalled();
+  });
+
+  it("Export Backup fires the export mutation and closes the palette", async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: () => true,
+      isAdmin: () => true,
+    });
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+    );
+    await user.click(screen.getByText("Export Backup"));
+    expect(backupExportMutate).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("Empty Trash opens a confirmation dialog without closing the palette", async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: () => true,
+      isAdmin: () => true,
+    });
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+    );
+    await user.click(screen.getByText("Empty Trash"));
+    expect(
+      await screen.findByRole("alertdialog", { name: /empty trash/i }),
+    ).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(purgeTrashMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("confirming Empty Trash fires purge and closes the palette", async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: () => true,
+      isAdmin: () => true,
+    });
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+    );
+    await user.click(screen.getByText("Empty Trash"));
+    const dialog = await screen.findByRole("alertdialog");
+    const confirm = within(dialog).getByRole("button", {
+      name: /empty trash/i,
+    });
+    await user.click(confirm);
+    await waitFor(() => {
+      expect(purgeTrashMutateAsync).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("cancelling Empty Trash closes the dialog without calling purge", async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: () => true,
+      isAdmin: () => true,
+    });
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+    );
+    await user.click(screen.getByText("Empty Trash"));
+    const dialog = await screen.findByRole("alertdialog");
+    const cancel = within(dialog).getByRole("button", { name: /cancel/i });
+    await user.click(cancel);
+    expect(purgeTrashMutateAsync).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it("collapses large entity groups to a Show N more trailer", async () => {

--- a/src/client/src/components/CommandPalette.tsx
+++ b/src/client/src/components/CommandPalette.tsx
@@ -111,9 +111,12 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const [recentIds, setRecentIds] = useState<string[]>(() => getRecent());
   const [confirmingEmptyTrash, setConfirmingEmptyTrash] = useState(false);
 
-  const bulkPushYnab = useBulkPushYnabTransactions();
-  const backupExport = useBackupExport();
-  const purgeTrash = usePurgeTrash();
+  // Destructure stable callbacks — TanStack Query guarantees mutate/mutateAsync
+  // are stable refs, but the surrounding mutation object is not.
+  const { mutate: bulkPushYnabMutate } = useBulkPushYnabTransactions();
+  const { mutate: backupExportMutate } = useBackupExport();
+  const { mutateAsync: purgeTrashMutateAsync, isPending: purgeTrashPending } =
+    usePurgeTrash();
 
   const admin = isAdmin();
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
@@ -130,16 +133,16 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           toast.info("No receipts to sync");
           return;
         }
-        bulkPushYnab.mutate(ids);
+        bulkPushYnabMutate(ids);
       } catch {
         toast.error("Failed to load receipts for YNAB sync");
       }
     })();
-  }, [bulkPushYnab]);
+  }, [bulkPushYnabMutate]);
 
   const exportBackup = useCallback(() => {
-    backupExport.mutate();
-  }, [backupExport]);
+    backupExportMutate();
+  }, [backupExportMutate]);
 
   const confirmEmptyTrash = useCallback(() => {
     setConfirmingEmptyTrash(true);
@@ -147,12 +150,15 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   const handleConfirmEmptyTrash = useCallback(async () => {
     try {
-      await purgeTrash.mutateAsync();
-    } finally {
+      await purgeTrashMutateAsync();
       setConfirmingEmptyTrash(false);
       onOpenChange(false);
+    } catch {
+      // Purge failed — keep the palette open so the user can retry. The
+      // error toast is surfaced by usePurgeTrash.onError.
+      setConfirmingEmptyTrash(false);
     }
-  }, [purgeTrash, onOpenChange]);
+  }, [purgeTrashMutateAsync, onOpenChange]);
 
   const ctx = useMemo<CommandContext>(
     () => ({
@@ -395,7 +401,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     <AlertDialog
       open={confirmingEmptyTrash}
       onOpenChange={(next) => {
-        if (!purgeTrash.isPending) setConfirmingEmptyTrash(next);
+        if (!purgeTrashPending) setConfirmingEmptyTrash(next);
       }}
     >
       <AlertDialogContent>
@@ -407,18 +413,18 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={purgeTrash.isPending}>
+          <AlertDialogCancel disabled={purgeTrashPending}>
             Cancel
           </AlertDialogCancel>
           <AlertDialogAction
             variant="destructive"
-            disabled={purgeTrash.isPending}
+            disabled={purgeTrashPending}
             onClick={(e) => {
               e.preventDefault();
               void handleConfirmEmptyTrash();
             }}
           >
-            {purgeTrash.isPending ? "Emptying…" : "Empty Trash"}
+            {purgeTrashPending ? "Emptying…" : "Empty Trash"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/client/src/components/CommandPalette.tsx
+++ b/src/client/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useContext, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { ChevronDown, Star } from "lucide-react";
 import { useTheme } from "next-themes";
+import { toast } from "sonner";
 import {
   CommandDialog,
   CommandEmpty,
@@ -12,8 +13,24 @@ import {
   CommandSeparator,
   CommandShortcut,
 } from "@/components/ui/command";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useAuth } from "@/hooks/useAuth";
 import { usePermission } from "@/hooks/usePermission";
+import { useBackupExport } from "@/hooks/useBackup";
+import { usePurgeTrash } from "@/hooks/useTrash";
+import {
+  fetchAllReceiptIds,
+  useBulkPushYnabTransactions,
+} from "@/hooks/useYnab";
 import { ShortcutsContext } from "@/contexts/shortcuts-context";
 import { COMMANDS } from "@/lib/command-palette/commands";
 import {
@@ -40,6 +57,7 @@ interface CommandPaletteProps {
 
 const GROUP_ORDER: CommandGroupId[] = [
   "create",
+  "actions",
   "navigate",
   "reports",
   "preferences",
@@ -91,6 +109,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [pinnedIds, setPinnedIds] = useState<string[]>(() => getPinned());
   const [recentIds, setRecentIds] = useState<string[]>(() => getRecent());
+  const [confirmingEmptyTrash, setConfirmingEmptyTrash] = useState(false);
+
+  const bulkPushYnab = useBulkPushYnabTransactions();
+  const backupExport = useBackupExport();
+  const purgeTrash = usePurgeTrash();
 
   const admin = isAdmin();
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
@@ -98,6 +121,38 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     () => shortcutsCtx?.setHelpOpen(true),
     [shortcutsCtx],
   );
+
+  const syncYnab = useCallback(() => {
+    void (async () => {
+      try {
+        const { ids } = await fetchAllReceiptIds();
+        if (ids.length === 0) {
+          toast.info("No receipts to sync");
+          return;
+        }
+        bulkPushYnab.mutate(ids);
+      } catch {
+        toast.error("Failed to load receipts for YNAB sync");
+      }
+    })();
+  }, [bulkPushYnab]);
+
+  const exportBackup = useCallback(() => {
+    backupExport.mutate();
+  }, [backupExport]);
+
+  const confirmEmptyTrash = useCallback(() => {
+    setConfirmingEmptyTrash(true);
+  }, []);
+
+  const handleConfirmEmptyTrash = useCallback(async () => {
+    try {
+      await purgeTrash.mutateAsync();
+    } finally {
+      setConfirmingEmptyTrash(false);
+      onOpenChange(false);
+    }
+  }, [purgeTrash, onOpenChange]);
 
   const ctx = useMemo<CommandContext>(
     () => ({
@@ -107,8 +162,21 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       setTheme,
       logout,
       openShortcutsHelp,
+      syncYnab,
+      exportBackup,
+      confirmEmptyTrash,
     }),
-    [navigate, close, location.pathname, setTheme, logout, openShortcutsHelp],
+    [
+      navigate,
+      close,
+      location.pathname,
+      setTheme,
+      logout,
+      openShortcutsHelp,
+      syncYnab,
+      exportBackup,
+      confirmEmptyTrash,
+    ],
   );
 
   const visibleCommands = useMemo(
@@ -119,6 +187,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const commandsByGroup = useMemo(() => {
     const map: Record<CommandGroupId, Command[]> = {
       create: [],
+      actions: [],
       navigate: [],
       reports: [],
       preferences: [],
@@ -220,6 +289,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   );
 
   return (
+    <>
     <CommandDialog open={open} onOpenChange={onOpenChange}>
       <CommandInput
         placeholder="Type a command or search…"
@@ -322,5 +392,37 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           })}
       </CommandList>
     </CommandDialog>
+    <AlertDialog
+      open={confirmingEmptyTrash}
+      onOpenChange={(next) => {
+        if (!purgeTrash.isPending) setConfirmingEmptyTrash(next);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Empty Trash?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete every item in the Recycle Bin. This
+            action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={purgeTrash.isPending}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            disabled={purgeTrash.isPending}
+            onClick={(e) => {
+              e.preventDefault();
+              void handleConfirmEmptyTrash();
+            }}
+          >
+            {purgeTrash.isPending ? "Emptying…" : "Empty Trash"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+    </>
   );
 }

--- a/src/client/src/hooks/useBackup.test.ts
+++ b/src/client/src/hooks/useBackup.test.ts
@@ -68,12 +68,14 @@ describe("useBackupExport", () => {
       wrapper: createWrapper(),
     });
 
+    // mutateAsync awaits the mutationFn; onSuccess/onError run synchronously
+    // after resolution, so showSuccess/URL spies are observable immediately.
     await act(async () => {
-      result.current.mutate();
+      await result.current.mutateAsync();
     });
-    await waitFor(() => {
-      expect(showSuccess).toHaveBeenCalledWith("Backup exported successfully.");
-    });
+
+    expect(showSuccess).toHaveBeenCalledWith("Backup exported successfully.");
+    expect(showError).not.toHaveBeenCalled();
     expect(globalThis.URL.createObjectURL).toHaveBeenCalled();
     expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock");
   });

--- a/src/client/src/hooks/useBackup.test.ts
+++ b/src/client/src/hooks/useBackup.test.ts
@@ -28,18 +28,29 @@ describe("useBackupExport", () => {
   const originalFetch = globalThis.fetch;
   const originalCreateObjectURL = globalThis.URL.createObjectURL;
   const originalRevokeObjectURL = globalThis.URL.revokeObjectURL;
+  const originalCreateElement = document.createElement.bind(document);
 
   beforeEach(() => {
     vi.clearAllMocks();
     // Minimal URL mocks — jsdom doesn't implement blob URLs.
     globalThis.URL.createObjectURL = vi.fn(() => "blob:mock");
     globalThis.URL.revokeObjectURL = vi.fn();
+    // jsdom warns/throws on anchor.click() because it cannot navigate. Stub
+    // the created anchor's click with a no-op so the happy-path test is stable.
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const el = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        (el as HTMLAnchorElement).click = vi.fn();
+      }
+      return el;
+    });
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
     globalThis.URL.createObjectURL = originalCreateObjectURL;
     globalThis.URL.revokeObjectURL = originalRevokeObjectURL;
+    vi.restoreAllMocks();
   });
 
   it("downloads the blob and toasts success on 200", async () => {

--- a/src/client/src/hooks/useBackup.test.ts
+++ b/src/client/src/hooks/useBackup.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+vi.mock("@/lib/auth", () => ({
+  getAccessToken: vi.fn(() => "mock-token"),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+}));
+
+import { useBackupExport } from "./useBackup";
+import { showSuccess, showError } from "@/lib/toast";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe("useBackupExport", () => {
+  const originalFetch = globalThis.fetch;
+  const originalCreateObjectURL = globalThis.URL.createObjectURL;
+  const originalRevokeObjectURL = globalThis.URL.revokeObjectURL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Minimal URL mocks — jsdom doesn't implement blob URLs.
+    globalThis.URL.createObjectURL = vi.fn(() => "blob:mock");
+    globalThis.URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.URL.createObjectURL = originalCreateObjectURL;
+    globalThis.URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it("downloads the blob and toasts success on 200", async () => {
+    const blob = new Blob(["backup-bytes"], { type: "application/octet-stream" });
+    globalThis.fetch = vi.fn(async () =>
+      new Response(blob, {
+        status: 200,
+        headers: {
+          "Content-Disposition": 'attachment; filename="my-backup.sqlite"',
+        },
+      }),
+    ) as typeof fetch;
+
+    const { result } = renderHook(() => useBackupExport(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith("Backup exported successfully.");
+    });
+    expect(globalThis.URL.createObjectURL).toHaveBeenCalled();
+    expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock");
+  });
+
+  it("toasts a permission error on 403", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("", { status: 403 }),
+    ) as typeof fetch;
+
+    const { result } = renderHook(() => useBackupExport(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(
+        "You do not have permission to export backups.",
+      );
+    });
+  });
+
+  it("toasts a generic error on other failures", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("", { status: 500 }),
+    ) as typeof fetch;
+
+    const { result } = renderHook(() => useBackupExport(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith("Export failed (500).");
+    });
+  });
+});

--- a/src/client/src/hooks/useBackup.test.ts
+++ b/src/client/src/hooks/useBackup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
 
@@ -54,15 +54,22 @@ describe("useBackupExport", () => {
   });
 
   it("downloads the blob and toasts success on 200", async () => {
-    const blob = new Blob(["backup-bytes"], { type: "application/octet-stream" });
-    globalThis.fetch = vi.fn(async () =>
-      new Response(blob, {
-        status: 200,
-        headers: {
-          "Content-Disposition": 'attachment; filename="my-backup.sqlite"',
-        },
-      }),
-    ) as typeof fetch;
+    const fakeBlob = { size: 12, type: "application/octet-stream" } as Blob;
+    // Hand-rolled response rather than `new Response(blob, ...)` — node's
+    // undici Response requires the init body to expose `.stream()`, which
+    // jsdom's Blob doesn't in CI, causing a TypeError before the mutationFn
+    // can observe the response.
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-disposition"
+            ? 'attachment; filename="my-backup.sqlite"'
+            : null,
+      },
+      blob: async () => fakeBlob,
+    })) as unknown as typeof fetch;
 
     const { result } = renderHook(() => useBackupExport(), {
       wrapper: createWrapper(),
@@ -76,43 +83,41 @@ describe("useBackupExport", () => {
 
     expect(showSuccess).toHaveBeenCalledWith("Backup exported successfully.");
     expect(showError).not.toHaveBeenCalled();
-    expect(globalThis.URL.createObjectURL).toHaveBeenCalled();
+    expect(globalThis.URL.createObjectURL).toHaveBeenCalledWith(fakeBlob);
     expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock");
   });
 
   it("toasts a permission error on 403", async () => {
-    globalThis.fetch = vi.fn(
-      async () => new Response("", { status: 403 }),
-    ) as typeof fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+    })) as unknown as typeof fetch;
 
     const { result } = renderHook(() => useBackupExport(), {
       wrapper: createWrapper(),
     });
 
     await act(async () => {
-      result.current.mutate();
+      await result.current.mutateAsync().catch(() => {});
     });
-    await waitFor(() => {
-      expect(showError).toHaveBeenCalledWith(
-        "You do not have permission to export backups.",
-      );
-    });
+    expect(showError).toHaveBeenCalledWith(
+      "You do not have permission to export backups.",
+    );
   });
 
   it("toasts a generic error on other failures", async () => {
-    globalThis.fetch = vi.fn(
-      async () => new Response("", { status: 500 }),
-    ) as typeof fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+    })) as unknown as typeof fetch;
 
     const { result } = renderHook(() => useBackupExport(), {
       wrapper: createWrapper(),
     });
 
     await act(async () => {
-      result.current.mutate();
+      await result.current.mutateAsync().catch(() => {});
     });
-    await waitFor(() => {
-      expect(showError).toHaveBeenCalledWith("Export failed (500).");
-    });
+    expect(showError).toHaveBeenCalledWith("Export failed (500).");
   });
 });

--- a/src/client/src/hooks/useBackup.ts
+++ b/src/client/src/hooks/useBackup.ts
@@ -1,0 +1,49 @@
+import { useMutation } from "@tanstack/react-query";
+import { getAccessToken } from "@/lib/auth";
+import { showSuccess, showError } from "@/lib/toast";
+
+const baseUrl = import.meta.env.VITE_API_URL ?? "";
+
+export function useBackupExport() {
+  return useMutation({
+    mutationFn: async () => {
+      const token = getAccessToken();
+      const res = await fetch(`${baseUrl}/api/backup/export`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        signal: AbortSignal.timeout(300_000),
+      });
+
+      if (!res.ok) {
+        if (res.status === 403)
+          throw new Error("You do not have permission to export backups.");
+        throw new Error(`Export failed (${res.status}).`);
+      }
+
+      const blob = await res.blob();
+      const disposition = res.headers.get("Content-Disposition");
+      let filename = `receipts-backup-${new Date().toISOString().slice(0, 10)}.sqlite`;
+      if (disposition) {
+        const match = disposition.match(/filename="?([^";\n]+)"?/);
+        if (match) filename = match[1];
+      }
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    },
+    onSuccess: () => {
+      showSuccess("Backup exported successfully.");
+    },
+    onError: (error: Error) => {
+      showError(error.message);
+    },
+  });
+}

--- a/src/client/src/hooks/useYnab.ts
+++ b/src/client/src/hooks/useYnab.ts
@@ -659,7 +659,7 @@ export function useBulkPushYnabTransactions() {
 
 const ALL_RECEIPTS_PAGE_SIZE = 500;
 
-async function fetchAllReceiptIds(): Promise<{
+export async function fetchAllReceiptIds(): Promise<{
   ids: string[];
   total: number;
 }> {

--- a/src/client/src/lib/command-palette/commands.test.ts
+++ b/src/client/src/lib/command-palette/commands.test.ts
@@ -10,6 +10,9 @@ function makeCtx(overrides: Partial<CommandContext> = {}): CommandContext {
     setTheme: vi.fn(),
     logout: vi.fn(async () => {}),
     openShortcutsHelp: vi.fn(),
+    syncYnab: vi.fn(),
+    exportBackup: vi.fn(),
+    confirmEmptyTrash: vi.fn(),
     ...overrides,
   };
 }
@@ -68,8 +71,37 @@ describe("command registry", () => {
         "nav:trash",
         "nav:backup",
         "create:user",
+        "action:backup-export",
+        "action:trash-empty",
       ]),
     );
+  });
+
+  it("exposes action commands outside of the admin-gated set when appropriate", () => {
+    const sync = COMMANDS.find((c) => c.id === "action:ynab-sync")!;
+    expect(sync.requiresAdmin).toBeFalsy();
+    expect(sync.group).toBe("actions");
+  });
+
+  it("action:ynab-sync closes and delegates to syncYnab", () => {
+    const ctx = makeCtx();
+    COMMANDS.find((c) => c.id === "action:ynab-sync")!.run(ctx);
+    expect(ctx.close).toHaveBeenCalled();
+    expect(ctx.syncYnab).toHaveBeenCalled();
+  });
+
+  it("action:backup-export closes and delegates to exportBackup", () => {
+    const ctx = makeCtx();
+    COMMANDS.find((c) => c.id === "action:backup-export")!.run(ctx);
+    expect(ctx.close).toHaveBeenCalled();
+    expect(ctx.exportBackup).toHaveBeenCalled();
+  });
+
+  it("action:trash-empty opens the confirm dialog without closing the palette", () => {
+    const ctx = makeCtx();
+    COMMANDS.find((c) => c.id === "action:trash-empty")!.run(ctx);
+    expect(ctx.confirmEmptyTrash).toHaveBeenCalled();
+    expect(ctx.close).not.toHaveBeenCalled();
   });
 
   it("exposes one command per documented report", () => {

--- a/src/client/src/lib/command-palette/commands.ts
+++ b/src/client/src/lib/command-palette/commands.ts
@@ -6,6 +6,7 @@ import {
   ChartColumn,
   CreditCard,
   Database,
+  Download,
   FolderTree,
   Home,
   Key,
@@ -153,6 +154,43 @@ export const COMMANDS: Command[] = [
     targetPath: "/admin/users",
     requiresAdmin: true,
     run: (ctx) => runNewItem("/admin/users", ctx),
+  },
+
+  // ---- Actions (direct-action commands that invoke mutations) ----
+  {
+    id: "action:ynab-sync",
+    label: "Sync YNAB Now",
+    group: "actions",
+    icon: ArrowRightLeft,
+    keywords: ["push", "update", "budget", "transactions"],
+    run: (ctx) => {
+      ctx.close();
+      ctx.syncYnab();
+    },
+  },
+  {
+    id: "action:backup-export",
+    label: "Export Backup",
+    group: "actions",
+    icon: Download,
+    keywords: ["download", "save", "sqlite", "admin"],
+    requiresAdmin: true,
+    run: (ctx) => {
+      ctx.close();
+      ctx.exportBackup();
+    },
+  },
+  {
+    id: "action:trash-empty",
+    label: "Empty Trash",
+    group: "actions",
+    icon: Trash2,
+    keywords: ["purge", "delete", "clear", "recycle", "admin"],
+    requiresAdmin: true,
+    run: (ctx) => {
+      // Do not close — the confirmation dialog manages the palette lifecycle.
+      ctx.confirmEmptyTrash();
+    },
   },
 
   // ---- Navigate ----

--- a/src/client/src/lib/command-palette/types.ts
+++ b/src/client/src/lib/command-palette/types.ts
@@ -3,6 +3,7 @@ import type { NavigateFunction } from "react-router";
 
 export type CommandGroupId =
   | "create"
+  | "actions"
   | "navigate"
   | "reports"
   | "preferences";
@@ -14,6 +15,9 @@ export interface CommandContext {
   setTheme: (theme: "light" | "dark" | "system") => void;
   logout: () => Promise<void>;
   openShortcutsHelp: () => void;
+  syncYnab: () => void;
+  exportBackup: () => void;
+  confirmEmptyTrash: () => void;
 }
 
 export interface Command {
@@ -31,6 +35,7 @@ export interface Command {
 
 export const COMMAND_GROUP_LABELS: Record<CommandGroupId, string> = {
   create: "Create",
+  actions: "Actions",
   navigate: "Go to",
   reports: "Reports",
   preferences: "Preferences",

--- a/src/client/src/pages/BackupRestore.tsx
+++ b/src/client/src/pages/BackupRestore.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useBackupExport } from "@/hooks/useBackup";
 import { getAccessToken } from "@/lib/auth";
 import { showSuccess, showError } from "@/lib/toast";
 import { Button } from "@/components/ui/button";
@@ -40,46 +41,7 @@ function BackupRestore() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [confirmImportOpen, setConfirmImportOpen] = useState(false);
 
-  const exportMutation = useMutation({
-    mutationFn: async () => {
-      const token = getAccessToken();
-      const res = await fetch(`${baseUrl}/api/backup/export`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        signal: AbortSignal.timeout(300_000), // 5-minute timeout for large exports
-      });
-
-      if (!res.ok) {
-        if (res.status === 403) throw new Error("You do not have permission to export backups.");
-        throw new Error(`Export failed (${res.status}).`);
-      }
-
-      const blob = await res.blob();
-      const disposition = res.headers.get("Content-Disposition");
-      let filename = `receipts-backup-${new Date().toISOString().slice(0, 10)}.sqlite`;
-      if (disposition) {
-        const match = disposition.match(/filename="?([^";\n]+)"?/);
-        if (match) filename = match[1];
-      }
-
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    },
-    onSuccess: () => {
-      showSuccess("Backup exported successfully.");
-    },
-    onError: (error: Error) => {
-      showError(error.message);
-    },
-  });
+  const exportMutation = useBackupExport();
 
   const importMutation = useMutation({
     mutationFn: async (file: File) => {


### PR DESCRIPTION
## Summary

Follow-up to [#432](https://github.com/mggarofalo/receipts/pull/432). The command palette previously only navigated to settings pages for actions like Sync YNAB, Export Backup, and Empty Trash. This PR adds a new **Actions** command group that invokes the underlying mutations directly so the user stays in context.

- **Sync YNAB Now** (all users) — fetches every receipt ID lazily on invocation, then calls the existing bulk-push mutation. Success/error toast is inherited from `useBulkPushYnabTransactions`.
- **Export Backup** (admin) — fires the export-download mutation; SQLite file downloads directly.
- **Empty Trash** (admin) — opens an `AlertDialog` (rendered as a sibling to `CommandDialog` — Radix portal stacks it above the palette). Confirming calls `usePurgeTrash`; cancelling closes the dialog.

### Implementation notes

- Added an `actions` group to `CommandGroupId` and inserted it between Create and Go to in `GROUP_ORDER`.
- Extended `CommandContext` with `syncYnab`, `exportBackup`, and `confirmEmptyTrash` — matches the existing `logout`, `setTheme`, `openShortcutsHelp` pattern.
- Extracted the inline export mutation from `BackupRestore.tsx` into a reusable `useBackupExport` hook. The refactor is transparent to `BackupRestore.test.tsx` (it mocks `useMutation` at the library level, and the hook is a thin wrapper).
- Exported `fetchAllReceiptIds` from `useYnab.ts` so the palette can fetch lazily on command invocation rather than on palette mount — mounting the palette must not trigger a paginated fetch of every receipt.
- The `Empty Trash` command keeps the palette open while the confirmation dialog is showing so the dialog doesn't unmount (Layout mounts `CommandPalette` conditionally on `searchOpen`).

Resolves RECEIPTS-571.

## Test plan

- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] `npx vitest run` — 1909 tests pass (was 1795 at the #432 baseline); 15 new (3 `useBackup` + 5 `commands` + 7 `CommandPalette`).
- [x] `npm run lint` — 0 errors, 2 pre-existing warnings unrelated to this change.
- [ ] Manual smoke (Aspire + browser): Ctrl+K opens palette; Actions group renders between Create and Go to; "Sync YNAB Now" visible to all users, "Export Backup"/"Empty Trash" hidden when not admin; clicking Empty Trash opens confirm dialog → cancel leaves palette open, confirm fires purge and closes palette; typing "sync" filters to "Sync YNAB Now".

## Non-goals

- Two-way YNAB memo sync. "Sync YNAB Now" maps to bulk transaction push — the primary sync action. Memo sync stays on the settings page.
- Wiring the settings pages. Their existing UI (Import, bulk sync card, recycle-bin tabs) is unchanged.