### PR TITLE
feat(api): admin endpoints for normalized-description management (RECEIPTS-579)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -1439,6 +1439,193 @@ paths:
               schema:
                 type: string
 
+  /api/normalized-descriptions:
+    get:
+      operationId: GetAllNormalizedDescriptions
+      tags: [NormalizedDescriptions]
+      summary: List normalized descriptions
+      description: |
+        Returns all canonical normalized-description rows, optionally filtered by
+        status. Not paginated — the row count is bounded by the number of unique
+        receipt-item descriptions ever seen. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [Active, PendingReview]
+          description: Optional status filter. When absent, returns rows of both statuses. Matching is case-insensitive.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionListResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/normalized-descriptions/{id}:
+    get:
+      operationId: GetNormalizedDescriptionById
+      tags: [NormalizedDescriptions]
+      summary: Get a normalized description by ID
+      description: Returns a single canonical normalized-description row by GUID. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "404":
+          description: Not Found
+
+  /api/normalized-descriptions/{id}/merge:
+    post:
+      operationId: MergeNormalizedDescriptions
+      tags: [NormalizedDescriptions]
+      summary: Merge two normalized descriptions
+      description: |
+        Re-links every ReceiptItem currently pointing at `discardId` to the
+        canonical row identified by the path `{id}` ("keep"), then deletes the
+        discarded row. Returns the count of re-linked items — zero when either
+        id was missing or the two ids were identical. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the canonical row to keep (all items from `discardId` move here).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MergeNormalizedDescriptionRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MergeNormalizedDescriptionsResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/normalized-descriptions/{id}/split:
+    post:
+      operationId: SplitNormalizedDescription
+      tags: [NormalizedDescriptions]
+      summary: Detach a receipt item from its normalized description
+      description: |
+        Creates a new canonical row for the supplied ReceiptItem's raw description
+        and re-points the item at it. Used to unpick bad auto-merges. The path
+        `{id}` is the current NormalizedDescription the item is being split away
+        from; the body identifies the specific ReceiptItem to isolate. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the NormalizedDescription the item is being split away from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SplitNormalizedDescriptionRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+
+  /api/normalized-descriptions/{id}/status:
+    patch:
+      operationId: UpdateNormalizedDescriptionStatus
+      tags: [NormalizedDescriptions]
+      summary: Update the status of a normalized description
+      description: |
+        Flips a NormalizedDescription between Active and PendingReview. Returns
+        204 when the status was changed and 404 when the row does not exist or
+        already has the requested status. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateNormalizedDescriptionStatusRequest"
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+
   # ──────────────────────────────────────────────
   # Receipts
   # ──────────────────────────────────────────────
@@ -5822,6 +6009,74 @@ components:
           type: integer
           format: int32
           description: Items currently unresolved (below pending-review threshold) that would move up to pending-review under the proposal.
