### PR TITLE
feat(api): spending-by-normalized-description report (RECEIPTS-581)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -4071,6 +4071,46 @@ paths:
                 type: string
 
   # ──────────────────────────────────────────────
+
+  /api/reports/spending-by-normalized-description:
+    get:
+      operationId: GetSpendingByNormalizedDescriptionReport
+      tags: [Reports]
+      summary: Get spending by normalized description report
+      description: Aggregates receipt item spending grouped by normalized description canonical name. Items without a normalized description bucket into a synthetic "(Not Normalized)" group.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: from
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Inclusive lower bound on receipt date (ISO 8601 date-time string). Defaults to all time when omitted.
+        - name: to
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Inclusive upper bound on receipt date (ISO 8601 date-time string). Defaults to all time when omitted.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpendingByNormalizedDescriptionResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  # ──────────────────────────────────────────────
   # Dashboard
   # ──────────────────────────────────────────────
 
@@ -5203,6 +5243,50 @@ components:
           type: ["string", "null"]
         pricingMode:
           type: string
+
+    SpendingByNormalizedDescriptionResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SpendingByNormalizedDescriptionItem"
+        fromDate:
+          type: ["string", "null"]
+          format: date-time
+          description: Inclusive lower bound on receipt date, echoed from the request.
+        toDate:
+          type: ["string", "null"]
+          format: date-time
+          description: Inclusive upper bound on receipt date, echoed from the request.
+
+    SpendingByNormalizedDescriptionItem:
+      type: object
+      required: [canonicalName, totalAmount, currency, itemCount]
+      properties:
+        canonicalName:
+          type: string
+          description: Canonical name of the normalized description, or "(Not Normalized)" for receipt items without a normalized description.
+        totalAmount:
+          type: number
+          format: double
+          description: Sum of ReceiptItem.TotalAmount for items in this bucket.
+        currency:
+          type: string
+          description: Dominant currency across the items in this bucket.
+        itemCount:
+          type: integer
+          format: int32
+          description: Number of receipt items in this bucket.
+        firstSeen:
+          type: ["string", "null"]
+          format: date-time
+          description: Earliest receipt date among items in this bucket.
+        lastSeen:
+          type: ["string", "null"]
+          format: date-time
+          description: Latest receipt date among items in this bucket.
 
     # ── Dashboard ──────────────────────────────────
 

--- a/src/Application/Interfaces/Services/IReportService.cs
+++ b/src/Application/Interfaces/Services/IReportService.cs
@@ -66,4 +66,9 @@ public interface IReportService
 		int page,
 		int pageSize,
 		CancellationToken cancellationToken);
+
+	Task<SpendingByNormalizedDescriptionResult> GetSpendingByNormalizedDescriptionAsync(
+		DateTimeOffset? from,
+		DateTimeOffset? to,
+		CancellationToken cancellationToken);
 }

--- a/src/Application/Models/Reports/SpendingByNormalizedDescriptionResult.cs
+++ b/src/Application/Models/Reports/SpendingByNormalizedDescriptionResult.cs
@@ -1,0 +1,14 @@
+namespace Application.Models.Reports;
+
+public record SpendingByNormalizedDescriptionItem(
+	string CanonicalName,
+	decimal TotalAmount,
+	string Currency,
+	int ItemCount,
+	DateTimeOffset? FirstSeen,
+	DateTimeOffset? LastSeen);
+
+public record SpendingByNormalizedDescriptionResult(
+	List<SpendingByNormalizedDescriptionItem> Items,
+	DateTimeOffset? FromDate,
+	DateTimeOffset? ToDate);

