### PR TITLE
feat(infra): admin-settable thresholds + match tester + preview (RECEIPTS-580)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -1322,6 +1322,124 @@ paths:
           description: Not Found
 
   # ──────────────────────────────────────────────
+  # Normalized Descriptions (admin-only)
+  # ──────────────────────────────────────────────
+
+  /api/normalized-descriptions/settings:
+    get:
+      operationId: GetNormalizedDescriptionSettings
+      tags: [NormalizedDescriptions]
+      summary: Get the current normalized-description threshold settings
+      description: |
+        Returns the live auto-accept and pending-review thresholds used by the
+        resolver when classifying new receipt item descriptions. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionSettingsResponse"
+    patch:
+      operationId: UpdateNormalizedDescriptionSettings
+      tags: [NormalizedDescriptions]
+      summary: Update the normalized-description threshold settings
+      description: |
+        Updates the auto-accept and pending-review thresholds. Both values must
+        satisfy `0 <= pendingReviewThreshold < autoAcceptThreshold <= 1`. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateNormalizedDescriptionSettingsRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionSettingsResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/normalized-descriptions/settings/preview:
+    post:
+      operationId: PreviewNormalizedDescriptionThresholdImpact
+      tags: [NormalizedDescriptions]
+      summary: Preview the impact of changing threshold settings
+      description: |
+        Returns current vs. proposed classification counts (auto-accepted,
+        pending-review, unresolved) and the reclassification deltas that a
+        threshold change would produce, computed against the live
+        `NormalizedDescriptionMatchScore` column on receipt items. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PreviewThresholdImpactRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ThresholdImpactPreviewResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/normalized-descriptions/test:
+    post:
+      operationId: TestNormalizedDescriptionMatch
+      tags: [NormalizedDescriptions]
+      summary: Probe the classifier for a given description
+      description: |
+        Returns the top-N ANN candidates for the supplied description along with
+        the classification branch the production resolver would take under the
+        supplied threshold overrides (or the live DB settings when absent).
+        Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestMatchRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MatchTestResultResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  # ──────────────────────────────────────────────
   # Receipts
   # ──────────────────────────────────────────────
 
@@ -5545,6 +5663,165 @@ components:
           type: integer
           format: int32
           description: Number of similar items with this category
+
+    # ── Normalized Descriptions ──────────────────
+
+    NormalizedDescriptionSettingsResponse:
+      type: object
+      required: [id, autoAcceptThreshold, pendingReviewThreshold, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Fixed singleton identifier for the settings row.
+        autoAcceptThreshold:
+          type: number
+          format: double
+          description: Cosine-similarity floor at which the resolver re-uses an existing canonical entry.
+        pendingReviewThreshold:
+          type: number
+          format: double
+          description: Cosine-similarity floor at which the resolver creates a PendingReview entry instead of a new Active one.
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the settings were last changed.
+
+    UpdateNormalizedDescriptionSettingsRequest:
+      type: object
+      required: [autoAcceptThreshold, pendingReviewThreshold]
+      properties:
+        autoAcceptThreshold:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+        pendingReviewThreshold:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+
+    TestMatchRequest:
+      type: object
+      required: [description]
+      properties:
+        description:
+          type: string
+          minLength: 1
+          description: Description to classify. Must be non-empty after trim.
+        topN:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 20
+          default: 5
+          description: Number of ANN candidates to return (ranked by cosine similarity).
+        autoAcceptThresholdOverride:
+          type: ["number", "null"]
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+          description: Override the live auto-accept threshold for simulation. Falls back to DB settings when null.
+        pendingReviewThresholdOverride:
+          type: ["number", "null"]
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+          description: Override the live pending-review threshold for simulation. Falls back to DB settings when null.
+
+    MatchTestResultResponse:
+      type: object
+      required: [candidates, simulatedOutcome]
+      properties:
+        candidates:
+          type: array
+          items:
+            $ref: "#/components/schemas/MatchCandidateDto"
+        simulatedOutcome:
+          type: string
+          description: "One of: AutoAccept, PendingReview, CreateNew, EmbeddingUnavailable."
+        simulatedTargetId:
+          type: ["string", "null"]
+          format: uuid
+          description: ID of the normalized-description row the resolver would reuse (AutoAccept) or null for CreateNew / PendingReview / EmbeddingUnavailable.
+
+    MatchCandidateDto:
+      type: object
+      required: [normalizedDescriptionId, canonicalName, cosineSimilarity, status]
+      properties:
+        normalizedDescriptionId:
+          type: string
+          format: uuid
+        canonicalName:
+          type: string
+        cosineSimilarity:
+          type: number
+          format: double
+        status:
+          type: string
+          description: "Active or PendingReview."
+
+    PreviewThresholdImpactRequest:
+      type: object
+      required: [autoAcceptThreshold, pendingReviewThreshold]
+      properties:
+        autoAcceptThreshold:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+        pendingReviewThreshold:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+
+    ThresholdImpactPreviewResponse:
+      type: object
+      required: [current, proposed, deltas]
+      properties:
+        current:
+          $ref: "#/components/schemas/ClassificationCountsDto"
+        proposed:
+          $ref: "#/components/schemas/ClassificationCountsDto"
+        deltas:
+          $ref: "#/components/schemas/ReclassificationDeltasDto"
+
+    ClassificationCountsDto:
+      type: object
+      required: [autoAccepted, pendingReview, unresolved]
+      properties:
+        autoAccepted:
+          type: integer
+          format: int32
+        pendingReview:
+          type: integer
+          format: int32
+        unresolved:
+          type: integer
+          format: int32
+
+    ReclassificationDeltasDto:
+      type: object
+      required: [autoToPending, pendingToAuto, unresolvedToAuto, unresolvedToPending]
+      properties:
+        autoToPending:
+          type: integer
+          format: int32
+          description: Items currently auto-accepted that would fall back to pending-review under the proposal.
+        pendingToAuto:
+          type: integer
+          format: int32
+          description: Items currently pending-review that would be auto-accepted under the proposal.
+        unresolvedToAuto:
+          type: integer
+          format: int32
+          description: Items currently unresolved (below pending-review threshold) that would be auto-accepted under the proposal.
+        unresolvedToPending:
+          type: integer
+          format: int32
+          description: Items currently unresolved (below pending-review threshold) that would move up to pending-review under the proposal.
 
     # ── Receipt ──────────────────────────────────
 

--- a/src/Application/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommand.cs
+++ b/src/Application/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommand.cs
@@ -1,0 +1,8 @@
+using Application.Interfaces;
+using Domain.NormalizedDescriptions;
+
+namespace Application.Commands.NormalizedDescription.UpdateSettings;
+
+public record UpdateNormalizedDescriptionSettingsCommand(
+	double AutoAcceptThreshold,
+	double PendingReviewThreshold) : ICommand<NormalizedDescriptionSettings>;

--- a/src/Application/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommandHandler.cs
+++ b/src/Application/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommandHandler.cs
@@ -1,0 +1,17 @@
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Commands.NormalizedDescription.UpdateSettings;
+
+public class UpdateNormalizedDescriptionSettingsCommandHandler(INormalizedDescriptionService service)
+	: IRequestHandler<UpdateNormalizedDescriptionSettingsCommand, NormalizedDescriptionSettings>
+{
+	public async Task<NormalizedDescriptionSettings> Handle(UpdateNormalizedDescriptionSettingsCommand request, CancellationToken cancellationToken)
+	{
+		return await service.UpdateSettingsAsync(
+			request.AutoAcceptThreshold,
+			request.PendingReviewThreshold,
+			cancellationToken);
+	}
+}

--- a/src/Application/Interfaces/Services/INormalizedDescriptionService.cs
+++ b/src/Application/Interfaces/Services/INormalizedDescriptionService.cs
@@ -1,13 +1,19 @@
+using Application.Models.NormalizedDescriptions;
 using Domain.NormalizedDescriptions;
 
 namespace Application.Interfaces.Services;
 
 public interface INormalizedDescriptionService
 {
-	Task<NormalizedDescription> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken);
+	Task<GetOrCreateResult> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken);
 	Task<NormalizedDescription?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 	Task<List<NormalizedDescription>> GetAllAsync(NormalizedDescriptionStatus? filter, CancellationToken cancellationToken);
 	Task<int> MergeAsync(Guid keepId, Guid discardId, CancellationToken cancellationToken);
 	Task<NormalizedDescription> SplitAsync(Guid receiptItemId, CancellationToken cancellationToken);
 	Task<bool> UpdateStatusAsync(Guid id, NormalizedDescriptionStatus status, CancellationToken cancellationToken);
+
+	Task<NormalizedDescriptionSettings> GetSettingsAsync(CancellationToken cancellationToken);
+	Task<NormalizedDescriptionSettings> UpdateSettingsAsync(double autoAcceptThreshold, double pendingReviewThreshold, CancellationToken cancellationToken);
+	Task<MatchTestResult> TestMatchAsync(string description, int topN, double? autoAcceptThresholdOverride, double? pendingReviewThresholdOverride, CancellationToken cancellationToken);
+	Task<ThresholdImpactPreview> PreviewThresholdImpactAsync(double autoAcceptThreshold, double pendingReviewThreshold, CancellationToken cancellationToken);
 }

--- a/src/Application/Models/NormalizedDescriptions/GetOrCreateResult.cs
+++ b/src/Application/Models/NormalizedDescriptions/GetOrCreateResult.cs
@@ -1,0 +1,11 @@
+using Domain.NormalizedDescriptions;
+
+namespace Application.Models.NormalizedDescriptions;
+
+// Returned by INormalizedDescriptionService.GetOrCreateAsync. The resolver (RECEIPTS-578)
+// uses MatchScore to populate ReceiptItem.NormalizedDescriptionMatchScore at the same time
+// it writes the NormalizedDescriptionId FK, so admins can later query threshold-impact
+// aggregates without recomputing embeddings. MatchScore is null when no ANN candidate was
+// above the pending-review floor (a brand-new canonical entry was created) or when the
+// embedding service was unavailable.
+public record GetOrCreateResult(NormalizedDescription Description, double? MatchScore);

--- a/src/Application/Models/NormalizedDescriptions/MatchTestResult.cs
+++ b/src/Application/Models/NormalizedDescriptions/MatchTestResult.cs
@@ -1,0 +1,26 @@
+namespace Application.Models.NormalizedDescriptions;
+
+// Result of INormalizedDescriptionService.TestMatchAsync — the admin-facing "what would happen
+// if I ran GetOrCreate on this description" probe. Candidates are the top-N ANN matches; the
+// simulated outcome tells the admin which branch (auto-accept / pending review / create new)
+// the production resolver would take given the supplied overrides or the live DB thresholds.
+public record MatchTestResult(
+	List<MatchCandidate> Candidates,
+	string SimulatedOutcome,
+	Guid? SimulatedTargetId);
+
+// Simulated outcomes for TestMatchAsync. Kept as string constants so the wire format stays
+// human-readable and stable across refactors.
+public static class MatchTestOutcomes
+{
+	public const string AutoAccept = "AutoAccept";
+	public const string PendingReview = "PendingReview";
+	public const string CreateNew = "CreateNew";
+	public const string EmbeddingUnavailable = "EmbeddingUnavailable";
+}
+
+public record MatchCandidate(
+	Guid NormalizedDescriptionId,
+	string CanonicalName,
+	double CosineSimilarity,
+	string Status);

--- a/src/Application/Models/NormalizedDescriptions/ThresholdImpactPreview.cs
+++ b/src/Application/Models/NormalizedDescriptions/ThresholdImpactPreview.cs
@@ -1,0 +1,19 @@
+namespace Application.Models.NormalizedDescriptions;
+
+// Result of INormalizedDescriptionService.PreviewThresholdImpactAsync. Counts are computed
+// against the live ReceiptItems.NormalizedDescriptionMatchScore column, once with the current
+// DB thresholds and once with the proposed ones. The deltas are an admin-friendly breakdown
+// of how many items would change classification bucket. Items with a NULL score contribute
+// to the Unresolved bucket in both sides.
+public record ThresholdImpactPreview(
+	ClassificationCounts Current,
+	ClassificationCounts Proposed,
+	ReclassificationDeltas Deltas);
+
+public record ClassificationCounts(int AutoAccepted, int PendingReview, int Unresolved);
+
+public record ReclassificationDeltas(
+	int AutoToPending,
+	int PendingToAuto,
+	int UnresolvedToAuto,
+	int UnresolvedToPending);

