### PR TITLE
feat(domain): normalized description schema + service (RECEIPTS-577)

### DIFF
--- a/src/Application/Interfaces/Services/INormalizedDescriptionService.cs
+++ b/src/Application/Interfaces/Services/INormalizedDescriptionService.cs
@@ -1,0 +1,13 @@
+using Domain.NormalizedDescriptions;
+
+namespace Application.Interfaces.Services;
+
+public interface INormalizedDescriptionService
+{
+	Task<NormalizedDescription> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken);
+	Task<NormalizedDescription?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+	Task<List<NormalizedDescription>> GetAllAsync(NormalizedDescriptionStatus? filter, CancellationToken cancellationToken);
+	Task<int> MergeAsync(Guid keepId, Guid discardId, CancellationToken cancellationToken);
+	Task<NormalizedDescription> SplitAsync(Guid receiptItemId, CancellationToken cancellationToken);
+	Task<bool> UpdateStatusAsync(Guid id, NormalizedDescriptionStatus status, CancellationToken cancellationToken);
+}

--- a/src/Domain/Core/ReceiptItem.cs
+++ b/src/Domain/Core/ReceiptItem.cs
@@ -18,6 +18,13 @@ public class ReceiptItem
 	public string? Subcategory { get; set; }
 	public PricingMode PricingMode { get; set; }
 
+	// Resolver-populated fields — readonly from a domain-logic perspective, but public setters
+	// are required so Mapperly can populate them. Not included in the constructor: the
+	// NormalizedDescription resolver (see RECEIPTS-578) writes the FK, and read paths
+	// populate the denormalized name from the entity nav property.
+	public Guid? NormalizedDescriptionId { get; set; }
+	public string? NormalizedDescriptionName { get; set; }
+
 	public const string DescriptionCannotBeEmpty = "Description cannot be empty";
 	public const string QuantityMustBePositive = "Quantity must be positive";
 	public const string CategoryCannotBeEmpty = "Category cannot be empty";

--- a/src/Domain/NormalizedDescriptions/NormalizedDescription.cs
+++ b/src/Domain/NormalizedDescriptions/NormalizedDescription.cs
@@ -1,0 +1,24 @@
+namespace Domain.NormalizedDescriptions;
+
+public class NormalizedDescription
+{
+	public Guid Id { get; set; }
+	public string CanonicalName { get; set; }
+	public NormalizedDescriptionStatus Status { get; set; }
+	public DateTimeOffset CreatedAt { get; set; }
+
+	public const string CanonicalNameCannotBeEmpty = "Canonical name cannot be empty";
+
+	public NormalizedDescription(Guid id, string canonicalName, NormalizedDescriptionStatus status, DateTimeOffset createdAt)
+	{
+		if (string.IsNullOrWhiteSpace(canonicalName))
+		{
+			throw new ArgumentException(CanonicalNameCannotBeEmpty, nameof(canonicalName));
+		}
+
+		Id = id;
+		CanonicalName = canonicalName;
+		Status = status;
+		CreatedAt = createdAt;
+	}
+}

--- a/src/Domain/NormalizedDescriptions/NormalizedDescriptionStatus.cs
+++ b/src/Domain/NormalizedDescriptions/NormalizedDescriptionStatus.cs
@@ -1,0 +1,7 @@
+namespace Domain.NormalizedDescriptions;
+
+public enum NormalizedDescriptionStatus
+{
+	Active,
+	PendingReview,
+}

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -50,6 +50,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 	public virtual DbSet<ApiKeyEntity> ApiKeys { get; set; } = null!;
 	public virtual DbSet<ItemTemplateEntity> ItemTemplates { get; set; } = null!;
 	public virtual DbSet<ItemEmbeddingEntity> ItemEmbeddings { get; set; } = null!;
+	public virtual DbSet<NormalizedDescriptionEntity> NormalizedDescriptions { get; set; } = null!;
 	public virtual DbSet<DistinctDescriptionEntity> DistinctDescriptions { get; set; } = null!;
 	public virtual DbSet<ItemSimilarityEdgeEntity> ItemSimilarityEdges { get; set; } = null!;
 	public virtual DbSet<AuditLogEntity> AuditLogs { get; set; } = null!;
@@ -77,6 +78,13 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 				.HasConversion(
 					v => string.Join(';', v.ToArray()),
 					v => new Pgvector.Vector(v.Split(';').Select(float.Parse).ToArray()));
+
+			modelBuilder.Entity<NormalizedDescriptionEntity>()
+				.Property(e => e.Embedding)
+				.HasColumnType(null)
+				.HasConversion(
+					v => v == null ? null : string.Join(';', v.ToArray()),
+					v => string.IsNullOrEmpty(v) ? null : new Pgvector.Vector(v.Split(';').Select(float.Parse).ToArray()));
 		}
 	}
 

--- a/src/Infrastructure/Configurations/NormalizedDescriptionEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/NormalizedDescriptionEntityConfiguration.cs
@@ -1,0 +1,35 @@
+using Domain.NormalizedDescriptions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Configurations;
+
+public class NormalizedDescriptionEntityConfiguration : IEntityTypeConfiguration<NormalizedDescriptionEntity>
+{
+	public void Configure(EntityTypeBuilder<NormalizedDescriptionEntity> builder)
+	{
+		builder.ToTable("NormalizedDescriptions");
+
+		builder.HasKey(e => e.Id);
+
+		builder.Property(e => e.Id)
+			.IsRequired()
+			.ValueGeneratedOnAdd();
+
+		// Status stored as string via HasConversion, mirroring the ReceiptItemEntity.PricingMode pattern.
+		builder.Property(e => e.Status)
+			.HasConversion(
+				v => v.ToString(),
+				v => Enum.Parse<NormalizedDescriptionStatus>(v, ignoreCase: true))
+			.HasMaxLength(32);
+
+		builder.Property(e => e.Embedding)
+			.HasColumnType($"vector({OnnxEmbeddingService.EmbeddingDimension})");
+
+		// The unique functional index on lower(CanonicalName) and the partial HNSW index on
+		// Embedding are added via raw SQL in the migration — EF cannot natively express
+		// functional indexes or pgvector operator classes.
+	}
+}