--- a/src/Application/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQuery.cs
@@ -1,0 +1,8 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetSpendingByNormalizedDescriptionQuery(
+	DateTimeOffset? From,
+	DateTimeOffset? To) : IQuery<SpendingByNormalizedDescriptionResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQueryHandler.cs
@@ -1,0 +1,17 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetSpendingByNormalizedDescriptionQueryHandler(IReportService reportService)
+	: IRequestHandler<GetSpendingByNormalizedDescriptionQuery, SpendingByNormalizedDescriptionResult>
+{
+	public async Task<SpendingByNormalizedDescriptionResult> Handle(GetSpendingByNormalizedDescriptionQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetSpendingByNormalizedDescriptionAsync(
+			request.From,
+			request.To,
+			cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Application.Interfaces.Services;
 using Application.Models.Reports;
+using Common;
 using Infrastructure.Entities.Core;
 using Microsoft.EntityFrameworkCore;
 
@@ -690,6 +691,86 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 
 		return periods;
 	}
+
+	public async Task<SpendingByNormalizedDescriptionResult> GetSpendingByNormalizedDescriptionAsync(
+		DateTimeOffset? from,
+		DateTimeOffset? to,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		// Receipt.Date is DateOnly; convert the caller-supplied DateTimeOffset bounds to DateOnly
+		// using the UTC day so filtering is deterministic regardless of the caller's offset.
+		DateOnly? fromDate = from.HasValue ? DateOnly.FromDateTime(from.Value.UtcDateTime) : null;
+		DateOnly? toDate = to.HasValue ? DateOnly.FromDateTime(to.Value.UtcDateTime) : null;
+
+		var receiptsQuery = context.Receipts.AsNoTracking()
+			.Where(r => r.DeletedAt == null);
+
+		if (fromDate.HasValue)
+		{
+			receiptsQuery = receiptsQuery.Where(r => r.Date >= fromDate.Value);
+		}
+
+		if (toDate.HasValue)
+		{
+			receiptsQuery = receiptsQuery.Where(r => r.Date <= toDate.Value);
+		}
+
+		// LEFT JOIN ReceiptItems -> NormalizedDescriptions (via nullable FK).
+		// Soft-deleted receipts already excluded above; exclude soft-deleted items here.
+		// The join via Receipt.Id enforces the date filter on the item side as well.
+		var joined = from ri in context.ReceiptItems.AsNoTracking().Where(ri => ri.DeletedAt == null)
+					 join r in receiptsQuery on ri.ReceiptId equals r.Id
+					 join n in context.NormalizedDescriptions.AsNoTracking() on ri.NormalizedDescriptionId equals n.Id into gj
+					 from n in gj.DefaultIfEmpty()
+					 select new
+					 {
+						 CanonicalName = n != null ? n.CanonicalName : null,
+						 ri.TotalAmount,
+						 ri.TotalAmountCurrency,
+						 r.Date,
+					 };
+
+		var materialized = await joined.ToListAsync(cancellationToken);
+
+		// Group by the canonical name; NULL FK buckets into a synthetic "(Not Normalized)" group.
+		const string NotNormalizedLabel = "(Not Normalized)";
+		List<SpendingByNormalizedDescriptionItem> items = materialized
+			.GroupBy(x => x.CanonicalName ?? NotNormalizedLabel)
+			.Select(g =>
+			{
+				decimal total = g.Sum(x => x.TotalAmount);
+				int count = g.Count();
+				DateOnly minDate = g.Min(x => x.Date);
+				DateOnly maxDate = g.Max(x => x.Date);
+
+				// Dominant currency: most common across the bucket. Ties broken by name asc
+				// (stable via Currency enum ordering). Empty groups fall back to USD.
+				string currency = g
+					.GroupBy(x => x.TotalAmountCurrency)
+					.OrderByDescending(cg => cg.Count())
+					.ThenBy(cg => cg.Key)
+					.Select(cg => cg.Key.ToString())
+					.FirstOrDefault() ?? Currency.USD.ToString();
+
+				return new SpendingByNormalizedDescriptionItem(
+					g.Key,
+					total,
+					currency,
+					count,
+					ToDateTimeOffset(minDate),
+					ToDateTimeOffset(maxDate));
+			})
+			.OrderByDescending(x => x.TotalAmount)
+			.ThenBy(x => x.CanonicalName)
+			.ToList();
+
+		return new SpendingByNormalizedDescriptionResult(items, from, to);
+	}
+
+	private static DateTimeOffset ToDateTimeOffset(DateOnly date) =>
+		new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.Zero);
 
 	public async Task<UncategorizedItemsResult> GetUncategorizedItemsAsync(
 		string sortBy,

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -464,4 +464,36 @@ public class ReportsController(IMediator mediator) : ControllerBase
 			}).ToList()
 		});
 	}