--- a/src/Application/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQuery.cs
@@ -1,0 +1,6 @@
+using Application.Interfaces;
+using Domain.NormalizedDescriptions;
+
+namespace Application.Queries.NormalizedDescription.GetSettings;
+
+public record GetNormalizedDescriptionSettingsQuery : IQuery<NormalizedDescriptionSettings>;

--- a/src/Application/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQueryHandler.cs
@@ -1,0 +1,14 @@
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.GetSettings;
+
+public class GetNormalizedDescriptionSettingsQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<GetNormalizedDescriptionSettingsQuery, NormalizedDescriptionSettings>
+{
+	public async Task<NormalizedDescriptionSettings> Handle(GetNormalizedDescriptionSettingsQuery request, CancellationToken cancellationToken)
+	{
+		return await service.GetSettingsAsync(cancellationToken);
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQuery.cs
@@ -1,0 +1,8 @@
+using Application.Interfaces;
+using Application.Models.NormalizedDescriptions;
+
+namespace Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+
+public record PreviewThresholdImpactQuery(
+	double AutoAcceptThreshold,
+	double PendingReviewThreshold) : IQuery<ThresholdImpactPreview>;

--- a/src/Application/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQueryHandler.cs
@@ -1,0 +1,17 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+
+public class PreviewThresholdImpactQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<PreviewThresholdImpactQuery, ThresholdImpactPreview>
+{
+	public async Task<ThresholdImpactPreview> Handle(PreviewThresholdImpactQuery request, CancellationToken cancellationToken)
+	{
+		return await service.PreviewThresholdImpactAsync(
+			request.AutoAcceptThreshold,
+			request.PendingReviewThreshold,
+			cancellationToken);
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQuery.cs
@@ -1,0 +1,10 @@
+using Application.Interfaces;
+using Application.Models.NormalizedDescriptions;
+
+namespace Application.Queries.NormalizedDescription.TestMatch;
+
+public record TestNormalizedDescriptionMatchQuery(
+	string Description,
+	int TopN,
+	double? AutoAcceptThresholdOverride,
+	double? PendingReviewThresholdOverride) : IQuery<MatchTestResult>;

--- a/src/Application/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQueryHandler.cs
@@ -1,0 +1,19 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.TestMatch;
+
+public class TestNormalizedDescriptionMatchQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<TestNormalizedDescriptionMatchQuery, MatchTestResult>
+{
+	public async Task<MatchTestResult> Handle(TestNormalizedDescriptionMatchQuery request, CancellationToken cancellationToken)
+	{
+		return await service.TestMatchAsync(
+			request.Description,
+			request.TopN,
+			request.AutoAcceptThresholdOverride,
+			request.PendingReviewThresholdOverride,
+			cancellationToken);
+	}
+}

--- a/src/Domain/Core/ReceiptItem.cs
+++ b/src/Domain/Core/ReceiptItem.cs
@@ -20,10 +20,11 @@ public class ReceiptItem
 
 	// Resolver-populated fields — readonly from a domain-logic perspective, but public setters
 	// are required so Mapperly can populate them. Not included in the constructor: the
-	// NormalizedDescription resolver (see RECEIPTS-578) writes the FK, and read paths
-	// populate the denormalized name from the entity nav property.
+	// NormalizedDescription resolver (see RECEIPTS-578) writes the FK, the match score, and
+	// read paths populate the denormalized name from the entity nav property.
 	public Guid? NormalizedDescriptionId { get; set; }
 	public string? NormalizedDescriptionName { get; set; }
+	public double? NormalizedDescriptionMatchScore { get; set; }
 
 	public const string DescriptionCannotBeEmpty = "Description cannot be empty";
 	public const string QuantityMustBePositive = "Quantity must be positive";

--- a/src/Domain/NormalizedDescriptions/NormalizedDescriptionSettings.cs
+++ b/src/Domain/NormalizedDescriptions/NormalizedDescriptionSettings.cs
@@ -1,0 +1,35 @@
+namespace Domain.NormalizedDescriptions;
+
+public class NormalizedDescriptionSettings
+{
+	public Guid Id { get; set; }
+	public double AutoAcceptThreshold { get; set; }
+	public double PendingReviewThreshold { get; set; }
+	public DateTimeOffset UpdatedAt { get; set; }
+
+	public const string ThresholdsMustBeInRange = "Thresholds must satisfy 0 <= pendingReviewThreshold < autoAcceptThreshold <= 1";
+	public const string PendingMustBeLessThanAuto = "pendingReviewThreshold must be strictly less than autoAcceptThreshold";
+
+	public NormalizedDescriptionSettings(Guid id, double autoAcceptThreshold, double pendingReviewThreshold, DateTimeOffset updatedAt)
+	{
+		Validate(autoAcceptThreshold, pendingReviewThreshold);
+
+		Id = id;
+		AutoAcceptThreshold = autoAcceptThreshold;
+		PendingReviewThreshold = pendingReviewThreshold;
+		UpdatedAt = updatedAt;
+	}
+
+	public static void Validate(double autoAcceptThreshold, double pendingReviewThreshold)
+	{
+		if (autoAcceptThreshold < 0 || autoAcceptThreshold > 1 || pendingReviewThreshold < 0 || pendingReviewThreshold > 1)
+		{
+			throw new ArgumentException(ThresholdsMustBeInRange);
+		}
+
+		if (pendingReviewThreshold >= autoAcceptThreshold)
+		{
+			throw new ArgumentException(PendingMustBeLessThanAuto);
+		}
+	}
+}

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -51,6 +51,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 	public virtual DbSet<ItemTemplateEntity> ItemTemplates { get; set; } = null!;
 	public virtual DbSet<ItemEmbeddingEntity> ItemEmbeddings { get; set; } = null!;
 	public virtual DbSet<NormalizedDescriptionEntity> NormalizedDescriptions { get; set; } = null!;
+	public virtual DbSet<NormalizedDescriptionSettingsEntity> NormalizedDescriptionSettings { get; set; } = null!;
 	public virtual DbSet<DistinctDescriptionEntity> DistinctDescriptions { get; set; } = null!;
 	public virtual DbSet<ItemSimilarityEdgeEntity> ItemSimilarityEdges { get; set; } = null!;
 	public virtual DbSet<AuditLogEntity> AuditLogs { get; set; } = null!;

--- a/src/Infrastructure/Configurations/NormalizedDescriptionSettingsEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/NormalizedDescriptionSettingsEntityConfiguration.cs
@@ -1,0 +1,44 @@
+using Infrastructure.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Configurations;
+
+public class NormalizedDescriptionSettingsEntityConfiguration : IEntityTypeConfiguration<NormalizedDescriptionSettingsEntity>
+{
+	// Fixed singleton ID for the one-row settings table. All reads and writes target this ID;
+	// HasData seeds a single row on migration so the service can always resolve thresholds.
+	public static readonly Guid SingletonId = new("00000000-0000-0000-0000-000000000001");
+
+	// Initial threshold defaults, mirrored from the (now-legacy) hardcoded constants on
+	// NormalizedDescriptionService. Retained here so the migration seed is self-contained
+	// and can be updated in isolation when we re-calibrate.
+	public const double InitialAutoAcceptThreshold = 0.81;
+	public const double InitialPendingReviewThreshold = 0.68;
+
+	// The seed timestamp is fixed so EF migrations are deterministic (DateTimeOffset.UtcNow
+	// would produce a different SQL on every `migrations add`). Runtime updates overwrite
+	// this value via UpdateSettingsAsync.
+	public static readonly DateTimeOffset SeedUpdatedAt = new(2026, 4, 19, 0, 0, 0, TimeSpan.Zero);
+
+	public void Configure(EntityTypeBuilder<NormalizedDescriptionSettingsEntity> builder)
+	{
+		builder.ToTable("NormalizedDescriptionSettings");
+
+		builder.HasKey(e => e.Id);
+
+		// ValueGeneratedNever — singleton row identity is fixed at seed time.
+		builder.Property(e => e.Id)
+			.IsRequired()
+			.ValueGeneratedNever();
+
+		builder.HasData(
+			new NormalizedDescriptionSettingsEntity
+			{
+				Id = SingletonId,
+				AutoAcceptThreshold = InitialAutoAcceptThreshold,
+				PendingReviewThreshold = InitialPendingReviewThreshold,
+				UpdatedAt = SeedUpdatedAt,
+			});
+	}
+}

--- a/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
@@ -34,6 +34,12 @@ public class ReceiptItemEntityConfiguration : IEntityTypeConfiguration<ReceiptIt
 
 		builder.HasIndex(e => e.NormalizedDescriptionId);
 
+		// Threshold-impact previews aggregate ReceiptItem counts by bucketing on match score.
+		// An index on NormalizedDescriptionMatchScore keeps those aggregates fast even as the
+		// table grows; the column is populated by the resolver (RECEIPTS-578) with the cosine
+		// similarity at resolve time and remains NULL for unresolved / newly-created items.
+		builder.HasIndex(e => e.NormalizedDescriptionMatchScore);
+
 		builder.HasQueryFilter(e => e.DeletedAt == null);
 	}
 }

--- a/src/Infrastructure/Entities/Core/NormalizedDescriptionSettingsEntity.cs
+++ b/src/Infrastructure/Entities/Core/NormalizedDescriptionSettingsEntity.cs
@@ -1,0 +1,9 @@
+namespace Infrastructure.Entities.Core;
+
+public class NormalizedDescriptionSettingsEntity
+{
+	public Guid Id { get; set; }
+	public double AutoAcceptThreshold { get; set; }
+	public double PendingReviewThreshold { get; set; }
+	public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/src/Infrastructure/Entities/Core/ReceiptItemEntity.cs
+++ b/src/Infrastructure/Entities/Core/ReceiptItemEntity.cs
@@ -18,6 +18,7 @@ public class ReceiptItemEntity : ISoftDeletable, IOwnedBy<ReceiptEntity>
 	public string? Subcategory { get; set; }
 	public PricingMode PricingMode { get; set; } = PricingMode.Quantity;
 	public Guid? NormalizedDescriptionId { get; set; }
+	public double? NormalizedDescriptionMatchScore { get; set; }
 	public virtual NormalizedDescriptionEntity? NormalizedDescription { get; set; }
 	public virtual ReceiptEntity? Receipt { get; set; }
 	public DateTimeOffset? DeletedAt { get; set; }

--- a/src/Infrastructure/Mapping/NormalizedDescriptionSettingsMapper.cs
+++ b/src/Infrastructure/Mapping/NormalizedDescriptionSettingsMapper.cs
@@ -1,0 +1,13 @@
+using Domain.NormalizedDescriptions;
+using Infrastructure.Entities.Core;
+using Riok.Mapperly.Abstractions;
+
+namespace Infrastructure.Mapping;
+
+[Mapper]
+public partial class NormalizedDescriptionSettingsMapper
+{
+	public partial NormalizedDescriptionSettingsEntity ToEntity(NormalizedDescriptionSettings source);
+
+	public partial NormalizedDescriptionSettings ToDomain(NormalizedDescriptionSettingsEntity source);
+}

--- a/src/Infrastructure/Migrations/20260420024810_AddNormalizedDescriptionSettingsAndMatchScore.Designer.cs
+++ b/src/Infrastructure/Migrations/20260420024810_AddNormalizedDescriptionSettingsAndMatchScore.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420024810_AddNormalizedDescriptionSettingsAndMatchScore")]
+    partial class AddNormalizedDescriptionSettingsAndMatchScore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260420024810_AddNormalizedDescriptionSettingsAndMatchScore.cs
+++ b/src/Infrastructure/Migrations/20260420024810_AddNormalizedDescriptionSettingsAndMatchScore.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddNormalizedDescriptionSettingsAndMatchScore : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AddColumn<double>(
+			name: "NormalizedDescriptionMatchScore",
+			table: "ReceiptItems",
+			type: "double precision",
+			nullable: true);
+
+		migrationBuilder.CreateTable(
+			name: "NormalizedDescriptionSettings",
+			columns: table => new
+			{
+				Id = table.Column<Guid>(type: "uuid", nullable: false),
+				AutoAcceptThreshold = table.Column<double>(type: "double precision", nullable: false),
+				PendingReviewThreshold = table.Column<double>(type: "double precision", nullable: false),
+				UpdatedAt = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false)
+			},
+			constraints: table =>
+			{
+				table.PrimaryKey("PK_NormalizedDescriptionSettings", x => x.Id);
+			});
+
+		migrationBuilder.InsertData(
+			table: "NormalizedDescriptionSettings",
+			columns: new[] { "Id", "AutoAcceptThreshold", "PendingReviewThreshold", "UpdatedAt" },
+			values: new object[] { new Guid("00000000-0000-0000-0000-000000000001"), 0.81000000000000005, 0.68000000000000005, new DateTimeOffset(new DateTime(2026, 4, 19, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)) });
+
+		migrationBuilder.CreateIndex(
+			name: "IX_ReceiptItems_NormalizedDescriptionMatchScore",
+			table: "ReceiptItems",
+			column: "NormalizedDescriptionMatchScore");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropTable(
+			name: "NormalizedDescriptionSettings");
+
+		migrationBuilder.DropIndex(
+			name: "IX_ReceiptItems_NormalizedDescriptionMatchScore",
+			table: "ReceiptItems");
+
+		migrationBuilder.DropColumn(
+			name: "NormalizedDescriptionMatchScore",
+			table: "ReceiptItems");
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -243,7 +243,8 @@ public static class InfrastructureService
 			.AddSingleton<TransactionMapper>()
 			.AddSingleton<AdjustmentMapper>()
 			.AddSingleton<ItemTemplateMapper>()
-			.AddSingleton<NormalizedDescriptionMapper>();
+			.AddSingleton<NormalizedDescriptionMapper>()
+			.AddSingleton<NormalizedDescriptionSettingsMapper>();
 
 		return services;
 	}

--- a/src/Infrastructure/Services/NormalizedDescriptionService.cs
+++ b/src/Infrastructure/Services/NormalizedDescriptionService.cs
@@ -1,5 +1,7 @@
 using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
 using Domain.NormalizedDescriptions;
+using Infrastructure.Configurations;
 using Infrastructure.Entities.Core;
 using Infrastructure.Mapping;
 using Microsoft.EntityFrameworkCore;
@@ -10,19 +12,24 @@ namespace Infrastructure.Services;
 public class NormalizedDescriptionService(
 	IDbContextFactory<ApplicationDbContext> contextFactory,
 	IEmbeddingService embeddingService,
-	NormalizedDescriptionMapper mapper) : INormalizedDescriptionService
+	NormalizedDescriptionMapper mapper,
+	NormalizedDescriptionSettingsMapper settingsMapper) : INormalizedDescriptionService
 {
-	// Threshold constants are hardcoded for RECEIPTS-577. A later issue (RECEIPTS-580) moves
-	// them into a DB-backed settings row so they can be tuned without a redeploy. The values
-	// below match the data-driven calibration baseline.
-	public const double AutoAcceptThreshold = 0.81;
-	public const double PendingReviewThreshold = 0.68;
+	// The thresholds used when no settings row exists yet. These match the migration seed so
+	// that pre-migration code paths (tests that don't seed, integration tests spinning up a
+	// fresh schema) still see the same decision boundaries as production would at rest.
+	public const double InitialAutoAcceptThreshold = NormalizedDescriptionSettingsEntityConfiguration.InitialAutoAcceptThreshold;
+	public const double InitialPendingReviewThreshold = NormalizedDescriptionSettingsEntityConfiguration.InitialPendingReviewThreshold;
 
 	public const string ReceiptItemNotFound = "Receipt item not found.";
+	public const string SettingsRowNotFound = "NormalizedDescriptionSettings singleton row is missing.";
+	public const string TestMatchDescriptionRequired = "Test match description must not be empty.";
+	public const string TopNOutOfRange = "topN must be between 1 and 20.";
 
+	private const int MaxTopN = 20;
 	private const string PostgreSQL = "Npgsql.EntityFrameworkCore.PostgreSQL";
 
-	public async Task<NormalizedDescription> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken)
+	public async Task<GetOrCreateResult> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken)
 	{
 		string normalized = (rawDescription ?? string.Empty).Trim();
 		if (string.IsNullOrEmpty(normalized))
@@ -32,18 +39,26 @@ public class NormalizedDescriptionService(
 
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
 
+		// Read thresholds fresh from the DB each call. Call frequency is bounded by the
+		// resolver's 30-second poll cycle, so the latency cost is negligible and admin
+		// updates take effect on the next run without any cache-invalidation plumbing.
+		(double autoAccept, double pendingReview) = await ResolveThresholdsAsync(context, cancellationToken);
+
 		// Step 1: exact case-insensitive match on existing canonical name.
 		NormalizedDescriptionEntity? existing = await FindExactCaseInsensitiveAsync(context, normalized, cancellationToken);
 		if (existing is not null)
 		{
-			return mapper.ToDomain(existing);
+			// An exact-name match is a perfect logical match — surface similarity = 1 so
+			// the resolver can record it on the ReceiptItem without requiring a second
+			// embedding roundtrip.
+			return new GetOrCreateResult(mapper.ToDomain(existing), MatchScore: 1.0);
 		}
 
 		// Step 2: no embedding capability — create Active entry directly with no vector.
 		if (!embeddingService.IsConfigured)
 		{
 			NormalizedDescriptionEntity created = await InsertAsync(context, normalized, NormalizedDescriptionStatus.Active, embedding: null, cancellationToken);
-			return mapper.ToDomain(created);
+			return new GetOrCreateResult(mapper.ToDomain(created), MatchScore: null);
 		}
 
 		// Step 3: generate embedding for the input.
@@ -62,20 +77,20 @@ public class NormalizedDescriptionService(
 
 		if (topMatch is not null && topSimilarity.HasValue)
 		{
-			if (topSimilarity.Value >= AutoAcceptThreshold)
+			if (topSimilarity.Value >= autoAccept)
 			{
-				return mapper.ToDomain(topMatch);
+				return new GetOrCreateResult(mapper.ToDomain(topMatch), topSimilarity.Value);
 			}
 
-			if (topSimilarity.Value >= PendingReviewThreshold)
+			if (topSimilarity.Value >= pendingReview)
 			{
 				NormalizedDescriptionEntity pending = await InsertAsync(context, normalized, NormalizedDescriptionStatus.PendingReview, embeddingVector, cancellationToken);
-				return mapper.ToDomain(pending);
+				return new GetOrCreateResult(mapper.ToDomain(pending), topSimilarity.Value);
 			}
 		}
 
 		NormalizedDescriptionEntity activeCreated = await InsertAsync(context, normalized, NormalizedDescriptionStatus.Active, embeddingVector, cancellationToken);
-		return mapper.ToDomain(activeCreated);
+		return new GetOrCreateResult(mapper.ToDomain(activeCreated), MatchScore: null);
 	}
 
 	public async Task<NormalizedDescription?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
@@ -200,6 +215,276 @@ public class NormalizedDescriptionService(
 		return true;
 	}
 
+	public async Task<NormalizedDescriptionSettings> GetSettingsAsync(CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity entity = await ResolveSettingsEntityAsync(context, cancellationToken);
+		return settingsMapper.ToDomain(entity);
+	}
+
+	public async Task<NormalizedDescriptionSettings> UpdateSettingsAsync(
+		double autoAcceptThreshold,
+		double pendingReviewThreshold,
+		CancellationToken cancellationToken)
+	{
+		// Domain-level validation: prevents malformed bounds (out-of-range, crossed thresholds)
+		// from ever hitting the DB. Mirrors the constructor on NormalizedDescriptionSettings.
+		NormalizedDescriptionSettings.Validate(autoAcceptThreshold, pendingReviewThreshold);
+
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity entity = await ResolveSettingsEntityAsync(context, cancellationToken);
+
+		entity.AutoAcceptThreshold = autoAcceptThreshold;
+		entity.PendingReviewThreshold = pendingReviewThreshold;
+		entity.UpdatedAt = DateTimeOffset.UtcNow;
+
+		await context.SaveChangesAsync(cancellationToken);
+		return settingsMapper.ToDomain(entity);
+	}
+
+	public async Task<MatchTestResult> TestMatchAsync(
+		string description,
+		int topN,
+		double? autoAcceptThresholdOverride,
+		double? pendingReviewThresholdOverride,
+		CancellationToken cancellationToken)
+	{
+		string normalized = (description ?? string.Empty).Trim();
+		if (string.IsNullOrEmpty(normalized))
+		{
+			throw new ArgumentException(TestMatchDescriptionRequired, nameof(description));
+		}
+
+		if (topN < 1 || topN > MaxTopN)
+		{
+			throw new ArgumentException(TopNOutOfRange, nameof(topN));
+		}
+
+		// Validate any thresholds the admin supplied. We accept partial overrides (one or the
+		// other) but still need the combined pair to satisfy the invariant: fall back to the
+		// DB values for the unset side, then validate the resulting pair.
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity settings = await ResolveSettingsEntityAsync(context, cancellationToken);
+
+		double autoAccept = autoAcceptThresholdOverride ?? settings.AutoAcceptThreshold;
+		double pendingReview = pendingReviewThresholdOverride ?? settings.PendingReviewThreshold;
+		NormalizedDescriptionSettings.Validate(autoAccept, pendingReview);
+
+		// If there is an exact case-insensitive match, the resolver would short-circuit
+		// without ever querying embeddings. Mirror that here so the preview is truthful.
+		NormalizedDescriptionEntity? exactMatch = await FindExactCaseInsensitiveAsync(context, normalized, cancellationToken);
+		if (exactMatch is not null)
+		{
+			List<MatchCandidate> exactCandidates =
+			[
+				new MatchCandidate(
+					exactMatch.Id,
+					exactMatch.CanonicalName,
+					1.0,
+					exactMatch.Status.ToString()),
+			];
+			return new MatchTestResult(exactCandidates, MatchTestOutcomes.AutoAccept, exactMatch.Id);
+		}
+
+		if (!embeddingService.IsConfigured)
+		{
+			// No embedding service — the real resolver would create a new Active entry, but
+			// admins still deserve an honest answer: no candidates, and a dedicated outcome
+			// so the UI can surface a banner. SimulatedTargetId is null because the new
+			// entry doesn't exist yet.
+			return new MatchTestResult([], MatchTestOutcomes.EmbeddingUnavailable, SimulatedTargetId: null);
+		}
+
+		float[] embeddingData = await embeddingService.GenerateEmbeddingAsync(normalized, cancellationToken);
+		if (embeddingData.Length == 0)
+		{
+			return new MatchTestResult([], MatchTestOutcomes.EmbeddingUnavailable, SimulatedTargetId: null);
+		}
+
+		Vector queryVector = new(embeddingData);
+		List<MatchCandidate> candidates = await AnnSearchTopNAsync(context, queryVector, topN, cancellationToken);
+
+		// The resolver makes its branch decision against the top-1 candidate, so we do too —
+		// the rest of the candidates are informational only.
+		MatchCandidate? top = candidates.Count > 0 ? candidates[0] : null;
+		if (top is not null)
+		{
+			if (top.CosineSimilarity >= autoAccept)
+			{
+				return new MatchTestResult(candidates, MatchTestOutcomes.AutoAccept, top.NormalizedDescriptionId);
+			}
+
+			if (top.CosineSimilarity >= pendingReview)
+			{
+				// In the real resolver this would create a new PendingReview entry linked in
+				// a neighbourhood of `top`; SimulatedTargetId=null because the row doesn't
+				// exist yet. The caller has the top candidate in `candidates[0]` for context.
+				return new MatchTestResult(candidates, MatchTestOutcomes.PendingReview, SimulatedTargetId: null);
+			}
+		}
+
+		return new MatchTestResult(candidates, MatchTestOutcomes.CreateNew, SimulatedTargetId: null);
+	}
+
+	public async Task<ThresholdImpactPreview> PreviewThresholdImpactAsync(
+		double autoAcceptThreshold,
+		double pendingReviewThreshold,
+		CancellationToken cancellationToken)
+	{
+		NormalizedDescriptionSettings.Validate(autoAcceptThreshold, pendingReviewThreshold);
+
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity settings = await ResolveSettingsEntityAsync(context, cancellationToken);
+
+		// Snapshot the scored live-set once. We bucketise twice (current thresholds and
+		// proposed thresholds) over the same in-memory list to keep the two classifications
+		// strictly comparable — querying twice would risk a race if items were resolved
+		// between the two counts. An item only enters this list if BOTH the FK and the
+		// score are populated; otherwise it's structurally unresolved and no threshold
+		// change can reclassify it. The set is bounded (only resolved items) so memory
+		// cost is modest relative to the total ReceiptItems table.
+		List<double> scored = await context.ReceiptItems
+			.AsNoTracking()
+			.IgnoreAutoIncludes()
+			.Where(r => r.NormalizedDescriptionMatchScore != null && r.NormalizedDescriptionId != null)
+			.Select(r => r.NormalizedDescriptionMatchScore!.Value)
+			.ToListAsync(cancellationToken);
+
+		// Items without a match score or without any linked NormalizedDescription are
+		// counted as structurally unresolved regardless of threshold choice.
+		int unresolvedCount = await context.ReceiptItems
+			.AsNoTracking()
+			.IgnoreAutoIncludes()
+			.CountAsync(r => r.NormalizedDescriptionMatchScore == null || r.NormalizedDescriptionId == null, cancellationToken);
+
+		ClassificationCounts current = Classify(scored, settings.AutoAcceptThreshold, settings.PendingReviewThreshold, unresolvedCount);
+		ClassificationCounts proposed = Classify(scored, autoAcceptThreshold, pendingReviewThreshold, unresolvedCount);
+
+		// Deltas: per-item transitions between the two classification maps. We don't have
+		// item identity here, just a list of scores — so we compute counts by bucket
+		// intersection (e.g., items currently auto-accepted but proposed-pending-review =
+		// scores where current.auto holds but proposed.auto doesn't and proposed.pending
+		// does). Same for Unresolved → {auto, pending}, which falls out of the score nulls:
+		// null-score items never change bucket, so Unresolved→X transitions only apply to
+		// the "scored but currently below pendingReview" sub-slice.
+		int autoToPending = scored.Count(s =>
+			s >= settings.AutoAcceptThreshold &&
+			s >= pendingReviewThreshold && s < autoAcceptThreshold);
+
+		int pendingToAuto = scored.Count(s =>
+			s >= settings.PendingReviewThreshold && s < settings.AutoAcceptThreshold &&
+			s >= autoAcceptThreshold);
+
+		// Unresolved→X deltas describe currently-unresolved-by-threshold items (i.e., scored
+		// but below the current pending-review floor) that would move up under the proposal.
+		// NULL-score items are "structurally unresolved" and cannot move via a threshold change.
+		int unresolvedToAuto = scored.Count(s =>
+			s < settings.PendingReviewThreshold &&
+			s >= autoAcceptThreshold);
+
+		int unresolvedToPending = scored.Count(s =>
+			s < settings.PendingReviewThreshold &&
+			s >= pendingReviewThreshold && s < autoAcceptThreshold);
+
+		ReclassificationDeltas deltas = new(autoToPending, pendingToAuto, unresolvedToAuto, unresolvedToPending);
+		return new ThresholdImpactPreview(current, proposed, deltas);
+	}
+
+	private static ClassificationCounts Classify(
+		List<double> scored,
+		double autoAcceptThreshold,
+		double pendingReviewThreshold,
+		int unresolvedCount)
+	{
+		int autoAccepted = 0;
+		int pendingReview = 0;
+		int belowFloor = 0;
+		foreach (double score in scored)
+		{
+			if (score >= autoAcceptThreshold)
+			{
+				autoAccepted++;
+			}
+			else if (score >= pendingReviewThreshold)
+			{
+				pendingReview++;
+			}
+			else
+			{
+				belowFloor++;
+			}
+		}
+
+		// Unresolved = structurally-unresolved (NULL score) + "scored but below pending-review"
+		// (i.e., the resolver would have created a new canonical entry, so they're still
+		// effectively unresolved against any existing NormalizedDescription).
+		return new ClassificationCounts(autoAccepted, pendingReview, unresolvedCount + belowFloor);
+	}
+
+	private async Task<(double AutoAccept, double PendingReview)> ResolveThresholdsAsync(
+		ApplicationDbContext context,
+		CancellationToken cancellationToken)
+	{
+		NormalizedDescriptionSettingsEntity? entity = await context.NormalizedDescriptionSettings
+			.AsNoTracking()
+			.FirstOrDefaultAsync(e => e.Id == NormalizedDescriptionSettingsEntityConfiguration.SingletonId, cancellationToken);
+
+		if (entity is null)
+		{
+			// Fallback path for contexts that haven't been seeded (unit tests using a fresh
+			// InMemory provider, integration harnesses that skip EF migrations). The initial
+			// constants mirror the seed row so behaviour is identical at rest.
+			return (InitialAutoAcceptThreshold, InitialPendingReviewThreshold);
+		}
+
+		return (entity.AutoAcceptThreshold, entity.PendingReviewThreshold);
+	}
+
+	private async Task<NormalizedDescriptionSettingsEntity> ResolveSettingsEntityAsync(
+		ApplicationDbContext context,
+		CancellationToken cancellationToken)
+	{
+		NormalizedDescriptionSettingsEntity? entity = await context.NormalizedDescriptionSettings
+			.FirstOrDefaultAsync(e => e.Id == NormalizedDescriptionSettingsEntityConfiguration.SingletonId, cancellationToken);
+
+		if (entity is not null)
+		{
+			return entity;
+		}
+
+		// Self-heal path: if the seed row is missing (e.g., migrations were rolled back and
+		// re-applied in a narrow window, or an InMemory test skipped seeding) we bootstrap
+		// the singleton with defaults on first read/write rather than failing loudly. The
+		// fixed SingletonId plus PK means the insert is race-safe: a second concurrent call
+		// would hit a PK violation and reload.
+		entity = new NormalizedDescriptionSettingsEntity
+		{
+			Id = NormalizedDescriptionSettingsEntityConfiguration.SingletonId,
+			AutoAcceptThreshold = InitialAutoAcceptThreshold,
+			PendingReviewThreshold = InitialPendingReviewThreshold,
+			UpdatedAt = DateTimeOffset.UtcNow,
+		};
+		context.NormalizedDescriptionSettings.Add(entity);
+		try
+		{
+			await context.SaveChangesAsync(cancellationToken);
+		}
+		catch (DbUpdateException)
+		{
+			context.Entry(entity).State = EntityState.Detached;
+			NormalizedDescriptionSettingsEntity? winner = await context.NormalizedDescriptionSettings
+				.FirstOrDefaultAsync(e => e.Id == NormalizedDescriptionSettingsEntityConfiguration.SingletonId, cancellationToken);
+			if (winner is null)
+			{
+				throw new InvalidOperationException(SettingsRowNotFound);
+			}
+
+			return winner;
+		}
+
+		return entity;
+	}
+
 	private static async Task<NormalizedDescriptionEntity?> FindExactCaseInsensitiveAsync(
 		ApplicationDbContext context, string canonicalName, CancellationToken cancellationToken)
 	{
@@ -295,6 +580,61 @@ public class NormalizedDescriptionService(
 		NormalizedDescriptionEntity? entity = await context.NormalizedDescriptions
 			.FirstOrDefaultAsync(e => e.Id == row.entity_id, cancellationToken);
 		return (entity, row.similarity);
+	}
+
+	// Virtual so tests can stub an N-row result without pgvector. Callers cap topN at MaxTopN.
+	protected virtual async Task<List<MatchCandidate>> AnnSearchTopNAsync(
+		ApplicationDbContext context,
+		Vector queryVector,
+		int topN,
+		CancellationToken cancellationToken)
+	{
+		if (context.Database.ProviderName != PostgreSQL)
+		{
+			return [];
+		}
+
+		// Same index as AnnSearchTopOneAsync (partial HNSW on Embedding). Raising LIMIT costs
+		// extra index probes but no additional table scans; safe to keep at topN ≤ 20.
+		string sql = """
+			SELECT "Id" AS entity_id,
+			       (1.0 - ("Embedding" <=> {0}::vector)) AS similarity
+			FROM "NormalizedDescriptions"
+			WHERE "Embedding" IS NOT NULL
+			ORDER BY "Embedding" <=> {0}::vector
+			LIMIT {1}
+			""";
+
+		List<AnnSearchRow> rows = await context.Database
+			.SqlQueryRaw<AnnSearchRow>(sql, queryVector, topN)
+			.ToListAsync(cancellationToken);
+
+		if (rows.Count == 0)
+		{
+			return [];
+		}
+
+		List<Guid> ids = [.. rows.Select(r => r.entity_id)];
+		Dictionary<Guid, NormalizedDescriptionEntity> entities = await context.NormalizedDescriptions
+			.Where(e => ids.Contains(e.Id))
+			.ToDictionaryAsync(e => e.Id, cancellationToken);
+
+		List<MatchCandidate> candidates = [];
+		foreach (AnnSearchRow row in rows)
+		{
+			if (!entities.TryGetValue(row.entity_id, out NormalizedDescriptionEntity? entity))
+			{
+				continue;
+			}
+
+			candidates.Add(new MatchCandidate(
+				entity.Id,
+				entity.CanonicalName,
+				row.similarity,
+				entity.Status.ToString()));
+		}
+
+		return candidates;
 	}
 
 	private sealed class AnnSearchRow

--- a/src/Presentation/API/Controllers/NormalizedDescriptionsController.cs
+++ b/src/Presentation/API/Controllers/NormalizedDescriptionsController.cs
@@ -1,0 +1,190 @@
+using API.Generated.Dtos;
+using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.GetSettings;
+using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+using Application.Queries.NormalizedDescription.TestMatch;
+using Asp.Versioning;
+using Domain.NormalizedDescriptions;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+// RECEIPTS-580 scaffolds this controller with the admin settings/test/preview endpoints
+// only; RECEIPTS-579 will extend the same class with merge/split/status/list/get endpoints.
+// All endpoints gate on RequireAdmin — tuning thresholds and probing the classifier are
+// operator tasks, not end-user ones.
+[ApiVersion("1.0")]
+[ApiController]
+[Route("api/normalized-descriptions")]
+[Produces("application/json")]
+[Authorize(Policy = "RequireAdmin")]
+public class NormalizedDescriptionsController(IMediator mediator) : ControllerBase
+{
+	public const string RouteSettings = "settings";
+	public const string RoutePreview = "settings/preview";
+	public const string RouteTest = "test";
+
+	public const string AutoAcceptOutOfRange = "autoAcceptThreshold must be between 0 and 1";
+	public const string PendingReviewOutOfRange = "pendingReviewThreshold must be between 0 and 1";
+	public const string PendingMustBeLessThanAuto = "pendingReviewThreshold must be strictly less than autoAcceptThreshold";
+	public const string DescriptionRequired = "description must not be empty";
+	public const string TopNOutOfRange = "topN must be between 1 and 20";
+	public const string OverrideOutOfRange = "threshold overrides must be between 0 and 1 when provided";
+
+	[HttpGet(RouteSettings)]
+	[EndpointSummary("Get the current normalized-description threshold settings")]
+	[EndpointDescription("Returns the live auto-accept and pending-review thresholds used by the resolver. Admin-only.")]
+	public async Task<Ok<NormalizedDescriptionSettingsResponse>> GetSettings(CancellationToken cancellationToken)
+	{
+		NormalizedDescriptionSettings settings = await mediator.Send(new GetNormalizedDescriptionSettingsQuery(), cancellationToken);
+		return TypedResults.Ok(ToResponse(settings));
+	}
+
+	[HttpPatch(RouteSettings)]
+	[EndpointSummary("Update the normalized-description threshold settings")]
+	[EndpointDescription("Both thresholds must satisfy 0 <= pendingReviewThreshold < autoAcceptThreshold <= 1. Admin-only.")]
+	public async Task<Results<Ok<NormalizedDescriptionSettingsResponse>, BadRequest<string>>> UpdateSettings(
+		[FromBody] UpdateNormalizedDescriptionSettingsRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (request.AutoAcceptThreshold < 0 || request.AutoAcceptThreshold > 1)
+		{
+			return TypedResults.BadRequest(AutoAcceptOutOfRange);
+		}
+
+		if (request.PendingReviewThreshold < 0 || request.PendingReviewThreshold > 1)
+		{
+			return TypedResults.BadRequest(PendingReviewOutOfRange);
+		}
+
+		if (request.PendingReviewThreshold >= request.AutoAcceptThreshold)
+		{
+			return TypedResults.BadRequest(PendingMustBeLessThanAuto);
+		}
+
+		UpdateNormalizedDescriptionSettingsCommand command = new(request.AutoAcceptThreshold, request.PendingReviewThreshold);
+		NormalizedDescriptionSettings result = await mediator.Send(command, cancellationToken);
+		return TypedResults.Ok(ToResponse(result));
+	}
+
+	[HttpPost(RouteTest)]
+	[EndpointSummary("Probe the normalized-description classifier for a given description")]
+	[EndpointDescription("Returns the top-N ANN candidates and the classification branch the resolver would take. Admin-only.")]
+	public async Task<Results<Ok<MatchTestResultResponse>, BadRequest<string>>> TestMatch(
+		[FromBody] TestMatchRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(request.Description))
+		{
+			return TypedResults.BadRequest(DescriptionRequired);
+		}
+
+		int topN = request.TopN == 0 ? 5 : request.TopN;
+		if (topN < 1 || topN > 20)
+		{
+			return TypedResults.BadRequest(TopNOutOfRange);
+		}
+
+		if (request.AutoAcceptThresholdOverride is double autoOverride &&
+			(autoOverride < 0 || autoOverride > 1))
+		{
+			return TypedResults.BadRequest(OverrideOutOfRange);
+		}
+
+		if (request.PendingReviewThresholdOverride is double pendingOverride &&
+			(pendingOverride < 0 || pendingOverride > 1))
+		{
+			return TypedResults.BadRequest(OverrideOutOfRange);
+		}
+
+		// If both overrides are supplied, reject a crossed pair up front for the same reason
+		// UpdateSettings does — don't wait for the service to throw.
+		if (request.AutoAcceptThresholdOverride is double autoSet &&
+			request.PendingReviewThresholdOverride is double pendingSet &&
+			pendingSet >= autoSet)
+		{
+			return TypedResults.BadRequest(PendingMustBeLessThanAuto);
+		}
+
+		TestNormalizedDescriptionMatchQuery query = new(
+			request.Description,
+			topN,
+			request.AutoAcceptThresholdOverride,
+			request.PendingReviewThresholdOverride);
+
+		MatchTestResult result = await mediator.Send(query, cancellationToken);
+		return TypedResults.Ok(ToResponse(result));
+	}
+
+	[HttpPost(RoutePreview)]
+	[EndpointSummary("Preview the impact of changing normalized-description thresholds")]
+	[EndpointDescription("Returns current and proposed classification counts with per-bucket deltas. Admin-only.")]
+	public async Task<Results<Ok<ThresholdImpactPreviewResponse>, BadRequest<string>>> PreviewThresholdImpact(
+		[FromBody] PreviewThresholdImpactRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (request.AutoAcceptThreshold < 0 || request.AutoAcceptThreshold > 1)
+		{
+			return TypedResults.BadRequest(AutoAcceptOutOfRange);
+		}
+
+		if (request.PendingReviewThreshold < 0 || request.PendingReviewThreshold > 1)
+		{
+			return TypedResults.BadRequest(PendingReviewOutOfRange);
+		}
+
+		if (request.PendingReviewThreshold >= request.AutoAcceptThreshold)
+		{
+			return TypedResults.BadRequest(PendingMustBeLessThanAuto);
+		}
+
+		PreviewThresholdImpactQuery query = new(request.AutoAcceptThreshold, request.PendingReviewThreshold);
+		ThresholdImpactPreview result = await mediator.Send(query, cancellationToken);
+		return TypedResults.Ok(ToResponse(result));
+	}
+
+	private static NormalizedDescriptionSettingsResponse ToResponse(NormalizedDescriptionSettings settings) => new()
+	{
+		Id = settings.Id,
+		AutoAcceptThreshold = settings.AutoAcceptThreshold,
+		PendingReviewThreshold = settings.PendingReviewThreshold,
+		UpdatedAt = settings.UpdatedAt,
+	};
+
+	private static MatchTestResultResponse ToResponse(MatchTestResult result) => new()
+	{
+		SimulatedOutcome = result.SimulatedOutcome,
+		SimulatedTargetId = result.SimulatedTargetId,
+		Candidates = [.. result.Candidates.Select(c => new MatchCandidateDto
+		{
+			NormalizedDescriptionId = c.NormalizedDescriptionId,
+			CanonicalName = c.CanonicalName,
+			CosineSimilarity = c.CosineSimilarity,
+			Status = c.Status,
+		})],
+	};
+
+	private static ThresholdImpactPreviewResponse ToResponse(ThresholdImpactPreview preview) => new()
+	{
+		Current = ToResponse(preview.Current),
+		Proposed = ToResponse(preview.Proposed),
+		Deltas = new ReclassificationDeltasDto
+		{
+			AutoToPending = preview.Deltas.AutoToPending,
+			PendingToAuto = preview.Deltas.PendingToAuto,
+			UnresolvedToAuto = preview.Deltas.UnresolvedToAuto,
+			UnresolvedToPending = preview.Deltas.UnresolvedToPending,
+		},
+	};
+
+	private static ClassificationCountsDto ToResponse(ClassificationCounts counts) => new()
+	{
+		AutoAccepted = counts.AutoAccepted,
+		PendingReview = counts.PendingReview,
+		Unresolved = counts.Unresolved,
+	};
+}

--- a/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
+++ b/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
@@ -12,10 +12,12 @@ public partial class ReceiptItemMapper
 	[MapProperty(nameof(ReceiptItem.UnitPrice.Amount), nameof(ReceiptItemResponse.UnitPrice))]
 	[MapperIgnoreSource(nameof(ReceiptItem.TotalAmount))]
 	[MapperIgnoreSource(nameof(ReceiptItem.PricingMode))]
-	// NormalizedDescription FK and name are deliberately not exposed on the API response here —
-	// RECEIPTS-583 will add them. Ignore them so Mapperly does not flag the unmapped members.
+	// NormalizedDescription FK, name, and match score are deliberately not exposed on the API
+	// response here — RECEIPTS-583 will add them. Ignore them so Mapperly does not flag the
+	// unmapped members.
 	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionId))]
 	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionName))]
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionMatchScore))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.AdditionalProperties))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.PricingMode))]
 	private partial ReceiptItemResponse ToResponsePartial(ReceiptItem source);

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -491,6 +491,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/normalized-descriptions/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the current normalized-description threshold settings
+         * @description Returns the live auto-accept and pending-review thresholds used by the
+         *     resolver when classifying new receipt item descriptions. Admin-only.
+         */
+        get: operations["GetNormalizedDescriptionSettings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update the normalized-description threshold settings
+         * @description Updates the auto-accept and pending-review thresholds. Both values must
+         *     satisfy `0 <= pendingReviewThreshold < autoAcceptThreshold <= 1`. Admin-only.
+         */
+        patch: operations["UpdateNormalizedDescriptionSettings"];
+        trace?: never;
+    };
+    "/api/normalized-descriptions/settings/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview the impact of changing threshold settings
+         * @description Returns current vs. proposed classification counts (auto-accepted,
+         *     pending-review, unresolved) and the reclassification deltas that a
+         *     threshold change would produce, computed against the live
+         *     `NormalizedDescriptionMatchScore` column on receipt items. Admin-only.
+         */
+        post: operations["PreviewNormalizedDescriptionThresholdImpact"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Probe the classifier for a given description
+         * @description Returns the top-N ANN candidates for the supplied description along with
+         *     the classification branch the production resolver would take under the
+         *     supplied threshold overrides (or the live DB settings when absent).
+         *     Admin-only.
+         */
+        post: operations["TestNormalizedDescriptionMatch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/receipts/{id}": {
         parameters: {
             query?: never;
@@ -2664,6 +2736,114 @@ export interface components {
              * @description Number of similar items with this category
              */
             occurrenceCount: number;
+        };
+        NormalizedDescriptionSettingsResponse: {
+            /**
+             * Format: uuid
+             * @description Fixed singleton identifier for the settings row.
+             */
+            id: string;
+            /**
+             * Format: double
+             * @description Cosine-similarity floor at which the resolver re-uses an existing canonical entry.
+             */
+            autoAcceptThreshold: number;
+            /**
+             * Format: double
+             * @description Cosine-similarity floor at which the resolver creates a PendingReview entry instead of a new Active one.
+             */
+            pendingReviewThreshold: number;
+            /**
+             * Format: date-time
+             * @description When the settings were last changed.
+             */
+            updatedAt: string;
+        };
+        UpdateNormalizedDescriptionSettingsRequest: {
+            /** Format: double */
+            autoAcceptThreshold: number;
+            /** Format: double */
+            pendingReviewThreshold: number;
+        };
+        TestMatchRequest: {
+            /** @description Description to classify. Must be non-empty after trim. */
+            description: string;
+            /**
+             * Format: int32
+             * @description Number of ANN candidates to return (ranked by cosine similarity).
+             * @default 5
+             */
+            topN: number;
+            /**
+             * Format: double
+             * @description Override the live auto-accept threshold for simulation. Falls back to DB settings when null.
+             */
+            autoAcceptThresholdOverride?: number | null;
+            /**
+             * Format: double
+             * @description Override the live pending-review threshold for simulation. Falls back to DB settings when null.
+             */
+            pendingReviewThresholdOverride?: number | null;
+        };
+        MatchTestResultResponse: {
+            candidates: components["schemas"]["MatchCandidateDto"][];
+            /** @description One of: AutoAccept, PendingReview, CreateNew, EmbeddingUnavailable. */
+            simulatedOutcome: string;
+            /**
+             * Format: uuid
+             * @description ID of the normalized-description row the resolver would reuse (AutoAccept) or null for CreateNew / PendingReview / EmbeddingUnavailable.
+             */
+            simulatedTargetId?: string | null;
+        };
+        MatchCandidateDto: {
+            /** Format: uuid */
+            normalizedDescriptionId: string;
+            canonicalName: string;
+            /** Format: double */
+            cosineSimilarity: number;
+            /** @description Active or PendingReview. */
+            status: string;
+        };
+        PreviewThresholdImpactRequest: {
+            /** Format: double */
+            autoAcceptThreshold: number;
+            /** Format: double */
+            pendingReviewThreshold: number;
+        };
+        ThresholdImpactPreviewResponse: {
+            current: components["schemas"]["ClassificationCountsDto"];
+            proposed: components["schemas"]["ClassificationCountsDto"];
+            deltas: components["schemas"]["ReclassificationDeltasDto"];
+        };
+        ClassificationCountsDto: {
+            /** Format: int32 */
+            autoAccepted: number;
+            /** Format: int32 */
+            pendingReview: number;
+            /** Format: int32 */
+            unresolved: number;
+        };
+        ReclassificationDeltasDto: {
+            /**
+             * Format: int32
+             * @description Items currently auto-accepted that would fall back to pending-review under the proposal.
+             */
+            autoToPending: number;
+            /**
+             * Format: int32
+             * @description Items currently pending-review that would be auto-accepted under the proposal.
+             */
+            pendingToAuto: number;
+            /**
+             * Format: int32
+             * @description Items currently unresolved (below pending-review threshold) that would be auto-accepted under the proposal.
+             */
+            unresolvedToAuto: number;
+            /**
+             * Format: int32
+             * @description Items currently unresolved (below pending-review threshold) that would move up to pending-review under the proposal.
+             */
+            unresolvedToPending: number;
         };
         CreateReceiptRequest: {
             location: string;
@@ -4905,6 +5085,125 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    GetNormalizedDescriptionSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionSettingsResponse"];
+                };
+            };
+        };
+    };
+    UpdateNormalizedDescriptionSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateNormalizedDescriptionSettingsRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionSettingsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    PreviewNormalizedDescriptionThresholdImpact: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PreviewThresholdImpactRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThresholdImpactPreviewResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    TestNormalizedDescriptionMatch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TestMatchRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchTestResultResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
             };
         };
     };