--- a/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
@@ -24,6 +24,16 @@ public class ReceiptItemEntityConfiguration : IEntityTypeConfiguration<ReceiptIt
 		builder.Navigation(e => e.Receipt)
 			.AutoInclude();
 
+		builder.HasOne(e => e.NormalizedDescription)
+			.WithMany()
+			.HasForeignKey(e => e.NormalizedDescriptionId)
+			.OnDelete(DeleteBehavior.SetNull);
+
+		builder.Navigation(e => e.NormalizedDescription)
+			.AutoInclude();
+
+		builder.HasIndex(e => e.NormalizedDescriptionId);
+
 		builder.HasQueryFilter(e => e.DeletedAt == null);
 	}
 }

--- a/src/Infrastructure/Entities/Core/NormalizedDescriptionEntity.cs
+++ b/src/Infrastructure/Entities/Core/NormalizedDescriptionEntity.cs
@@ -1,0 +1,14 @@
+using Domain.NormalizedDescriptions;
+using Pgvector;
+
+namespace Infrastructure.Entities.Core;
+
+public class NormalizedDescriptionEntity
+{
+	public Guid Id { get; set; }
+	public string CanonicalName { get; set; } = string.Empty;
+	public NormalizedDescriptionStatus Status { get; set; }
+	public Vector? Embedding { get; set; }
+	public string? EmbeddingModelVersion { get; set; }
+	public DateTimeOffset CreatedAt { get; set; }
+}

--- a/src/Infrastructure/Entities/Core/ReceiptItemEntity.cs
+++ b/src/Infrastructure/Entities/Core/ReceiptItemEntity.cs
@@ -17,6 +17,8 @@ public class ReceiptItemEntity : ISoftDeletable, IOwnedBy<ReceiptEntity>
 	public string Category { get; set; } = string.Empty;
 	public string? Subcategory { get; set; }
 	public PricingMode PricingMode { get; set; } = PricingMode.Quantity;
+	public Guid? NormalizedDescriptionId { get; set; }
+	public virtual NormalizedDescriptionEntity? NormalizedDescription { get; set; }
 	public virtual ReceiptEntity? Receipt { get; set; }
 	public DateTimeOffset? DeletedAt { get; set; }
 	public string? DeletedByUserId { get; set; }

--- a/src/Infrastructure/Mapping/NormalizedDescriptionMapper.cs
+++ b/src/Infrastructure/Mapping/NormalizedDescriptionMapper.cs
@@ -1,0 +1,17 @@
+using Domain.NormalizedDescriptions;
+using Infrastructure.Entities.Core;
+using Riok.Mapperly.Abstractions;
+
+namespace Infrastructure.Mapping;
+
+[Mapper]
+public partial class NormalizedDescriptionMapper
+{
+	[MapperIgnoreTarget(nameof(NormalizedDescriptionEntity.Embedding))]
+	[MapperIgnoreTarget(nameof(NormalizedDescriptionEntity.EmbeddingModelVersion))]
+	public partial NormalizedDescriptionEntity ToEntity(NormalizedDescription source);
+
+	[MapperIgnoreSource(nameof(NormalizedDescriptionEntity.Embedding))]
+	[MapperIgnoreSource(nameof(NormalizedDescriptionEntity.EmbeddingModelVersion))]
+	public partial NormalizedDescription ToDomain(NormalizedDescriptionEntity source);
+}

--- a/src/Infrastructure/Mapping/ReceiptItemMapper.cs
+++ b/src/Infrastructure/Mapping/ReceiptItemMapper.cs
@@ -14,8 +14,12 @@ public partial class ReceiptItemMapper
 	[MapProperty(nameof(ReceiptItem.TotalAmount.Amount), nameof(ReceiptItemEntity.TotalAmount))]
 	[MapProperty(nameof(ReceiptItem.TotalAmount.Currency), nameof(ReceiptItemEntity.TotalAmountCurrency))]
 	[MapperIgnoreSource(nameof(ReceiptItem.ReceiptId))]
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionId))]
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionName))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.Receipt))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.ReceiptId))]
+	[MapperIgnoreTarget(nameof(ReceiptItemEntity.NormalizedDescription))]
+	[MapperIgnoreTarget(nameof(ReceiptItemEntity.NormalizedDescriptionId))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.DeletedAt))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.DeletedByUserId))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.DeletedByApiKeyId))]
@@ -28,9 +32,21 @@ public partial class ReceiptItemMapper
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.Receipt))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.UnitPriceCurrency))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.TotalAmountCurrency))]
+	[MapperIgnoreSource(nameof(ReceiptItemEntity.NormalizedDescription))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.DeletedAt))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.DeletedByUserId))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.DeletedByApiKeyId))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.CascadeDeletedByParentId))]
-	public partial ReceiptItem ToDomain(ReceiptItemEntity source);
+	[MapperIgnoreTarget(nameof(ReceiptItem.NormalizedDescriptionName))]
+	private partial ReceiptItem ToDomainPartial(ReceiptItemEntity source);
+
+	public ReceiptItem ToDomain(ReceiptItemEntity source)
+	{
+		ReceiptItem domain = ToDomainPartial(source);
+		// Denormalize CanonicalName from the nav property for read paths. Mapperly can emit
+		// the direct FK via the partial method above, but the nested path through the
+		// navigation requires a custom projection.
+		domain.NormalizedDescriptionName = source.NormalizedDescription?.CanonicalName;
+		return domain;
+	}
 }

