### PR TITLE
feat(api): expose normalized-description fields on ReceiptItemResponse (RECEIPTS-583)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -6513,6 +6513,17 @@ components:
         pricingMode:
           type: string
           description: "Pricing mode: 'quantity' (qty x unit price) or 'flat' (single flat price)"
+        normalizedDescriptionId:
+          type: ["string", "null"]
+          format: uuid
+          description: "FK to the canonical NormalizedDescription. Null until the resolver links this item."
+        normalizedDescriptionName:
+          type: ["string", "null"]
+          description: "Denormalized CanonicalName from the linked NormalizedDescription for display."
+        normalizedDescriptionMatchScore:
+          type: ["number", "null"]
+          format: double
+          description: "Cosine similarity captured when the resolver linked this item; null for unresolved or no-match-created items."
 
     ReceiptItemListResponse:
       type: object

--- a/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
+++ b/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
@@ -12,12 +12,6 @@ public partial class ReceiptItemMapper
 	[MapProperty(nameof(ReceiptItem.UnitPrice.Amount), nameof(ReceiptItemResponse.UnitPrice))]
 	[MapperIgnoreSource(nameof(ReceiptItem.TotalAmount))]
 	[MapperIgnoreSource(nameof(ReceiptItem.PricingMode))]
-	// NormalizedDescription FK, name, and match score are deliberately not exposed on the API
-	// response here — RECEIPTS-583 will add them. Ignore them so Mapperly does not flag the
-	// unmapped members.
-	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionId))]
-	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionName))]
-	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionMatchScore))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.AdditionalProperties))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.PricingMode))]
 	private partial ReceiptItemResponse ToResponsePartial(ReceiptItem source);

--- a/src/client/src/components/ReceiptItemsCard.test.tsx
+++ b/src/client/src/components/ReceiptItemsCard.test.tsx
@@ -342,6 +342,81 @@ describe("ReceiptItemsCard", () => {
     expect(submitButton).toBeInTheDocument();
   });
 