--- a/tests/Application.Tests/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommandHandlerTests.cs
@@ -1,0 +1,36 @@
+using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.NormalizedDescription.UpdateSettings;
+
+public class UpdateNormalizedDescriptionSettingsCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsThresholdsToServiceAndReturnsResult()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		NormalizedDescriptionSettings expected = new(
+			Guid.NewGuid(),
+			autoAcceptThreshold: 0.9,
+			pendingReviewThreshold: 0.5,
+			updatedAt: new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		mockService
+			.Setup(s => s.UpdateSettingsAsync(0.9, 0.5, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		UpdateNormalizedDescriptionSettingsCommandHandler handler = new(mockService.Object);
+		UpdateNormalizedDescriptionSettingsCommand command = new(0.9, 0.5);
+
+		// Act
+		NormalizedDescriptionSettings actual = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.UpdateSettingsAsync(0.9, 0.5, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQueryHandlerTests.cs
@@ -1,0 +1,33 @@
+using Application.Interfaces.Services;
+using Application.Queries.NormalizedDescription.GetSettings;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.GetSettings;
+
+public class GetNormalizedDescriptionSettingsQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ReturnsSettingsFromService()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		NormalizedDescriptionSettings expected = new(
+			Guid.NewGuid(),
+			autoAcceptThreshold: 0.81,
+			pendingReviewThreshold: 0.68,
+			updatedAt: new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		mockService
+			.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetNormalizedDescriptionSettingsQueryHandler handler = new(mockService.Object);
+		GetNormalizedDescriptionSettingsQuery query = new();
+
+		NormalizedDescriptionSettings actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQueryHandlerTests.cs
@@ -1,0 +1,32 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.PreviewThresholdImpact;
+
+public class PreviewThresholdImpactQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsThresholdsToServiceAndReturnsResult()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		ThresholdImpactPreview expected = new(
+			Current: new ClassificationCounts(10, 5, 2),
+			Proposed: new ClassificationCounts(12, 3, 2),
+			Deltas: new ReclassificationDeltas(AutoToPending: 0, PendingToAuto: 2, UnresolvedToAuto: 0, UnresolvedToPending: 0));
+
+		mockService
+			.Setup(s => s.PreviewThresholdImpactAsync(0.75, 0.5, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		PreviewThresholdImpactQueryHandler handler = new(mockService.Object);
+		PreviewThresholdImpactQuery query = new(0.75, 0.5);
+
+		ThresholdImpactPreview actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.PreviewThresholdImpactAsync(0.75, 0.5, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQueryHandlerTests.cs
@@ -1,0 +1,32 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.TestMatch;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.TestMatch;
+
+public class TestNormalizedDescriptionMatchQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsParametersToServiceAndReturnsResult()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		MatchTestResult expected = new(
+			Candidates: [new MatchCandidate(Guid.NewGuid(), "Milk", 0.92, "Active")],
+			SimulatedOutcome: MatchTestOutcomes.AutoAccept,
+			SimulatedTargetId: Guid.NewGuid());
+
+		mockService
+			.Setup(s => s.TestMatchAsync("whole milk", 3, 0.85, 0.55, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		TestNormalizedDescriptionMatchQueryHandler handler = new(mockService.Object);
+		TestNormalizedDescriptionMatchQuery query = new("whole milk", 3, 0.85, 0.55);
+
+		MatchTestResult actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.TestMatchAsync("whole milk", 3, 0.85, 0.55, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Domain.Tests/NormalizedDescriptions/NormalizedDescriptionSettingsTests.cs
+++ b/tests/Domain.Tests/NormalizedDescriptions/NormalizedDescriptionSettingsTests.cs
@@ -1,0 +1,53 @@
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+
+namespace Domain.Tests.NormalizedDescriptions;
+
+public class NormalizedDescriptionSettingsTests
+{
+	private static readonly DateTimeOffset NowTimestamp = new(2026, 4, 19, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public void Constructor_ValidThresholds_AssignsProperties()
+	{
+		Guid id = Guid.NewGuid();
+		NormalizedDescriptionSettings settings = new(id, autoAcceptThreshold: 0.9, pendingReviewThreshold: 0.5, updatedAt: NowTimestamp);
+
+		settings.Id.Should().Be(id);
+		settings.AutoAcceptThreshold.Should().Be(0.9);
+		settings.PendingReviewThreshold.Should().Be(0.5);
+		settings.UpdatedAt.Should().Be(NowTimestamp);
+	}
+
+	[Theory]
+	[InlineData(0.0, 0.0)] // pending == auto — pending must be strictly less
+	[InlineData(1.0, 1.0)]
+	[InlineData(0.5, 0.8)] // pending > auto
+	[InlineData(0.81, 0.81)]
+	public void Constructor_PendingNotStrictlyLessThanAuto_Throws(double autoAccept, double pendingReview)
+	{
+		Action act = () => _ = new NormalizedDescriptionSettings(Guid.NewGuid(), autoAccept, pendingReview, NowTimestamp);
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(-0.01, 0.5)]
+	[InlineData(1.01, 0.5)]
+	[InlineData(0.8, -0.01)]
+	[InlineData(0.8, 1.01)]
+	public void Constructor_ThresholdOutOfRange_Throws(double autoAccept, double pendingReview)
+	{
+		Action act = () => _ = new NormalizedDescriptionSettings(Guid.NewGuid(), autoAccept, pendingReview, NowTimestamp);
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(0.81, 0.68)] // the canonical baseline
+	[InlineData(1.0, 0.0)]   // boundary values both allowed
+	[InlineData(0.5, 0.499)] // tight spread
+	public void Validate_ValidPairs_DoesNotThrow(double autoAccept, double pendingReview)
+	{
+		Action act = () => NormalizedDescriptionSettings.Validate(autoAccept, pendingReview);
+		act.Should().NotThrow();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/NormalizedDescriptionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/NormalizedDescriptionServiceTests.cs
@@ -1,4 +1,5 @@
 using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
 using Common;
 using Domain.NormalizedDescriptions;
 using FluentAssertions;
@@ -18,6 +19,7 @@ public class NormalizedDescriptionServiceTests
 	private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
 	private readonly Mock<IEmbeddingService> _embeddingServiceMock;
 	private readonly NormalizedDescriptionMapper _mapper;
+	private readonly NormalizedDescriptionSettingsMapper _settingsMapper;
 
 	public NormalizedDescriptionServiceTests()
 	{
@@ -25,6 +27,7 @@ public class NormalizedDescriptionServiceTests
 		accessor.UserId = "test-user";
 		_embeddingServiceMock = new Mock<IEmbeddingService>();
 		_mapper = new NormalizedDescriptionMapper();
+		_settingsMapper = new NormalizedDescriptionSettingsMapper();
 	}
 
 	[Fact]
@@ -45,14 +48,17 @@ public class NormalizedDescriptionServiceTests
 		}
 
 		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act — query with different casing; it should short-circuit without generating an embedding.
-		NormalizedDescription result = await service.GetOrCreateAsync("organic MILK", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("organic MILK", CancellationToken.None);
 
 		// Assert
-		result.Id.Should().Be(existingId);
-		result.CanonicalName.Should().Be("Organic Milk");
+		result.Description.Id.Should().Be(existingId);
+		result.Description.CanonicalName.Should().Be("Organic Milk");
+		// Exact-match short-circuit surfaces a perfect similarity score so the resolver
+		// can persist it on the ReceiptItem without a second embedding roundtrip.
+		result.MatchScore.Should().Be(1.0);
 		_embeddingServiceMock.Verify(
 			e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
 			Times.Never);
@@ -63,16 +69,18 @@ public class NormalizedDescriptionServiceTests
 	{
 		// Arrange
 		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
-		NormalizedDescription result = await service.GetOrCreateAsync("New Item", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("New Item", CancellationToken.None);
 
 		// Assert — a new Active row was created, and no embedding was generated.
-		result.Status.Should().Be(NormalizedDescriptionStatus.Active);
-		result.CanonicalName.Should().Be("New Item");
+		result.Description.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		result.Description.CanonicalName.Should().Be("New Item");
+		// No embedding → no ANN search → no MatchScore to surface.
+		result.MatchScore.Should().BeNull();
 		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
-		NormalizedDescriptionEntity stored = await verify.NormalizedDescriptions.SingleAsync(e => e.Id == result.Id);
+		NormalizedDescriptionEntity stored = await verify.NormalizedDescriptions.SingleAsync(e => e.Id == result.Description.Id);
 		stored.Embedding.Should().BeNull();
 		stored.EmbeddingModelVersion.Should().BeNull();
 		_embeddingServiceMock.Verify(
@@ -106,15 +114,18 @@ public class NormalizedDescriptionServiceTests
 			_contextFactory,
 			_embeddingServiceMock.Object,
 			_mapper,
+			_settingsMapper,
 			matchedId,
-			similarity: NormalizedDescriptionService.AutoAcceptThreshold + 0.01);
+			similarity: NormalizedDescriptionService.InitialAutoAcceptThreshold + 0.01);
 
 		// Act
-		NormalizedDescription result = await service.GetOrCreateAsync("Whole Milk", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("Whole Milk", CancellationToken.None);
 
 		// Assert — returned the ANN match; no new row inserted.
-		result.Id.Should().Be(matchedId);
-		result.CanonicalName.Should().Be("Gallon of Milk");
+		result.Description.Id.Should().Be(matchedId);
+		result.Description.CanonicalName.Should().Be("Gallon of Milk");
+		// AutoAccept branch returns the ANN similarity so the resolver can persist it.
+		result.MatchScore.Should().Be(NormalizedDescriptionService.InitialAutoAcceptThreshold + 0.01);
 		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
 		int count = await verify.NormalizedDescriptions.CountAsync();
 		count.Should().Be(1);
@@ -142,21 +153,23 @@ public class NormalizedDescriptionServiceTests
 			.Setup(e => e.GenerateEmbeddingAsync("Milky Thing", It.IsAny<CancellationToken>()))
 			.ReturnsAsync(CreateFakeEmbedding());
 
-		double between = (NormalizedDescriptionService.AutoAcceptThreshold + NormalizedDescriptionService.PendingReviewThreshold) / 2;
+		double between = (NormalizedDescriptionService.InitialAutoAcceptThreshold + NormalizedDescriptionService.InitialPendingReviewThreshold) / 2;
 		TestableNormalizedDescriptionService service = new(
 			_contextFactory,
 			_embeddingServiceMock.Object,
 			_mapper,
+			_settingsMapper,
 			matchedId,
 			similarity: between);
 
 		// Act
-		NormalizedDescription result = await service.GetOrCreateAsync("Milky Thing", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("Milky Thing", CancellationToken.None);
 
 		// Assert — a new PendingReview row was created with the input text as canonical name.
-		result.Status.Should().Be(NormalizedDescriptionStatus.PendingReview);
-		result.CanonicalName.Should().Be("Milky Thing");
-		result.Id.Should().NotBe(matchedId);
+		result.Description.Status.Should().Be(NormalizedDescriptionStatus.PendingReview);
+		result.Description.CanonicalName.Should().Be("Milky Thing");
+		result.Description.Id.Should().NotBe(matchedId);
+		result.MatchScore.Should().Be(between);
 		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
 		int count = await verify.NormalizedDescriptions.CountAsync();
 		count.Should().Be(2);
@@ -189,15 +202,18 @@ public class NormalizedDescriptionServiceTests
 			_contextFactory,
 			_embeddingServiceMock.Object,
 			_mapper,
+			_settingsMapper,
 			matchedId,
-			similarity: NormalizedDescriptionService.PendingReviewThreshold - 0.1);
+			similarity: NormalizedDescriptionService.InitialPendingReviewThreshold - 0.1);
 
 		// Act
-		NormalizedDescription result = await service.GetOrCreateAsync("Totally Different", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("Totally Different", CancellationToken.None);
 
 		// Assert — a new Active entry was created with the input text as canonical.
-		result.Status.Should().Be(NormalizedDescriptionStatus.Active);
-		result.CanonicalName.Should().Be("Totally Different");
+		result.Description.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		result.Description.CanonicalName.Should().Be("Totally Different");
+		// Below pending-review floor → a brand-new canonical entry; no similarity to persist.
+		result.MatchScore.Should().BeNull();
 		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
 		int count = await verify.NormalizedDescriptions.CountAsync();
 		count.Should().Be(2);
@@ -207,7 +223,7 @@ public class NormalizedDescriptionServiceTests
 	public async Task GetOrCreateAsync_EmptyOrWhitespace_Throws()
 	{
 		// Arrange
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act + Assert
 		await service.Invoking(s => s.GetOrCreateAsync("   ", CancellationToken.None))
@@ -234,7 +250,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		int moved = await service.MergeAsync(keepId, discardId, CancellationToken.None);
@@ -273,7 +289,7 @@ public class NormalizedDescriptionServiceTests
 		}
 
 		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		NormalizedDescription created = await service.SplitAsync(itemId, CancellationToken.None);
@@ -307,7 +323,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		bool changed = await service.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, CancellationToken.None);
@@ -336,7 +352,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		bool changed = await service.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, CancellationToken.None);
@@ -362,7 +378,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		NormalizedDescription? result = await service.GetByIdAsync(id, CancellationToken.None);
@@ -385,7 +401,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		List<NormalizedDescription> pending = await service.GetAllAsync(NormalizedDescriptionStatus.PendingReview, CancellationToken.None);
@@ -395,6 +411,312 @@ public class NormalizedDescriptionServiceTests
 		pending.Should().ContainSingle();
 		pending[0].CanonicalName.Should().Be("Pending B");
 		all.Should().HaveCount(3);
+	}
+
+	// ── RECEIPTS-580: settings / test-match / threshold-impact ─────────────────
+
+	[Fact]
+	public async Task GetSettingsAsync_NoRow_BootstrapsSingletonWithInitialDefaults()
+	{
+		// Arrange — no seed row. On InMemory we hit the self-heal path.
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		// Act
+		NormalizedDescriptionSettings result = await service.GetSettingsAsync(CancellationToken.None);
+
+		// Assert — initial values are the same as the migration seed defaults.
+		result.AutoAcceptThreshold.Should().Be(NormalizedDescriptionService.InitialAutoAcceptThreshold);
+		result.PendingReviewThreshold.Should().Be(NormalizedDescriptionService.InitialPendingReviewThreshold);
+		result.Id.Should().Be(new Guid("00000000-0000-0000-0000-000000000001"));
+	}
+
+	[Fact]
+	public async Task GetSettingsAsync_WithSeededRow_ReturnsStoredValues()
+	{
+		// Arrange
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptionSettings.Add(new NormalizedDescriptionSettingsEntity
+			{
+				Id = new Guid("00000000-0000-0000-0000-000000000001"),
+				AutoAcceptThreshold = 0.9,
+				PendingReviewThreshold = 0.5,
+				UpdatedAt = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero),
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		// Act
+		NormalizedDescriptionSettings result = await service.GetSettingsAsync(CancellationToken.None);
+
+		// Assert
+		result.AutoAcceptThreshold.Should().Be(0.9);
+		result.PendingReviewThreshold.Should().Be(0.5);
+	}
+
+	[Fact]
+	public async Task UpdateSettingsAsync_ValidBounds_PersistsAndReturnsNewValues()
+	{
+		// Arrange
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+		DateTimeOffset before = DateTimeOffset.UtcNow.AddSeconds(-1);
+
+		// Act
+		NormalizedDescriptionSettings updated = await service.UpdateSettingsAsync(0.95, 0.5, CancellationToken.None);
+
+		// Assert — returned values match input, UpdatedAt advanced, row was persisted.
+		updated.AutoAcceptThreshold.Should().Be(0.95);
+		updated.PendingReviewThreshold.Should().Be(0.5);
+		updated.UpdatedAt.Should().BeAfter(before);
+
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity stored = await verify.NormalizedDescriptionSettings.SingleAsync();
+		stored.AutoAcceptThreshold.Should().Be(0.95);
+		stored.PendingReviewThreshold.Should().Be(0.5);
+	}
+
+	[Theory]
+	[InlineData(-0.01, 0.5)]
+	[InlineData(1.01, 0.5)]
+	[InlineData(0.8, -0.01)]
+	[InlineData(0.8, 1.01)]
+	[InlineData(0.5, 0.8)] // pending >= auto
+	[InlineData(0.8, 0.8)] // pending == auto (must be strictly less)
+	public async Task UpdateSettingsAsync_InvalidBounds_Throws(double autoAccept, double pendingReview)
+	{
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		await service.Invoking(s => s.UpdateSettingsAsync(autoAccept, pendingReview, CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_ExactCaseInsensitiveMatch_ReturnsAutoAcceptWithTarget()
+	{
+		// Arrange
+		Guid existingId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = existingId,
+				CanonicalName = "Whole Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		// Act — lowercase variant should short-circuit via exact-match path.
+		MatchTestResult result = await service.TestMatchAsync("whole milk", topN: 5, null, null, CancellationToken.None);
+
+		// Assert — exact match collapses to a single synthetic candidate with similarity = 1.
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.AutoAccept);
+		result.SimulatedTargetId.Should().Be(existingId);
+		result.Candidates.Should().ContainSingle();
+		result.Candidates[0].CosineSimilarity.Should().Be(1.0);
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_EmbeddingUnavailable_ReturnsEmbeddingUnavailableOutcome()
+	{
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		MatchTestResult result = await service.TestMatchAsync("Brand New Item", topN: 5, null, null, CancellationToken.None);
+
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.EmbeddingUnavailable);
+		result.SimulatedTargetId.Should().BeNull();
+		result.Candidates.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_AutoAcceptBranch_WithOverride()
+	{
+		// Arrange — seed a candidate the fake ANN returns at similarity = 0.9.
+		Guid topId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = topId,
+				CanonicalName = "Similar Thing",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper, topId, similarity: 0.9);
+
+		// Override auto-accept to 0.85 → 0.9 is above, so auto-accept wins.
+		MatchTestResult result = await service.TestMatchAsync(
+			"Fresh Input",
+			topN: 5,
+			autoAcceptThresholdOverride: 0.85,
+			pendingReviewThresholdOverride: 0.5,
+			CancellationToken.None);
+
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.AutoAccept);
+		result.SimulatedTargetId.Should().Be(topId);
+		result.Candidates.Should().ContainSingle();
+		result.Candidates[0].CosineSimilarity.Should().Be(0.9);
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_PendingReviewBranch_ReturnsPendingWithNullTarget()
+	{
+		Guid topId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = topId,
+				CanonicalName = "Near Match",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper, topId, similarity: 0.75);
+
+		// Default DB settings (0.81 / 0.68) → 0.75 lands between the thresholds.
+		MatchTestResult result = await service.TestMatchAsync(
+			"Something Close",
+			topN: 5,
+			autoAcceptThresholdOverride: null,
+			pendingReviewThresholdOverride: null,
+			CancellationToken.None);
+
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.PendingReview);
+		result.SimulatedTargetId.Should().BeNull();
+		result.Candidates.Should().ContainSingle();
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_BelowPendingFloor_ReturnsCreateNewOutcome()
+	{
+		Guid topId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = topId,
+				CanonicalName = "Distant Thing",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper, topId, similarity: 0.3);
+
+		MatchTestResult result = await service.TestMatchAsync("Very Different", topN: 5, null, null, CancellationToken.None);
+
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.CreateNew);
+		result.SimulatedTargetId.Should().BeNull();
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	public async Task TestMatchAsync_EmptyInput_Throws(string input)
+	{
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		await service.Invoking(s => s.TestMatchAsync(input, topN: 5, null, null, CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(21)]
+	[InlineData(-1)]
+	public async Task TestMatchAsync_TopNOutOfRange_Throws(int topN)
+	{
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		await service.Invoking(s => s.TestMatchAsync("desc", topN, null, null, CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Fact]
+	public async Task PreviewThresholdImpactAsync_CountsItemsByScore()
+	{
+		// Arrange — seed receipt items across all threshold bands plus a below-floor scored
+		// row AND a structurally-unresolved row. Default settings: auto = 0.81, pending = 0.68.
+		Guid receiptId = Guid.NewGuid();
+		Guid linkedId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.ReceiptItems.AddRange(
+				BuildReceiptItemWithScore(receiptId, "A", score: 0.95, normalizedId: Guid.NewGuid()), // auto-accepted (current)
+				BuildReceiptItemWithScore(receiptId, "B", score: 0.82, normalizedId: Guid.NewGuid()), // auto-accepted (current)
+				BuildReceiptItemWithScore(receiptId, "C", score: 0.70, normalizedId: Guid.NewGuid()), // pending-review (current)
+				BuildReceiptItemWithScore(receiptId, "D", score: 0.50, normalizedId: linkedId),        // below-floor scored → "unresolved-by-threshold" (current)
+				BuildReceiptItemWithScore(receiptId, "E", score: null, normalizedId: null));           // structurally unresolved
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		// Act — propose lowering both thresholds so some items shift bucket.
+		ThresholdImpactPreview preview = await service.PreviewThresholdImpactAsync(
+			autoAcceptThreshold: 0.6,
+			pendingReviewThreshold: 0.4,
+			CancellationToken.None);
+
+		// Assert current classification: A(0.95) + B(0.82) auto; C(0.70) pending; D below
+		// floor + E null FK → both unresolved.
+		preview.Current.AutoAccepted.Should().Be(2);
+		preview.Current.PendingReview.Should().Be(1);
+		preview.Current.Unresolved.Should().Be(2);
+
+		// Under proposed (0.6 / 0.4): A(0.95) B(0.82) C(0.70) all auto; D(0.50) pending-review
+		// (scored and ≥ 0.4); E still structurally unresolved.
+		preview.Proposed.AutoAccepted.Should().Be(3);
+		preview.Proposed.PendingReview.Should().Be(1);
+		preview.Proposed.Unresolved.Should().Be(1);
+
+		// Deltas: C moves pending → auto; D moves unresolved-by-threshold → pending. A/B stay
+		// auto, E stays structurally unresolved.
+		preview.Deltas.PendingToAuto.Should().Be(1);
+		preview.Deltas.UnresolvedToPending.Should().Be(1);
+		preview.Deltas.AutoToPending.Should().Be(0);
+		preview.Deltas.UnresolvedToAuto.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task PreviewThresholdImpactAsync_InvalidBounds_Throws()
+	{
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		await service.Invoking(s => s.PreviewThresholdImpactAsync(0.5, 0.5, CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
 	}
 
 	private static ReceiptItemEntity BuildReceiptItem(Guid id, Guid receiptId, string description, Guid? normalizedId)
@@ -411,6 +733,24 @@ public class NormalizedDescriptionServiceTests
 			TotalAmountCurrency = Currency.USD,
 			Category = "Groceries",
 			NormalizedDescriptionId = normalizedId,
+		};
+	}
+
+	private static ReceiptItemEntity BuildReceiptItemWithScore(Guid receiptId, string description, double? score, Guid? normalizedId)
+	{
+		return new ReceiptItemEntity
+		{
+			Id = Guid.NewGuid(),
+			ReceiptId = receiptId,
+			Description = description,
+			Quantity = 1,
+			UnitPrice = 1,
+			UnitPriceCurrency = Currency.USD,
+			TotalAmount = 1,
+			TotalAmountCurrency = Currency.USD,
+			Category = "Groceries",
+			NormalizedDescriptionId = normalizedId,
+			NormalizedDescriptionMatchScore = score,
 		};
 	}
 
@@ -433,8 +773,9 @@ public class NormalizedDescriptionServiceTests
 		IDbContextFactory<ApplicationDbContext> contextFactory,
 		IEmbeddingService embeddingService,
 		NormalizedDescriptionMapper mapper,
+		NormalizedDescriptionSettingsMapper settingsMapper,
 		Guid matchId,
-		double similarity) : NormalizedDescriptionService(contextFactory, embeddingService, mapper)
+		double similarity) : NormalizedDescriptionService(contextFactory, embeddingService, mapper, settingsMapper)
 	{
 		private readonly Guid _matchId = matchId;
 		private readonly double _similarity = similarity;
@@ -445,6 +786,19 @@ public class NormalizedDescriptionServiceTests
 			NormalizedDescriptionEntity? match = await context.NormalizedDescriptions
 				.FirstOrDefaultAsync(e => e.Id == _matchId, cancellationToken);
 			return (match, _similarity);
+		}
+
+		protected override async Task<List<MatchCandidate>> AnnSearchTopNAsync(
+			ApplicationDbContext context, Vector queryVector, int topN, CancellationToken cancellationToken)
+		{
+			NormalizedDescriptionEntity? match = await context.NormalizedDescriptions
+				.FirstOrDefaultAsync(e => e.Id == _matchId, cancellationToken);
+			if (match is null)
+			{
+				return [];
+			}
+
+			return [new MatchCandidate(match.Id, match.CanonicalName, _similarity, match.Status.ToString())];
 		}
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/NormalizedDescriptionsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/NormalizedDescriptionsControllerTests.cs
@@ -1,0 +1,282 @@
+using API.Controllers;
+using API.Generated.Dtos;
+using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.GetSettings;
+using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+using Application.Queries.NormalizedDescription.TestMatch;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+
+namespace Presentation.API.Tests.Controllers;
+
+public class NormalizedDescriptionsControllerTests
+{
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly NormalizedDescriptionsController _controller;
+
+	public NormalizedDescriptionsControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_controller = new NormalizedDescriptionsController(_mediatorMock.Object);
+	}
+
+	// ── GET settings ────────────────────────────────────────────
+
+	[Fact]
+	public async Task GetSettings_ReturnsOkWithMappedResponse()
+	{
+		NormalizedDescriptionSettings settings = new(
+			Guid.NewGuid(), 0.81, 0.68,
+			new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<GetNormalizedDescriptionSettingsQuery>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(settings);
+
+		Ok<NormalizedDescriptionSettingsResponse> result = await _controller.GetSettings(CancellationToken.None);
+
+		result.Value!.Id.Should().Be(settings.Id);
+		result.Value.AutoAcceptThreshold.Should().Be(0.81);
+		result.Value.PendingReviewThreshold.Should().Be(0.68);
+	}
+
+	// ── PATCH settings ──────────────────────────────────────────
+
+	[Fact]
+	public async Task UpdateSettings_ValidRequest_ReturnsOkWithUpdatedValues()
+	{
+		UpdateNormalizedDescriptionSettingsRequest request = new()
+		{
+			AutoAcceptThreshold = 0.9,
+			PendingReviewThreshold = 0.5,
+		};
+
+		NormalizedDescriptionSettings updated = new(
+			Guid.NewGuid(), 0.9, 0.5,
+			new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<UpdateNormalizedDescriptionSettingsCommand>(c => c.AutoAcceptThreshold == 0.9 && c.PendingReviewThreshold == 0.5),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(updated);
+
+		Results<Ok<NormalizedDescriptionSettingsResponse>, BadRequest<string>> result =
+			await _controller.UpdateSettings(request, CancellationToken.None);
+
+		Ok<NormalizedDescriptionSettingsResponse> ok = Assert.IsType<Ok<NormalizedDescriptionSettingsResponse>>(result.Result);
+		ok.Value!.AutoAcceptThreshold.Should().Be(0.9);
+		ok.Value.PendingReviewThreshold.Should().Be(0.5);
+	}
+
+	[Theory]
+	[InlineData(-0.01, 0.5, NormalizedDescriptionsController.AutoAcceptOutOfRange)]
+	[InlineData(1.01, 0.5, NormalizedDescriptionsController.AutoAcceptOutOfRange)]
+	[InlineData(0.8, -0.01, NormalizedDescriptionsController.PendingReviewOutOfRange)]
+	[InlineData(0.8, 1.01, NormalizedDescriptionsController.PendingReviewOutOfRange)]
+	[InlineData(0.5, 0.6, NormalizedDescriptionsController.PendingMustBeLessThanAuto)]
+	[InlineData(0.5, 0.5, NormalizedDescriptionsController.PendingMustBeLessThanAuto)]
+	public async Task UpdateSettings_InvalidRequest_ReturnsBadRequest(double autoAccept, double pendingReview, string expectedMessage)
+	{
+		UpdateNormalizedDescriptionSettingsRequest request = new()
+		{
+			AutoAcceptThreshold = autoAccept,
+			PendingReviewThreshold = pendingReview,
+		};
+
+		Results<Ok<NormalizedDescriptionSettingsResponse>, BadRequest<string>> result =
+			await _controller.UpdateSettings(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(expectedMessage);
+
+		// Should short-circuit without invoking the mediator.
+		_mediatorMock.Verify(m => m.Send(It.IsAny<UpdateNormalizedDescriptionSettingsCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── POST test ───────────────────────────────────────────────
+
+	[Fact]
+	public async Task TestMatch_ValidRequest_ReturnsOkWithCandidates()
+	{
+		TestMatchRequest request = new()
+		{
+			Description = "whole milk",
+			TopN = 3,
+			AutoAcceptThresholdOverride = 0.85,
+			PendingReviewThresholdOverride = 0.55,
+		};
+
+		Guid candidateId = Guid.NewGuid();
+		MatchTestResult serviceResult = new(
+			Candidates: [new MatchCandidate(candidateId, "Whole Milk", 0.92, "Active")],
+			SimulatedOutcome: MatchTestOutcomes.AutoAccept,
+			SimulatedTargetId: candidateId);
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<TestNormalizedDescriptionMatchQuery>(q =>
+					q.Description == "whole milk" &&
+					q.TopN == 3 &&
+					q.AutoAcceptThresholdOverride == 0.85 &&
+					q.PendingReviewThresholdOverride == 0.55),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(serviceResult);
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		Ok<MatchTestResultResponse> ok = Assert.IsType<Ok<MatchTestResultResponse>>(result.Result);
+		ok.Value!.SimulatedOutcome.Should().Be("AutoAccept");
+		ok.Value.SimulatedTargetId.Should().Be(candidateId);
+		ok.Value.Candidates.Should().ContainSingle();
+		MatchCandidateDto first = ok.Value.Candidates.First();
+		first.CanonicalName.Should().Be("Whole Milk");
+		first.CosineSimilarity.Should().Be(0.92);
+	}
+
+	[Fact]
+	public async Task TestMatch_ZeroTopN_DefaultsToFive()
+	{
+		// The generated DTO has TopN default = 5, but JSON deserialization from a client
+		// that omits TopN (or sends topN=0 explicitly) can set it to 0. The controller
+		// coerces 0 → 5 as a defensive fallback.
+		TestMatchRequest request = new()
+		{
+			Description = "milk",
+			TopN = 0,
+		};
+
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<TestNormalizedDescriptionMatchQuery>(q => q.TopN == 5), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new MatchTestResult([], MatchTestOutcomes.CreateNew, null));
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		Assert.IsType<Ok<MatchTestResultResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(It.Is<TestNormalizedDescriptionMatchQuery>(q => q.TopN == 5), It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Theory]
+	[InlineData("", NormalizedDescriptionsController.DescriptionRequired)]
+	[InlineData("   ", NormalizedDescriptionsController.DescriptionRequired)]
+	public async Task TestMatch_EmptyDescription_ReturnsBadRequest(string description, string expectedMessage)
+	{
+		TestMatchRequest request = new() { Description = description, TopN = 5 };
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(expectedMessage);
+	}
+
+	[Theory]
+	[InlineData(-1)]
+	[InlineData(21)]
+	public async Task TestMatch_TopNOutOfRange_ReturnsBadRequest(int topN)
+	{
+		TestMatchRequest request = new() { Description = "milk", TopN = topN };
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.TopNOutOfRange);
+	}
+
+	[Fact]
+	public async Task TestMatch_OverrideOutOfRange_ReturnsBadRequest()
+	{
+		TestMatchRequest request = new()
+		{
+			Description = "milk",
+			TopN = 5,
+			AutoAcceptThresholdOverride = 1.5,
+		};
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.OverrideOutOfRange);
+	}
+
+	[Fact]
+	public async Task TestMatch_CrossedOverrides_ReturnsBadRequest()
+	{
+		TestMatchRequest request = new()
+		{
+			Description = "milk",
+			TopN = 5,
+			AutoAcceptThresholdOverride = 0.5,
+			PendingReviewThresholdOverride = 0.8,
+		};
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.PendingMustBeLessThanAuto);
+	}
+
+	// ── POST settings/preview ────────────────────────────────────
+
+	[Fact]
+	public async Task PreviewThresholdImpact_ValidRequest_ReturnsOkWithMappedCounts()
+	{
+		PreviewThresholdImpactRequest request = new()
+		{
+			AutoAcceptThreshold = 0.75,
+			PendingReviewThreshold = 0.4,
+		};
+
+		ThresholdImpactPreview preview = new(
+			Current: new ClassificationCounts(10, 5, 3),
+			Proposed: new ClassificationCounts(15, 2, 1),
+			Deltas: new ReclassificationDeltas(AutoToPending: 0, PendingToAuto: 3, UnresolvedToAuto: 2, UnresolvedToPending: 0));
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<PreviewThresholdImpactQuery>(q => q.AutoAcceptThreshold == 0.75 && q.PendingReviewThreshold == 0.4),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(preview);
+
+		Results<Ok<ThresholdImpactPreviewResponse>, BadRequest<string>> result =
+			await _controller.PreviewThresholdImpact(request, CancellationToken.None);
+
+		Ok<ThresholdImpactPreviewResponse> ok = Assert.IsType<Ok<ThresholdImpactPreviewResponse>>(result.Result);
+		ok.Value!.Current.AutoAccepted.Should().Be(10);
+		ok.Value.Proposed.AutoAccepted.Should().Be(15);
+		ok.Value.Deltas.PendingToAuto.Should().Be(3);
+		ok.Value.Deltas.UnresolvedToAuto.Should().Be(2);
+	}
+
+	[Theory]
+	[InlineData(-0.1, 0.5, NormalizedDescriptionsController.AutoAcceptOutOfRange)]
+	[InlineData(1.1, 0.5, NormalizedDescriptionsController.AutoAcceptOutOfRange)]
+	[InlineData(0.8, -0.1, NormalizedDescriptionsController.PendingReviewOutOfRange)]
+	[InlineData(0.8, 1.1, NormalizedDescriptionsController.PendingReviewOutOfRange)]
+	[InlineData(0.5, 0.6, NormalizedDescriptionsController.PendingMustBeLessThanAuto)]
+	public async Task PreviewThresholdImpact_InvalidRequest_ReturnsBadRequest(double autoAccept, double pendingReview, string expectedMessage)
+	{
+		PreviewThresholdImpactRequest request = new()
+		{
+			AutoAcceptThreshold = autoAccept,
+			PendingReviewThreshold = pendingReview,
+		};
+
+		Results<Ok<ThresholdImpactPreviewResponse>, BadRequest<string>> result =
+			await _controller.PreviewThresholdImpact(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(expectedMessage);
+
+		_mediatorMock.Verify(m => m.Send(It.IsAny<PreviewThresholdImpactQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+}


### PR DESCRIPTION
## Summary

Settings row + admin tooling for the normalized description registry under [RECEIPTS-576](https://plane.wallingford.me/dev/browse/RECEIPTS-576/).

- `NormalizedDescriptionSettings` singleton table — thresholds tunable at runtime without redeploy (seeded 0.81 / 0.68 from calibration)
- `ReceiptItem.NormalizedDescriptionMatchScore` column — populated by the resolver (RECEIPTS-578), enables O(1) impact previews on existing data
- `NormalizedDescriptionService`: thresholds read fresh from DB each call; `GetOrCreateAsync` now returns `GetOrCreateResult(Description, MatchScore?)` so the resolver gets the score without a second embedding call
- Admin API skeleton: `GET/PATCH /settings`, `POST /test`, `POST /settings/preview`. [RECEIPTS-579](https://plane.wallingford.me/dev/browse/RECEIPTS-579/) extends the same controller with merge/split/status/list endpoints.
- Self-heal: service bootstraps the singleton seed row if somehow missing

## Test plan

- [x] Full solution: **2,327 tests, 0 failures** (+77 vs pre-580 baseline)
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI: backend + frontend suites + Postgres integration tests

## Out of scope (later RECEIPTS-576 children)

- Merge/Split/Status/GetAll/GetById admin endpoints (579)
- Background resolver that populates the match score column (578)
- Reporting endpoint (581)
- `normalizedDescriptionMatchScore` surfaced on `ReceiptItemResponse` (583)
- React admin page + settings panel (582)

🤖 Generated with [Claude Code](https://claude.com/claude-code)