--- a/src/Infrastructure/Migrations/20260420021000_AddNormalizedDescriptions.Designer.cs
+++ b/src/Infrastructure/Migrations/20260420021000_AddNormalizedDescriptions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420021000_AddNormalizedDescriptions")]
+    partial class AddNormalizedDescriptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260420021000_AddNormalizedDescriptions.cs
+++ b/src/Infrastructure/Migrations/20260420021000_AddNormalizedDescriptions.cs
@@ -1,0 +1,92 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pgvector;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddNormalizedDescriptions : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AddColumn<Guid>(
+			name: "NormalizedDescriptionId",
+			table: "ReceiptItems",
+			type: "uuid",
+			nullable: true);
+
+		migrationBuilder.CreateTable(
+			name: "NormalizedDescriptions",
+			columns: table => new
+			{
+				Id = table.Column<Guid>(type: "uuid", nullable: false),
+				CanonicalName = table.Column<string>(type: "text", nullable: false),
+				Status = table.Column<string>(type: "text", maxLength: 32, nullable: false),
+				Embedding = table.Column<Vector>(type: "vector(1024)", nullable: true),
+				EmbeddingModelVersion = table.Column<string>(type: "text", nullable: true),
+				CreatedAt = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false)
+			},
+			constraints: table =>
+			{
+				table.PrimaryKey("PK_NormalizedDescriptions", x => x.Id);
+			});
+
+		migrationBuilder.CreateIndex(
+			name: "IX_ReceiptItems_NormalizedDescriptionId",
+			table: "ReceiptItems",
+			column: "NormalizedDescriptionId");
+
+		migrationBuilder.AddForeignKey(
+			name: "FK_ReceiptItems_NormalizedDescriptions_NormalizedDescriptionId",
+			table: "ReceiptItems",
+			column: "NormalizedDescriptionId",
+			principalTable: "NormalizedDescriptions",
+			principalColumn: "Id",
+			onDelete: ReferentialAction.SetNull);
+
+		// Unique functional index on lower("CanonicalName") — EF does not natively model
+		// functional indexes. Ensures case-insensitive canonical name uniqueness across the
+		// table and supports the service's exact-match short-circuit with an index hit.
+		migrationBuilder.Sql(
+			"""
+			CREATE UNIQUE INDEX "IX_NormalizedDescriptions_CanonicalName_Lower"
+			    ON "NormalizedDescriptions" (lower("CanonicalName"));
+			""");
+
+		// Partial HNSW index for ANN similarity search on rows that have an embedding.
+		// pgvector cosine_ops + a WHERE predicate are not modelable in EF, so raw SQL.
+		migrationBuilder.Sql(
+			"""
+			CREATE INDEX "IX_NormalizedDescriptions_Embedding_hnsw"
+			    ON "NormalizedDescriptions" USING hnsw ("Embedding" vector_cosine_ops)
+			    WITH (m = 16, ef_construction = 64)
+			    WHERE "Embedding" IS NOT NULL;
+			""");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		// Drop raw-SQL indexes first, then let EF drop the foreign key/table/index/column.
+		migrationBuilder.Sql("""DROP INDEX IF EXISTS "IX_NormalizedDescriptions_Embedding_hnsw";""");
+		migrationBuilder.Sql("""DROP INDEX IF EXISTS "IX_NormalizedDescriptions_CanonicalName_Lower";""");
+
+		migrationBuilder.DropForeignKey(
+			name: "FK_ReceiptItems_NormalizedDescriptions_NormalizedDescriptionId",
+			table: "ReceiptItems");
+
+		migrationBuilder.DropTable(
+			name: "NormalizedDescriptions");
+
+		migrationBuilder.DropIndex(
+			name: "IX_ReceiptItems_NormalizedDescriptionId",
+			table: "ReceiptItems");
+
+		migrationBuilder.DropColumn(
+			name: "NormalizedDescriptionId",
+			table: "ReceiptItems");
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -131,6 +131,7 @@ public static class InfrastructureService
 			.AddScoped<IBackupImportService, BackupImportService>()
 			.AddScoped<IItemTemplateService, ItemTemplateService>()
 			.AddScoped<IItemTemplateSimilarityService, ItemTemplateSimilarityService>()
+			.AddScoped<INormalizedDescriptionService, NormalizedDescriptionService>()
 			.AddScoped<IReceiptRepository, ReceiptRepository>()
 			.AddScoped<IAccountRepository, AccountRepository>()
 			.AddScoped<ICardRepository, CardRepository>()
@@ -241,7 +242,8 @@ public static class InfrastructureService
 			.AddSingleton<ReceiptItemMapper>()
 			.AddSingleton<TransactionMapper>()
 			.AddSingleton<AdjustmentMapper>()
-			.AddSingleton<ItemTemplateMapper>();
+			.AddSingleton<ItemTemplateMapper>()
+			.AddSingleton<NormalizedDescriptionMapper>();
 
 		return services;
 	}

--- a/src/Infrastructure/Services/NormalizedDescriptionService.cs
+++ b/src/Infrastructure/Services/NormalizedDescriptionService.cs
@@ -121,10 +121,11 @@ public class NormalizedDescriptionService(
 			return 0;
 		}
 
-		// Re-link every ReceiptItem currently pointing at discard to point at keep.
+		// Re-link every live ReceiptItem currently pointing at discard to point at keep.
+		// Soft-deleted items are deliberately excluded via the default query filter — re-linking
+		// logically-deleted rows would inflate the returned count and muddy the audit trail.
 		List<ReceiptItemEntity> items = await context.ReceiptItems
 			.IgnoreAutoIncludes()
