### PR TITLE
feat(client): admin UI for normalized description registry (RECEIPTS-582)

### DIFF
--- a/src/client/src/components/reports/NormalizedDescriptions.test.tsx
+++ b/src/client/src/components/reports/NormalizedDescriptions.test.tsx
@@ -1,0 +1,491 @@
+import { screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { mockMutationResult, mockQueryResult } from "@/test/mock-hooks";
+import NormalizedDescriptions from "./NormalizedDescriptions";
+
+vi.mock("@/hooks/useNormalizedDescriptions", () => ({
+  useNormalizedDescriptions: vi.fn(),
+  useNormalizedDescription: vi.fn(),
+}));
+
+vi.mock("@/hooks/useNormalizedDescriptionActions", () => ({
+  useMergeMutation: vi.fn(() => mockMutationResult()),
+  useSplitMutation: vi.fn(() => mockMutationResult()),
+  useUpdateStatusMutation: vi.fn(() => mockMutationResult()),
+}));
+
+vi.mock("@/hooks/useNormalizedDescriptionSettings", () => ({
+  useSettings: vi.fn(),
+  useUpdateSettingsMutation: vi.fn(() => mockMutationResult()),
+  useTestMatchMutation: vi.fn(() => mockMutationResult()),
+  usePreviewImpactMutation: vi.fn(() => mockMutationResult()),
+}));
+
+vi.mock("@/hooks/useReceiptItems", () => ({
+  useReceiptItems: vi.fn(() => ({
+    data: [],
+    total: 0,
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/hooks/usePermission", () => ({
+  usePermission: vi.fn(() => ({
+    roles: ["Admin"],
+    hasRole: (role: string) => role === "Admin",
+    isAdmin: () => true,
+  })),
+}));
+
+import { useNormalizedDescriptions } from "@/hooks/useNormalizedDescriptions";
+import {
+  useMergeMutation,
+  useSplitMutation,
+  useUpdateStatusMutation,
+} from "@/hooks/useNormalizedDescriptionActions";
+import {
+  useSettings,
+  useUpdateSettingsMutation,
+  useTestMatchMutation,
+  usePreviewImpactMutation,
+} from "@/hooks/useNormalizedDescriptionSettings";
+import { useReceiptItems } from "@/hooks/useReceiptItems";
+import { usePermission } from "@/hooks/usePermission";
+
+const pendingItems = [
+  {
+    id: "p-1",
+    canonicalName: "Strawberry Preserves",
+    status: "pendingReview" as const,
+    createdAt: "2025-03-01T00:00:00Z",
+  },
+  {
+    id: "p-2",
+    canonicalName: "Organic Milk",
+    status: "pendingReview" as const,
+    createdAt: "2025-03-02T00:00:00Z",
+  },
+];
+
+const activeItems = [
+  {
+    id: "a-1",
+    canonicalName: "Apples",
+    status: "active" as const,
+    createdAt: "2025-02-01T00:00:00Z",
+  },
+  {
+    id: "a-2",
+    canonicalName: "Milk",
+    status: "active" as const,
+    createdAt: "2025-02-02T00:00:00Z",
+  },
+];
+
+function mockList(status: string | undefined) {
+  if (status === "PendingReview") {
+    return mockQueryResult({
+      data: { items: pendingItems, totalCount: pendingItems.length },
+      isLoading: false,
+      isSuccess: true,
+      isPending: false,
+      status: "success",
+    });
+  }
+  if (status === "Active") {
+    return mockQueryResult({
+      data: { items: activeItems, totalCount: activeItems.length },
+      isLoading: false,
+      isSuccess: true,
+      isPending: false,
+      status: "success",
+    });
+  }
+  return mockQueryResult({
+    data: { items: [], totalCount: 0 },
+    isLoading: false,
+    isSuccess: true,
+    isPending: false,
+    status: "success",
+  });
+}
+
+const liveSettings = {
+  id: "00000000-0000-0000-0000-000000000001",
+  autoAcceptThreshold: 0.9,
+  pendingReviewThreshold: 0.75,
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+function wireDefaults() {
+  vi.mocked(useNormalizedDescriptions).mockImplementation((status) =>
+    mockList(status),
+  );
+  vi.mocked(useSettings).mockReturnValue(
+    mockQueryResult({
+      data: liveSettings,
+      isLoading: false,
+      isSuccess: true,
+      isPending: false,
+      status: "success",
+    }),
+  );
+  vi.mocked(useMergeMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useSplitMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useUpdateStatusMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useUpdateSettingsMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useTestMatchMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(usePreviewImpactMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useReceiptItems).mockReturnValue({
+    data: [],
+    total: 0,
+    isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  vi.mocked(usePermission).mockReturnValue({
+    roles: ["Admin"],
+    hasRole: (role: string) => role === "Admin",
+    isAdmin: () => true,
+  });
+}
+
+describe("NormalizedDescriptions review queue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wireDefaults();
+  });
+
+  it("renders pending-review rows by default", async () => {
+    renderWithQueryClient(<NormalizedDescriptions />);
+    expect(
+      await screen.findByText("Strawberry Preserves"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Organic Milk")).toBeInTheDocument();
+  });
+
+  it("shows empty state when queue is empty", () => {
+    vi.mocked(useNormalizedDescriptions).mockImplementation((status) => {
+      if (status === "PendingReview") {
+        return mockQueryResult({
+          data: { items: [], totalCount: 0 },
+          isLoading: false,
+          isSuccess: true,
+          isPending: false,
+          status: "success",
+        });
+      }
+      return mockList(status);
+    });
+    renderWithQueryClient(<NormalizedDescriptions />);
+    expect(screen.getByText("Review Queue Empty")).toBeInTheDocument();
+  });
+
+  it("approve button calls status update mutation", async () => {
+    const mutate = vi.fn();
+    vi.mocked(useUpdateStatusMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    const row = (await screen.findByText("Strawberry Preserves")).closest(
+      "tr",
+    )!;
+    const approveBtn = within(row).getByRole("button", { name: "Approve" });
+    await user.click(approveBtn);
+    expect(mutate).toHaveBeenCalledWith({ id: "p-1", status: "active" });
+  });
+
+  it("opens merge dialog when Merge is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    const row = (await screen.findByText("Strawberry Preserves")).closest(
+      "tr",
+    )!;
+    await user.click(within(row).getByRole("button", { name: "Merge" }));
+    expect(screen.getByText("Merge Into Active Entry")).toBeInTheDocument();
+    expect(screen.getByText("Apples")).toBeInTheDocument();
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+  });
+
+  it("confirm merge calls mutation with discard and target ids", async () => {
+    const mutate = vi.fn((_vars, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+    vi.mocked(useMergeMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    const row = (await screen.findByText("Strawberry Preserves")).closest(
+      "tr",
+    )!;
+    await user.click(within(row).getByRole("button", { name: "Merge" }));
+
+    // Select target
+    const dialog = screen.getByRole("dialog");
+    const appleLabel = within(dialog).getByText("Apples").closest("label")!;
+    const appleRadio = within(appleLabel).getByRole("radio");
+    await user.click(appleRadio);
+    await user.click(within(dialog).getByRole("button", { name: "Merge" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { id: "a-1", discardId: "p-1" },
+      expect.any(Object),
+    );
+  });
+
+  it("opens split dialog and confirms with receipt item id", async () => {
+    const mutate = vi.fn((_vars, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+    vi.mocked(useSplitMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+    vi.mocked(useReceiptItems).mockReturnValue({
+      data: [
+        {
+          id: "ri-1",
+          description: "STRAWBERRY PRESERVES",
+          normalizedDescriptionId: "p-1",
+          normalizedDescriptionName: "Strawberry Preserves",
+        },
+        {
+          id: "ri-2",
+          description: "OTHER",
+          normalizedDescriptionId: "different",
+        },
+      ],
+      total: 2,
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    const row = (await screen.findByText("Strawberry Preserves")).closest(
+      "tr",
+    )!;
+    await user.click(within(row).getByRole("button", { name: "Split" }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByText("Split Out a Receipt Item"),
+    ).toBeInTheDocument();
+    const label = within(dialog)
+      .getByText("STRAWBERRY PRESERVES")
+      .closest("label")!;
+    const radio = within(label).getByRole("radio");
+    await user.click(radio);
+    await user.click(within(dialog).getByRole("button", { name: "Split" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { id: "p-1", receiptItemId: "ri-1" },
+      expect.any(Object),
+    );
+  });
+});
+
+describe("NormalizedDescriptions registry tab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wireDefaults();
+  });
+
+  it("shows active entries when registry tab is selected", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Registry" }));
+    expect(await screen.findByText("Apples")).toBeInTheDocument();
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+  });
+
+  it("filters by search box", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Registry" }));
+    const input = await screen.findByLabelText("Search");
+    await user.type(input, "apple");
+    await waitFor(() => {
+      expect(screen.getByText("Apples")).toBeInTheDocument();
+      expect(screen.queryByText("Milk")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("NormalizedDescriptions settings tab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wireDefaults();
+  });
+
+  it("renders settings tab for admins and hydrates from live settings", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    const pendingInput = screen.getByLabelText(
+      "Pending-Review Threshold",
+    ) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+    expect(pendingInput.value).toBe("0.75");
+  });
+
+  it("hides settings tab for non-admins", () => {
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["User"],
+      hasRole: (role: string) => role === "User",
+      isAdmin: () => false,
+    });
+    renderWithQueryClient(<NormalizedDescriptions />);
+    expect(
+      screen.queryByRole("tab", { name: "Settings" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("save triggers update mutation with parsed thresholds", async () => {
+    const mutate = vi.fn();
+    vi.mocked(useUpdateSettingsMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(mutate).toHaveBeenCalledWith({
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.75,
+    });
+  });
+
+  it("shows validation error when pending >= auto", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    const pendingInput = (await screen.findByLabelText(
+      "Pending-Review Threshold",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+
+    await user.clear(autoInput);
+    await user.type(autoInput, "0.5");
+    await user.clear(pendingInput);
+    await user.type(pendingInput, "0.8");
+
+    expect(
+      await screen.findByTestId("threshold-validation-error"),
+    ).toHaveTextContent(/strictly less than the auto-accept threshold/i);
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("shows validation error when a value is out of range", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+
+    await user.clear(autoInput);
+    await user.type(autoInput, "2");
+
+    expect(
+      await screen.findByTestId("threshold-validation-error"),
+    ).toHaveTextContent(/between 0 and 1/i);
+  });
+
+  it("preview impact shows panel with deltas", async () => {
+    vi.mocked(usePreviewImpactMutation).mockReturnValue(
+      mockMutationResult({
+        data: {
+          current: { autoAccepted: 5, pendingReview: 2, unresolved: 1 },
+          proposed: { autoAccepted: 6, pendingReview: 1, unresolved: 1 },
+          deltas: {
+            autoToPending: 0,
+            pendingToAuto: 1,
+            unresolvedToAuto: 0,
+            unresolvedToPending: 0,
+          },
+        },
+        isSuccess: true,
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    expect(
+      await screen.findByTestId("preview-impact-panel"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/pending-to-auto: 1/i)).toBeInTheDocument();
+  });
+
+  it("preview impact button calls mutation with current edited thresholds", async () => {
+    const mutate = vi.fn();
+    vi.mocked(usePreviewImpactMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+    await user.click(
+      screen.getByRole("button", { name: /preview impact/i }),
+    );
+    expect(mutate).toHaveBeenCalledWith({
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.75,
+    });
+  });
+
+  it("test description box renders candidates and outcome", async () => {
+    const mutate = vi.fn();
+    vi.mocked(useTestMatchMutation).mockReturnValue(
+      mockMutationResult({
+        mutate,
+        data: {
+          candidates: [
+            {
+              normalizedDescriptionId: "a-1",
+              canonicalName: "Apples",
+              cosineSimilarity: 0.87,
+              status: "Active",
+            },
+          ],
+          simulatedOutcome: "AutoAccept",
+        },
+        isSuccess: true,
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+
+    const testInput = await screen.findByLabelText("Description");
+    await user.type(testInput, "apples");
+    await user.click(screen.getByRole("button", { name: "Test" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "apples", topN: 5 }),
+    );
+
+    const panel = await screen.findByTestId("test-match-panel");
+    expect(within(panel).getByText("AutoAccept")).toBeInTheDocument();
+    expect(within(panel).getByText("Apples")).toBeInTheDocument();
+    expect(within(panel).getByText("0.8700")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/reports/NormalizedDescriptions.tsx
+++ b/src/client/src/components/reports/NormalizedDescriptions.tsx
@@ -1,0 +1,806 @@
+import { useMemo, useState } from "react";
+import { useNormalizedDescriptions } from "@/hooks/useNormalizedDescriptions";
+import {
+  useMergeMutation,
+  useSplitMutation,
+  useUpdateStatusMutation,
+} from "@/hooks/useNormalizedDescriptionActions";
+import {
+  useSettings,
+  useUpdateSettingsMutation,
+  useTestMatchMutation,
+  usePreviewImpactMutation,
+} from "@/hooks/useNormalizedDescriptionSettings";
+import { useReceiptItems } from "@/hooks/useReceiptItems";
+import { usePermission } from "@/hooks/usePermission";
+import { formatDecimal } from "@/lib/format";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { components } from "@/generated/api";
+
+type NormalizedDescription =
+  components["schemas"]["NormalizedDescriptionResponse"];
+
+type ReceiptItem = {
+  id: string;
+  description: string;
+  normalizedDescriptionId?: string | null;
+  normalizedDescriptionName?: string | null;
+};
+
+type TabKey = "review" | "registry" | "settings";
+
+export default function NormalizedDescriptions() {
+  const { isAdmin } = usePermission();
+  const [tab, setTab] = useState<TabKey>("review");
+
+  return (
+    <Tabs
+      value={tab}
+      onValueChange={(v) => setTab(v as TabKey)}
+      className="space-y-4"
+    >
+      <TabsList>
+        <TabsTrigger value="review">Review Queue</TabsTrigger>
+        <TabsTrigger value="registry">Registry</TabsTrigger>
+        {isAdmin() && <TabsTrigger value="settings">Settings</TabsTrigger>}
+      </TabsList>
+      <TabsContent value="review">
+        <ReviewQueueTab />
+      </TabsContent>
+      <TabsContent value="registry">
+        <RegistryTab />
+      </TabsContent>
+      {isAdmin() && (
+        <TabsContent value="settings">
+          <SettingsTab />
+        </TabsContent>
+      )}
+    </Tabs>
+  );
+}
+
+function ReviewQueueTab() {
+  const { data: pendingData, isLoading, isError } = useNormalizedDescriptions(
+    "PendingReview",
+  );
+  const { data: activeData } = useNormalizedDescriptions("Active");
+  const updateStatus = useUpdateStatusMutation();
+  const [mergeTarget, setMergeTarget] = useState<NormalizedDescription | null>(
+    null,
+  );
+  const [splitTarget, setSplitTarget] = useState<NormalizedDescription | null>(
+    null,
+  );
+
+  const pending = useMemo(() => {
+    const items = pendingData?.items ?? [];
+    return [...items].sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+  }, [pendingData?.items]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">Failed to load review queue.</p>
+      </div>
+    );
+  }
+
+  if (pending.length === 0) {
+    return (
+      <div className="rounded-lg border p-6 text-center">
+        <h2 className="text-lg font-semibold">Review Queue Empty</h2>
+        <p className="mt-2 text-muted-foreground">
+          No descriptions are awaiting review right now.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-6 rounded-lg border p-4">
+        <div>
+          <p className="text-sm text-muted-foreground">Pending Review</p>
+          <p className="text-2xl font-bold">
+            {pendingData?.totalCount ?? pending.length}
+          </p>
+        </div>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Canonical Name</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Created</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {pending.map((row) => (
+            <TableRow key={row.id}>
+              <TableCell className="font-medium">{row.canonicalName}</TableCell>
+              <TableCell>
+                <Badge variant="secondary">Pending Review</Badge>
+              </TableCell>
+              <TableCell>
+                <span className="text-sm text-muted-foreground">
+                  {new Date(row.createdAt).toLocaleDateString()}
+                </span>
+              </TableCell>
+              <TableCell className="text-right space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={updateStatus.isPending}
+                  onClick={() =>
+                    updateStatus.mutate({ id: row.id, status: "active" })
+                  }
+                >
+                  Approve
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setMergeTarget(row)}
+                >
+                  Merge
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setSplitTarget(row)}
+                >
+                  Split
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <MergeDialog
+        source={mergeTarget}
+        candidates={activeData?.items ?? []}
+        onClose={() => setMergeTarget(null)}
+      />
+      <SplitDialog
+        source={splitTarget}
+        onClose={() => setSplitTarget(null)}
+      />
+    </div>
+  );
+}
+
+interface MergeDialogProps {
+  source: NormalizedDescription | null;
+  candidates: NormalizedDescription[];
+  onClose: () => void;
+}
+
+function MergeDialog({ source, candidates, onClose }: MergeDialogProps) {
+  const merge = useMergeMutation();
+  const [targetId, setTargetId] = useState<string | undefined>();
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const list = candidates.filter((c) => c.id !== source?.id);
+    if (!q) return list.slice(0, 50);
+    return list
+      .filter((c) => c.canonicalName.toLowerCase().includes(q))
+      .slice(0, 50);
+  }, [candidates, search, source?.id]);
+
+  function handleClose() {
+    setTargetId(undefined);
+    setSearch("");
+    onClose();
+  }
+
+  function handleConfirm() {
+    if (!source || !targetId) return;
+    merge.mutate(
+      { id: targetId, discardId: source.id },
+      { onSuccess: () => handleClose() },
+    );
+  }
+
+  return (
+    <Dialog
+      open={source !== null}
+      onOpenChange={(open) => {
+        if (!open) handleClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Merge Into Active Entry</DialogTitle>
+          <DialogDescription>
+            Pick the canonical row to keep. All receipt items currently linked
+            to &quot;{source?.canonicalName}&quot; will be re-pointed at the
+            chosen row, and this pending-review entry will be deleted.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div>
+            <Label htmlFor="merge-search">Search active entries</Label>
+            <Input
+              id="merge-search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Start typing a canonical name…"
+              className="mt-1"
+            />
+          </div>
+          <div className="max-h-64 overflow-y-auto rounded border">
+            {filtered.length === 0 ? (
+              <p className="p-4 text-sm text-muted-foreground">
+                No matching active entries.
+              </p>
+            ) : (
+              <ul className="divide-y">
+                {filtered.map((c) => (
+                  <li key={c.id}>
+                    <label className="flex cursor-pointer items-center gap-2 p-2 text-sm hover:bg-muted/50">
+                      <input
+                        type="radio"
+                        name="merge-target"
+                        value={c.id}
+                        checked={targetId === c.id}
+                        onChange={() => setTargetId(c.id)}
+                      />
+                      <span className="font-medium">{c.canonicalName}</span>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={!targetId || merge.isPending}
+          >
+            {merge.isPending ? "Merging…" : "Merge"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface SplitDialogProps {
+  source: NormalizedDescription | null;
+  onClose: () => void;
+}
+
+function SplitDialog({ source, onClose }: SplitDialogProps) {
+  const split = useSplitMutation();
+  const [selectedItemId, setSelectedItemId] = useState<string | undefined>();
+  // Pull a broad page of receipt items and filter client-side by normalized
+  // description id. The list endpoint doesn't expose a dedicated filter today,
+  // so this keeps the dialog functional without requiring a new API.
+  const { data: items, isLoading } = useReceiptItems(0, 200);
+
+  const linked = useMemo(() => {
+    if (!source || !items) return [] as ReceiptItem[];
+    return (items as ReceiptItem[]).filter(
+      (i) => i.normalizedDescriptionId === source.id,
+    );
+  }, [items, source]);
+
+  function handleClose() {
+    setSelectedItemId(undefined);
+    onClose();
+  }
+
+  function handleConfirm() {
+    if (!source || !selectedItemId) return;
+    split.mutate(
+      { id: source.id, receiptItemId: selectedItemId },
+      { onSuccess: () => handleClose() },
+    );
+  }
+
+  return (
+    <Dialog
+      open={source !== null}
+      onOpenChange={(open) => {
+        if (!open) handleClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Split Out a Receipt Item</DialogTitle>
+          <DialogDescription>
+            Pick a receipt item currently linked to &quot;
+            {source?.canonicalName}&quot;. It will be detached into a brand-new
+            normalized description that keeps the item&apos;s raw description.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          {isLoading ? (
+            <Skeleton className="h-24 w-full rounded" />
+          ) : linked.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No linked receipt items found in the most recent 200 items. Split
+              from the receipt detail page if the item is older.
+            </p>
+          ) : (
+            <ul className="max-h-64 overflow-y-auto divide-y rounded border">
+              {linked.map((item) => (
+                <li key={item.id}>
+                  <label className="flex cursor-pointer items-center gap-2 p-2 text-sm hover:bg-muted/50">
+                    <input
+                      type="radio"
+                      name="split-target"
+                      value={item.id}
+                      checked={selectedItemId === item.id}
+                      onChange={() => setSelectedItemId(item.id)}
+                    />
+                    <span>{item.description}</span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={!selectedItemId || split.isPending}
+          >
+            {split.isPending ? "Splitting…" : "Split"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RegistryTab() {
+  const { data, isLoading, isError } = useNormalizedDescriptions("Active");
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    const items = data?.items ?? [];
+    const q = search.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((i) => i.canonicalName.toLowerCase().includes(q));
+  }, [data?.items, search]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">Failed to load registry.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-end gap-4">
+        <div className="flex-1 max-w-md">
+          <Label htmlFor="registry-search">Search</Label>
+          <Input
+            id="registry-search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Filter by canonical name…"
+            className="mt-1"
+          />
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-muted-foreground">Active Entries</p>
+          <p className="text-2xl font-bold">{data?.totalCount ?? 0}</p>
+        </div>
+      </div>
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border p-6 text-center">
+          <p className="text-muted-foreground">
+            {search
+              ? "No active entries match your search."
+              : "No active entries yet."}
+          </p>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Canonical Name</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell className="font-medium">
+                  {row.canonicalName}
+                </TableCell>
+                <TableCell>
+                  <span className="text-sm text-muted-foreground">
+                    {new Date(row.createdAt).toLocaleDateString()}
+                  </span>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}
+
+function SettingsTab() {
+  const settings = useSettings();
+
+  if (settings.isLoading) {
+    return <Skeleton className="h-48 w-full rounded-lg" />;
+  }
+
+  if (settings.isError || !settings.data) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">Failed to load settings.</p>
+      </div>
+    );
+  }
+
+  return (
+    <SettingsForm
+      initialAutoAccept={settings.data.autoAcceptThreshold}
+      initialPendingReview={settings.data.pendingReviewThreshold}
+    />
+  );
+}
+
+interface SettingsFormProps {
+  initialAutoAccept: number;
+  initialPendingReview: number;
+}
+
+function SettingsForm({
+  initialAutoAccept,
+  initialPendingReview,
+}: SettingsFormProps) {
+  const updateSettings = useUpdateSettingsMutation();
+  const previewImpact = usePreviewImpactMutation();
+  const testMatch = useTestMatchMutation();
+
+  const [autoAccept, setAutoAccept] = useState(() => String(initialAutoAccept));
+  const [pendingReview, setPendingReview] = useState(() =>
+    String(initialPendingReview),
+  );
+  const [testDescription, setTestDescription] = useState("");
+  const [topN, setTopN] = useState(5);
+
+  const autoVal = parseFloat(autoAccept);
+  const pendingVal = parseFloat(pendingReview);
+  const autoValid = Number.isFinite(autoVal) && autoVal >= 0 && autoVal <= 1;
+  const pendingValid =
+    Number.isFinite(pendingVal) && pendingVal >= 0 && pendingVal <= 1;
+  const orderValid = autoValid && pendingValid && pendingVal < autoVal;
+  const canSubmit = autoValid && pendingValid && orderValid;
+
+  function validationMessage() {
+    if (!autoValid || !pendingValid) {
+      return "Thresholds must be numbers between 0 and 1.";
+    }
+    if (!orderValid) {
+      return "Pending-review threshold must be strictly less than the auto-accept threshold.";
+    }
+    return null;
+  }
+
+  function handleSave() {
+    if (!canSubmit) return;
+    updateSettings.mutate({
+      autoAcceptThreshold: autoVal,
+      pendingReviewThreshold: pendingVal,
+    });
+  }
+
+  function handlePreview() {
+    if (!canSubmit) return;
+    previewImpact.mutate({
+      autoAcceptThreshold: autoVal,
+      pendingReviewThreshold: pendingVal,
+    });
+  }
+
+  function handleTest() {
+    const trimmed = testDescription.trim();
+    if (!trimmed) return;
+    testMatch.mutate({
+      description: trimmed,
+      topN,
+      autoAcceptThresholdOverride: autoValid ? autoVal : undefined,
+      pendingReviewThresholdOverride: pendingValid ? pendingVal : undefined,
+    });
+  }
+
+  const validationError = validationMessage();
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Thresholds</CardTitle>
+          <CardDescription>
+            Auto-accept is the similarity score at which the resolver re-uses an
+            existing canonical entry. Pending-review is the floor for flagging a
+            new description for admin review. Both are between 0 and 1, and
+            pending-review must be strictly less than auto-accept.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="auto-accept-input">Auto-Accept Threshold</Label>
+              <Input
+                id="auto-accept-input"
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={autoAccept}
+                onChange={(e) => setAutoAccept(e.target.value)}
+                className="mt-1"
+                aria-invalid={!autoValid}
+              />
+            </div>
+            <div>
+              <Label htmlFor="pending-review-input">
+                Pending-Review Threshold
+              </Label>
+              <Input
+                id="pending-review-input"
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={pendingReview}
+                onChange={(e) => setPendingReview(e.target.value)}
+                className="mt-1"
+                aria-invalid={!pendingValid || !orderValid}
+              />
+            </div>
+          </div>
+          {validationError && (
+            <p
+              role="alert"
+              className="text-sm text-destructive"
+              data-testid="threshold-validation-error"
+            >
+              {validationError}
+            </p>
+          )}
+          <div className="flex gap-2">
+            <Button
+              onClick={handleSave}
+              disabled={!canSubmit || updateSettings.isPending}
+            >
+              {updateSettings.isPending ? "Saving…" : "Save"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handlePreview}
+              disabled={!canSubmit || previewImpact.isPending}
+            >
+              {previewImpact.isPending ? "Computing…" : "Preview impact"}
+            </Button>
+          </div>
+          {previewImpact.data && (
+            <div
+              className="rounded border p-3 text-sm"
+              data-testid="preview-impact-panel"
+            >
+              <h3 className="font-semibold">Projected impact</h3>
+              <div className="mt-2 grid grid-cols-3 gap-4">
+                <div>
+                  <p className="text-xs text-muted-foreground">Auto-accepted</p>
+                  <p>
+                    <span>{previewImpact.data.current.autoAccepted}</span>
+                    {" \u2192 "}
+                    <strong>{previewImpact.data.proposed.autoAccepted}</strong>
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">
+                    Pending review
+                  </p>
+                  <p>
+                    <span>{previewImpact.data.current.pendingReview}</span>
+                    {" \u2192 "}
+                    <strong>{previewImpact.data.proposed.pendingReview}</strong>
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Unresolved</p>
+                  <p>
+                    <span>{previewImpact.data.current.unresolved}</span>
+                    {" \u2192 "}
+                    <strong>{previewImpact.data.proposed.unresolved}</strong>
+                  </p>
+                </div>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Auto-to-pending: {previewImpact.data.deltas.autoToPending} |
+                Pending-to-auto: {previewImpact.data.deltas.pendingToAuto} |
+                Unresolved-to-auto: {previewImpact.data.deltas.unresolvedToAuto}{" "}
+                | Unresolved-to-pending:{" "}
+                {previewImpact.data.deltas.unresolvedToPending}
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Test a Description</CardTitle>
+          <CardDescription>
+            Run any description through the classifier with the currently-edited
+            thresholds (or the live values when the inputs are blank) to see
+            which canonical rows would match.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="flex-1 min-w-[220px]">
+              <Label htmlFor="test-description-input">Description</Label>
+              <Input
+                id="test-description-input"
+                value={testDescription}
+                onChange={(e) => setTestDescription(e.target.value)}
+                placeholder="e.g. banana"
+                className="mt-1"
+              />
+            </div>
+            <div className="w-28">
+              <Label htmlFor="test-topn-input">Top N</Label>
+              <Select
+                value={String(topN)}
+                onValueChange={(v) => setTopN(Number(v))}
+              >
+                <SelectTrigger
+                  id="test-topn-input"
+                  className="mt-1 w-full"
+                  aria-label="Top N candidates"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {[3, 5, 10, 20].map((n) => (
+                    <SelectItem key={n} value={String(n)}>
+                      {n}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              onClick={handleTest}
+              disabled={!testDescription.trim() || testMatch.isPending}
+            >
+              {testMatch.isPending ? "Testing…" : "Test"}
+            </Button>
+          </div>
+          {testMatch.data && (
+            <div
+              className="rounded border p-3 text-sm"
+              data-testid="test-match-panel"
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-semibold">Simulated outcome:</span>
+                <Badge variant="secondary">
+                  {testMatch.data.simulatedOutcome}
+                </Badge>
+              </div>
+              {testMatch.data.candidates.length === 0 ? (
+                <p className="mt-2 text-muted-foreground">
+                  No candidates returned.
+                </p>
+              ) : (
+                <Table className="mt-2">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Canonical Name</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead className="text-right">Similarity</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {testMatch.data.candidates.map((c) => (
+                      <TableRow key={c.normalizedDescriptionId}>
+                        <TableCell className="font-medium">
+                          {c.canonicalName}
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              c.status === "Active" ? "default" : "secondary"
+                            }
+                          >
+                            {c.status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatDecimal(c.cosineSimilarity, 4)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/client/src/components/reports/SpendingByNormalizedDescription.test.tsx
+++ b/src/client/src/components/reports/SpendingByNormalizedDescription.test.tsx
@@ -1,0 +1,93 @@
+import { screen } from "@testing-library/react";
+import { renderWithQueryClient } from "@/test/test-utils";
+import SpendingByNormalizedDescription from "./SpendingByNormalizedDescription";
+
+vi.mock("@/hooks/useSpendingByNormalizedDescription", () => ({
+  useSpendingByNormalizedDescription: vi.fn(),
+}));
+
+vi.mock("@/components/dashboard/DateRangeSelector", () => ({
+  DateRangeSelector: () => <div data-testid="date-range-selector" />,
+}));
+
+vi.mock("@/components/charts", () => ({
+  ChartCard: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="chart-card">{children}</div>
+  ),
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+import { useSpendingByNormalizedDescription } from "@/hooks/useSpendingByNormalizedDescription";
+const mockHook = vi.mocked(useSpendingByNormalizedDescription);
+
+const sampleItems = [
+  {
+    canonicalName: "Apples",
+    totalAmount: 12.5,
+    currency: "USD",
+    itemCount: 3,
+    firstSeen: null,
+    lastSeen: null,
+  },
+  {
+    canonicalName: "Bananas",
+    totalAmount: 40,
+    currency: "USD",
+    itemCount: 5,
+    firstSeen: null,
+    lastSeen: null,
+  },
+];
+
+function setupMock(overrides: Record<string, unknown> = {}) {
+  mockHook.mockReturnValue({
+    data: { items: sampleItems },
+    isLoading: false,
+    isError: false,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+describe("SpendingByNormalizedDescription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton", () => {
+    setupMock({ isLoading: true, data: undefined });
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    const skeletons = document.querySelectorAll("[data-slot='skeleton']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state", () => {
+    setupMock({ isError: true, data: undefined });
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    expect(
+      screen.getByText(/failed to load spending by normalized description/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no items", () => {
+    setupMock({ data: { items: [] } });
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    expect(screen.getByText("No Data")).toBeInTheDocument();
+  });
+
+  it("renders items sorted by total desc", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    const table = screen.getByRole("table");
+    const rows = table.querySelectorAll("tbody tr");
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent).toContain("Bananas");
+    expect(rows[1].textContent).toContain("Apples");
+  });
+
+  it("formats totals as currency and sums grand total", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    expect(screen.getByText("$52.50")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/reports/SpendingByNormalizedDescription.tsx
+++ b/src/client/src/components/reports/SpendingByNormalizedDescription.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useMemo, useState } from "react";
+import { format, subMonths } from "date-fns";
+import { useSpendingByNormalizedDescription } from "@/hooks/useSpendingByNormalizedDescription";
+import { formatCurrency } from "@/lib/format";
+import { DateRangeSelector } from "@/components/dashboard/DateRangeSelector";
+import type { DateRange } from "@/hooks/useDashboard";
+import { ChartCard, BarChart } from "@/components/charts";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function getDefaultRange(): DateRange {
+  const now = new Date();
+  return {
+    startDate: format(subMonths(now, 1), "yyyy-MM-dd"),
+    endDate: format(now, "yyyy-MM-dd"),
+  };
+}
+
+export default function SpendingByNormalizedDescription() {
+  const [dateRange, setDateRange] = useState<DateRange>(getDefaultRange);
+
+  const handleDateRangeChange = useCallback((range: DateRange) => {
+    setDateRange(range);
+  }, []);
+
+  const { data, isLoading, isError } = useSpendingByNormalizedDescription({
+    from: dateRange.startDate,
+    to: dateRange.endDate,
+  });
+
+  const sorted = useMemo(() => {
+    const items = data?.items ?? [];
+    return [...items].sort((a, b) => (b.totalAmount ?? 0) - (a.totalAmount ?? 0));
+  }, [data?.items]);
+
+  const grandTotal = useMemo(
+    () => sorted.reduce((sum, item) => sum + (item.totalAmount ?? 0), 0),
+    [sorted],
+  );
+
+  const chartData = useMemo(
+    () =>
+      sorted.slice(0, 10).map((item) => ({
+        name: item.canonicalName,
+        value: Number(item.totalAmount ?? 0),
+      })),
+    [sorted],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-full rounded-lg" />
+        <Skeleton className="h-20 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">
+          Failed to load spending by normalized description report.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data || sorted.length === 0) {
+    return (
+      <div className="space-y-4">
+        <div className="flex justify-end">
+          <DateRangeSelector
+            value={dateRange}
+            onChange={handleDateRangeChange}
+          />
+        </div>
+        <div className="rounded-lg border p-6 text-center">
+          <h2 className="text-lg font-semibold">No Data</h2>
+          <p className="mt-2 text-muted-foreground">
+            No spending data found for the selected date range.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex gap-6">
+          <div>
+            <p className="text-sm text-muted-foreground">Descriptions</p>
+            <p className="text-2xl font-bold">{sorted.length}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Total Spending</p>
+            <p className="text-2xl font-bold">{formatCurrency(grandTotal)}</p>
+          </div>
+        </div>
+        <DateRangeSelector
+          value={dateRange}
+          onChange={handleDateRangeChange}
+        />
+      </div>
+
+      <ChartCard
+        title="Top Normalized Descriptions by Spending"
+        empty={chartData.length === 0}
+      >
+        <BarChart
+          data={chartData}
+          layout="horizontal"
+          height={Math.max(200, chartData.length * 40)}
+          formatValue={formatCurrency}
+        />
+      </ChartCard>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Canonical Name</TableHead>
+            <TableHead className="text-right">Items</TableHead>
+            <TableHead className="text-right">Total</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map((item) => (
+            <TableRow key={item.canonicalName}>
+              <TableCell className="font-medium">
+                {item.canonicalName}
+              </TableCell>
+              <TableCell className="text-right">{item.itemCount}</TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(Number(item.totalAmount ?? 0))}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/client/src/hooks/useNormalizedDescriptionActions.test.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionActions.test.ts
@@ -1,0 +1,158 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import {
+  useMergeMutation,
+  useSplitMutation,
+  useUpdateStatusMutation,
+} from "./useNormalizedDescriptionActions";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    POST: vi.fn(),
+    PATCH: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useMergeMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("merges with path and body", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: { itemsRelinkedCount: 4 },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useMergeMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({ id: "keep-1", discardId: "drop-1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/{id}/merge",
+      {
+        params: { path: { id: "keep-1" } },
+        body: { discardId: "drop-1" },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: undefined,
+      error: { message: "nope" },
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { result } = renderHook(() => useMergeMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+    result.current.mutate({ id: "a", discardId: "b" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useSplitMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("splits with path and body", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: {
+        id: "new-id",
+        canonicalName: "Banana",
+        status: "active",
+        createdAt: "2025-01-01T00:00:00Z",
+      },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSplitMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({ id: "src-1", receiptItemId: "item-1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/{id}/split",
+      {
+        params: { path: { id: "src-1" } },
+        body: { receiptItemId: "item-1" },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: undefined,
+      error: { message: "nope" },
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { result } = renderHook(() => useSplitMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+    result.current.mutate({ id: "a", receiptItemId: "b" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useUpdateStatusMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("patches with status", async () => {
+    mockClient.PATCH.mockResolvedValue({
+      data: undefined,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useUpdateStatusMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({ id: "n-1", status: "active" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.PATCH).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/{id}/status",
+      {
+        params: { path: { id: "n-1" } },
+        body: { status: "active" },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    mockClient.PATCH.mockResolvedValue({
+      data: undefined,
+      error: { message: "nope" },
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { result } = renderHook(() => useUpdateStatusMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+    result.current.mutate({ id: "a", status: "pendingReview" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/client/src/hooks/useNormalizedDescriptionActions.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionActions.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+import { toast } from "sonner";
+import type { components } from "@/generated/api";
+
+type NormalizedDescriptionStatus =
+  components["schemas"]["NormalizedDescriptionStatus"];
+
+export function useMergeMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      discardId,
+    }: {
+      id: string;
+      discardId: string;
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/normalized-descriptions/{id}/merge",
+        {
+          params: { path: { id } },
+          body: { discardId },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["normalized-descriptions"] });
+      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
+      const count = data?.itemsRelinkedCount ?? 0;
+      if (count > 0) {
+        toast.success(`Merged — ${count} items re-linked`);
+      } else {
+        toast.success("Merge completed");
+      }
+    },
+    onError: () => {
+      toast.error("Failed to merge normalized descriptions");
+    },
+  });
+}
+
+export function useSplitMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      receiptItemId,
+    }: {
+      id: string;
+      receiptItemId: string;
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/normalized-descriptions/{id}/split",
+        {
+          params: { path: { id } },
+          body: { receiptItemId },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["normalized-descriptions"] });
+      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
+      toast.success("Receipt item split into a new normalized description");
+    },
+    onError: () => {
+      toast.error("Failed to split normalized description");
+    },
+  });
+}
+
+export function useUpdateStatusMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      status,
+    }: {
+      id: string;
+      status: NormalizedDescriptionStatus;
+    }) => {
+      const { error } = await client.PATCH(
+        "/api/normalized-descriptions/{id}/status",
+        {
+          params: { path: { id } },
+          body: { status },
+        },
+      );
+      if (error) throw error;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["normalized-descriptions"] });
+      toast.success(
+        variables.status === "active"
+          ? "Approved as active"
+          : "Moved to pending review",
+      );
+    },
+    onError: () => {
+      toast.error("Failed to update status");
+    },
+  });
+}

--- a/src/client/src/hooks/useNormalizedDescriptionSettings.test.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionSettings.test.ts
@@ -1,0 +1,222 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import {
+  useSettings,
+  useUpdateSettingsMutation,
+  useTestMatchMutation,
+  usePreviewImpactMutation,
+} from "./useNormalizedDescriptionSettings";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PATCH: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches live settings", async () => {
+    const mockData = {
+      id: "00000000-0000-0000-0000-000000000001",
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.75,
+      updatedAt: "2025-01-01T00:00:00Z",
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSettings(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/settings",
+    );
+  });
+});
+
+describe("useUpdateSettingsMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("patches settings with thresholds", async () => {
+    mockClient.PATCH.mockResolvedValue({
+      data: {
+        id: "n-1",
+        autoAcceptThreshold: 0.95,
+        pendingReviewThreshold: 0.7,
+        updatedAt: "2025-01-01T00:00:00Z",
+      },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useUpdateSettingsMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({
+      autoAcceptThreshold: 0.95,
+      pendingReviewThreshold: 0.7,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.PATCH).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/settings",
+      {
+        body: {
+          autoAcceptThreshold: 0.95,
+          pendingReviewThreshold: 0.7,
+        },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    mockClient.PATCH.mockResolvedValue({
+      data: undefined,
+      error: { message: "nope" },
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { result } = renderHook(() => useUpdateSettingsMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+    result.current.mutate({
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.7,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useTestMatchMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts test description with defaults", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: { candidates: [], simulatedOutcome: "CreateNew" },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useTestMatchMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({ description: "apples" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/test",
+      {
+        body: {
+          description: "apples",
+          topN: 5,
+          autoAcceptThresholdOverride: undefined,
+          pendingReviewThresholdOverride: undefined,
+        },
+      },
+    );
+  });
+
+  it("passes overrides", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: { candidates: [], simulatedOutcome: "AutoAccept" },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useTestMatchMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({
+      description: "apples",
+      topN: 10,
+      autoAcceptThresholdOverride: 0.8,
+      pendingReviewThresholdOverride: 0.6,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/test",
+      {
+        body: {
+          description: "apples",
+          topN: 10,
+          autoAcceptThresholdOverride: 0.8,
+          pendingReviewThresholdOverride: 0.6,
+        },
+      },
+    );
+  });
+});
+
+describe("usePreviewImpactMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts threshold preview", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: {
+        current: { autoAccepted: 1, pendingReview: 2, unresolved: 3 },
+        proposed: { autoAccepted: 2, pendingReview: 2, unresolved: 2 },
+        deltas: {
+          autoToPending: 0,
+          pendingToAuto: 1,
+          unresolvedToAuto: 0,
+          unresolvedToPending: 0,
+        },
+      },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => usePreviewImpactMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.7,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/settings/preview",
+      {
+        body: {
+          autoAcceptThreshold: 0.9,
+          pendingReviewThreshold: 0.7,
+        },
+      },
+    );
+  });
+});

--- a/src/client/src/hooks/useNormalizedDescriptionSettings.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionSettings.ts
@@ -1,0 +1,106 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+import { toast } from "sonner";
+
+export function useSettings() {
+  return useQuery({
+    queryKey: ["normalized-descriptions", "settings"],
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/normalized-descriptions/settings",
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useUpdateSettingsMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      autoAcceptThreshold,
+      pendingReviewThreshold,
+    }: {
+      autoAcceptThreshold: number;
+      pendingReviewThreshold: number;
+    }) => {
+      const { data, error } = await client.PATCH(
+        "/api/normalized-descriptions/settings",
+        {
+          body: { autoAcceptThreshold, pendingReviewThreshold },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["normalized-descriptions", "settings"],
+      });
+      toast.success("Settings saved");
+    },
+    onError: () => {
+      toast.error("Failed to save settings");
+    },
+  });
+}
+
+export function useTestMatchMutation() {
+  return useMutation({
+    mutationFn: async ({
+      description,
+      topN = 5,
+      autoAcceptThresholdOverride,
+      pendingReviewThresholdOverride,
+    }: {
+      description: string;
+      topN?: number;
+      autoAcceptThresholdOverride?: number | null;
+      pendingReviewThresholdOverride?: number | null;
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/normalized-descriptions/test",
+        {
+          body: {
+            description,
+            topN,
+            autoAcceptThresholdOverride:
+              autoAcceptThresholdOverride ?? undefined,
+            pendingReviewThresholdOverride:
+              pendingReviewThresholdOverride ?? undefined,
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onError: () => {
+      toast.error("Failed to test description");
+    },
+  });
+}
+
+export function usePreviewImpactMutation() {
+  return useMutation({
+    mutationFn: async ({
+      autoAcceptThreshold,
+      pendingReviewThreshold,
+    }: {
+      autoAcceptThreshold: number;
+      pendingReviewThreshold: number;
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/normalized-descriptions/settings/preview",
+        {
+          body: { autoAcceptThreshold, pendingReviewThreshold },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onError: () => {
+      toast.error("Failed to preview impact");
+    },
+  });
+}

--- a/src/client/src/hooks/useNormalizedDescriptions.test.ts
+++ b/src/client/src/hooks/useNormalizedDescriptions.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import {
+  useNormalizedDescriptions,
+  useNormalizedDescription,
+} from "./useNormalizedDescriptions";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useNormalizedDescriptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches list with no filter", async () => {
+    const mockData = {
+      items: [
+        {
+          id: "n-1",
+          canonicalName: "Apples",
+          status: "active",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      ],
+      totalCount: 1,
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useNormalizedDescriptions(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/normalized-descriptions",
+      { params: { query: { status: undefined } } },
+    );
+  });
+
+  it("fetches list with PendingReview filter", async () => {
+    mockClient.GET.mockResolvedValue({
+      data: { items: [], totalCount: 0 },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () => useNormalizedDescriptions("PendingReview"),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/normalized-descriptions",
+      { params: { query: { status: "PendingReview" } } },
+    );
+  });
+
+  it("propagates API errors", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useNormalizedDescriptions(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});
+
+describe("useNormalizedDescription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not fetch when id is null", () => {
+    const { result } = renderHook(() => useNormalizedDescription(null), {
+      wrapper: createQueryWrapper(),
+    });
+    expect(result.current.isPending).toBe(true);
+    expect(mockClient.GET).not.toHaveBeenCalled();
+  });
+
+  it("fetches by id", async () => {
+    const mockData = {
+      id: "n-1",
+      canonicalName: "Apples",
+      status: "active",
+      createdAt: "2025-01-01T00:00:00Z",
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useNormalizedDescription("n-1"), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/{id}",
+      { params: { path: { id: "n-1" } } },
+    );
+  });
+});

--- a/src/client/src/hooks/useNormalizedDescriptions.ts
+++ b/src/client/src/hooks/useNormalizedDescriptions.ts
@@ -1,0 +1,35 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export type NormalizedDescriptionStatusFilter = "Active" | "PendingReview";
+
+export function useNormalizedDescriptions(
+  statusFilter?: NormalizedDescriptionStatusFilter,
+) {
+  return useQuery({
+    queryKey: ["normalized-descriptions", "list", statusFilter],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/normalized-descriptions", {
+        params: { query: { status: statusFilter } },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useNormalizedDescription(id: string | null) {
+  return useQuery({
+    queryKey: ["normalized-descriptions", id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/normalized-descriptions/{id}",
+        { params: { path: { id: id! } } },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/src/client/src/hooks/useSpendingByNormalizedDescription.test.ts
+++ b/src/client/src/hooks/useSpendingByNormalizedDescription.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import { useSpendingByNormalizedDescription } from "./useSpendingByNormalizedDescription";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useSpendingByNormalizedDescription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches report with no params", async () => {
+    const mockData = { items: [] };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSpendingByNormalizedDescription(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/spending-by-normalized-description",
+      {
+        params: {
+          query: {
+            from: undefined,
+            to: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("passes from/to params", async () => {
+    mockClient.GET.mockResolvedValue({
+      data: { items: [] },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useSpendingByNormalizedDescription({
+          from: "2025-01-01",
+          to: "2025-12-31",
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/spending-by-normalized-description",
+      {
+        params: {
+          query: {
+            from: "2025-01-01",
+            to: "2025-12-31",
+          },
+        },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSpendingByNormalizedDescription(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/src/client/src/hooks/useSpendingByNormalizedDescription.ts
+++ b/src/client/src/hooks/useSpendingByNormalizedDescription.ts
@@ -1,0 +1,36 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export interface SpendingByNormalizedDescriptionParams {
+  from?: string;
+  to?: string;
+}
+
+export function useSpendingByNormalizedDescription(
+  params: SpendingByNormalizedDescriptionParams = {},
+) {
+  return useQuery({
+    queryKey: [
+      "reports",
+      "spending-by-normalized-description",
+      params.from,
+      params.to,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/reports/spending-by-normalized-description",
+        {
+          params: {
+            query: {
+              from: params.from,
+              to: params.to,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/src/client/src/pages/Reports.test.tsx
+++ b/src/client/src/pages/Reports.test.tsx
@@ -1,6 +1,24 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@/test/test-utils";
 import Reports, { REPORTS, DEFAULT_REPORT } from "./Reports";
+
+// jsdom polyfills required by Radix UI Select (used for the report picker).
+beforeAll(() => {
+  if (
+    !(Element.prototype as unknown as { hasPointerCapture?: unknown })
+      .hasPointerCapture
+  ) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.releasePointerCapture = () => {};
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (
+    !(Element.prototype as unknown as { scrollIntoView?: unknown }).scrollIntoView
+  ) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
 
 vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
@@ -46,7 +64,40 @@ vi.mock("@/components/reports/UncategorizedItems", () => ({
   ),
 }));
 
+vi.mock("@/components/reports/SpendingByNormalizedDescription", () => ({
+  default: () => (
+    <div data-testid="report-spending-by-normalized-description">
+      Spending by Normalized Description
+    </div>
+  ),
+}));
+
+vi.mock("@/components/reports/NormalizedDescriptions", () => ({
+  default: () => (
+    <div data-testid="report-normalized-descriptions">
+      Normalized Descriptions
+    </div>
+  ),
+}));
+
+vi.mock("@/hooks/usePermission", () => ({
+  usePermission: vi.fn(() => ({
+    roles: ["User"],
+    hasRole: (role: string) => role === "User",
+    isAdmin: () => false,
+  })),
+}));
+
 describe("Reports", () => {
+  beforeEach(async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["User"],
+      hasRole: (role: string) => role === "User",
+      isAdmin: () => false,
+    });
+  });
+
   it("renders the page heading", () => {
     renderWithProviders(<Reports />, { route: "/reports" });
     expect(
@@ -104,10 +155,43 @@ describe("Reports", () => {
   });
 
   it("exports REPORTS config with correct number of reports", () => {
-    expect(REPORTS).toHaveLength(7);
+    expect(REPORTS).toHaveLength(9);
   });
 
   it("exports DEFAULT_REPORT as out-of-balance", () => {
     expect(DEFAULT_REPORT).toBe("out-of-balance");
+  });
+
+  it("hides admin-only reports for non-admin users", async () => {
+    renderWithProviders(<Reports />, { route: "/reports" });
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+    expect(
+      screen.queryByRole("option", { name: /normalized descriptions/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows admin-only reports for admin users", async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: (role: string) => role === "Admin",
+      isAdmin: () => true,
+    });
+    renderWithProviders(<Reports />, { route: "/reports" });
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+    expect(
+      screen.getByRole("option", { name: /normalized descriptions/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to default when admin-only slug is used by non-admin", async () => {
+    renderWithProviders(<Reports />, {
+      route: "/reports?report=normalized-descriptions",
+    });
+    expect(
+      await screen.findByTestId("report-out-of-balance"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/client/src/pages/Reports.tsx
+++ b/src/client/src/pages/Reports.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { usePermission } from "@/hooks/usePermission";
 import {
   Select,
   SelectContent,
@@ -14,6 +15,7 @@ interface ReportConfig {
   slug: string;
   name: string;
   component: React.LazyExoticComponent<React.ComponentType>;
+  adminOnly?: boolean;
 }
 
 const REPORTS: ReportConfig[] = [
@@ -38,6 +40,13 @@ const REPORTS: ReportConfig[] = [
     component: lazy(() => import("@/components/reports/SpendingByLocation")),
   },
   {
+    slug: "spending-by-normalized-description",
+    name: "Spending by Normalized Description",
+    component: lazy(
+      () => import("@/components/reports/SpendingByNormalizedDescription"),
+    ),
+  },
+  {
     slug: "category-trends",
     name: "Category Trends",
     component: lazy(() => import("@/components/reports/CategoryTrends")),
@@ -52,10 +61,15 @@ const REPORTS: ReportConfig[] = [
     name: "Uncategorized Items",
     component: lazy(() => import("@/components/reports/UncategorizedItems")),
   },
+  {
+    slug: "normalized-descriptions",
+    name: "Normalized Descriptions",
+    component: lazy(() => import("@/components/reports/NormalizedDescriptions")),
+    adminOnly: true,
+  },
 ];
 
 const DEFAULT_REPORT = REPORTS[0].slug;
-const VALID_SLUGS = new Set(REPORTS.map((r) => r.slug));
 
 function ReportFallback() {
   return <Skeleton className="h-32 w-full rounded-lg" />;
@@ -63,13 +77,25 @@ function ReportFallback() {
 
 function Reports() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { isAdmin } = usePermission();
+
+  const availableReports = useMemo(
+    () => REPORTS.filter((r) => !r.adminOnly || isAdmin()),
+    [isAdmin],
+  );
+  const validSlugs = useMemo(
+    () => new Set(availableReports.map((r) => r.slug)),
+    [availableReports],
+  );
+
   const rawReport = searchParams.get("report");
   const activeSlug =
-    rawReport && VALID_SLUGS.has(rawReport) ? rawReport : DEFAULT_REPORT;
+    rawReport && validSlugs.has(rawReport) ? rawReport : DEFAULT_REPORT;
 
   const activeReport = useMemo(
-    () => REPORTS.find((r) => r.slug === activeSlug)!,
-    [activeSlug],
+    () =>
+      availableReports.find((r) => r.slug === activeSlug) ?? availableReports[0],
+    [activeSlug, availableReports],
   );
 
   usePageTitle(`Reports - ${activeReport.name}`);
@@ -85,12 +111,12 @@ function Reports() {
     <div className="space-y-6">
       <div className="flex items-center gap-4">
         <h1 className="text-2xl font-bold tracking-tight">Reports</h1>
-        <Select value={activeSlug} onValueChange={handleReportChange}>
-          <SelectTrigger className="w-[220px]" aria-label="Select report">
+        <Select value={activeReport.slug} onValueChange={handleReportChange}>
+          <SelectTrigger className="w-[260px]" aria-label="Select report">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {REPORTS.map((report) => (
+            {availableReports.map((report) => (
               <SelectItem key={report.slug} value={report.slug}>
                 {report.name}
               </SelectItem>


### PR DESCRIPTION
## Summary

Final piece of the [RECEIPTS-576](https://plane.wallingford.me/dev/browse/RECEIPTS-576/) epic. Adds the admin-facing React UI: Review Queue + Registry + Settings (threshold form with preview-impact and test-description tools), plus a spending-by-normalized-description chart report.

- Page: `/reports?report=normalized-descriptions` (admin-only)
- Also new: `/reports?report=spending-by-normalized-description` (all authenticated users)
- 4 hooks wrapping the API, 2 components, 44 new tests
- Admin gating at the Reports.tsx selector level (not just component level) so non-admins never see the entry

## Test plan

- [x] 44 new tests across 6 new files + 3 in Reports.test.tsx
- [x] Full client suite: 1,963 passed, 0 failed
- [x] `npx tsc --noEmit` clean, `npm run lint` clean
- [ ] CI: full suite
- [ ] Manual: spot-check the UI in dev (QA would exercise these paths; leaving for post-merge smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)