+
+	[HttpGet("spending-by-normalized-description")]
+	[EndpointSummary("Get spending by normalized description report")]
+	[EndpointDescription("Aggregates receipt item spending grouped by normalized description canonical name. Items without a normalized description bucket into a synthetic \"(Not Normalized)\" group.")]
+	public async Task<Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>>> GetSpendingByNormalizedDescription(
+		[FromQuery] DateTimeOffset? from,
+		[FromQuery] DateTimeOffset? to,
+		CancellationToken cancellationToken)
+	{
+		if (from.HasValue && to.HasValue && from.Value > to.Value)
+		{
+			return TypedResults.BadRequest("from must be before or equal to to");
+		}
+
+		GetSpendingByNormalizedDescriptionQuery query = new(from, to);
+		AppReports.SpendingByNormalizedDescriptionResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new SpendingByNormalizedDescriptionResponse
+		{
+			FromDate = result.FromDate,
+			ToDate = result.ToDate,
+			Items = result.Items.Select(i => new SpendingByNormalizedDescriptionItem
+			{
+				CanonicalName = i.CanonicalName,
+				TotalAmount = (double)i.TotalAmount,
+				Currency = i.Currency,
+				ItemCount = i.ItemCount,
+				FirstSeen = i.FirstSeen,
+				LastSeen = i.LastSeen
+			}).ToList()
+		});
+	}
 }

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -1793,6 +1793,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/reports/spending-by-normalized-description": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get spending by normalized description report
+         * @description Aggregates receipt item spending grouped by normalized description canonical name. Items without a normalized description bucket into a synthetic "(Not Normalized)" group.
+         */
+        get: operations["GetSpendingByNormalizedDescriptionReport"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/dashboard/summary": {
         parameters: {
             query?: never;
@@ -2541,6 +2561,45 @@ export interface components {
             category: string;
             subcategory?: string | null;
             pricingMode: string;
+        };
+        SpendingByNormalizedDescriptionResponse: {
+            items: components["schemas"]["SpendingByNormalizedDescriptionItem"][];
+            /**
+             * Format: date-time
+             * @description Inclusive lower bound on receipt date, echoed from the request.
+             */
+            fromDate?: string | null;
+            /**
+             * Format: date-time
+             * @description Inclusive upper bound on receipt date, echoed from the request.
+             */
+            toDate?: string | null;
+        };
+        SpendingByNormalizedDescriptionItem: {
+            /** @description Canonical name of the normalized description, or "(Not Normalized)" for receipt items without a normalized description. */
+            canonicalName: string;
+            /**
+             * Format: double
+             * @description Sum of ReceiptItem.TotalAmount for items in this bucket.
+             */
+            totalAmount: number;
+            /** @description Dominant currency across the items in this bucket. */
+            currency: string;
+            /**
+             * Format: int32
+             * @description Number of receipt items in this bucket.
+             */
+            itemCount: number;
+            /**
+             * Format: date-time
+             * @description Earliest receipt date among items in this bucket.
+             */
+            firstSeen?: string | null;
+            /**
+             * Format: date-time
+             * @description Latest receipt date among items in this bucket.
+             */
+            lastSeen?: string | null;
         };
         DashboardSummaryResponse: {
             /** Format: int32 */
@@ -7978,6 +8037,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UncategorizedItemsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    GetSpendingByNormalizedDescriptionReport: {
+        parameters: {
+            query?: {
+                /** @description Inclusive lower bound on receipt date (ISO 8601 date-time string). Defaults to all time when omitted. */
+                from?: string;
+                /** @description Inclusive upper bound on receipt date (ISO 8601 date-time string). Defaults to all time when omitted. */
+                to?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SpendingByNormalizedDescriptionResponse"];
                 };
             };
             /** @description Bad Request */

--- a/tests/Application.Tests/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQueryHandlerTests.cs
@@ -1,0 +1,94 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Reports;
+
+public class GetSpendingByNormalizedDescriptionQueryHandlerTests
+{
+	private readonly Mock<IReportService> _reportServiceMock;
+	private readonly GetSpendingByNormalizedDescriptionQueryHandler _handler;
+
+	public GetSpendingByNormalizedDescriptionQueryHandlerTests()
+	{
+		_reportServiceMock = new Mock<IReportService>();
+		_handler = new GetSpendingByNormalizedDescriptionQueryHandler(_reportServiceMock.Object);
+	}
+
+	[Fact]
+	public async Task Handle_DelegatesToReportService_WithNullDates()
+	{
+		// Arrange
+		GetSpendingByNormalizedDescriptionQuery query = new(null, null);
+		SpendingByNormalizedDescriptionResult expectedResult = new([], null, null);
+
+		_reportServiceMock
+			.Setup(s => s.GetSpendingByNormalizedDescriptionAsync(null, null, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+		_reportServiceMock.Verify(
+			s => s.GetSpendingByNormalizedDescriptionAsync(null, null, It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PassesDateRangeToService()
+	{
+		// Arrange
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 12, 31, 23, 59, 59, TimeSpan.Zero);
+		GetSpendingByNormalizedDescriptionQuery query = new(from, to);
+		SpendingByNormalizedDescriptionResult expectedResult = new([], from, to);
+
+		_reportServiceMock
+			.Setup(s => s.GetSpendingByNormalizedDescriptionAsync(from, to, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		_reportServiceMock.Verify(
+			s => s.GetSpendingByNormalizedDescriptionAsync(from, to, It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsServiceResult()
+	{
+		// Arrange
+		GetSpendingByNormalizedDescriptionQuery query = new(null, null);
+		SpendingByNormalizedDescriptionItem item = new(
+			"Bananas",
+			42.50m,
+			"USD",
+			5,
+			new DateTimeOffset(2025, 1, 5, 0, 0, 0, TimeSpan.Zero),
+			new DateTimeOffset(2025, 3, 15, 0, 0, 0, TimeSpan.Zero));
+		SpendingByNormalizedDescriptionResult expectedResult = new([item], null, null);
+
+		_reportServiceMock
+			.Setup(s => s.GetSpendingByNormalizedDescriptionAsync(
+				It.IsAny<DateTimeOffset?>(),
+				It.IsAny<DateTimeOffset?>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		result.Items[0].CanonicalName.Should().Be("Bananas");
+		result.Items[0].TotalAmount.Should().Be(42.50m);
+		result.Items[0].Currency.Should().Be("USD");
+		result.Items[0].ItemCount.Should().Be(5);
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/Services/ReportServiceSpendingByNormalizedDescriptionTests.cs
+++ b/tests/Infrastructure.IntegrationTests/Services/ReportServiceSpendingByNormalizedDescriptionTests.cs
@@ -1,0 +1,201 @@
+using Application.Models.Reports;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests.Services;
+
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class ReportServiceSpendingByNormalizedDescriptionTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_AggregatesByCanonicalName_AndBucketsNullFk()
+	{
+		// Arrange
+		await ResetTablesAsync();
+
+		Guid normalizedId = Guid.NewGuid();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Organic Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			setup.Receipts.Add(receipt);
+
+			ReceiptItemEntity linked1 = ReceiptItemEntityGenerator.Generate(receipt.Id);
+			linked1.Description = "organic milk";
+			linked1.TotalAmount = 4.00m;
+			linked1.NormalizedDescriptionId = normalizedId;
+
+			ReceiptItemEntity linked2 = ReceiptItemEntityGenerator.Generate(receipt.Id);
+			linked2.Description = "ORGANIC MILK";
+			linked2.TotalAmount = 5.50m;
+			linked2.NormalizedDescriptionId = normalizedId;
+
+			ReceiptItemEntity unlinked = ReceiptItemEntityGenerator.Generate(receipt.Id);
+			unlinked.Description = "mystery item";
+			unlinked.TotalAmount = 2.00m;
+			unlinked.NormalizedDescriptionId = null;
+
+			setup.ReceiptItems.AddRange(linked1, linked2, unlinked);
+			await setup.SaveChangesAsync();
+		}
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(from: null, to: null, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().HaveCount(2);
+
+		SpendingByNormalizedDescriptionItem milk = result.Items.Single(i => i.CanonicalName == "Organic Milk");
+		milk.TotalAmount.Should().Be(9.50m);
+		milk.ItemCount.Should().Be(2);
+		milk.Currency.Should().Be("USD");
+		milk.FirstSeen.Should().NotBeNull();
+		milk.LastSeen.Should().NotBeNull();
+
+		SpendingByNormalizedDescriptionItem notNormalized = result.Items.Single(i => i.CanonicalName == "(Not Normalized)");
+		notNormalized.TotalAmount.Should().Be(2.00m);
+		notNormalized.ItemCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_FiltersByDateRange()
+	{
+		// Arrange
+		await ResetTablesAsync();
+
+		Guid normalizedId = Guid.NewGuid();
+
+		ReceiptEntity receiptInRange = ReceiptEntityGenerator.Generate();
+		receiptInRange.Date = new DateOnly(2025, 6, 15);
+
+		ReceiptEntity receiptOutOfRange = ReceiptEntityGenerator.Generate();
+		receiptOutOfRange.Date = new DateOnly(2024, 1, 1);
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Bananas",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			setup.Receipts.AddRange(receiptInRange, receiptOutOfRange);
+
+			ReceiptItemEntity inRange = ReceiptItemEntityGenerator.Generate(receiptInRange.Id);
+			inRange.Description = "bananas";
+			inRange.TotalAmount = 1.50m;
+			inRange.NormalizedDescriptionId = normalizedId;
+
+			ReceiptItemEntity outOfRange = ReceiptItemEntityGenerator.Generate(receiptOutOfRange.Id);
+			outOfRange.Description = "bananas";
+			outOfRange.TotalAmount = 99.99m;
+			outOfRange.NormalizedDescriptionId = normalizedId;
+
+			setup.ReceiptItems.AddRange(inRange, outOfRange);
+			await setup.SaveChangesAsync();
+		}
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(from, to, CancellationToken.None);
+
+		// Assert — only the receipt within the range contributed
+		result.Items.Should().ContainSingle();
+		result.Items[0].CanonicalName.Should().Be("Bananas");
+		result.Items[0].TotalAmount.Should().Be(1.50m);
+		result.Items[0].ItemCount.Should().Be(1);
+		result.FromDate.Should().Be(from);
+		result.ToDate.Should().Be(to);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_IgnoresSoftDeletedItemsAndReceipts()
+	{
+		// Arrange
+		await ResetTablesAsync();
+
+		Guid normalizedId = Guid.NewGuid();
+		ReceiptEntity live = ReceiptEntityGenerator.Generate();
+		ReceiptEntity deleted = ReceiptEntityGenerator.Generate();
+		deleted.DeletedAt = DateTimeOffset.UtcNow;
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Eggs",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			setup.Receipts.AddRange(live, deleted);
+
+			ReceiptItemEntity liveItem = ReceiptItemEntityGenerator.Generate(live.Id);
+			liveItem.Description = "eggs";
+			liveItem.TotalAmount = 3.00m;
+			liveItem.NormalizedDescriptionId = normalizedId;
+
+			ReceiptItemEntity softDeletedItem = ReceiptItemEntityGenerator.Generate(live.Id);
+			softDeletedItem.Description = "eggs";
+			softDeletedItem.TotalAmount = 100.00m;
+			softDeletedItem.NormalizedDescriptionId = normalizedId;
+			softDeletedItem.DeletedAt = DateTimeOffset.UtcNow;
+
+			ReceiptItemEntity itemOnDeletedReceipt = ReceiptItemEntityGenerator.Generate(deleted.Id);
+			itemOnDeletedReceipt.Description = "eggs";
+			itemOnDeletedReceipt.TotalAmount = 50.00m;
+			itemOnDeletedReceipt.NormalizedDescriptionId = normalizedId;
+
+			setup.ReceiptItems.AddRange(liveItem, softDeletedItem, itemOnDeletedReceipt);
+			await setup.SaveChangesAsync();
+		}
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(null, null, CancellationToken.None);
+
+		// Assert — only the live item on the live receipt counted
+		result.Items.Should().ContainSingle();
+		result.Items[0].CanonicalName.Should().Be("Eggs");
+		result.Items[0].TotalAmount.Should().Be(3.00m);
+		result.Items[0].ItemCount.Should().Be(1);
+	}
+
+	private async Task ResetTablesAsync()
+	{
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		await context.Database.ExecuteSqlRawAsync(
+			"""TRUNCATE "ReceiptItems", "Receipts", "NormalizedDescriptions", "DistinctDescriptions" RESTART IDENTITY CASCADE;""");
+	}
+
+	private sealed class FixtureDbContextFactory(PostgresFixture fixture) : IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => fixture.CreateDbContext();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
@@ -649,4 +649,349 @@ public class ReportServiceTests
 
 		contextFactory.ResetDatabase();
 	}
+
+	// ── GetSpendingByNormalizedDescriptionAsync ──────────────────────────────
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_GroupsByCanonicalName_AndBucketsNullFk()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid receiptId = Guid.NewGuid();
+		Guid normalizedId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Organic Milk",
+				Status = Domain.NormalizedDescriptions.NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			context.Receipts.Add(new ReceiptEntity
+			{
+				Id = receiptId,
+				Location = "Store A",
+				Date = date,
+				TaxAmount = 0m,
+			});
+
+			// Two items linked to "Organic Milk"
+			context.ReceiptItems.AddRange(
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptId,
+					Description = "organic milk",
+					Quantity = 1,
+					UnitPrice = 4.00m,
+					TotalAmount = 4.00m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+				},
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptId,
+					Description = "ORGANIC MILK",
+					Quantity = 1,
+					UnitPrice = 5.50m,
+					TotalAmount = 5.50m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+				},
+				// One item with no normalized description
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptId,
+					Description = "Mystery Item",
+					Quantity = 1,
+					UnitPrice = 2.00m,
+					TotalAmount = 2.00m,
+					Category = "Uncategorized",
+					NormalizedDescriptionId = null,
+				});
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(from: null, to: null, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().HaveCount(2);
+		result.FromDate.Should().BeNull();
+		result.ToDate.Should().BeNull();
+
+		SpendingByNormalizedDescriptionItem milkBucket = result.Items.Single(i => i.CanonicalName == "Organic Milk");
+		milkBucket.TotalAmount.Should().Be(9.50m);
+		milkBucket.ItemCount.Should().Be(2);
+		milkBucket.Currency.Should().Be("USD");
+		milkBucket.FirstSeen.Should().NotBeNull();
+		milkBucket.LastSeen.Should().NotBeNull();
+
+		SpendingByNormalizedDescriptionItem notNormalizedBucket = result.Items.Single(i => i.CanonicalName == "(Not Normalized)");
+		notNormalizedBucket.TotalAmount.Should().Be(2.00m);
+		notNormalizedBucket.ItemCount.Should().Be(1);
+
+		// Ordered by total desc
+		result.Items[0].CanonicalName.Should().Be("Organic Milk");
+		result.Items[1].CanonicalName.Should().Be("(Not Normalized)");
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_FiltersByDateRange()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid normalizedId = Guid.NewGuid();
+
+		Guid receiptInRange = Guid.NewGuid();
+		Guid receiptOutOfRange = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Bananas",
+				Status = Domain.NormalizedDescriptions.NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			context.Receipts.AddRange(
+				new ReceiptEntity
+				{
+					Id = receiptInRange,
+					Location = "Store",
+					Date = new DateOnly(2025, 6, 15),
+					TaxAmount = 0m,
+				},
+				new ReceiptEntity
+				{
+					Id = receiptOutOfRange,
+					Location = "Store",
+					Date = new DateOnly(2024, 1, 1),
+					TaxAmount = 0m,
+				});
+
+			context.ReceiptItems.AddRange(
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptInRange,
+					Description = "bananas",
+					Quantity = 1,
+					UnitPrice = 1.50m,
+					TotalAmount = 1.50m,
+					Category = "Produce",
+					NormalizedDescriptionId = normalizedId,
+				},
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptOutOfRange,
+					Description = "bananas",
+					Quantity = 1,
+					UnitPrice = 99.99m,
+					TotalAmount = 99.99m,
+					Category = "Produce",
+					NormalizedDescriptionId = normalizedId,
+				});
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(from, to, CancellationToken.None);
+
+		// Assert — only the receipt in range contributed
+		result.Items.Should().ContainSingle();
+		result.Items[0].TotalAmount.Should().Be(1.50m);
+		result.Items[0].ItemCount.Should().Be(1);
+		result.FromDate.Should().Be(from);
+		result.ToDate.Should().Be(to);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_IgnoresSoftDeletedItemsAndReceipts()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid normalizedId = Guid.NewGuid();
+		Guid liveReceipt = Guid.NewGuid();
+		Guid deletedReceipt = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Eggs",
+				Status = Domain.NormalizedDescriptions.NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			context.Receipts.AddRange(
+				new ReceiptEntity
+				{
+					Id = liveReceipt,
+					Location = "Store",
+					Date = new DateOnly(2025, 3, 1),
+					TaxAmount = 0m,
+				},
+				new ReceiptEntity
+				{
+					Id = deletedReceipt,
+					Location = "Store",
+					Date = new DateOnly(2025, 3, 1),
+					TaxAmount = 0m,
+					DeletedAt = DateTimeOffset.UtcNow,
+				});
+
+			context.ReceiptItems.AddRange(
+				// Live item on live receipt — counted
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = liveReceipt,
+					Description = "eggs",
+					Quantity = 1,
+					UnitPrice = 3.00m,
+					TotalAmount = 3.00m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+				},
+				// Soft-deleted item on live receipt — excluded
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = liveReceipt,
+					Description = "eggs",
+					Quantity = 1,
+					UnitPrice = 100.00m,
+					TotalAmount = 100.00m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+					DeletedAt = DateTimeOffset.UtcNow,
+				},
+				// Live item on deleted receipt — excluded (because receipt is deleted)
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = deletedReceipt,
+					Description = "eggs",
+					Quantity = 1,
+					UnitPrice = 50.00m,
+					TotalAmount = 50.00m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+				});
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(null, null, CancellationToken.None);
+
+		// Assert — only the live item on the live receipt survives
+		result.Items.Should().ContainSingle();
+		result.Items[0].CanonicalName.Should().Be("Eggs");
+		result.Items[0].TotalAmount.Should().Be(3.00m);
+		result.Items[0].ItemCount.Should().Be(1);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_ReturnsEmpty_WhenNoItems()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		ReportService service = new(contextFactory);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(null, null, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().BeEmpty();
+		result.FromDate.Should().BeNull();
+		result.ToDate.Should().BeNull();
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_UsesFirstAndLastSeenDates()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid normalizedId = Guid.NewGuid();
+		Guid r1 = Guid.NewGuid();
+		Guid r2 = Guid.NewGuid();
+		Guid r3 = Guid.NewGuid();
+
+		DateOnly day1 = new(2025, 1, 5);
+		DateOnly day2 = new(2025, 6, 20);
+		DateOnly day3 = new(2025, 11, 30);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Coffee",
+				Status = Domain.NormalizedDescriptions.NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			context.Receipts.AddRange(
+				new ReceiptEntity { Id = r1, Location = "S", Date = day1, TaxAmount = 0m },
+				new ReceiptEntity { Id = r2, Location = "S", Date = day2, TaxAmount = 0m },
+				new ReceiptEntity { Id = r3, Location = "S", Date = day3, TaxAmount = 0m });
+
+			context.ReceiptItems.AddRange(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = r1, Description = "coffee", Quantity = 1, UnitPrice = 4m, TotalAmount = 4m, Category = "Beverages", NormalizedDescriptionId = normalizedId },
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = r2, Description = "coffee", Quantity = 1, UnitPrice = 4m, TotalAmount = 4m, Category = "Beverages", NormalizedDescriptionId = normalizedId },
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = r3, Description = "coffee", Quantity = 1, UnitPrice = 4m, TotalAmount = 4m, Category = "Beverages", NormalizedDescriptionId = normalizedId });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(null, null, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		SpendingByNormalizedDescriptionItem bucket = result.Items[0];
+		bucket.ItemCount.Should().Be(3);
+		bucket.FirstSeen.Should().Be(new DateTimeOffset(day1.Year, day1.Month, day1.Day, 0, 0, 0, TimeSpan.Zero));
+		bucket.LastSeen.Should().Be(new DateTimeOffset(day3.Year, day3.Month, day3.Day, 0, 0, 0, TimeSpan.Zero));
+
+		contextFactory.ResetDatabase();
+	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
@@ -720,4 +720,173 @@ public class ReportsControllerTests
 		receipt.Date.Should().Be(date);
 		receipt.TransactionTotal.Should().Be(42.99);
 	}
+
+	// ── GetSpendingByNormalizedDescription ─────────────────
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_ReturnsOkResult_WithDefaultParameters()
+	{
+		// Arrange
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new([], null, null);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == null && q.To == null),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(null, null, CancellationToken.None);
+
+		// Assert
+		Ok<SpendingByNormalizedDescriptionResponse> okResult = Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+		okResult.Value!.Items.Should().BeEmpty();
+		okResult.Value!.FromDate.Should().BeNull();
+		okResult.Value!.ToDate.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_PassesDateRangeToMediator()
+	{
+		// Arrange
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new([], from, to);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == from && q.To == to),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(from, to, CancellationToken.None);
+
+		// Assert
+		Ok<SpendingByNormalizedDescriptionResponse> okResult = Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+		okResult.Value!.FromDate.Should().Be(from);
+		okResult.Value!.ToDate.Should().Be(to);
+
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == from && q.To == to),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_ReturnsBadRequest_WhenFromAfterTo()
+	{
+		// Arrange
+		DateTimeOffset from = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(from, to, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("from must be before or equal to to");
+		_mediatorMock.Verify(
+			m => m.Send(It.IsAny<GetSpendingByNormalizedDescriptionQuery>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_MapsResponseFieldsCorrectly()
+	{
+		// Arrange
+		DateTimeOffset firstSeen = new(2025, 1, 5, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset lastSeen = new(2025, 11, 30, 0, 0, 0, TimeSpan.Zero);
+
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new(
+		[
+			new AppReports.SpendingByNormalizedDescriptionItem("Organic Milk", 42.50m, "USD", 5, firstSeen, lastSeen),
+			new AppReports.SpendingByNormalizedDescriptionItem("(Not Normalized)", 12.00m, "USD", 2, null, null),
+		], null, null);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingByNormalizedDescriptionQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(null, null, CancellationToken.None);
+
+		// Assert
+		Ok<SpendingByNormalizedDescriptionResponse> okResult = Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+		SpendingByNormalizedDescriptionResponse response = okResult.Value!;
+		response.Items.Should().HaveCount(2);
+
+		SpendingByNormalizedDescriptionItem first = response.Items.First(i => i.CanonicalName == "Organic Milk");
+		first.TotalAmount.Should().Be(42.50);
+		first.Currency.Should().Be("USD");
+		first.ItemCount.Should().Be(5);
+		first.FirstSeen.Should().Be(firstSeen);
+		first.LastSeen.Should().Be(lastSeen);
+
+		SpendingByNormalizedDescriptionItem notNormalized = response.Items.First(i => i.CanonicalName == "(Not Normalized)");
+		notNormalized.TotalAmount.Should().Be(12.00);
+		notNormalized.ItemCount.Should().Be(2);
+		notNormalized.FirstSeen.Should().BeNull();
+		notNormalized.LastSeen.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_AcceptsOnlyFromSet()
+	{
+		// Arrange
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new([], from, null);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == from && q.To == null),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(from, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_AcceptsOnlyToSet()
+	{
+		// Arrange
+		DateTimeOffset to = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new([], null, to);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == null && q.To == to),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(null, to, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+	}
+
+	[Fact]
+	public void GetSpendingByNormalizedDescription_RequiresAuthorization()
+	{
+		// Assert — the ReportsController-level [Authorize] attribute applies to this action.
+		System.Reflection.MethodInfo method = typeof(ReportsController)
+			.GetMethod(nameof(ReportsController.GetSpendingByNormalizedDescription))!;
+
+		bool classAttribute = typeof(ReportsController)
+			.GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), inherit: true)
+			.Length > 0;
+		bool methodAllowsAnonymous = method
+			.GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute), inherit: true)
+			.Length > 0;
+
+		classAttribute.Should().BeTrue("ReportsController requires authentication at the class level");
+		methodAllowsAnonymous.Should().BeFalse("GetSpendingByNormalizedDescription should not bypass authorization");
+	}
 }


### PR DESCRIPTION
## Summary

New read-only report aggregating item spend by canonical normalized description. Items without a resolved `NormalizedDescriptionId` bucket into a synthetic `(Not Normalized)` group so existing data still appears before [RECEIPTS-578](https://plane.wallingford.me/dev/browse/RECEIPTS-578/) (the resolver) lands.

- `GET /api/reports/spending-by-normalized-description?from=&to=`
- LEFT JOIN + COALESCE on canonical name; SUM total, COUNT items, MIN/MAX receipt date per bucket
- Honors soft-delete filter on both receipts and items
- Sort: total DESC, canonical name ASC tiebreaker

## Test plan

- [x] 15 new unit tests + 3 integration tests
- [x] Full unit suite: 2,375 passed, 0 failed
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI: full backend + frontend + Postgres integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)