+
+    NormalizedDescriptionStatus:
+      type: string
+      enum: [active, pendingReview]
+      description: Active rows are confidently-classified and re-used as-is by the resolver; pendingReview rows are flagged for admin review before being promoted.
+
+    NormalizedDescriptionResponse:
+      type: object
+      required: [id, canonicalName, status, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        canonicalName:
+          type: string
+          description: The canonical name shared by every receipt item linked to this row.
+        status:
+          $ref: "#/components/schemas/NormalizedDescriptionStatus"
+        createdAt:
+          type: string
+          format: date-time
+
+    NormalizedDescriptionListResponse:
+      type: object
+      required: [items, totalCount]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/NormalizedDescriptionResponse"
+        totalCount:
+          type: integer
+          format: int32
+          description: Total number of rows returned. Matches the length of `items` since the endpoint is not paginated.
+
+    MergeNormalizedDescriptionRequest:
+      type: object
+      required: [discardId]
+      properties:
+        discardId:
+          type: string
+          format: uuid
+          description: ID of the NormalizedDescription to merge away. All ReceiptItems pointing at this row will be re-linked to the kept row.
+
+    SplitNormalizedDescriptionRequest:
+      type: object
+      required: [receiptItemId]
+      properties:
+        receiptItemId:
+          type: string
+          format: uuid
+          description: ID of the ReceiptItem to detach from its current NormalizedDescription.
+
+    UpdateNormalizedDescriptionStatusRequest:
+      type: object
+      required: [status]
+      properties:
+        status:
+          $ref: "#/components/schemas/NormalizedDescriptionStatus"
+
+    MergeNormalizedDescriptionsResponse:
+      type: object
+      required: [itemsRelinkedCount]
+      properties:
+        itemsRelinkedCount:
+          type: integer
+          format: int32
+          description: Number of ReceiptItems that were re-linked from the discarded row to the kept row. Zero when either id was missing or the two ids were identical.
 
     # ── Receipt ──────────────────────────────────
 

--- a/src/Application/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommand.cs
+++ b/src/Application/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommand.cs
@@ -1,0 +1,9 @@
+using Application.Interfaces;
+
+namespace Application.Commands.NormalizedDescription.Merge;
+
+// Merges two NormalizedDescription rows. All ReceiptItems currently pointing at DiscardId are
+// re-linked to KeepId, then the DiscardId row is deleted. The handler returns the count of
+// items that were actually re-linked — 0 if either id was missing or if KeepId == DiscardId,
+// which is the service contract.
+public record MergeNormalizedDescriptionsCommand(Guid KeepId, Guid DiscardId) : ICommand<int>;

--- a/src/Application/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommandHandler.cs
+++ b/src/Application/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommandHandler.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Commands.NormalizedDescription.Merge;
+
+public class MergeNormalizedDescriptionsCommandHandler(INormalizedDescriptionService service)
+	: IRequestHandler<MergeNormalizedDescriptionsCommand, int>
+{
+	public async Task<int> Handle(MergeNormalizedDescriptionsCommand request, CancellationToken cancellationToken)
+	{
+		return await service.MergeAsync(request.KeepId, request.DiscardId, cancellationToken);
+	}
+}

--- a/src/Application/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommand.cs
+++ b/src/Application/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommand.cs
@@ -1,0 +1,9 @@
+using Application.Interfaces;
+
+namespace Application.Commands.NormalizedDescription.Split;
+
+// Detaches a single ReceiptItem from its current NormalizedDescription by creating a new
+// canonical entry for the item's raw description and re-pointing the item at it. Used by
+// admins to unpick bad merges or isolate an item that was auto-classified into the wrong
+// canonical group. The service throws KeyNotFoundException if the ReceiptItem does not exist.
+public record SplitNormalizedDescriptionCommand(Guid ReceiptItemId) : ICommand<Domain.NormalizedDescriptions.NormalizedDescription>;

--- a/src/Application/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommandHandler.cs
+++ b/src/Application/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommandHandler.cs
@@ -1,0 +1,14 @@
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Commands.NormalizedDescription.Split;
+
+public class SplitNormalizedDescriptionCommandHandler(INormalizedDescriptionService service)
+	: IRequestHandler<SplitNormalizedDescriptionCommand, Domain.NormalizedDescriptions.NormalizedDescription>
+{
+	public async Task<Domain.NormalizedDescriptions.NormalizedDescription> Handle(SplitNormalizedDescriptionCommand request, CancellationToken cancellationToken)
+	{
+		return await service.SplitAsync(request.ReceiptItemId, cancellationToken);
+	}
+}

--- a/src/Application/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommand.cs
+++ b/src/Application/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommand.cs
@@ -1,0 +1,9 @@
+using Application.Interfaces;
+using Domain.NormalizedDescriptions;
+
+namespace Application.Commands.NormalizedDescription.UpdateStatus;
+
+// Flips a NormalizedDescription between Active and PendingReview. Returns true when the status
+// was actually changed, false when the row was missing or already had the requested status —
+// matches the service contract, and lets the controller distinguish 404 from no-op.
+public record UpdateNormalizedDescriptionStatusCommand(Guid Id, NormalizedDescriptionStatus Status) : ICommand<bool>;

--- a/src/Application/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommandHandler.cs
+++ b/src/Application/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommandHandler.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Commands.NormalizedDescription.UpdateStatus;
+
+public class UpdateNormalizedDescriptionStatusCommandHandler(INormalizedDescriptionService service)
+	: IRequestHandler<UpdateNormalizedDescriptionStatusCommand, bool>
+{
+	public async Task<bool> Handle(UpdateNormalizedDescriptionStatusCommand request, CancellationToken cancellationToken)
+	{
+		return await service.UpdateStatusAsync(request.Id, request.Status, cancellationToken);
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQuery.cs
@@ -1,0 +1,12 @@
+using Application.Interfaces;
+using Domain.NormalizedDescriptions;
+
+namespace Application.Queries.NormalizedDescription.GetAll;
+
+// Lists canonical normalized-description rows, optionally filtered to a single status.
+// Unlike the Core entity list queries, this isn't paginated — the row count is bounded by
+// the number of unique receipt-item descriptions ever seen, which stays small enough that
+// the admin screen can render the full set without server-side paging for the foreseeable
+// future. When pressure grows we can add offset/limit/sort in a follow-up without changing
+// the existing URL shape.
+public record GetAllNormalizedDescriptionsQuery(NormalizedDescriptionStatus? StatusFilter) : IQuery<List<Domain.NormalizedDescriptions.NormalizedDescription>>;

--- a/src/Application/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQueryHandler.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.GetAll;
+
+public class GetAllNormalizedDescriptionsQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<GetAllNormalizedDescriptionsQuery, List<Domain.NormalizedDescriptions.NormalizedDescription>>
+{
+	public async Task<List<Domain.NormalizedDescriptions.NormalizedDescription>> Handle(GetAllNormalizedDescriptionsQuery request, CancellationToken cancellationToken)
+	{
+		return await service.GetAllAsync(request.StatusFilter, cancellationToken);
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQuery.cs
@@ -1,0 +1,19 @@
+using Application.Interfaces;
+
+namespace Application.Queries.NormalizedDescription.GetById;
+
+public record GetNormalizedDescriptionByIdQuery : IQuery<Domain.NormalizedDescriptions.NormalizedDescription?>
+{
+	public Guid Id { get; }
+	public const string IdCannotBeEmptyExceptionMessage = "NormalizedDescription Id cannot be empty.";
+
+	public GetNormalizedDescriptionByIdQuery(Guid id)
+	{
+		if (id == Guid.Empty)
+		{
+			throw new ArgumentException(IdCannotBeEmptyExceptionMessage, nameof(id));
+		}
+
+		Id = id;
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQueryHandler.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.GetById;
+
+public class GetNormalizedDescriptionByIdQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<GetNormalizedDescriptionByIdQuery, Domain.NormalizedDescriptions.NormalizedDescription?>
+{
+	public async Task<Domain.NormalizedDescriptions.NormalizedDescription?> Handle(GetNormalizedDescriptionByIdQuery request, CancellationToken cancellationToken)
+	{
+		return await service.GetByIdAsync(request.Id, cancellationToken);
+	}
+}

--- a/src/Presentation/API/Controllers/NormalizedDescriptionsController.cs
+++ b/src/Presentation/API/Controllers/NormalizedDescriptionsController.cs
@@ -1,6 +1,11 @@
 using API.Generated.Dtos;
+using Application.Commands.NormalizedDescription.Merge;
+using Application.Commands.NormalizedDescription.Split;
 using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Commands.NormalizedDescription.UpdateStatus;
 using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.GetAll;
+using Application.Queries.NormalizedDescription.GetById;
 using Application.Queries.NormalizedDescription.GetSettings;
 using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
 using Application.Queries.NormalizedDescription.TestMatch;
@@ -10,13 +15,16 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using DomainStatus = Domain.NormalizedDescriptions.NormalizedDescriptionStatus;
+using DtoStatus = API.Generated.Dtos.NormalizedDescriptionStatus;
 
 namespace API.Controllers;
 
-// RECEIPTS-580 scaffolds this controller with the admin settings/test/preview endpoints
-// only; RECEIPTS-579 will extend the same class with merge/split/status/list/get endpoints.
-// All endpoints gate on RequireAdmin — tuning thresholds and probing the classifier are
-// operator tasks, not end-user ones.
+// Admin-only surface for the canonical-descriptions registry. Wired up across two issues:
+// RECEIPTS-580 scaffolds the settings/test/preview endpoints; RECEIPTS-579 extends the class
+// with list/get/merge/split/status endpoints. Every endpoint gates on RequireAdmin because
+// tuning thresholds, probing the classifier, and editing the registry are operator tasks,
+// not end-user ones.
 [ApiVersion("1.0")]
 [ApiController]
 [Route("api/normalized-descriptions")]
@@ -27,6 +35,11 @@ public class NormalizedDescriptionsController(IMediator mediator) : ControllerBa
 	public const string RouteSettings = "settings";
 	public const string RoutePreview = "settings/preview";
 	public const string RouteTest = "test";
+	public const string RouteGetAll = "";
+	public const string RouteGetById = "{id}";
+	public const string RouteMerge = "{id}/merge";
+	public const string RouteSplit = "{id}/split";
+	public const string RouteUpdateStatus = "{id}/status";
 
 	public const string AutoAcceptOutOfRange = "autoAcceptThreshold must be between 0 and 1";
 	public const string PendingReviewOutOfRange = "pendingReviewThreshold must be between 0 and 1";
@@ -34,6 +47,11 @@ public class NormalizedDescriptionsController(IMediator mediator) : ControllerBa
 	public const string DescriptionRequired = "description must not be empty";
 	public const string TopNOutOfRange = "topN must be between 1 and 20";
 	public const string OverrideOutOfRange = "threshold overrides must be between 0 and 1 when provided";
+	public const string IdCannotBeEmpty = "id must not be empty";
+	public const string DiscardIdCannotBeEmpty = "discardId must not be empty";
+	public const string ReceiptItemIdCannotBeEmpty = "receiptItemId must not be empty";
+	public const string MergeIdsMustDiffer = "keep id and discardId must differ";
+	public const string InvalidStatusFilter = "status must be 'Active' or 'PendingReview' when provided";
 
 	[HttpGet(RouteSettings)]
 	[EndpointSummary("Get the current normalized-description threshold settings")]
@@ -146,6 +164,169 @@ public class NormalizedDescriptionsController(IMediator mediator) : ControllerBa
 		ThresholdImpactPreview result = await mediator.Send(query, cancellationToken);
 		return TypedResults.Ok(ToResponse(result));
 	}
+
+	[HttpGet(RouteGetAll)]
+	[EndpointSummary("List normalized descriptions")]
+	[EndpointDescription("Returns all canonical normalized-description rows, optionally filtered by status (Active or PendingReview). Admin-only.")]
+	public async Task<Results<Ok<NormalizedDescriptionListResponse>, BadRequest<string>>> GetAllNormalizedDescriptions(
+		[FromQuery] string? status,
+		CancellationToken cancellationToken)
+	{
+		DomainStatus? filter = null;
+		if (!string.IsNullOrWhiteSpace(status))
+		{
+			// Parse case-insensitively so the URL is tolerant of "active", "Active", "ACTIVE" —
+			// the spec enumerates PascalCase to stay symmetric with the response-body enum,
+			// but query params traditionally flex on case.
+			if (!Enum.TryParse(status, ignoreCase: true, out DomainStatus parsed))
+			{
+				return TypedResults.BadRequest(InvalidStatusFilter);
+			}
+
+			filter = parsed;
+		}
+
+		GetAllNormalizedDescriptionsQuery query = new(filter);
+		List<NormalizedDescription> items = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new NormalizedDescriptionListResponse
+		{
+			Items = [.. items.Select(ToResponse)],
+			TotalCount = items.Count,
+		});
+	}
+
+	[HttpGet(RouteGetById)]
+	[EndpointSummary("Get a normalized description by ID")]
+	[EndpointDescription("Returns a single canonical normalized-description row by GUID. Admin-only.")]
+	public async Task<Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>>> GetNormalizedDescriptionById(
+		[FromRoute] Guid id,
+		CancellationToken cancellationToken)
+	{
+		if (id == Guid.Empty)
+		{
+			return TypedResults.BadRequest(IdCannotBeEmpty);
+		}
+
+		GetNormalizedDescriptionByIdQuery query = new(id);
+		NormalizedDescription? result = await mediator.Send(query, cancellationToken);
+		if (result is null)
+		{
+			return TypedResults.NotFound();
+		}
+
+		return TypedResults.Ok(ToResponse(result));
+	}
+
+	[HttpPost(RouteMerge)]
+	[EndpointSummary("Merge two normalized descriptions")]
+	[EndpointDescription("Re-links every live ReceiptItem currently pointing at discardId to the canonical row identified by the path {id}, then deletes the discarded row. Returns the count of re-linked items — zero when either id was missing or the two ids were identical. Admin-only.")]
+	public async Task<Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>>> MergeNormalizedDescriptions(
+		[FromRoute] Guid id,
+		[FromBody] MergeNormalizedDescriptionRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (id == Guid.Empty)
+		{
+			return TypedResults.BadRequest(IdCannotBeEmpty);
+		}
+
+		if (request.DiscardId == Guid.Empty)
+		{
+			return TypedResults.BadRequest(DiscardIdCannotBeEmpty);
+		}
+
+		if (id == request.DiscardId)
+		{
+			return TypedResults.BadRequest(MergeIdsMustDiffer);
+		}
+
+		MergeNormalizedDescriptionsCommand command = new(id, request.DiscardId);
+		int itemsRelinkedCount = await mediator.Send(command, cancellationToken);
+		return TypedResults.Ok(new MergeNormalizedDescriptionsResponse { ItemsRelinkedCount = itemsRelinkedCount });
+	}
+
+	[HttpPost(RouteSplit)]
+	[EndpointSummary("Detach a receipt item from its normalized description")]
+	[EndpointDescription("Creates a new canonical NormalizedDescription row for the supplied ReceiptItem's raw description and re-points the item at it. Used to unpick bad auto-merges. Admin-only.")]
+	public async Task<Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>>> SplitNormalizedDescription(
+		[FromRoute] Guid id,
+		[FromBody] SplitNormalizedDescriptionRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (id == Guid.Empty)
+		{
+			return TypedResults.BadRequest(IdCannotBeEmpty);
+		}
+
+		if (request.ReceiptItemId == Guid.Empty)
+		{
+			return TypedResults.BadRequest(ReceiptItemIdCannotBeEmpty);
+		}
+
+		SplitNormalizedDescriptionCommand command = new(request.ReceiptItemId);
+		try
+		{
+			NormalizedDescription created = await mediator.Send(command, cancellationToken);
+			return TypedResults.Ok(ToResponse(created));
+		}
+		catch (KeyNotFoundException)
+		{
+			// The service throws when the ReceiptItem does not exist — surface it as a 404.
+			// We don't translate every exception type because that would mask genuine server
+			// errors (DB failures, embedding service outages) behind a 404; only this one
+			// maps cleanly to a client-facing 404.
+			return TypedResults.NotFound();
+		}
+	}
+
+	[HttpPatch(RouteUpdateStatus)]
+	[EndpointSummary("Update the status of a normalized description")]
+	[EndpointDescription("Flips a NormalizedDescription between Active and PendingReview. Returns 204 on success and 404 when the row does not exist. Admin-only.")]
+	public async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateNormalizedDescriptionStatus(
+		[FromRoute] Guid id,
+		[FromBody] UpdateNormalizedDescriptionStatusRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (id == Guid.Empty)
+		{
+			return TypedResults.BadRequest(IdCannotBeEmpty);
+		}
+
+		DomainStatus domainStatus = request.Status switch
+		{
+			DtoStatus.Active => DomainStatus.Active,
+			DtoStatus.PendingReview => DomainStatus.PendingReview,
+			_ => throw new InvalidOperationException($"Unhandled status value: {request.Status}"),
+		};
+
+		// The UpdateStatusAsync service returns false for both "row missing" and "row already at
+		// target status". To preserve REST semantics, do an existence check first so we can
+		// reliably return 404 for the missing case and 204 for both a real flip and a no-op.
+		GetNormalizedDescriptionByIdQuery existsQuery = new(id);
+		NormalizedDescription? existing = await mediator.Send(existsQuery, cancellationToken);
+		if (existing is null)
+		{
+			return TypedResults.NotFound();
+		}
+
+		UpdateNormalizedDescriptionStatusCommand command = new(id, domainStatus);
+		await mediator.Send(command, cancellationToken);
+		return TypedResults.NoContent();
+	}
+
+	private static NormalizedDescriptionResponse ToResponse(NormalizedDescription source) => new()
+	{
+		Id = source.Id,
+		CanonicalName = source.CanonicalName,
+		Status = source.Status switch
+		{
+			DomainStatus.Active => DtoStatus.Active,
+			DomainStatus.PendingReview => DtoStatus.PendingReview,
+			_ => throw new InvalidOperationException($"Unhandled status value: {source.Status}"),
+		},
+		CreatedAt = source.CreatedAt,
+	};
 
 	private static NormalizedDescriptionSettingsResponse ToResponse(NormalizedDescriptionSettings settings) => new()
 	{

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -563,6 +563,116 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/normalized-descriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List normalized descriptions
+         * @description Returns all canonical normalized-description rows, optionally filtered by
+         *     status. Not paginated — the row count is bounded by the number of unique
+         *     receipt-item descriptions ever seen. Admin-only.
+         */
+        get: operations["GetAllNormalizedDescriptions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a normalized description by ID
+         * @description Returns a single canonical normalized-description row by GUID. Admin-only.
+         */
+        get: operations["GetNormalizedDescriptionById"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/{id}/merge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Merge two normalized descriptions
+         * @description Re-links every ReceiptItem currently pointing at `discardId` to the
+         *     canonical row identified by the path `{id}` ("keep"), then deletes the
+         *     discarded row. Returns the count of re-linked items — zero when either
+         *     id was missing or the two ids were identical. Admin-only.
+         */
+        post: operations["MergeNormalizedDescriptions"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/{id}/split": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Detach a receipt item from its normalized description
+         * @description Creates a new canonical row for the supplied ReceiptItem's raw description
+         *     and re-points the item at it. Used to unpick bad auto-merges. The path
+         *     `{id}` is the current NormalizedDescription the item is being split away
+         *     from; the body identifies the specific ReceiptItem to isolate. Admin-only.
+         */
+        post: operations["SplitNormalizedDescription"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/{id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update the status of a normalized description
+         * @description Flips a NormalizedDescription between Active and PendingReview. Returns
+         *     204 when the status was changed and 404 when the row does not exist or
+         *     already has the requested status. Admin-only.
+         */
+        patch: operations["UpdateNormalizedDescriptionStatus"];
+        trace?: never;
+    };
     "/api/receipts/{id}": {
         parameters: {
             query?: never;
@@ -2844,6 +2954,52 @@ export interface components {
              * @description Items currently unresolved (below pending-review threshold) that would move up to pending-review under the proposal.
              */
             unresolvedToPending: number;
+        };
+        /**
+         * @description Active rows are confidently-classified and re-used as-is by the resolver; pendingReview rows are flagged for admin review before being promoted.
+         * @enum {string}
+         */
+        NormalizedDescriptionStatus: "active" | "pendingReview";
+        NormalizedDescriptionResponse: {
+            /** Format: uuid */
+            id: string;
+            /** @description The canonical name shared by every receipt item linked to this row. */
+            canonicalName: string;
+            status: components["schemas"]["NormalizedDescriptionStatus"];
+            /** Format: date-time */
+            createdAt: string;
+        };
+        NormalizedDescriptionListResponse: {
+            items: components["schemas"]["NormalizedDescriptionResponse"][];
+            /**
+             * Format: int32
+             * @description Total number of rows returned. Matches the length of `items` since the endpoint is not paginated.
+             */
+            totalCount: number;
+        };
+        MergeNormalizedDescriptionRequest: {
+            /**
+             * Format: uuid
+             * @description ID of the NormalizedDescription to merge away. All ReceiptItems pointing at this row will be re-linked to the kept row.
+             */
+            discardId: string;
+        };
+        SplitNormalizedDescriptionRequest: {
+            /**
+             * Format: uuid
+             * @description ID of the ReceiptItem to detach from its current NormalizedDescription.
+             */
+            receiptItemId: string;
+        };
+        UpdateNormalizedDescriptionStatusRequest: {
+            status: components["schemas"]["NormalizedDescriptionStatus"];
+        };
+        MergeNormalizedDescriptionsResponse: {
+            /**
+             * Format: int32
+             * @description Number of ReceiptItems that were re-linked from the discarded row to the kept row. Zero when either id was missing or the two ids were identical.
+             */
+            itemsRelinkedCount: number;
         };
         CreateReceiptRequest: {
             location: string;
@@ -5204,6 +5360,195 @@ export interface operations {
                 content: {
                     "application/json": string;
                 };
+            };
+        };
+    };
+    GetAllNormalizedDescriptions: {
+        parameters: {
+            query?: {
+                /** @description Optional status filter. When absent, returns rows of both statuses. Matching is case-insensitive. */
+                status?: "Active" | "PendingReview";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionListResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    GetNormalizedDescriptionById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    MergeNormalizedDescriptions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the canonical row to keep (all items from `discardId` move here). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MergeNormalizedDescriptionRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MergeNormalizedDescriptionsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    SplitNormalizedDescription: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the NormalizedDescription the item is being split away from. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SplitNormalizedDescriptionRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UpdateNormalizedDescriptionStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateNormalizedDescriptionStatusRequest"];
+            };
+        };
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/tests/Application.Tests/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommandHandlerTests.cs
@@ -1,0 +1,53 @@
+using Application.Commands.NormalizedDescription.Merge;
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.NormalizedDescription.Merge;
+
+public class MergeNormalizedDescriptionsCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsIdsToServiceAndReturnsRelinkCount()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid keepId = Guid.NewGuid();
+		Guid discardId = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.MergeAsync(keepId, discardId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(7);
+
+		MergeNormalizedDescriptionsCommandHandler handler = new(mockService.Object);
+		MergeNormalizedDescriptionsCommand command = new(keepId, discardId);
+
+		// Act
+		int result = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().Be(7);
+		mockService.Verify(s => s.MergeAsync(keepId, discardId, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_MissingRowReturnsZero_ReflectsServiceContract()
+	{
+		// The service returns 0 when either id is missing or both ids are equal. The handler
+		// just forwards that count — it's the controller's job to validate inputs before call.
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid keepId = Guid.NewGuid();
+		Guid discardId = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.MergeAsync(keepId, discardId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(0);
+
+		MergeNormalizedDescriptionsCommandHandler handler = new(mockService.Object);
+		MergeNormalizedDescriptionsCommand command = new(keepId, discardId);
+
+		int result = await handler.Handle(command, CancellationToken.None);
+
+		result.Should().Be(0);
+	}
+}

--- a/tests/Application.Tests/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using Application.Commands.NormalizedDescription.Split;
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.NormalizedDescription.Split;
+
+public class SplitNormalizedDescriptionCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsReceiptItemIdAndReturnsCreated()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid receiptItemId = Guid.NewGuid();
+		Domain.NormalizedDescriptions.NormalizedDescription expected = new(
+			Guid.NewGuid(),
+			"cherry cola",
+			NormalizedDescriptionStatus.Active,
+			new DateTimeOffset(2026, 4, 19, 12, 0, 0, TimeSpan.Zero));
+
+		mockService
+			.Setup(s => s.SplitAsync(receiptItemId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		SplitNormalizedDescriptionCommandHandler handler = new(mockService.Object);
+		SplitNormalizedDescriptionCommand command = new(receiptItemId);
+
+		// Act
+		Domain.NormalizedDescriptions.NormalizedDescription actual = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.SplitAsync(receiptItemId, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ServicePropagatesKeyNotFound()
+	{
+		// The service throws KeyNotFoundException when the receipt item is missing; the
+		// handler should propagate rather than swallow so controller/test callers can map
+		// it to a 404.
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid missing = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.SplitAsync(missing, It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new KeyNotFoundException("Receipt item not found."));
+
+		SplitNormalizedDescriptionCommandHandler handler = new(mockService.Object);
+		SplitNormalizedDescriptionCommand command = new(missing);
+
+		Func<Task> act = () => handler.Handle(command, CancellationToken.None);
+		await act.Should().ThrowAsync<KeyNotFoundException>();
+	}
+}

--- a/tests/Application.Tests/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommandHandlerTests.cs
@@ -1,0 +1,53 @@
+using Application.Commands.NormalizedDescription.UpdateStatus;
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.NormalizedDescription.UpdateStatus;
+
+public class UpdateNormalizedDescriptionStatusCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_StatusChanged_ReturnsTrue()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid id = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		UpdateNormalizedDescriptionStatusCommandHandler handler = new(mockService.Object);
+		UpdateNormalizedDescriptionStatusCommand command = new(id, NormalizedDescriptionStatus.Active);
+
+		// Act
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().BeTrue();
+		mockService.Verify(s => s.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_RowMissingOrAlreadyAtStatus_ReturnsFalse()
+	{
+		// The service returns false for both "row missing" and "row already at target" cases.
+		// The handler forwards without distinguishing — it's the controller's job to do an
+		// existence check first to distinguish 404 from idempotent no-op.
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid id = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.UpdateStatusAsync(id, NormalizedDescriptionStatus.PendingReview, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		UpdateNormalizedDescriptionStatusCommandHandler handler = new(mockService.Object);
+		UpdateNormalizedDescriptionStatusCommand command = new(id, NormalizedDescriptionStatus.PendingReview);
+
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQueryHandlerTests.cs
@@ -1,0 +1,74 @@
+using Application.Interfaces.Services;
+using Application.Queries.NormalizedDescription.GetAll;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.GetAll;
+
+public class GetAllNormalizedDescriptionsQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_NoFilter_ReturnsAllFromService()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		List<Domain.NormalizedDescriptions.NormalizedDescription> expected =
+		[
+			new(Guid.NewGuid(), "coffee beans", NormalizedDescriptionStatus.Active, DateTimeOffset.UtcNow),
+			new(Guid.NewGuid(), "whole milk", NormalizedDescriptionStatus.PendingReview, DateTimeOffset.UtcNow),
+		];
+
+		mockService
+			.Setup(s => s.GetAllAsync(null, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetAllNormalizedDescriptionsQueryHandler handler = new(mockService.Object);
+		GetAllNormalizedDescriptionsQuery query = new(StatusFilter: null);
+
+		// Act
+		List<Domain.NormalizedDescriptions.NormalizedDescription> actual = await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetAllAsync(null, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_WithFilter_ForwardsToService()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		List<Domain.NormalizedDescriptions.NormalizedDescription> expected =
+		[
+			new(Guid.NewGuid(), "whole milk", NormalizedDescriptionStatus.PendingReview, DateTimeOffset.UtcNow),
+		];
+
+		mockService
+			.Setup(s => s.GetAllAsync(NormalizedDescriptionStatus.PendingReview, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetAllNormalizedDescriptionsQueryHandler handler = new(mockService.Object);
+		GetAllNormalizedDescriptionsQuery query = new(NormalizedDescriptionStatus.PendingReview);
+
+		List<Domain.NormalizedDescriptions.NormalizedDescription> actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetAllAsync(NormalizedDescriptionStatus.PendingReview, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_EmptyResult_ReturnsEmptyList()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		mockService
+			.Setup(s => s.GetAllAsync(It.IsAny<NormalizedDescriptionStatus?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+
+		GetAllNormalizedDescriptionsQueryHandler handler = new(mockService.Object);
+		GetAllNormalizedDescriptionsQuery query = new(NormalizedDescriptionStatus.Active);
+
+		List<Domain.NormalizedDescriptions.NormalizedDescription> actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeEmpty();
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQueryHandlerTests.cs
@@ -1,0 +1,64 @@
+using Application.Interfaces.Services;
+using Application.Queries.NormalizedDescription.GetById;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.GetById;
+
+public class GetNormalizedDescriptionByIdQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_Found_ReturnsEntityFromService()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid id = Guid.NewGuid();
+		Domain.NormalizedDescriptions.NormalizedDescription expected = new(
+			id,
+			"cherry cola",
+			NormalizedDescriptionStatus.Active,
+			new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		mockService
+			.Setup(s => s.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetNormalizedDescriptionByIdQueryHandler handler = new(mockService.Object);
+		GetNormalizedDescriptionByIdQuery query = new(id);
+
+		// Act
+		Domain.NormalizedDescriptions.NormalizedDescription? actual = await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetByIdAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_NotFound_ReturnsNull()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid id = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Domain.NormalizedDescriptions.NormalizedDescription?)null);
+
+		GetNormalizedDescriptionByIdQueryHandler handler = new(mockService.Object);
+		GetNormalizedDescriptionByIdQuery query = new(id);
+
+		Domain.NormalizedDescriptions.NormalizedDescription? actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeNull();
+	}
+
+	[Fact]
+	public void Query_EmptyGuid_ThrowsArgumentException()
+	{
+		// The query rejects Guid.Empty up-front so a malformed request never reaches the service.
+		Action act = () => _ = new GetNormalizedDescriptionByIdQuery(Guid.Empty);
+		act.Should().Throw<ArgumentException>()
+			.WithMessage(GetNormalizedDescriptionByIdQuery.IdCannotBeEmptyExceptionMessage + "*");
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/NormalizedDescriptionsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/NormalizedDescriptionsControllerTests.cs
@@ -1,7 +1,12 @@
 using API.Controllers;
 using API.Generated.Dtos;
+using Application.Commands.NormalizedDescription.Merge;
+using Application.Commands.NormalizedDescription.Split;
 using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Commands.NormalizedDescription.UpdateStatus;
 using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.GetAll;
+using Application.Queries.NormalizedDescription.GetById;
 using Application.Queries.NormalizedDescription.GetSettings;
 using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
 using Application.Queries.NormalizedDescription.TestMatch;
@@ -10,6 +15,8 @@ using FluentAssertions;
 using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Moq;
+using DomainStatus = Domain.NormalizedDescriptions.NormalizedDescriptionStatus;
+using DtoStatus = API.Generated.Dtos.NormalizedDescriptionStatus;
 
 namespace Presentation.API.Tests.Controllers;
 
@@ -278,5 +285,330 @@ public class NormalizedDescriptionsControllerTests
 		bad.Value.Should().Be(expectedMessage);
 
 		_mediatorMock.Verify(m => m.Send(It.IsAny<PreviewThresholdImpactQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── GET list ─────────────────────────────────────────────────
+
+	[Fact]
+	public async Task GetAllNormalizedDescriptions_NoFilter_ReturnsOkWithAllItems()
+	{
+		List<NormalizedDescription> items =
+		[
+			new(Guid.NewGuid(), "coffee beans", DomainStatus.Active, new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero)),
+			new(Guid.NewGuid(), "whole milk", DomainStatus.PendingReview, new DateTimeOffset(2026, 4, 2, 0, 0, 0, TimeSpan.Zero)),
+		];
+
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetAllNormalizedDescriptionsQuery>(q => q.StatusFilter == null), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(items);
+
+		Results<Ok<NormalizedDescriptionListResponse>, BadRequest<string>> result =
+			await _controller.GetAllNormalizedDescriptions(status: null, CancellationToken.None);
+
+		Ok<NormalizedDescriptionListResponse> ok = Assert.IsType<Ok<NormalizedDescriptionListResponse>>(result.Result);
+		ok.Value!.Items.Should().HaveCount(2);
+		ok.Value.TotalCount.Should().Be(2);
+		ok.Value.Items.First().CanonicalName.Should().Be("coffee beans");
+	}
+
+	[Theory]
+	[InlineData("Active", DomainStatus.Active)]
+	[InlineData("PendingReview", DomainStatus.PendingReview)]
+	[InlineData("active", DomainStatus.Active)]
+	[InlineData("pendingreview", DomainStatus.PendingReview)]
+	public async Task GetAllNormalizedDescriptions_WithStatusFilter_ForwardsToQuery(string status, DomainStatus expected)
+	{
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetAllNormalizedDescriptionsQuery>(q => q.StatusFilter == expected), It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+
+		Results<Ok<NormalizedDescriptionListResponse>, BadRequest<string>> result =
+			await _controller.GetAllNormalizedDescriptions(status, CancellationToken.None);
+
+		Ok<NormalizedDescriptionListResponse> ok = Assert.IsType<Ok<NormalizedDescriptionListResponse>>(result.Result);
+		ok.Value!.Items.Should().BeEmpty();
+		ok.Value.TotalCount.Should().Be(0);
+		_mediatorMock.Verify(m => m.Send(It.Is<GetAllNormalizedDescriptionsQuery>(q => q.StatusFilter == expected), It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetAllNormalizedDescriptions_InvalidStatusFilter_ReturnsBadRequest()
+	{
+		Results<Ok<NormalizedDescriptionListResponse>, BadRequest<string>> result =
+			await _controller.GetAllNormalizedDescriptions(status: "archived", CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.InvalidStatusFilter);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<GetAllNormalizedDescriptionsQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── GET by id ────────────────────────────────────────────────
+
+	[Fact]
+	public async Task GetNormalizedDescriptionById_Found_ReturnsOkWithMappedResponse()
+	{
+		Guid id = Guid.NewGuid();
+		NormalizedDescription item = new(
+			id,
+			"cherry cola",
+			DomainStatus.PendingReview,
+			new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(item);
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.GetNormalizedDescriptionById(id, CancellationToken.None);
+
+		Ok<NormalizedDescriptionResponse> ok = Assert.IsType<Ok<NormalizedDescriptionResponse>>(result.Result);
+		ok.Value!.Id.Should().Be(id);
+		ok.Value.CanonicalName.Should().Be("cherry cola");
+		ok.Value.Status.Should().Be(DtoStatus.PendingReview);
+		ok.Value.CreatedAt.Should().Be(item.CreatedAt);
+	}
+
+	[Fact]
+	public async Task GetNormalizedDescriptionById_NotFound_ReturnsNotFound()
+	{
+		Guid id = Guid.NewGuid();
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((NormalizedDescription?)null);
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.GetNormalizedDescriptionById(id, CancellationToken.None);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetNormalizedDescriptionById_EmptyGuid_ReturnsBadRequest()
+	{
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.GetNormalizedDescriptionById(Guid.Empty, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.IdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<GetNormalizedDescriptionByIdQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── POST merge ───────────────────────────────────────────────
+
+	[Fact]
+	public async Task MergeNormalizedDescriptions_ValidRequest_ReturnsOkWithRelinkCount()
+	{
+		Guid keepId = Guid.NewGuid();
+		Guid discardId = Guid.NewGuid();
+		MergeNormalizedDescriptionRequest request = new() { DiscardId = discardId };
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<MergeNormalizedDescriptionsCommand>(c => c.KeepId == keepId && c.DiscardId == discardId),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(12);
+
+		Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.MergeNormalizedDescriptions(keepId, request, CancellationToken.None);
+
+		Ok<MergeNormalizedDescriptionsResponse> ok = Assert.IsType<Ok<MergeNormalizedDescriptionsResponse>>(result.Result);
+		ok.Value!.ItemsRelinkedCount.Should().Be(12);
+	}
+
+	[Fact]
+	public async Task MergeNormalizedDescriptions_EmptyKeepId_ReturnsBadRequest()
+	{
+		MergeNormalizedDescriptionRequest request = new() { DiscardId = Guid.NewGuid() };
+
+		Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.MergeNormalizedDescriptions(Guid.Empty, request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.IdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<MergeNormalizedDescriptionsCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task MergeNormalizedDescriptions_EmptyDiscardId_ReturnsBadRequest()
+	{
+		MergeNormalizedDescriptionRequest request = new() { DiscardId = Guid.Empty };
+
+		Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.MergeNormalizedDescriptions(Guid.NewGuid(), request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.DiscardIdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<MergeNormalizedDescriptionsCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task MergeNormalizedDescriptions_SameKeepAndDiscard_ReturnsBadRequest()
+	{
+		Guid id = Guid.NewGuid();
+		MergeNormalizedDescriptionRequest request = new() { DiscardId = id };
+
+		Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.MergeNormalizedDescriptions(id, request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.MergeIdsMustDiffer);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<MergeNormalizedDescriptionsCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── POST split ───────────────────────────────────────────────
+
+	[Fact]
+	public async Task SplitNormalizedDescription_ValidRequest_ReturnsOkWithNewResource()
+	{
+		Guid currentId = Guid.NewGuid();
+		Guid receiptItemId = Guid.NewGuid();
+		Guid newId = Guid.NewGuid();
+		SplitNormalizedDescriptionRequest request = new() { ReceiptItemId = receiptItemId };
+
+		NormalizedDescription created = new(
+			newId,
+			"reese cup",
+			DomainStatus.Active,
+			new DateTimeOffset(2026, 4, 19, 12, 0, 0, TimeSpan.Zero));
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<SplitNormalizedDescriptionCommand>(c => c.ReceiptItemId == receiptItemId),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(created);
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.SplitNormalizedDescription(currentId, request, CancellationToken.None);
+
+		Ok<NormalizedDescriptionResponse> ok = Assert.IsType<Ok<NormalizedDescriptionResponse>>(result.Result);
+		ok.Value!.Id.Should().Be(newId);
+		ok.Value.CanonicalName.Should().Be("reese cup");
+		ok.Value.Status.Should().Be(DtoStatus.Active);
+	}
+
+	[Fact]
+	public async Task SplitNormalizedDescription_ReceiptItemMissing_ReturnsNotFound()
+	{
+		Guid currentId = Guid.NewGuid();
+		Guid missingReceiptItemId = Guid.NewGuid();
+		SplitNormalizedDescriptionRequest request = new() { ReceiptItemId = missingReceiptItemId };
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<SplitNormalizedDescriptionCommand>(c => c.ReceiptItemId == missingReceiptItemId),
+				It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new KeyNotFoundException("Receipt item not found."));
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.SplitNormalizedDescription(currentId, request, CancellationToken.None);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task SplitNormalizedDescription_EmptyId_ReturnsBadRequest()
+	{
+		SplitNormalizedDescriptionRequest request = new() { ReceiptItemId = Guid.NewGuid() };
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.SplitNormalizedDescription(Guid.Empty, request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.IdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<SplitNormalizedDescriptionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task SplitNormalizedDescription_EmptyReceiptItemId_ReturnsBadRequest()
+	{
+		SplitNormalizedDescriptionRequest request = new() { ReceiptItemId = Guid.Empty };
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.SplitNormalizedDescription(Guid.NewGuid(), request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.ReceiptItemIdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<SplitNormalizedDescriptionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── PATCH status ─────────────────────────────────────────────
+
+	[Fact]
+	public async Task UpdateNormalizedDescriptionStatus_ExistingRow_ReturnsNoContent()
+	{
+		Guid id = Guid.NewGuid();
+		UpdateNormalizedDescriptionStatusRequest request = new() { Status = DtoStatus.PendingReview };
+
+		NormalizedDescription existing = new(id, "whole milk", DomainStatus.Active, DateTimeOffset.UtcNow);
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(existing);
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<UpdateNormalizedDescriptionStatusCommand>(c => c.Id == id && c.Status == DomainStatus.PendingReview),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound, BadRequest<string>> result =
+			await _controller.UpdateNormalizedDescriptionStatus(id, request, CancellationToken.None);
+
+		Assert.IsType<NoContent>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<UpdateNormalizedDescriptionStatusCommand>(c => c.Id == id && c.Status == DomainStatus.PendingReview),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task UpdateNormalizedDescriptionStatus_ActiveStatus_MapsToDomainCorrectly()
+	{
+		Guid id = Guid.NewGuid();
+		UpdateNormalizedDescriptionStatusRequest request = new() { Status = DtoStatus.Active };
+
+		NormalizedDescription existing = new(id, "whole milk", DomainStatus.PendingReview, DateTimeOffset.UtcNow);
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(existing);
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<UpdateNormalizedDescriptionStatusCommand>(c => c.Id == id && c.Status == DomainStatus.Active),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound, BadRequest<string>> result =
+			await _controller.UpdateNormalizedDescriptionStatus(id, request, CancellationToken.None);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateNormalizedDescriptionStatus_MissingRow_ReturnsNotFound()
+	{
+		Guid id = Guid.NewGuid();
+		UpdateNormalizedDescriptionStatusRequest request = new() { Status = DtoStatus.Active };
+
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((NormalizedDescription?)null);
+
+		Results<NoContent, NotFound, BadRequest<string>> result =
+			await _controller.UpdateNormalizedDescriptionStatus(id, request, CancellationToken.None);
+
+		Assert.IsType<NotFound>(result.Result);
+		// Should never reach the update command when the existence check fails.
+		_mediatorMock.Verify(m => m.Send(It.IsAny<UpdateNormalizedDescriptionStatusCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task UpdateNormalizedDescriptionStatus_EmptyId_ReturnsBadRequest()
+	{
+		UpdateNormalizedDescriptionStatusRequest request = new() { Status = DtoStatus.Active };
+
+		Results<NoContent, NotFound, BadRequest<string>> result =
+			await _controller.UpdateNormalizedDescriptionStatus(Guid.Empty, request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.IdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<GetNormalizedDescriptionByIdQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<UpdateNormalizedDescriptionStatusCommand>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 }


### PR DESCRIPTION
## Summary

MediatR + controller wiring for admin operations on the [RECEIPTS-576](https://plane.wallingford.me/dev/browse/RECEIPTS-576/) normalized description registry. Service methods were already implemented in [RECEIPTS-577](https://plane.wallingford.me/dev/browse/RECEIPTS-577/); this PR exposes them via 5 admin-only endpoints.

- `GET /api/normalized-descriptions?status=...`
- `GET /api/normalized-descriptions/{id}`
- `POST /api/normalized-descriptions/{id}/merge` → `{ itemsRelinkedCount }`
- `POST /api/normalized-descriptions/{id}/split` → `NormalizedDescriptionResponse`
- `PATCH /api/normalized-descriptions/{id}/status` → 204

Spec refactored to share a `NormalizedDescriptionStatus` enum schema across request and response bodies (matches NSwag's single generated DTO). Controller + tests use `DtoStatus`/`DomainStatus` aliases to disambiguate.

## Test plan

- [x] 39 new tests (12 handler + 27 controller)
- [x] Full solution: 2,360 tests, 0 failures
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI: full suite + Postgres integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)