### PR TITLE
feat(client): capture Card on transactions and display alongside Account (RECEIPTS-573)

### DIFF
--- a/src/client/src/components/ReceiptTransactionForm.test.tsx
+++ b/src/client/src/components/ReceiptTransactionForm.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import "@/test/setup-combobox-polyfills";
+import { ReceiptTransactionForm } from "./ReceiptTransactionForm";
+
+vi.mock("@/hooks/useFormShortcuts", () => ({
+  useFormShortcuts: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAccounts", () => ({
+  useAccounts: vi.fn(() => ({
+    data: [
+      { id: "acct-1", name: "Checking", isActive: true },
+      { id: "acct-2", name: "Savings", isActive: true },
+    ],
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/hooks/useCards", () => ({
+  useCards: vi.fn(() => ({
+    data: [
+      { id: "card-1", name: "Visa 4321", cardCode: "V4321", isActive: true, accountId: "acct-1" },
+      { id: "card-2", name: "Amex 7777", cardCode: "A7777", isActive: true, accountId: null },
+    ],
+    isLoading: false,
+  })),
+}));
+
+describe("ReceiptTransactionForm", () => {
+  it("renders the Card, Account, Amount, and Date fields", () => {
+    renderWithProviders(
+      <ReceiptTransactionForm
+        mode="create"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/^Card$/)).toBeInTheDocument();
+    expect(screen.getByText(/^Account$/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Date$/)).toBeInTheDocument();
+  });
+
+  it("blocks submit when Card is empty", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <ReceiptTransactionForm
+        mode="create"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        defaultValues={{ accountId: "acct-1", amount: 42, date: "2024-01-15" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add transaction/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(await screen.findByText("Card is required")).toBeInTheDocument();
+  });
+
+  it("auto-fills Account when a Card with a parent account is selected", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <ReceiptTransactionForm
+        mode="create"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        defaultValues={{ amount: 42, date: "2024-01-15" }}
+      />,
+    );
+
+    const [cardCombobox] = screen.getAllByRole("combobox");
+    await user.click(cardCombobox);
+    await user.click(await screen.findByText("Visa 4321"));
+
+    await user.click(screen.getByRole("button", { name: /add transaction/i }));
+
+    expect(onSubmit.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        cardId: "card-1",
+        accountId: "acct-1",
+        amount: 42,
+        date: "2024-01-15",
+      }),
+    );
+  });
+
+  it("leaves Account alone when the selected Card has no parent account", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <ReceiptTransactionForm
+        mode="create"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        defaultValues={{ accountId: "acct-2", amount: 42, date: "2024-01-15" }}
+      />,
+    );
+
+    const [cardCombobox] = screen.getAllByRole("combobox");
+    await user.click(cardCombobox);
+    await user.click(await screen.findByText("Amex 7777"));
+
+    await user.click(screen.getByRole("button", { name: /add transaction/i }));
+
+    expect(onSubmit.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        cardId: "card-2",
+        accountId: "acct-2",
+      }),
+    );
+  });
+});

--- a/src/client/src/components/ReceiptTransactionForm.test.tsx
+++ b/src/client/src/components/ReceiptTransactionForm.test.tsx
@@ -89,6 +89,28 @@ describe("ReceiptTransactionForm", () => {
     );
   });
 
+  it("allows saving in edit mode when the Card field is empty (legacy rows)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <ReceiptTransactionForm
+        mode="edit"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        defaultValues={{ cardId: "", accountId: "acct-1", amount: 42, date: "2024-01-15" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /update transaction/i }));
+
+    expect(onSubmit.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        cardId: "",
+        accountId: "acct-1",
+      }),
+    );
+  });
+
   it("leaves Account alone when the selected Card has no parent account", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();

--- a/src/client/src/components/ReceiptTransactionForm.tsx
+++ b/src/client/src/components/ReceiptTransactionForm.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useRef } from "react";
-import { useForm } from "react-hook-form";
+import { useEffect, useMemo, useRef } from "react";
+import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useAccounts } from "@/hooks/useAccounts";
-import { accountToOption } from "@/lib/combobox-options";
+import { useCards } from "@/hooks/useCards";
+import { accountToOption, cardToOption } from "@/lib/combobox-options";
 import { Button } from "@/components/ui/button";
 import { DateInput } from "@/components/ui/date-input";
 import { Combobox } from "@/components/ui/combobox";