+  it("renders 'normalized as' label when normalizedDescriptionName is present and differs from description", () => {
+    const itemsWithNormalized = [
+      {
+        id: "item-norm-1",
+        receiptItemCode: "ITEM-NORM-1",
+        description: "Red Seedless Grapes 2LB",
+        quantity: 1,
+        unitPrice: 5.99,
+        category: "Groceries",
+        subcategory: "Produce",
+        pricingMode: "quantity",
+        normalizedDescriptionName: "Grapes",
+      },
+    ];
+    renderWithQueryClient(
+      <ReceiptItemsCard
+        receiptId="receipt-1"
+        items={itemsWithNormalized}
+        subtotal={5.99}
+      />,
+    );
+    expect(screen.getByText("Red Seedless Grapes 2LB")).toBeInTheDocument();
+    expect(screen.getByText(/normalized as Grapes/i)).toBeInTheDocument();
+  });
+
+  it("does not render 'normalized as' label when normalizedDescriptionName is null", () => {
+    const itemsWithoutNormalized = [
+      {
+        id: "item-plain-1",
+        receiptItemCode: "ITEM-PLAIN-1",
+        description: "Eggs",
+        quantity: 1,
+        unitPrice: 3.49,
+        category: "Groceries",
+        subcategory: "Dairy",
+        pricingMode: "quantity",
+        normalizedDescriptionName: null,
+      },
+    ];
+    renderWithQueryClient(
+      <ReceiptItemsCard
+        receiptId="receipt-1"
+        items={itemsWithoutNormalized}
+        subtotal={3.49}
+      />,
+    );
+    expect(screen.getByText("Eggs")).toBeInTheDocument();
+    expect(screen.queryByText(/normalized as/i)).not.toBeInTheDocument();
+  });
+
+  it("does not render 'normalized as' label when normalizedDescriptionName equals description", () => {
+    const itemsWithSameNormalized = [
+      {
+        id: "item-same-1",
+        receiptItemCode: "ITEM-SAME-1",
+        description: "Milk",
+        quantity: 1,
+        unitPrice: 4.29,
+        category: "Groceries",
+        subcategory: "Dairy",
+        pricingMode: "quantity",
+        normalizedDescriptionName: "Milk",
+      },
+    ];
+    renderWithQueryClient(
+      <ReceiptItemsCard
+        receiptId="receipt-1"
+        items={itemsWithSameNormalized}
+        subtotal={4.29}
+      />,
+    );
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+    expect(screen.queryByText(/normalized as/i)).not.toBeInTheDocument();
+  });
+
   it("cancels delete dialog without deleting", async () => {
     const { useDeleteReceiptItems } = await import(
       "@/hooks/useReceiptItems"

--- a/src/client/src/components/ReceiptItemsCard.tsx
+++ b/src/client/src/components/ReceiptItemsCard.tsx
@@ -48,6 +48,7 @@ interface ReceiptItem {
   category: string;
   subcategory?: string | null;
   pricingMode?: string | null;
+  normalizedDescriptionName?: string | null;
 }
 
 interface ReceiptItemsCardProps {
@@ -221,7 +222,19 @@ export function ReceiptItemsCard({
                       <TableCell className="font-mono">
                         {item.receiptItemCode ?? ""}
                       </TableCell>
-                      <TableCell>{item.description}</TableCell>
+                      <TableCell>
+                        <div>{item.description}</div>
+                        {item.normalizedDescriptionName &&
+                          item.normalizedDescriptionName !==
+                            item.description && (
+                            <div
+                              className="text-xs text-muted-foreground"
+                              data-testid={`normalized-as-${item.id}`}
+                            >
+                              normalized as {item.normalizedDescriptionName}
+                            </div>
+                          )}
+                      </TableCell>
                       <TableCell className="text-right">
                         {item.quantity}
                       </TableCell>

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -3212,6 +3212,18 @@ export interface components {
             subcategory?: string | null;
             /** @description Pricing mode: 'quantity' (qty x unit price) or 'flat' (single flat price) */
             pricingMode: string;
+            /**
+             * Format: uuid
+             * @description FK to the canonical NormalizedDescription. Null until the resolver links this item.
+             */
+            normalizedDescriptionId?: string | null;
+            /** @description Denormalized CanonicalName from the linked NormalizedDescription for display. */
+            normalizedDescriptionName?: string | null;
+            /**
+             * Format: double
+             * @description Cosine similarity captured when the resolver linked this item; null for unresolved or no-match-created items.
+             */
+            normalizedDescriptionMatchScore?: number | null;
         };
         ReceiptItemListResponse: {
             data: components["schemas"]["ReceiptItemResponse"][];

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -180,6 +180,7 @@ function ReceiptDetail() {
               category: i.category,
               subcategory: i.subcategory,
               pricingMode: i.pricingMode,
+              normalizedDescriptionName: i.normalizedDescriptionName,
             }))}
             subtotal={subtotal}
             location={trip.receipt.receipt.location}

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptItemsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptItemsControllerTests.cs
@@ -635,4 +635,52 @@ public class ReceiptItemsControllerTests
 		// Assert
 		await act.Should().ThrowAsync<Exception>();
 	}
+
+	[Fact]
+	public async Task GetReceiptItemById_IncludesNormalizedDescriptionFields_WhenPopulated()
+	{
+		// Arrange - RECEIPTS-583: normalized description fields surface on the response
+		Guid normalizedId = Guid.NewGuid();
+		ReceiptItem mediatorReturn = ReceiptItemGenerator.Generate();
+		mediatorReturn.NormalizedDescriptionId = normalizedId;
+		mediatorReturn.NormalizedDescriptionName = "Grapes";
+		mediatorReturn.NormalizedDescriptionMatchScore = 0.87;
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetReceiptItemByIdQuery>(q => q.Id == mediatorReturn.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(mediatorReturn);
+
+		// Act
+		Results<Ok<ReceiptItemResponse>, NotFound> result = await _controller.GetReceiptItemById(mediatorReturn.Id);
+
+		// Assert
+		Ok<ReceiptItemResponse> okResult = Assert.IsType<Ok<ReceiptItemResponse>>(result.Result);
+		ReceiptItemResponse response = Assert.IsType<ReceiptItemResponse>(okResult.Value);
+		response.NormalizedDescriptionId.Should().Be(normalizedId);
+		response.NormalizedDescriptionName.Should().Be("Grapes");
+		response.NormalizedDescriptionMatchScore.Should().Be(0.87);
+	}
+
+	[Fact]
+	public async Task GetReceiptItemById_NormalizedDescriptionFieldsAreNull_WhenUnresolved()
+	{
+		// Arrange - RECEIPTS-583: unresolved items expose null normalized fields
+		ReceiptItem mediatorReturn = ReceiptItemGenerator.Generate();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetReceiptItemByIdQuery>(q => q.Id == mediatorReturn.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(mediatorReturn);
+
+		// Act
+		Results<Ok<ReceiptItemResponse>, NotFound> result = await _controller.GetReceiptItemById(mediatorReturn.Id);
+
+		// Assert
+		Ok<ReceiptItemResponse> okResult = Assert.IsType<Ok<ReceiptItemResponse>>(result.Result);
+		ReceiptItemResponse response = Assert.IsType<ReceiptItemResponse>(okResult.Value);
+		response.NormalizedDescriptionId.Should().BeNull();
+		response.NormalizedDescriptionName.Should().BeNull();
+		response.NormalizedDescriptionMatchScore.Should().BeNull();
+	}
 }

--- a/tests/Presentation.API.Tests/Mapping/Core/ReceiptItemMapperTests.cs
+++ b/tests/Presentation.API.Tests/Mapping/Core/ReceiptItemMapperTests.cs
@@ -425,4 +425,60 @@ public class ReceiptItemMapperTests
 		// Assert
 		Assert.Equal(PricingMode.Quantity, actual.PricingMode);
 	}
+
+	[Fact]
+	public void ToResponse_MapsNormalizedDescriptionFields_WhenPopulated()
+	{
+		// Arrange
+		Guid expectedId = Guid.NewGuid();
+		Guid expectedNormalizedId = Guid.NewGuid();
+		ReceiptItem item = new(
+			expectedId,
+			"ITEM-NORM-001",
+			"Red Seedless Grapes 2LB",
+			1.0m,
+			new Money(5.99m, Currency.USD),
+			new Money(5.99m, Currency.USD),
+			"Groceries",
+			"Produce"
+		)
+		{
+			NormalizedDescriptionId = expectedNormalizedId,
+			NormalizedDescriptionName = "Grapes",
+			NormalizedDescriptionMatchScore = 0.92
+		};
+
+		// Act
+		ReceiptItemResponse actual = _mapper.ToResponse(item);
+
+		// Assert
+		Assert.Equal(expectedNormalizedId, actual.NormalizedDescriptionId);
+		Assert.Equal("Grapes", actual.NormalizedDescriptionName);
+		Assert.Equal(0.92, actual.NormalizedDescriptionMatchScore);
+	}
+
+	[Fact]
+	public void ToResponse_MapsNullNormalizedDescriptionFields_WhenUnresolved()
+	{
+		// Arrange
+		Guid expectedId = Guid.NewGuid();
+		ReceiptItem item = new(
+			expectedId,
+			"ITEM-NORM-002",
+			"Unresolved Item",
+			1.0m,
+			new Money(1.00m, Currency.USD),
+			new Money(1.00m, Currency.USD),
+			"Test",
+			"Unresolved"
+		);
+
+		// Act
+		ReceiptItemResponse actual = _mapper.ToResponse(item);
+
+		// Assert
+		Assert.Null(actual.NormalizedDescriptionId);
+		Assert.Null(actual.NormalizedDescriptionName);
+		Assert.Null(actual.NormalizedDescriptionMatchScore);
+	}
 }


### PR DESCRIPTION
## Summary

Surfaces the 3 normalized-description fields on `ReceiptItemResponse` (read-only) + renders a subtle `normalized as {name}` secondary line on the receipt detail page when a link is present.

- API: `normalizedDescriptionId`, `normalizedDescriptionName`, `normalizedDescriptionMatchScore` (all optional, nullable)
- UI: detail page only; `normalizedDescriptionMatchScore` is on the response for future admin UI but not rendered for end users
- Mapper: Mapperly auto-maps by matching property name; `MapperIgnoreSource` attributes removed

## Test plan

- [x] 4 new C# tests (2 mapper + 2 controller) + 3 React component tests
- [x] Full unit suite: 2,403 C# + 1,919 client tests, 0 failures
- [x] `dotnet format --verify-no-changes` clean, `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)