-			.IgnoreQueryFilters()
 			.Where(r => r.NormalizedDescriptionId == discardId)
 			.ToListAsync(cancellationToken);
 
@@ -151,12 +152,20 @@ public class NormalizedDescriptionService(
 			throw new KeyNotFoundException(ReceiptItemNotFound);
 		}
 
+		// Match the normalization contract from GetOrCreateAsync so that callers can't create
+		// whitespace-divergent duplicates via Split.
+		string canonicalName = (item.Description ?? string.Empty).Trim();
+		if (string.IsNullOrEmpty(canonicalName))
+		{
+			throw new ArgumentException(NormalizedDescription.CanonicalNameCannotBeEmpty, nameof(receiptItemId));
+		}
+
 		// Generate an embedding for the split item's raw description if possible, so the
 		// new entry is consistent with entries produced by GetOrCreateAsync.
 		Vector? embeddingVector = null;
 		if (embeddingService.IsConfigured)
 		{
-			float[] data = await embeddingService.GenerateEmbeddingAsync(item.Description, cancellationToken);
+			float[] data = await embeddingService.GenerateEmbeddingAsync(canonicalName, cancellationToken);
 			if (data.Length > 0)
 			{
 				embeddingVector = new Vector(data);
@@ -165,7 +174,7 @@ public class NormalizedDescriptionService(
 
 		NormalizedDescriptionEntity created = await InsertAsync(
 			context,
-			item.Description,
+			canonicalName,
 			NormalizedDescriptionStatus.Active,
 			embeddingVector,
 			cancellationToken);

--- a/src/Infrastructure/Services/NormalizedDescriptionService.cs
+++ b/src/Infrastructure/Services/NormalizedDescriptionService.cs
@@ -1,0 +1,298 @@
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Mapping;
+using Microsoft.EntityFrameworkCore;
+using Pgvector;
+
+namespace Infrastructure.Services;
+
+public class NormalizedDescriptionService(
+	IDbContextFactory<ApplicationDbContext> contextFactory,
+	IEmbeddingService embeddingService,
+	NormalizedDescriptionMapper mapper) : INormalizedDescriptionService
+{
+	// Threshold constants are hardcoded for RECEIPTS-577. A later issue (RECEIPTS-580) moves
+	// them into a DB-backed settings row so they can be tuned without a redeploy. The values
+	// below match the data-driven calibration baseline.
+	public const double AutoAcceptThreshold = 0.81;
+	public const double PendingReviewThreshold = 0.68;
+
+	public const string ReceiptItemNotFound = "Receipt item not found.";
+
+	private const string PostgreSQL = "Npgsql.EntityFrameworkCore.PostgreSQL";
+
+	public async Task<NormalizedDescription> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken)
+	{
+		string normalized = (rawDescription ?? string.Empty).Trim();
+		if (string.IsNullOrEmpty(normalized))
+		{
+			throw new ArgumentException(NormalizedDescription.CanonicalNameCannotBeEmpty, nameof(rawDescription));
+		}
+
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		// Step 1: exact case-insensitive match on existing canonical name.
+		NormalizedDescriptionEntity? existing = await FindExactCaseInsensitiveAsync(context, normalized, cancellationToken);
+		if (existing is not null)
+		{
+			return mapper.ToDomain(existing);
+		}
+
+		// Step 2: no embedding capability — create Active entry directly with no vector.
+		if (!embeddingService.IsConfigured)
+		{
+			NormalizedDescriptionEntity created = await InsertAsync(context, normalized, NormalizedDescriptionStatus.Active, embedding: null, cancellationToken);
+			return mapper.ToDomain(created);
+		}
+
+		// Step 3: generate embedding for the input.
+		float[] embeddingData = await embeddingService.GenerateEmbeddingAsync(normalized, cancellationToken);
+		Vector? embeddingVector = embeddingData.Length > 0 ? new Vector(embeddingData) : null;
+
+		// Step 4: ANN top-1 search — only supported on Postgres. On other providers (InMemory tests)
+		// the method is a no-op by default; tests can override AnnSearchTopOneAsync to simulate
+		// specific top-1 matches and exercise each threshold band.
+		double? topSimilarity = null;
+		NormalizedDescriptionEntity? topMatch = null;
+		if (embeddingVector is not null)
+		{
+			(topMatch, topSimilarity) = await AnnSearchTopOneAsync(context, embeddingVector, cancellationToken);
+		}
+
+		if (topMatch is not null && topSimilarity.HasValue)
+		{
+			if (topSimilarity.Value >= AutoAcceptThreshold)
+			{
+				return mapper.ToDomain(topMatch);
+			}
+
+			if (topSimilarity.Value >= PendingReviewThreshold)
+			{
+				NormalizedDescriptionEntity pending = await InsertAsync(context, normalized, NormalizedDescriptionStatus.PendingReview, embeddingVector, cancellationToken);
+				return mapper.ToDomain(pending);
+			}
+		}
+
+		NormalizedDescriptionEntity activeCreated = await InsertAsync(context, normalized, NormalizedDescriptionStatus.Active, embeddingVector, cancellationToken);
+		return mapper.ToDomain(activeCreated);
+	}
+
+	public async Task<NormalizedDescription?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionEntity? entity = await context.NormalizedDescriptions
+			.AsNoTracking()
+			.FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
+		return entity is null ? null : mapper.ToDomain(entity);
+	}
+
+	public async Task<List<NormalizedDescription>> GetAllAsync(NormalizedDescriptionStatus? filter, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		IQueryable<NormalizedDescriptionEntity> query = context.NormalizedDescriptions.AsNoTracking();
+		if (filter.HasValue)
+		{
+			query = query.Where(e => e.Status == filter.Value);
+		}
+
+		List<NormalizedDescriptionEntity> entities = await query
+			.OrderBy(e => e.CanonicalName)
+			.ToListAsync(cancellationToken);
+		return [.. entities.Select(mapper.ToDomain)];
+	}
+
+	public async Task<int> MergeAsync(Guid keepId, Guid discardId, CancellationToken cancellationToken)
+	{
+		if (keepId == discardId)
+		{
+			return 0;
+		}
+
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		NormalizedDescriptionEntity? keep = await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(e => e.Id == keepId, cancellationToken);
+		NormalizedDescriptionEntity? discard = await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(e => e.Id == discardId, cancellationToken);
+
+		if (keep is null || discard is null)
+		{
+			return 0;
+		}
+
+		// Re-link every ReceiptItem currently pointing at discard to point at keep.
+		List<ReceiptItemEntity> items = await context.ReceiptItems
+			.IgnoreAutoIncludes()
+			.IgnoreQueryFilters()
+			.Where(r => r.NormalizedDescriptionId == discardId)
+			.ToListAsync(cancellationToken);
+
+		foreach (ReceiptItemEntity item in items)
+		{
+			item.NormalizedDescriptionId = keepId;
+		}
+
+		context.NormalizedDescriptions.Remove(discard);
+
+		await context.SaveChangesAsync(cancellationToken);
+		return items.Count;
+	}
+
+	public async Task<NormalizedDescription> SplitAsync(Guid receiptItemId, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		ReceiptItemEntity? item = await context.ReceiptItems
+			.IgnoreAutoIncludes()
+			.FirstOrDefaultAsync(r => r.Id == receiptItemId, cancellationToken);
+		if (item is null)
+		{
+			throw new KeyNotFoundException(ReceiptItemNotFound);
+		}
+
+		// Generate an embedding for the split item's raw description if possible, so the
+		// new entry is consistent with entries produced by GetOrCreateAsync.
+		Vector? embeddingVector = null;
+		if (embeddingService.IsConfigured)
+		{
+			float[] data = await embeddingService.GenerateEmbeddingAsync(item.Description, cancellationToken);
+			if (data.Length > 0)
+			{
+				embeddingVector = new Vector(data);
+			}
+		}
+
+		NormalizedDescriptionEntity created = await InsertAsync(
+			context,
+			item.Description,
+			NormalizedDescriptionStatus.Active,
+			embeddingVector,
+			cancellationToken);
+
+		item.NormalizedDescriptionId = created.Id;
+		await context.SaveChangesAsync(cancellationToken);
+
+		return mapper.ToDomain(created);
+	}
+
+	public async Task<bool> UpdateStatusAsync(Guid id, NormalizedDescriptionStatus status, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionEntity? entity = await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
+		if (entity is null || entity.Status == status)
+		{
+			return false;
+		}
+
+		entity.Status = status;
+		await context.SaveChangesAsync(cancellationToken);
+		return true;
+	}
+
+	private static async Task<NormalizedDescriptionEntity?> FindExactCaseInsensitiveAsync(
+		ApplicationDbContext context, string canonicalName, CancellationToken cancellationToken)
+	{
+		// ToLower() translates to LOWER() on both PostgreSQL and InMemory. Paired with the
+		// unique functional index on lower("CanonicalName") in the migration, this avoids
+		// a sequential scan on Postgres while still working under InMemory for tests.
+		string lowered = canonicalName.ToLowerInvariant();
+		return await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(
+				e => e.CanonicalName.ToLower() == lowered,
+				cancellationToken);
+	}
+
+	private async Task<NormalizedDescriptionEntity> InsertAsync(
+		ApplicationDbContext context,
+		string canonicalName,
+		NormalizedDescriptionStatus status,
+		Vector? embedding,
+		CancellationToken cancellationToken)
+	{
+		// Double-check for a race: between the caller's exact-match lookup and this insert,
+		// another request may have created a row with the same canonical name. The DB has a
+		// unique functional index on lower(CanonicalName), so a second lookup inside this
+		// save path gives us a race-safe compromise without needing a distributed lock.
+		NormalizedDescriptionEntity? preInsert = await FindExactCaseInsensitiveAsync(context, canonicalName, cancellationToken);
+		if (preInsert is not null)
+		{
+			return preInsert;
+		}
+
+		NormalizedDescriptionEntity entity = new()
+		{
+			Id = Guid.NewGuid(),
+			CanonicalName = canonicalName,
+			Status = status,
+			Embedding = embedding,
+			EmbeddingModelVersion = embedding is null ? null : OnnxEmbeddingService.ModelName,
+			CreatedAt = DateTimeOffset.UtcNow,
+		};
+
+		context.NormalizedDescriptions.Add(entity);
+		try
+		{
+			await context.SaveChangesAsync(cancellationToken);
+		}
+		catch (DbUpdateException)
+		{
+			// Another writer raced us to the unique functional index on lower(CanonicalName).
+			// Detach our losing insert, reload the winner, and return it.
+			context.Entry(entity).State = EntityState.Detached;
+			NormalizedDescriptionEntity? winner = await FindExactCaseInsensitiveAsync(context, canonicalName, cancellationToken);
+			if (winner is null)
+			{
+				throw;
+			}
+
+			return winner;
+		}
+
+		return entity;
+	}
+
+	// Virtual so tests can simulate specific top-1 matches without a real Postgres. On providers
+	// that don't support pgvector (e.g., InMemory) the default implementation is a no-op.
+	protected virtual async Task<(NormalizedDescriptionEntity? Match, double? Similarity)> AnnSearchTopOneAsync(
+		ApplicationDbContext context, Vector queryVector, CancellationToken cancellationToken)
+	{
+		if (context.Database.ProviderName != PostgreSQL)
+		{
+			return (null, null);
+		}
+
+		// pgvector's `<=>` operator returns cosine distance (1 - cosine_similarity).
+		// The partial HNSW index covers the WHERE "Embedding" IS NOT NULL clause.
+		string sql = """
+			SELECT "Id" AS entity_id,
+			       (1.0 - ("Embedding" <=> {0}::vector)) AS similarity
+			FROM "NormalizedDescriptions"
+			WHERE "Embedding" IS NOT NULL
+			ORDER BY "Embedding" <=> {0}::vector
+			LIMIT 1
+			""";
+
+		AnnSearchRow? row = await context.Database
+			.SqlQueryRaw<AnnSearchRow>(sql, queryVector)
+			.FirstOrDefaultAsync(cancellationToken);
+
+		if (row is null)
+		{
+			return (null, null);
+		}
+
+		NormalizedDescriptionEntity? entity = await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(e => e.Id == row.entity_id, cancellationToken);
+		return (entity, row.similarity);
+	}
+
+	private sealed class AnnSearchRow
+	{
+#pragma warning disable IDE1006 // Underscore naming matches raw-SQL column aliases.
+		public Guid entity_id { get; set; }
+		public double similarity { get; set; }
+#pragma warning restore IDE1006
+	}
+}

--- a/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
+++ b/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
@@ -12,6 +12,10 @@ public partial class ReceiptItemMapper
 	[MapProperty(nameof(ReceiptItem.UnitPrice.Amount), nameof(ReceiptItemResponse.UnitPrice))]
 	[MapperIgnoreSource(nameof(ReceiptItem.TotalAmount))]
 	[MapperIgnoreSource(nameof(ReceiptItem.PricingMode))]
+	// NormalizedDescription FK and name are deliberately not exposed on the API response here —
+	// RECEIPTS-583 will add them. Ignore them so Mapperly does not flag the unmapped members.
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionId))]
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionName))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.AdditionalProperties))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.PricingMode))]
 	private partial ReceiptItemResponse ToResponsePartial(ReceiptItem source);