@@ -20,6 +21,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 
 const receiptTransactionSchema = z.object({
+  cardId: z.string().min(1, "Card is required"),
   accountId: z.string().min(1, "Account is required"),
   amount: z.number().refine((v) => v !== 0, "Amount is required"),
   date: z.string().min(1, "Date is required"),
@@ -50,22 +52,48 @@ export function ReceiptTransactionForm({
   useFormShortcuts({ formRef });
 
   const { data: accounts, isLoading: accountsLoading } = useAccounts(0, 50, undefined, undefined, true);
+  const { data: cards, isLoading: cardsLoading } = useCards(0, 500, undefined, undefined, true);
 
   const accountOptions = useMemo(
     () => (accounts ?? []).map(accountToOption),
     [accounts],
   );
 
+  const cardOptions = useMemo(
+    () => (cards ?? []).map(cardToOption),
+    [cards],
+  );
+
+  const cardById = useMemo(() => {
+    const map = new Map<string, { id: string; accountId?: string | null }>();
+    for (const c of cards ?? []) map.set(c.id, c);
+    return map;
+  }, [cards]);
+
   const form = useForm<ReceiptTransactionFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolver: zodResolver(receiptTransactionSchema) as any,
     defaultValues: {
+      cardId: "",
       accountId: "",
       amount: 0,
       date: "",
       ...defaultValues,
     },
   });
+
+  const selectedCardId = useWatch({ control: form.control, name: "cardId" });
+  const prevCardIdRef = useRef(selectedCardId);
+
+  useEffect(() => {
+    if (selectedCardId && selectedCardId !== prevCardIdRef.current) {
+      const card = cardById.get(selectedCardId);
+      if (card?.accountId) {
+        form.setValue("accountId", card.accountId, { shouldValidate: true });
+      }
+    }
+    prevCardIdRef.current = selectedCardId;
+  }, [selectedCardId, cardById, form]);
 
   return (
     <Form {...form}>
@@ -74,6 +102,34 @@ export function ReceiptTransactionForm({
         onSubmit={form.handleSubmit(onSubmit)}
         className="space-y-4"
       >
+        <FormField
+          control={form.control}
+          name="cardId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel required>Card</FormLabel>
+              <FormControl>
+                <Combobox
+                  options={cardOptions}
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  placeholder="Select a card..."
+                  searchPlaceholder="Search cards..."
+                  emptyMessage="No cards found."
+                  loading={cardsLoading}
+                  aria-required="true"
+                />
+              </FormControl>
+              <FormMessage />
+              {serverErrors?.cardId && (
+                <p className="text-sm font-medium text-destructive">
+                  {serverErrors.cardId}
+                </p>
+              )}
+            </FormItem>
+          )}
+        />
+
         <FormField
           control={form.control}
           name="accountId"

--- a/src/client/src/components/ReceiptTransactionForm.tsx
+++ b/src/client/src/components/ReceiptTransactionForm.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef } from "react";
-import { useForm, useWatch } from "react-hook-form";
+import { useMemo, useRef } from "react";
+import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
@@ -82,18 +82,13 @@ export function ReceiptTransactionForm({
     },
   });
 
-  const selectedCardId = useWatch({ control: form.control, name: "cardId" });
-  const prevCardIdRef = useRef(selectedCardId);
-
-  useEffect(() => {
-    if (selectedCardId && selectedCardId !== prevCardIdRef.current) {
-      const card = cardById.get(selectedCardId);
-      if (card?.accountId) {
-        form.setValue("accountId", card.accountId, { shouldValidate: true });
-      }
+  function handleCardChange(value: string) {
+    form.setValue("cardId", value, { shouldValidate: true });
+    const card = cardById.get(value);
+    if (card?.accountId) {
+      form.setValue("accountId", card.accountId, { shouldValidate: true });
     }
-    prevCardIdRef.current = selectedCardId;
-  }, [selectedCardId, cardById, form]);
+  }
 
   return (
     <Form {...form}>
@@ -112,7 +107,7 @@ export function ReceiptTransactionForm({
                 <Combobox
                   options={cardOptions}
                   value={field.value}
-                  onValueChange={field.onChange}
+                  onValueChange={handleCardChange}
                   placeholder="Select a card..."
                   searchPlaceholder="Search cards..."
                   emptyMessage="No cards found."

--- a/src/client/src/components/ReceiptTransactionForm.tsx
+++ b/src/client/src/components/ReceiptTransactionForm.tsx
@@ -20,15 +20,26 @@ import {
 } from "@/components/ui/form";
 import { Spinner } from "@/components/ui/spinner";
 
-const receiptTransactionSchema = z.object({
-  cardId: z.string().min(1, "Card is required"),
+const baseTransactionSchema = z.object({
   accountId: z.string().min(1, "Account is required"),
   amount: z.number().refine((v) => v !== 0, "Amount is required"),
   date: z.string().min(1, "Date is required"),
 });
 
+const createTransactionSchema = baseTransactionSchema.extend({
+  cardId: z.string().min(1, "Card is required"),
+});
+
+// Edit mode keeps cardId string-typed but skips the min(1) check so legacy
+// transactions with cardId = null can still be edited (amount, date, account)
+// without forcing the user to assign a card first. RECEIPTS-574 will tighten
+// this once all rows are backfilled.
+const editTransactionSchema = baseTransactionSchema.extend({
+  cardId: z.string(),
+});
+
 export type ReceiptTransactionFormValues = z.output<
-  typeof receiptTransactionSchema
+  typeof createTransactionSchema
 >;
 
 interface ReceiptTransactionFormProps {
@@ -70,9 +81,10 @@ export function ReceiptTransactionForm({
     return map;
   }, [cards]);
 
+  const schema = mode === "create" ? createTransactionSchema : editTransactionSchema;
   const form = useForm<ReceiptTransactionFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    resolver: zodResolver(receiptTransactionSchema) as any,
+    resolver: zodResolver(schema) as any,
     defaultValues: {
       cardId: "",
       accountId: "",

--- a/src/client/src/components/ReceiptTransactionsCard.test.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.test.tsx
@@ -15,6 +15,16 @@ vi.mock("@/hooks/useAccounts", () => ({
   })),
 }));
 
+vi.mock("@/hooks/useCards", () => ({
+  useCards: vi.fn(() => ({
+    data: [
+      { id: "card-1", name: "Visa 4321", cardCode: "V4321", isActive: true, accountId: "acc-1" },
+      { id: "card-2", name: "Amex 7777", cardCode: "A7777", isActive: true, accountId: null },
+    ],
+    isLoading: false,
+  })),
+}));
+
 vi.mock("@/hooks/useTransactions", () => ({
   useCreateTransaction: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateTransaction: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -23,7 +33,7 @@ vi.mock("@/hooks/useTransactions", () => ({
 
 const mockTransactions = [
   {
-    transaction: { id: "txn-1", amount: 50.0, date: "2024-01-15" },
+    transaction: { id: "txn-1", amount: 50.0, date: "2024-01-15", cardId: "card-1" },
     account: {
       id: "acc-1",
       name: "Checking",
@@ -31,7 +41,7 @@ const mockTransactions = [
     },
   },
   {
-    transaction: { id: "txn-2", amount: 25.5, date: "2024-01-16" },
+    transaction: { id: "txn-2", amount: 25.5, date: "2024-01-16", cardId: null },
     account: {
       id: "acc-2",
       name: "Savings",
@@ -80,9 +90,24 @@ describe("ReceiptTransactionsCard", () => {
     );
     expect(screen.getByText("Amount")).toBeInTheDocument();
     expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Card")).toBeInTheDocument();
     expect(screen.getByText("Account")).toBeInTheDocument();
     expect(screen.getByText("Status")).toBeInTheDocument();
     expect(screen.getByText("Actions")).toBeInTheDocument();
+  });
+
+  it("renders the Card column value and an empty cell for rows with null cardId", () => {
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    // card-1 row shows the card name
+    expect(screen.getByText("Visa 4321")).toBeInTheDocument();
+    // card-2 row (null cardId) renders empty — we can't directly query the cell, but there should be no "Amex 7777"
+    expect(screen.queryByText("Amex 7777")).not.toBeInTheDocument();
   });
 
   it("renders the transaction total in the footer", () => {

--- a/src/client/src/components/ReceiptTransactionsCard.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   useCreateTransaction,
   useUpdateTransaction,
   useDeleteTransactions,
 } from "@/hooks/useTransactions";
+import { useCards } from "@/hooks/useCards";
 import {
   ReceiptTransactionForm,
   type ReceiptTransactionFormValues,
@@ -44,6 +45,7 @@ interface TransactionRow {
     id: string;
     amount: number;
     date: string;
+    cardId: string | null;
   };
   account: {
     id: string;
@@ -69,6 +71,14 @@ export function ReceiptTransactionsCard({
   const updateTransaction = useUpdateTransaction();
   const deleteTransactions = useDeleteTransactions();
 
+  const { data: cards } = useCards(0, 500, undefined, undefined, null);
+
+  const cardNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of cards ?? []) map.set(c.id, c.name);
+    return map;
+  }, [cards]);
+
   const [createOpen, setCreateOpen] = useState(false);
   const [editTxn, setEditTxn] = useState<TransactionRow | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -81,6 +91,7 @@ export function ReceiptTransactionsCard({
       {
         receiptId,
         body: {
+          cardId: values.cardId,
           accountId: values.accountId,
           amount: values.amount,
           date: values.date,
@@ -103,6 +114,7 @@ export function ReceiptTransactionsCard({
       {
         body: {
           id: editTxn.transaction.id,
+          cardId: values.cardId,
           accountId: values.accountId,
           amount: values.amount,
           date: values.date,
@@ -181,6 +193,7 @@ export function ReceiptTransactionsCard({
                     </TableHead>
                     <TableHead className="text-right">Amount</TableHead>
                     <TableHead>Date</TableHead>
+                    <TableHead>Card</TableHead>
                     <TableHead>Account</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead className="w-24">Actions</TableHead>
@@ -202,6 +215,11 @@ export function ReceiptTransactionsCard({
                         {formatCurrency(ta.transaction.amount)}
                       </TableCell>
                       <TableCell>{ta.transaction.date}</TableCell>
+                      <TableCell>
+                        {ta.transaction.cardId
+                          ? (cardNameMap.get(ta.transaction.cardId) ?? "")
+                          : ""}
+                      </TableCell>
                       <TableCell>{ta.account.name}</TableCell>
                       <TableCell>
                         <Badge
@@ -236,7 +254,7 @@ export function ReceiptTransactionsCard({
                     <TableCell className="text-right font-bold">
                       {formatCurrency(transactionsTotal)}
                     </TableCell>
-                    <TableCell colSpan={5} />
+                    <TableCell colSpan={6} />
                   </TableRow>
                 </TableFooter>
               </Table>
@@ -275,6 +293,7 @@ export function ReceiptTransactionsCard({
             <ReceiptTransactionForm
               mode="edit"
               defaultValues={{
+                cardId: editTxn.transaction.cardId ?? "",
                 accountId: editTxn.account.id,
                 amount: editTxn.transaction.amount,
                 date: editTxn.transaction.date,

--- a/src/client/src/hooks/useReceipts.ts
+++ b/src/client/src/hooks/useReceipts.ts
@@ -154,7 +154,7 @@ export function useCreateCompleteReceipt() {
   return useMutation({
     mutationFn: async (body: {
       receipt: { location: string; date: string; taxAmount: number };
-      transactions: { amount: number; date: string; accountId: string }[];
+      transactions: { amount: number; date: string; accountId: string; cardId: string }[];
       items: {
         receiptItemCode: string;
         description: string;

--- a/src/client/src/hooks/useTransactions.test.ts
+++ b/src/client/src/hooks/useTransactions.test.ts
@@ -107,18 +107,18 @@ describe("useTransactions", () => {
 
     await result.current.mutateAsync({
       receiptId: "r-1",
-      body: { ...body, accountId: "acc-1" },
+      body: { ...body, accountId: "acc-1", cardId: "card-1" },
     });
 
     expect(client.POST).toHaveBeenCalledWith(
       "/api/receipts/{receiptId}/transactions",
-      { params: { path: { receiptId: "r-1" } }, body: { ...body, accountId: "acc-1" } },
+      { params: { path: { receiptId: "r-1" } }, body: { ...body, accountId: "acc-1", cardId: "card-1" } },
     );
     expect(toast.success).toHaveBeenCalledWith("Transaction created");
   });
 
   it("update mutation calls PUT and shows toast on success", async () => {
-    const body = { id: "1", amount: 250, date: "2025-03-02", accountId: "acc-1" };
+    const body = { id: "1", amount: 250, date: "2025-03-02", accountId: "acc-1", cardId: "card-1" };
     (client.PUT as Mock).mockResolvedValue({ error: undefined });
 
     const { result } = renderHook(() => useUpdateTransaction(), {
@@ -190,7 +190,7 @@ describe("useTransactions", () => {
       wrapper: createWrapper(),
     });
 
-    result.current.mutate({ receiptId: "r-1", body: { amount: 100, date: "2025-01-01", accountId: "acc-1" } });
+    result.current.mutate({ receiptId: "r-1", body: { amount: 100, date: "2025-01-01", accountId: "acc-1", cardId: "card-1" } });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(toast.error).toHaveBeenCalledWith("Failed to create transaction");
@@ -203,7 +203,7 @@ describe("useTransactions", () => {
       wrapper: createWrapper(),
     });
 
-    result.current.mutate({ receiptId: "r-1", body: [{ amount: 100, date: "2025-01-01", accountId: "acc-1" }] });
+    result.current.mutate({ receiptId: "r-1", body: [{ amount: 100, date: "2025-01-01", accountId: "acc-1", cardId: "card-1" }] });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(toast.error).toHaveBeenCalledWith("Failed to create transactions");
@@ -225,7 +225,7 @@ describe("useTransactions", () => {
       wrapper: Wrapper,
     });
 
-    result.current.mutate({ receiptId: "r-1", body: [{ amount: 100, date: "2025-01-01", accountId: "acc-1" }] });
+    result.current.mutate({ receiptId: "r-1", body: [{ amount: 100, date: "2025-01-01", accountId: "acc-1", cardId: "card-1" }] });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["transactions"] });
@@ -238,7 +238,7 @@ describe("useTransactions", () => {
       wrapper: createWrapper(),
     });
 
-    result.current.mutate({ body: { id: "1", amount: 100, date: "2025-01-01", accountId: "acc-1" } });
+    result.current.mutate({ body: { id: "1", amount: 100, date: "2025-01-01", accountId: "acc-1", cardId: "card-1" } });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(toast.error).toHaveBeenCalledWith("Failed to update transaction");
@@ -387,7 +387,7 @@ describe("useTransactions", () => {
       wrapper: Wrapper,
     });
 
-    result.current.mutate({ receiptId: "r-1", body: { amount: 100, date: "2025-01-01", accountId: "acc-1" } });
+    result.current.mutate({ receiptId: "r-1", body: { amount: 100, date: "2025-01-01", accountId: "acc-1", cardId: "card-1" } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["trips"] });
@@ -409,7 +409,7 @@ describe("useTransactions", () => {
       wrapper: Wrapper,
     });
 
-    result.current.mutate({ body: { id: "1", amount: 100, date: "2025-01-01", accountId: "acc-1" } });
+    result.current.mutate({ body: { id: "1", amount: 100, date: "2025-01-01", accountId: "acc-1", cardId: "card-1" } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["trips"] });

--- a/src/client/src/hooks/useTransactions.ts
+++ b/src/client/src/hooks/useTransactions.ts
@@ -54,7 +54,7 @@ export function useCreateTransaction() {
       body,
     }: {
       receiptId: string;
-      body: { amount: number; date: string; accountId: string };
+      body: { amount: number; date: string; accountId: string; cardId: string };
     }) => {
       const { data, error } = await client.POST(
         "/api/receipts/{receiptId}/transactions",
@@ -82,7 +82,7 @@ export function useCreateTransactionsBatch() {
       body,
     }: {
       receiptId: string;
-      body: { amount: number; date: string; accountId: string }[];
+      body: { amount: number; date: string; accountId: string; cardId: string }[];
     }) => {
       const { data, error } = await client.POST(
         "/api/receipts/{receiptId}/transactions/batch",
@@ -106,7 +106,7 @@ export function useUpdateTransaction() {
     mutationFn: async ({
       body,
     }: {
-      body: { id: string; amount: number; date: string; accountId: string };
+      body: { id: string; amount: number; date: string; accountId: string; cardId: string };
     }) => {
       const { error } = await client.PUT("/api/transactions/{id}", {
         params: { path: { id: body.id } },

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -253,6 +253,7 @@ function ReceiptDetail() {
                 id: ta.transaction.id,
                 amount: Number(ta.transaction.amount ?? 0),
                 date: ta.transaction.date,
+                cardId: ta.transaction.cardId ?? null,
               },
               account: {
                 id: ta.account.id,

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -52,7 +52,7 @@ vi.mock("./TransactionsSection", () => ({
       <button
         onClick={() =>
           onChange([
-            { id: "t1", accountId: "acct-1", amount: 55, date: "2024-01-15" },
+            { id: "t1", cardId: "card-1", accountId: "acct-1", amount: 55, date: "2024-01-15" },
           ])
         }
       >
@@ -289,6 +289,7 @@ describe("NewReceiptPage", () => {
           }),
           transactions: [
             expect.objectContaining({
+              cardId: "card-1",
               accountId: "acct-1",
               amount: 55,
             }),

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -163,6 +163,7 @@ export default function NewReceiptPage({
           taxAmount: headerValues.taxAmount,
         },
         transactions: transactions.map((txn) => ({
+          cardId: txn.cardId,
           accountId: txn.accountId,
           amount: txn.amount,
           date: txn.date,

--- a/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.test.tsx
@@ -23,9 +23,23 @@ vi.mock("@/hooks/useAccounts", () => ({
   ),
 }));
 
+vi.mock("@/hooks/useCards", () => ({
+  useCards: vi.fn(() =>
+    mockQueryResult({
+      data: [
+        { id: "card-1", name: "Visa 4321", cardCode: "V4321", isActive: true, accountId: "acct-1" },
+        { id: "card-2", name: "Amex 7777", cardCode: "A7777", isActive: true, accountId: null },
+      ],
+      total: 2,
+      isLoading: false,
+      isSuccess: true,
+    }),
+  ),
+}));
+
 describe("TransactionsSection", () => {
   const defaultProps = {
-    transactions: [] as { id: string; accountId: string; amount: number; date: string }[],
+    transactions: [] as { id: string; cardId: string; accountId: string; amount: number; date: string }[],
     defaultDate: "2024-01-15",
     onChange: vi.fn(),
   };
@@ -59,27 +73,28 @@ describe("TransactionsSection", () => {
 
   it("renders existing transactions", () => {
     const transactions = [
-      { id: "1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
+      { id: "1", cardId: "card-1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
     ];
     renderWithProviders(
       <TransactionsSection {...defaultProps} transactions={transactions} />,
     );
     expect(screen.getByText("$25.50")).toBeInTheDocument();
     expect(screen.getByText("Checking")).toBeInTheDocument();
+    expect(screen.getByText("Visa 4321")).toBeInTheDocument();
   });
 
-  it("calls onChange when a transaction is added via form submit", async () => {
+  it("calls onChange when a transaction is added via form submit; card selection auto-fills account", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     renderWithProviders(
       <TransactionsSection {...defaultProps} onChange={onChange} />,
     );
 
-    // Select account via combobox
-    const combobox = screen.getByRole("combobox");
-    await user.click(combobox);
-    const checkingOption = await screen.findByText("Checking");
-    await user.click(checkingOption);
+    // Select card via combobox (first combobox is Card)
+    const [cardCombobox] = screen.getAllByRole("combobox");
+    await user.click(cardCombobox);
+    const cardOption = await screen.findByText("Visa 4321");
+    await user.click(cardOption);
 
     // Type amount
     const amountInput = screen.getByLabelText(/amount/i);
@@ -92,6 +107,7 @@ describe("TransactionsSection", () => {
     expect(onChange).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
+          cardId: "card-1",
           accountId: "acct-1",
           amount: 42.5,
           date: "2024-01-15",
@@ -104,7 +120,7 @@ describe("TransactionsSection", () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     const transactions = [
-      { id: "1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
+      { id: "1", cardId: "card-1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
     ];
     renderWithProviders(
       <TransactionsSection
@@ -153,8 +169,8 @@ describe("TransactionsSection", () => {
 
   it("displays running total with existing transactions", () => {
     const transactions = [
-      { id: "1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
-      { id: "2", accountId: "acct-2", amount: 10.0, date: "2024-01-15" },
+      { id: "1", cardId: "card-1", accountId: "acct-1", amount: 25.5, date: "2024-01-15" },
+      { id: "2", cardId: "card-2", accountId: "acct-2", amount: 10.0, date: "2024-01-15" },
     ];
     renderWithProviders(
       <TransactionsSection {...defaultProps} transactions={transactions} />,

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useCallback, useRef, useEffect } from "react";
 import { generateId } from "@/lib/id";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useAccounts } from "@/hooks/useAccounts";
-import { accountToOption } from "@/lib/combobox-options";
+import { useCards } from "@/hooks/useCards";
+import { accountToOption, cardToOption } from "@/lib/combobox-options";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -31,6 +32,7 @@ import {
 import { Plus, Trash2 } from "lucide-react";
 
 const txnSchema = z.object({
+  cardId: z.string().min(1, "Card is required"),
   accountId: z.string().min(1, "Account is required"),
   amount: z.number().refine((v) => v !== 0, "Amount is required"),
   date: z.string().min(1, "Date is required"),
@@ -40,6 +42,7 @@ type TxnFormValues = z.output<typeof txnSchema>;
 
 export interface ReceiptTransaction {
   id: string;
+  cardId: string;
   accountId: string;
   amount: number;
   date: string;
@@ -57,13 +60,19 @@ export function TransactionsSection({
   onChange,
 }: TransactionsSectionProps) {
   const formRef = useRef<HTMLFormElement>(null);
-  const accountRef = useRef<HTMLButtonElement>(null);
+  const cardRef = useRef<HTMLButtonElement>(null);
   const { data: accounts } = useAccounts(0, 50, undefined, undefined, true);
+  const { data: cards } = useCards(0, 500, undefined, undefined, true);
   useFormShortcuts({ formRef });
 
   const accountOptions = useMemo(
     () => (accounts ?? []).map(accountToOption),
     [accounts],
+  );
+
+  const cardOptions = useMemo(
+    () => (cards ?? []).map(cardToOption),
+    [cards],
   );
 
   const accountNameMap = useMemo(() => {
@@ -74,15 +83,43 @@ export function TransactionsSection({
     return map;
   }, [accountOptions]);
 
+  const cardNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const opt of cardOptions) {
+      map.set(opt.value, opt.label);
+    }
+    return map;
+  }, [cardOptions]);
+
+  const cardById = useMemo(() => {
+    const map = new Map<string, { id: string; accountId?: string | null }>();
+    for (const c of cards ?? []) map.set(c.id, c);
+    return map;
+  }, [cards]);
+
   const form = useForm<TxnFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolver: zodResolver(txnSchema) as any,
     defaultValues: {
+      cardId: "",
       accountId: "",
       amount: 0,
       date: defaultDate,
     },
   });
+
+  const selectedCardId = useWatch({ control: form.control, name: "cardId" });
+  const prevCardIdRef = useRef(selectedCardId);
+
+  useEffect(() => {
+    if (selectedCardId && selectedCardId !== prevCardIdRef.current) {
+      const card = cardById.get(selectedCardId);
+      if (card?.accountId) {
+        form.setValue("accountId", card.accountId, { shouldValidate: true });
+      }
+    }
+    prevCardIdRef.current = selectedCardId;
+  }, [selectedCardId, cardById, form]);
 
   // Sync the date field when the receipt date changes and the field is empty
   const prevDefaultDateRef = useRef(defaultDate);
@@ -110,16 +147,16 @@ export function TransactionsSection({
       };
       onChange([...transactions, newTxn]);
       (document.activeElement as HTMLElement)?.blur?.();
-      form.reset({ accountId: "", amount: 0, date: defaultDate });
+      form.reset({ cardId: "", accountId: "", amount: 0, date: defaultDate });
     },
     [form, defaultDate, transactions, onChange],
   );
 
-  // Focus account field after adding a transaction for rapid entry
+  // Focus card field after adding a transaction for rapid entry
   const prevCountRef = useRef(transactions.length);
   useEffect(() => {
     if (transactions.length > prevCountRef.current) {
-      accountRef.current?.focus();
+      cardRef.current?.focus();
     }
     prevCountRef.current = transactions.length;
   }, [transactions.length]);
@@ -146,8 +183,31 @@ export function TransactionsSection({
           <form
             ref={formRef}
             onSubmit={form.handleSubmit(handleAdd)}
-            className="grid grid-cols-1 gap-4 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end"
+            className="grid grid-cols-1 gap-4 sm:grid-cols-[1fr_1fr_auto_auto_auto] sm:items-end"
           >
+            <FormField
+              control={form.control}
+              name="cardId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>Card</FormLabel>
+                  <FormControl>
+                    <Combobox
+                      ref={cardRef}
+                      options={cardOptions}
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      placeholder="Select card..."
+                      searchPlaceholder="Search cards..."
+                      emptyMessage="No cards found."
+                      aria-required="true"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
             <FormField
               control={form.control}
               name="accountId"
@@ -156,7 +216,6 @@ export function TransactionsSection({
                   <FormLabel required>Account</FormLabel>
                   <FormControl>
                     <Combobox
-                      ref={accountRef}
                       options={accountOptions}
                       value={field.value}
                       onValueChange={field.onChange}
@@ -210,6 +269,7 @@ export function TransactionsSection({
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead>Card</TableHead>
                 <TableHead>Account</TableHead>
                 <TableHead>Amount</TableHead>
                 <TableHead>Date</TableHead>
@@ -221,6 +281,9 @@ export function TransactionsSection({
             <TableBody>
               {transactions.map((txn) => (
                 <TableRow key={txn.id}>
+                  <TableCell>
+                    {cardNameMap.get(txn.cardId) ?? txn.cardId}
+                  </TableCell>
                   <TableCell>
                     {accountNameMap.get(txn.accountId) ?? txn.accountId}
                   </TableCell>

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useCallback, useRef, useEffect } from "react";
 import { generateId } from "@/lib/id";
-import { useForm, useWatch } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
@@ -85,11 +85,9 @@ export function TransactionsSection({
 
   const cardNameMap = useMemo(() => {
     const map = new Map<string, string>();
-    for (const opt of cardOptions) {
-      map.set(opt.value, opt.label);
-    }
+    for (const c of cards ?? []) map.set(c.id, c.name);
     return map;
-  }, [cardOptions]);
+  }, [cards]);
 
   const cardById = useMemo(() => {
     const map = new Map<string, { id: string; accountId?: string | null }>();
@@ -108,18 +106,13 @@ export function TransactionsSection({
     },
   });
 
-  const selectedCardId = useWatch({ control: form.control, name: "cardId" });
-  const prevCardIdRef = useRef(selectedCardId);
-
-  useEffect(() => {
-    if (selectedCardId && selectedCardId !== prevCardIdRef.current) {
-      const card = cardById.get(selectedCardId);
-      if (card?.accountId) {
-        form.setValue("accountId", card.accountId, { shouldValidate: true });
-      }
+  function handleCardChange(value: string) {
+    form.setValue("cardId", value, { shouldValidate: true });
+    const card = cardById.get(value);
+    if (card?.accountId) {
+      form.setValue("accountId", card.accountId, { shouldValidate: true });
     }
-    prevCardIdRef.current = selectedCardId;
-  }, [selectedCardId, cardById, form]);
+  }
 
   // Sync the date field when the receipt date changes and the field is empty
   const prevDefaultDateRef = useRef(defaultDate);
@@ -196,7 +189,7 @@ export function TransactionsSection({
                       ref={cardRef}
                       options={cardOptions}
                       value={field.value}
-                      onValueChange={field.onChange}
+                      onValueChange={handleCardChange}
                       placeholder="Select card..."
                       searchPlaceholder="Search cards..."
                       emptyMessage="No cards found."
@@ -282,7 +275,7 @@ export function TransactionsSection({
               {transactions.map((txn) => (
                 <TableRow key={txn.id}>
                   <TableCell>
-                    {cardNameMap.get(txn.cardId) ?? txn.cardId}
+                    {cardNameMap.get(txn.cardId) ?? ""}
                   </TableCell>
                   <TableCell>
                     {accountNameMap.get(txn.accountId) ?? txn.accountId}

--- a/src/client/src/pages/wizard/NewReceipt.test.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.test.tsx
@@ -334,7 +334,7 @@ describe("NewReceipt", () => {
             taxAmount: 5,
           },
           transactions: [
-            { accountId: "acct-1", amount: 55, date: "2024-01-15" },
+            { cardId: "", accountId: "acct-1", amount: 55, date: "2024-01-15" },
           ],
           items: [
             {

--- a/src/client/src/pages/wizard/NewReceipt.tsx
+++ b/src/client/src/pages/wizard/NewReceipt.tsx
@@ -79,6 +79,7 @@ export default function NewReceipt() {
             taxAmount: state.receipt.taxAmount,
           },
           transactions: state.transactions.map((txn) => ({
+            cardId: txn.cardId ?? "",
             accountId: txn.accountId,
             amount: txn.amount,
             date: txn.date,

--- a/src/client/src/pages/wizard/wizardReducer.ts
+++ b/src/client/src/pages/wizard/wizardReducer.ts
@@ -6,6 +6,7 @@ export interface WizardReceiptData {
 
 export interface WizardTransaction {
   id: string;
+  cardId?: string;
   accountId: string;
   amount: number;
   date: string;


### PR DESCRIPTION
## Summary

- Adds a **required Card combobox** to the transaction entry form in both the receipt-detail dialog and the new-receipt wizard step.
- Selecting a Card **auto-fills Account** from the card's parent `accountId` (it's a join in the DB). Account remains editable.
- **Display**: two separate columns — **Card** and **Account** — on both the staged-transactions table in the wizard and the persisted-transactions table on receipt detail. Card name is resolved client-side via `useCards()`.
- **Hook bodies** (`useCreateTransaction`, `useCreateTransactionsBatch`, `useUpdateTransaction`, `useCreateCompleteReceipt`) now carry `cardId` through to the already-ready backend (RECEIPTS-553).

Resolves RECEIPTS-573.

API contract stays backward-compatible — `cardId` is still optional in the OpenAPI spec. Promoting `Transaction.CardId` to NOT NULL is tracked as **RECEIPTS-574**, and preventing orphan Cards end-to-end is tracked as **RECEIPTS-575**.

## Test plan

- [x] Unit tests: `ReceiptTransactionForm.test.tsx` (new), `TransactionsSection.test.tsx`, `ReceiptTransactionsCard.test.tsx`, `useTransactions.test.ts`, `NewReceiptPage.test.tsx` — all updated/added; full client suite green (1915 passed).
- [x] Card is required; submit blocked with "Card is required" when empty.
- [x] Card with parent Account auto-fills Account on selection.
- [x] Card with no parent Account leaves Account unchanged.
- [x] Table shows empty cell for legacy rows with `cardId = null`.
- [x] TypeScript + ESLint clean.
- [ ] Manual smoke in Aspire: new-receipt wizard and receipt-detail Add/Edit dialogs render and behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)