--- a/tests/Infrastructure.Tests/Services/NormalizedDescriptionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/NormalizedDescriptionServiceTests.cs
@@ -1,0 +1,450 @@
+using Application.Interfaces.Services;
+using Common;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Mapping;
+using Infrastructure.Services;
+using Infrastructure.Tests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Pgvector;
+
+namespace Infrastructure.Tests.Services;
+
+[Trait("Category", "Unit")]
+public class NormalizedDescriptionServiceTests
+{
+	private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+	private readonly Mock<IEmbeddingService> _embeddingServiceMock;
+	private readonly NormalizedDescriptionMapper _mapper;
+
+	public NormalizedDescriptionServiceTests()
+	{
+		(_contextFactory, MockCurrentUserAccessor accessor) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		accessor.UserId = "test-user";
+		_embeddingServiceMock = new Mock<IEmbeddingService>();
+		_mapper = new NormalizedDescriptionMapper();
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_ExactCaseInsensitiveMatch_ReturnsExisting()
+	{
+		// Arrange — seed an existing canonical entry.
+		Guid existingId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = existingId,
+				CanonicalName = "Organic Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act — query with different casing; it should short-circuit without generating an embedding.
+		NormalizedDescription result = await service.GetOrCreateAsync("organic MILK", CancellationToken.None);
+
+		// Assert
+		result.Id.Should().Be(existingId);
+		result.CanonicalName.Should().Be("Organic Milk");
+		_embeddingServiceMock.Verify(
+			e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_EmbeddingServiceUnavailable_CreatesActiveEntryWithNoEmbedding()
+	{
+		// Arrange
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		NormalizedDescription result = await service.GetOrCreateAsync("New Item", CancellationToken.None);
+
+		// Assert — a new Active row was created, and no embedding was generated.
+		result.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		result.CanonicalName.Should().Be("New Item");
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		NormalizedDescriptionEntity stored = await verify.NormalizedDescriptions.SingleAsync(e => e.Id == result.Id);
+		stored.Embedding.Should().BeNull();
+		stored.EmbeddingModelVersion.Should().BeNull();
+		_embeddingServiceMock.Verify(
+			e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_AboveAutoAcceptThreshold_ReturnsAnnMatchWithoutInserting()
+	{
+		// Arrange — seed an existing Active entry that the fake ANN will return as the top-1.
+		Guid matchedId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = matchedId,
+				CanonicalName = "Gallon of Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync("Whole Milk", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory,
+			_embeddingServiceMock.Object,
+			_mapper,
+			matchedId,
+			similarity: NormalizedDescriptionService.AutoAcceptThreshold + 0.01);
+
+		// Act
+		NormalizedDescription result = await service.GetOrCreateAsync("Whole Milk", CancellationToken.None);
+
+		// Assert — returned the ANN match; no new row inserted.
+		result.Id.Should().Be(matchedId);
+		result.CanonicalName.Should().Be("Gallon of Milk");
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		int count = await verify.NormalizedDescriptions.CountAsync();
+		count.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_BetweenThresholds_CreatesPendingReviewWithInputText()
+	{
+		// Arrange — seed a close-but-not-exact match that the fake ANN will return.
+		Guid matchedId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = matchedId,
+				CanonicalName = "Gallon of Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync("Milky Thing", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		double between = (NormalizedDescriptionService.AutoAcceptThreshold + NormalizedDescriptionService.PendingReviewThreshold) / 2;
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory,
+			_embeddingServiceMock.Object,
+			_mapper,
+			matchedId,
+			similarity: between);
+
+		// Act
+		NormalizedDescription result = await service.GetOrCreateAsync("Milky Thing", CancellationToken.None);
+
+		// Assert — a new PendingReview row was created with the input text as canonical name.
+		result.Status.Should().Be(NormalizedDescriptionStatus.PendingReview);
+		result.CanonicalName.Should().Be("Milky Thing");
+		result.Id.Should().NotBe(matchedId);
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		int count = await verify.NormalizedDescriptions.CountAsync();
+		count.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_BelowPendingReviewThreshold_CreatesActiveEntry()
+	{
+		// Arrange — seed an unrelated Active entry that the fake ANN will return as the top-1 match
+		// but with a similarity below the PendingReview threshold.
+		Guid matchedId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = matchedId,
+				CanonicalName = "Unrelated Item",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync("Totally Different", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory,
+			_embeddingServiceMock.Object,
+			_mapper,
+			matchedId,
+			similarity: NormalizedDescriptionService.PendingReviewThreshold - 0.1);
+
+		// Act
+		NormalizedDescription result = await service.GetOrCreateAsync("Totally Different", CancellationToken.None);
+
+		// Assert — a new Active entry was created with the input text as canonical.
+		result.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		result.CanonicalName.Should().Be("Totally Different");
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		int count = await verify.NormalizedDescriptions.CountAsync();
+		count.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_EmptyOrWhitespace_Throws()
+	{
+		// Arrange
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act + Assert
+		await service.Invoking(s => s.GetOrCreateAsync("   ", CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Fact]
+	public async Task MergeAsync_ReLinksReceiptItemsAndDeletesDiscard()
+	{
+		// Arrange — two NormalizedDescriptions plus two ReceiptItems pointing at the discard entry.
+		Guid keepId = Guid.NewGuid();
+		Guid discardId = Guid.NewGuid();
+		Guid itemAId = Guid.NewGuid();
+		Guid itemBId = Guid.NewGuid();
+		Guid receiptId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.AddRange(
+				new NormalizedDescriptionEntity { Id = keepId, CanonicalName = "Milk", Status = NormalizedDescriptionStatus.Active, CreatedAt = DateTimeOffset.UtcNow },
+				new NormalizedDescriptionEntity { Id = discardId, CanonicalName = "Mlik", Status = NormalizedDescriptionStatus.Active, CreatedAt = DateTimeOffset.UtcNow });
+			seed.ReceiptItems.AddRange(
+				BuildReceiptItem(itemAId, receiptId, "Mlik", discardId),
+				BuildReceiptItem(itemBId, receiptId, "Mlik", discardId));
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		int moved = await service.MergeAsync(keepId, discardId, CancellationToken.None);
+
+		// Assert
+		moved.Should().Be(2);
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		(await verify.NormalizedDescriptions.AnyAsync(e => e.Id == discardId)).Should().BeFalse();
+		(await verify.NormalizedDescriptions.AnyAsync(e => e.Id == keepId)).Should().BeTrue();
+		List<Guid?> linkedIds = await verify.ReceiptItems
+			.IgnoreAutoIncludes()
+			.Where(r => r.Id == itemAId || r.Id == itemBId)
+			.Select(r => r.NormalizedDescriptionId)
+			.ToListAsync();
+		linkedIds.Should().OnlyContain(id => id == keepId);
+	}
+
+	[Fact]
+	public async Task SplitAsync_CreatesNewActiveEntryAndRepointsReceiptItem()
+	{
+		// Arrange — an existing NormalizedDescription shared by a ReceiptItem.
+		Guid sharedId = Guid.NewGuid();
+		Guid itemId = Guid.NewGuid();
+		Guid receiptId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = sharedId,
+				CanonicalName = "Shared Name",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			seed.ReceiptItems.Add(BuildReceiptItem(itemId, receiptId, "Specific Raw Text", sharedId));
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		NormalizedDescription created = await service.SplitAsync(itemId, CancellationToken.None);
+
+		// Assert — a new Active entry was created with the ReceiptItem's raw text, and the
+		// ReceiptItem now points at the new entry.
+		created.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		created.CanonicalName.Should().Be("Specific Raw Text");
+		created.Id.Should().NotBe(sharedId);
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		ReceiptItemEntity updatedItem = await verify.ReceiptItems
+			.IgnoreAutoIncludes()
+			.SingleAsync(r => r.Id == itemId);
+		updatedItem.NormalizedDescriptionId.Should().Be(created.Id);
+	}
+
+	[Fact]
+	public async Task UpdateStatusAsync_ChangesPendingReviewToActive()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = id,
+				CanonicalName = "Pending Entry",
+				Status = NormalizedDescriptionStatus.PendingReview,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		bool changed = await service.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, CancellationToken.None);
+
+		// Assert
+		changed.Should().BeTrue();
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		NormalizedDescriptionEntity stored = await verify.NormalizedDescriptions.SingleAsync(e => e.Id == id);
+		stored.Status.Should().Be(NormalizedDescriptionStatus.Active);
+	}
+
+	[Fact]
+	public async Task UpdateStatusAsync_NoChange_ReturnsFalse()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = id,
+				CanonicalName = "Already Active",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		bool changed = await service.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, CancellationToken.None);
+
+		// Assert
+		changed.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task GetByIdAsync_ReturnsEntity_WhenPresent()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = id,
+				CanonicalName = "Findable",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		NormalizedDescription? result = await service.GetByIdAsync(id, CancellationToken.None);
+
+		// Assert
+		result.Should().NotBeNull();
+		result!.CanonicalName.Should().Be("Findable");
+	}
+
+	[Fact]
+	public async Task GetAllAsync_FilterByStatus_ReturnsOnlyMatching()
+	{
+		// Arrange
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.AddRange(
+				new NormalizedDescriptionEntity { Id = Guid.NewGuid(), CanonicalName = "Active A", Status = NormalizedDescriptionStatus.Active, CreatedAt = DateTimeOffset.UtcNow },
+				new NormalizedDescriptionEntity { Id = Guid.NewGuid(), CanonicalName = "Pending B", Status = NormalizedDescriptionStatus.PendingReview, CreatedAt = DateTimeOffset.UtcNow },
+				new NormalizedDescriptionEntity { Id = Guid.NewGuid(), CanonicalName = "Active C", Status = NormalizedDescriptionStatus.Active, CreatedAt = DateTimeOffset.UtcNow });
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		List<NormalizedDescription> pending = await service.GetAllAsync(NormalizedDescriptionStatus.PendingReview, CancellationToken.None);
+		List<NormalizedDescription> all = await service.GetAllAsync(null, CancellationToken.None);
+
+		// Assert
+		pending.Should().ContainSingle();
+		pending[0].CanonicalName.Should().Be("Pending B");
+		all.Should().HaveCount(3);
+	}
+
+	private static ReceiptItemEntity BuildReceiptItem(Guid id, Guid receiptId, string description, Guid? normalizedId)
+	{
+		return new ReceiptItemEntity
+		{
+			Id = id,
+			ReceiptId = receiptId,
+			Description = description,
+			Quantity = 1,
+			UnitPrice = 1,
+			UnitPriceCurrency = Currency.USD,
+			TotalAmount = 1,
+			TotalAmountCurrency = Currency.USD,
+			Category = "Groceries",
+			NormalizedDescriptionId = normalizedId,
+		};
+	}
+
+	private static float[] CreateFakeEmbedding()
+	{
+		float[] embedding = new float[OnnxEmbeddingService.EmbeddingDimension];
+		Random rng = new(42);
+		for (int i = 0; i < embedding.Length; i++)
+		{
+			embedding[i] = (float)(rng.NextDouble() * 2 - 1);
+		}
+
+		return embedding;
+	}
+
+	// Test subclass that overrides the ANN search to deterministically return a seeded match.
+	// This lets us exercise the threshold-band logic against InMemory, which cannot run the
+	// pgvector `<=>` operator.
+	private sealed class TestableNormalizedDescriptionService(
+		IDbContextFactory<ApplicationDbContext> contextFactory,
+		IEmbeddingService embeddingService,
+		NormalizedDescriptionMapper mapper,
+		Guid matchId,
+		double similarity) : NormalizedDescriptionService(contextFactory, embeddingService, mapper)
+	{
+		private readonly Guid _matchId = matchId;
+		private readonly double _similarity = similarity;
+
+		protected override async Task<(NormalizedDescriptionEntity? Match, double? Similarity)> AnnSearchTopOneAsync(
+			ApplicationDbContext context, Vector queryVector, CancellationToken cancellationToken)
+		{
+			NormalizedDescriptionEntity? match = await context.NormalizedDescriptions
+				.FirstOrDefaultAsync(e => e.Id == _matchId, cancellationToken);
+			return (match, _similarity);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Foundation for the [RECEIPTS-576](https://plane.wallingford.me/dev/browse/RECEIPTS-576/) normalized description registry epic. Adds domain entity, EF persistence, service layer with pgvector ANN matching, and the nullable FK on `ReceiptItem` that downstream consumers depend on.

**Blocks**: 578 (resolver), 579 (admin API), 580 (settings), 581 (report), 582 (UI), 583 (response exposure).

## Scope

- **Domain**: `NormalizedDescription` + `NormalizedDescriptionStatus` enum; two mapper-populated readonly props on `ReceiptItem`
- **Infra**: entity + config (`vector(1024)`, status-as-text conversion), EF migration with unique functional index on `lower(CanonicalName)` and partial HNSW on `Embedding`, DbSet, FK with `SetNull` on ReceiptItemEntity
- **Service**: `INormalizedDescriptionService` — exact case-insensitive match, then embedding + pgvector `<=>` ANN top-1, classify by thresholds `0.81 / 0.68` (data-driven from [RECEIPTS-585](https://github.com/mggarofalo/receipts/pull/448) calibration; [RECEIPTS-580](https://plane.wallingford.me/dev/browse/RECEIPTS-580/) will move these to a DB-backed settings row). Race-safe insert against the unique index.
- **Tests**: 12 new unit tests covering every threshold band, exact-match short-circuit, embedding-unavailable path, merge, split, update-status

## Test plan

- [x] `dotnet build` — 0 errors
- [x] Full `Infrastructure.Tests` suite: **622 passed**
- [x] `dotnet format --verify-no-changes` clean on Domain/Infrastructure/Tests
- [ ] CI must pass: full cross-project tests + CI's Postgres integration tests will exercise the migration end-to-end
- [ ] CI must confirm the HNSW partial index and unique functional index apply cleanly against the test Postgres container

## Out of scope (separate child issues under RECEIPTS-576)

- RECEIPTS-578: background resolver that populates `ReceiptItem.NormalizedDescriptionId`
- RECEIPTS-579: admin API (MediatR commands/queries + controller)
- RECEIPTS-580: DB-backed settings + match tester + preview impact + `NormalizedDescriptionMatchScore` column
- RECEIPTS-581: spending-by-normalized-description report
- RECEIPTS-582: React admin page + settings panel
- RECEIPTS-583: expose `normalizedDescriptionId` / `Name` on `ReceiptItemResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)