### PR TITLE
feat: normalized description registry epic (RECEIPTS-576)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -6513,6 +6513,17 @@ components:
         pricingMode:
           type: string
           description: "Pricing mode: 'quantity' (qty x unit price) or 'flat' (single flat price)"
+        normalizedDescriptionId:
+          type: ["string", "null"]
+          format: uuid
+          description: "FK to the canonical NormalizedDescription. Null until the resolver links this item."
+        normalizedDescriptionName:
+          type: ["string", "null"]
+          description: "Denormalized CanonicalName from the linked NormalizedDescription for display."
+        normalizedDescriptionMatchScore:
+          type: ["number", "null"]
+          format: double
+          description: "Cosine similarity captured when the resolver linked this item; null for unresolved or no-match-created items."
 
     ReceiptItemListResponse:
       type: object

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -1322,6 +1322,124 @@ paths:
           description: Not Found
 
   # ──────────────────────────────────────────────
+  # Normalized Descriptions (admin-only)
+  # ──────────────────────────────────────────────
+
+  /api/normalized-descriptions/settings:
+    get:
+      operationId: GetNormalizedDescriptionSettings
+      tags: [NormalizedDescriptions]
+      summary: Get the current normalized-description threshold settings
+      description: |
+        Returns the live auto-accept and pending-review thresholds used by the
+        resolver when classifying new receipt item descriptions. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionSettingsResponse"
+    patch:
+      operationId: UpdateNormalizedDescriptionSettings
+      tags: [NormalizedDescriptions]
+      summary: Update the normalized-description threshold settings
+      description: |
+        Updates the auto-accept and pending-review thresholds. Both values must
+        satisfy `0 <= pendingReviewThreshold < autoAcceptThreshold <= 1`. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateNormalizedDescriptionSettingsRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionSettingsResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/normalized-descriptions/settings/preview:
+    post:
+      operationId: PreviewNormalizedDescriptionThresholdImpact
+      tags: [NormalizedDescriptions]
+      summary: Preview the impact of changing threshold settings
+      description: |
+        Returns current vs. proposed classification counts (auto-accepted,
+        pending-review, unresolved) and the reclassification deltas that a
+        threshold change would produce, computed against the live
+        `NormalizedDescriptionMatchScore` column on receipt items. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PreviewThresholdImpactRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ThresholdImpactPreviewResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/normalized-descriptions/test:
+    post:
+      operationId: TestNormalizedDescriptionMatch
+      tags: [NormalizedDescriptions]
+      summary: Probe the classifier for a given description
+      description: |
+        Returns the top-N ANN candidates for the supplied description along with
+        the classification branch the production resolver would take under the
+        supplied threshold overrides (or the live DB settings when absent).
+        Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestMatchRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MatchTestResultResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  # ──────────────────────────────────────────────
   # Receipts
   # ──────────────────────────────────────────────
 
@@ -5545,6 +5663,165 @@ components:
           type: integer
           format: int32
           description: Number of similar items with this category
+
+    # ── Normalized Descriptions ──────────────────
+
+    NormalizedDescriptionSettingsResponse:
+      type: object
+      required: [id, autoAcceptThreshold, pendingReviewThreshold, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Fixed singleton identifier for the settings row.
+        autoAcceptThreshold:
+          type: number
+          format: double
+          description: Cosine-similarity floor at which the resolver re-uses an existing canonical entry.
+        pendingReviewThreshold:
+          type: number
+          format: double
+          description: Cosine-similarity floor at which the resolver creates a PendingReview entry instead of a new Active one.
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the settings were last changed.
+
+    UpdateNormalizedDescriptionSettingsRequest:
+      type: object
+      required: [autoAcceptThreshold, pendingReviewThreshold]
+      properties:
+        autoAcceptThreshold:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+        pendingReviewThreshold:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+
+    TestMatchRequest:
+      type: object
+      required: [description]
+      properties:
+        description:
+          type: string
+          minLength: 1
+          description: Description to classify. Must be non-empty after trim.
+        topN:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 20
+          default: 5
+          description: Number of ANN candidates to return (ranked by cosine similarity).
+        autoAcceptThresholdOverride:
+          type: ["number", "null"]
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+          description: Override the live auto-accept threshold for simulation. Falls back to DB settings when null.
+        pendingReviewThresholdOverride:
+          type: ["number", "null"]
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+          description: Override the live pending-review threshold for simulation. Falls back to DB settings when null.
+
+    MatchTestResultResponse:
+      type: object
+      required: [candidates, simulatedOutcome]
+      properties:
+        candidates:
+          type: array
+          items:
+            $ref: "#/components/schemas/MatchCandidateDto"
+        simulatedOutcome:
+          type: string
+          description: "One of: AutoAccept, PendingReview, CreateNew, EmbeddingUnavailable."
+        simulatedTargetId:
+          type: ["string", "null"]
+          format: uuid
+          description: ID of the normalized-description row the resolver would reuse (AutoAccept) or null for CreateNew / PendingReview / EmbeddingUnavailable.
+
+    MatchCandidateDto:
+      type: object
+      required: [normalizedDescriptionId, canonicalName, cosineSimilarity, status]
+      properties:
+        normalizedDescriptionId:
+          type: string
+          format: uuid
+        canonicalName:
+          type: string
+        cosineSimilarity:
+          type: number
+          format: double
+        status:
+          type: string
+          description: "Active or PendingReview."
+
+    PreviewThresholdImpactRequest:
+      type: object
+      required: [autoAcceptThreshold, pendingReviewThreshold]
+      properties:
+        autoAcceptThreshold:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+        pendingReviewThreshold:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+
+    ThresholdImpactPreviewResponse:
+      type: object
+      required: [current, proposed, deltas]
+      properties:
+        current:
+          $ref: "#/components/schemas/ClassificationCountsDto"
+        proposed:
+          $ref: "#/components/schemas/ClassificationCountsDto"
+        deltas:
+          $ref: "#/components/schemas/ReclassificationDeltasDto"
+
+    ClassificationCountsDto:
+      type: object
+      required: [autoAccepted, pendingReview, unresolved]
+      properties:
+        autoAccepted:
+          type: integer
+          format: int32
+        pendingReview:
+          type: integer
+          format: int32
+        unresolved:
+          type: integer
+          format: int32
+
+    ReclassificationDeltasDto:
+      type: object
+      required: [autoToPending, pendingToAuto, unresolvedToAuto, unresolvedToPending]
+      properties:
+        autoToPending:
+          type: integer
+          format: int32
+          description: Items currently auto-accepted that would fall back to pending-review under the proposal.
+        pendingToAuto:
+          type: integer
+          format: int32
+          description: Items currently pending-review that would be auto-accepted under the proposal.
+        unresolvedToAuto:
+          type: integer
+          format: int32
+          description: Items currently unresolved (below pending-review threshold) that would be auto-accepted under the proposal.
+        unresolvedToPending:
+          type: integer
+          format: int32
+          description: Items currently unresolved (below pending-review threshold) that would move up to pending-review under the proposal.
 
     # ── Receipt ──────────────────────────────────
 

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -4071,6 +4071,46 @@ paths:
                 type: string
 
   # ──────────────────────────────────────────────
+
+  /api/reports/spending-by-normalized-description:
+    get:
+      operationId: GetSpendingByNormalizedDescriptionReport
+      tags: [Reports]
+      summary: Get spending by normalized description report
+      description: Aggregates receipt item spending grouped by normalized description canonical name. Items without a normalized description bucket into a synthetic "(Not Normalized)" group.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: from
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Inclusive lower bound on receipt date (ISO 8601 date-time string). Defaults to all time when omitted.
+        - name: to
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Inclusive upper bound on receipt date (ISO 8601 date-time string). Defaults to all time when omitted.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpendingByNormalizedDescriptionResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  # ──────────────────────────────────────────────
   # Dashboard
   # ──────────────────────────────────────────────
 
@@ -5203,6 +5243,50 @@ components:
           type: ["string", "null"]
         pricingMode:
           type: string
+
+    SpendingByNormalizedDescriptionResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SpendingByNormalizedDescriptionItem"
+        fromDate:
+          type: ["string", "null"]
+          format: date-time
+          description: Inclusive lower bound on receipt date, echoed from the request.
+        toDate:
+          type: ["string", "null"]
+          format: date-time
+          description: Inclusive upper bound on receipt date, echoed from the request.
+
+    SpendingByNormalizedDescriptionItem:
+      type: object
+      required: [canonicalName, totalAmount, currency, itemCount]
+      properties:
+        canonicalName:
+          type: string
+          description: Canonical name of the normalized description, or "(Not Normalized)" for receipt items without a normalized description.
+        totalAmount:
+          type: number
+          format: double
+          description: Sum of ReceiptItem.TotalAmount for items in this bucket.
+        currency:
+          type: string
+          description: Dominant currency across the items in this bucket.
+        itemCount:
+          type: integer
+          format: int32
+          description: Number of receipt items in this bucket.
+        firstSeen:
+          type: ["string", "null"]
+          format: date-time
+          description: Earliest receipt date among items in this bucket.
+        lastSeen:
+          type: ["string", "null"]
+          format: date-time
+          description: Latest receipt date among items in this bucket.
 
     # ── Dashboard ──────────────────────────────────
 

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -1439,6 +1439,193 @@ paths:
               schema:
                 type: string
 
+  /api/normalized-descriptions:
+    get:
+      operationId: GetAllNormalizedDescriptions
+      tags: [NormalizedDescriptions]
+      summary: List normalized descriptions
+      description: |
+        Returns all canonical normalized-description rows, optionally filtered by
+        status. Not paginated — the row count is bounded by the number of unique
+        receipt-item descriptions ever seen. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [Active, PendingReview]
+          description: Optional status filter. When absent, returns rows of both statuses. Matching is case-insensitive.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionListResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/normalized-descriptions/{id}:
+    get:
+      operationId: GetNormalizedDescriptionById
+      tags: [NormalizedDescriptions]
+      summary: Get a normalized description by ID
+      description: Returns a single canonical normalized-description row by GUID. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "404":
+          description: Not Found
+
+  /api/normalized-descriptions/{id}/merge:
+    post:
+      operationId: MergeNormalizedDescriptions
+      tags: [NormalizedDescriptions]
+      summary: Merge two normalized descriptions
+      description: |
+        Re-links every ReceiptItem currently pointing at `discardId` to the
+        canonical row identified by the path `{id}` ("keep"), then deletes the
+        discarded row. Returns the count of re-linked items — zero when either
+        id was missing or the two ids were identical. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the canonical row to keep (all items from `discardId` move here).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MergeNormalizedDescriptionRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MergeNormalizedDescriptionsResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/normalized-descriptions/{id}/split:
+    post:
+      operationId: SplitNormalizedDescription
+      tags: [NormalizedDescriptions]
+      summary: Detach a receipt item from its normalized description
+      description: |
+        Creates a new canonical row for the supplied ReceiptItem's raw description
+        and re-points the item at it. Used to unpick bad auto-merges. The path
+        `{id}` is the current NormalizedDescription the item is being split away
+        from; the body identifies the specific ReceiptItem to isolate. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the NormalizedDescription the item is being split away from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SplitNormalizedDescriptionRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NormalizedDescriptionResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+
+  /api/normalized-descriptions/{id}/status:
+    patch:
+      operationId: UpdateNormalizedDescriptionStatus
+      tags: [NormalizedDescriptions]
+      summary: Update the status of a normalized description
+      description: |
+        Flips a NormalizedDescription between Active and PendingReview. Returns
+        204 when the status was changed and 404 when the row does not exist or
+        already has the requested status. Admin-only.
+      security:
+        - BearerAuth: []
+        - ApiKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateNormalizedDescriptionStatusRequest"
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+
   # ──────────────────────────────────────────────
   # Receipts
   # ──────────────────────────────────────────────
@@ -5822,6 +6009,74 @@ components:
           type: integer
           format: int32
           description: Items currently unresolved (below pending-review threshold) that would move up to pending-review under the proposal.
+
+    NormalizedDescriptionStatus:
+      type: string
+      enum: [active, pendingReview]
+      description: Active rows are confidently-classified and re-used as-is by the resolver; pendingReview rows are flagged for admin review before being promoted.
+
+    NormalizedDescriptionResponse:
+      type: object
+      required: [id, canonicalName, status, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        canonicalName:
+          type: string
+          description: The canonical name shared by every receipt item linked to this row.
+        status:
+          $ref: "#/components/schemas/NormalizedDescriptionStatus"
+        createdAt:
+          type: string
+          format: date-time
+
+    NormalizedDescriptionListResponse:
+      type: object
+      required: [items, totalCount]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/NormalizedDescriptionResponse"
+        totalCount:
+          type: integer
+          format: int32
+          description: Total number of rows returned. Matches the length of `items` since the endpoint is not paginated.
+
+    MergeNormalizedDescriptionRequest:
+      type: object
+      required: [discardId]
+      properties:
+        discardId:
+          type: string
+          format: uuid
+          description: ID of the NormalizedDescription to merge away. All ReceiptItems pointing at this row will be re-linked to the kept row.
+
+    SplitNormalizedDescriptionRequest:
+      type: object
+      required: [receiptItemId]
+      properties:
+        receiptItemId:
+          type: string
+          format: uuid
+          description: ID of the ReceiptItem to detach from its current NormalizedDescription.
+
+    UpdateNormalizedDescriptionStatusRequest:
+      type: object
+      required: [status]
+      properties:
+        status:
+          $ref: "#/components/schemas/NormalizedDescriptionStatus"
+
+    MergeNormalizedDescriptionsResponse:
+      type: object
+      required: [itemsRelinkedCount]
+      properties:
+        itemsRelinkedCount:
+          type: integer
+          format: int32
+          description: Number of ReceiptItems that were re-linked from the discarded row to the kept row. Zero when either id was missing or the two ids were identical.
 
     # ── Receipt ──────────────────────────────────
 

--- a/src/Application/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommand.cs
+++ b/src/Application/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommand.cs
@@ -1,0 +1,9 @@
+using Application.Interfaces;
+
+namespace Application.Commands.NormalizedDescription.Merge;
+
+// Merges two NormalizedDescription rows. All ReceiptItems currently pointing at DiscardId are
+// re-linked to KeepId, then the DiscardId row is deleted. The handler returns the count of
+// items that were actually re-linked — 0 if either id was missing or if KeepId == DiscardId,
+// which is the service contract.
+public record MergeNormalizedDescriptionsCommand(Guid KeepId, Guid DiscardId) : ICommand<int>;

--- a/src/Application/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommandHandler.cs
+++ b/src/Application/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommandHandler.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Commands.NormalizedDescription.Merge;
+
+public class MergeNormalizedDescriptionsCommandHandler(INormalizedDescriptionService service)
+	: IRequestHandler<MergeNormalizedDescriptionsCommand, int>
+{
+	public async Task<int> Handle(MergeNormalizedDescriptionsCommand request, CancellationToken cancellationToken)
+	{
+		return await service.MergeAsync(request.KeepId, request.DiscardId, cancellationToken);
+	}
+}

--- a/src/Application/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommand.cs
+++ b/src/Application/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommand.cs
@@ -1,0 +1,9 @@
+using Application.Interfaces;
+
+namespace Application.Commands.NormalizedDescription.Split;
+
+// Detaches a single ReceiptItem from its current NormalizedDescription by creating a new
+// canonical entry for the item's raw description and re-pointing the item at it. Used by
+// admins to unpick bad merges or isolate an item that was auto-classified into the wrong
+// canonical group. The service throws KeyNotFoundException if the ReceiptItem does not exist.
+public record SplitNormalizedDescriptionCommand(Guid ReceiptItemId) : ICommand<Domain.NormalizedDescriptions.NormalizedDescription>;

--- a/src/Application/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommandHandler.cs
+++ b/src/Application/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommandHandler.cs
@@ -1,0 +1,14 @@
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Commands.NormalizedDescription.Split;
+
+public class SplitNormalizedDescriptionCommandHandler(INormalizedDescriptionService service)
+	: IRequestHandler<SplitNormalizedDescriptionCommand, Domain.NormalizedDescriptions.NormalizedDescription>
+{
+	public async Task<Domain.NormalizedDescriptions.NormalizedDescription> Handle(SplitNormalizedDescriptionCommand request, CancellationToken cancellationToken)
+	{
+		return await service.SplitAsync(request.ReceiptItemId, cancellationToken);
+	}
+}

--- a/src/Application/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommand.cs
+++ b/src/Application/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommand.cs
@@ -1,0 +1,8 @@
+using Application.Interfaces;
+using Domain.NormalizedDescriptions;
+
+namespace Application.Commands.NormalizedDescription.UpdateSettings;
+
+public record UpdateNormalizedDescriptionSettingsCommand(
+	double AutoAcceptThreshold,
+	double PendingReviewThreshold) : ICommand<NormalizedDescriptionSettings>;

--- a/src/Application/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommandHandler.cs
+++ b/src/Application/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommandHandler.cs
@@ -1,0 +1,17 @@
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Commands.NormalizedDescription.UpdateSettings;
+
+public class UpdateNormalizedDescriptionSettingsCommandHandler(INormalizedDescriptionService service)
+	: IRequestHandler<UpdateNormalizedDescriptionSettingsCommand, NormalizedDescriptionSettings>
+{
+	public async Task<NormalizedDescriptionSettings> Handle(UpdateNormalizedDescriptionSettingsCommand request, CancellationToken cancellationToken)
+	{
+		return await service.UpdateSettingsAsync(
+			request.AutoAcceptThreshold,
+			request.PendingReviewThreshold,
+			cancellationToken);
+	}
+}

--- a/src/Application/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommand.cs
+++ b/src/Application/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommand.cs
@@ -1,0 +1,9 @@
+using Application.Interfaces;
+using Domain.NormalizedDescriptions;
+
+namespace Application.Commands.NormalizedDescription.UpdateStatus;
+
+// Flips a NormalizedDescription between Active and PendingReview. Returns true when the status
+// was actually changed, false when the row was missing or already had the requested status —
+// matches the service contract, and lets the controller distinguish 404 from no-op.
+public record UpdateNormalizedDescriptionStatusCommand(Guid Id, NormalizedDescriptionStatus Status) : ICommand<bool>;

--- a/src/Application/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommandHandler.cs
+++ b/src/Application/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommandHandler.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Commands.NormalizedDescription.UpdateStatus;
+
+public class UpdateNormalizedDescriptionStatusCommandHandler(INormalizedDescriptionService service)
+	: IRequestHandler<UpdateNormalizedDescriptionStatusCommand, bool>
+{
+	public async Task<bool> Handle(UpdateNormalizedDescriptionStatusCommand request, CancellationToken cancellationToken)
+	{
+		return await service.UpdateStatusAsync(request.Id, request.Status, cancellationToken);
+	}
+}

--- a/src/Application/Interfaces/Services/INormalizedDescriptionService.cs
+++ b/src/Application/Interfaces/Services/INormalizedDescriptionService.cs
@@ -1,13 +1,19 @@
+using Application.Models.NormalizedDescriptions;
 using Domain.NormalizedDescriptions;
 
 namespace Application.Interfaces.Services;
 
 public interface INormalizedDescriptionService
 {
-	Task<NormalizedDescription> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken);
+	Task<GetOrCreateResult> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken);
 	Task<NormalizedDescription?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 	Task<List<NormalizedDescription>> GetAllAsync(NormalizedDescriptionStatus? filter, CancellationToken cancellationToken);
 	Task<int> MergeAsync(Guid keepId, Guid discardId, CancellationToken cancellationToken);
 	Task<NormalizedDescription> SplitAsync(Guid receiptItemId, CancellationToken cancellationToken);
 	Task<bool> UpdateStatusAsync(Guid id, NormalizedDescriptionStatus status, CancellationToken cancellationToken);
+
+	Task<NormalizedDescriptionSettings> GetSettingsAsync(CancellationToken cancellationToken);
+	Task<NormalizedDescriptionSettings> UpdateSettingsAsync(double autoAcceptThreshold, double pendingReviewThreshold, CancellationToken cancellationToken);
+	Task<MatchTestResult> TestMatchAsync(string description, int topN, double? autoAcceptThresholdOverride, double? pendingReviewThresholdOverride, CancellationToken cancellationToken);
+	Task<ThresholdImpactPreview> PreviewThresholdImpactAsync(double autoAcceptThreshold, double pendingReviewThreshold, CancellationToken cancellationToken);
 }

--- a/src/Application/Interfaces/Services/INormalizedDescriptionService.cs
+++ b/src/Application/Interfaces/Services/INormalizedDescriptionService.cs
@@ -1,0 +1,13 @@
+using Domain.NormalizedDescriptions;
+
+namespace Application.Interfaces.Services;
+
+public interface INormalizedDescriptionService
+{
+	Task<NormalizedDescription> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken);
+	Task<NormalizedDescription?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+	Task<List<NormalizedDescription>> GetAllAsync(NormalizedDescriptionStatus? filter, CancellationToken cancellationToken);
+	Task<int> MergeAsync(Guid keepId, Guid discardId, CancellationToken cancellationToken);
+	Task<NormalizedDescription> SplitAsync(Guid receiptItemId, CancellationToken cancellationToken);
+	Task<bool> UpdateStatusAsync(Guid id, NormalizedDescriptionStatus status, CancellationToken cancellationToken);
+}

--- a/src/Application/Interfaces/Services/IReportService.cs
+++ b/src/Application/Interfaces/Services/IReportService.cs
@@ -66,4 +66,9 @@ public interface IReportService
 		int page,
 		int pageSize,
 		CancellationToken cancellationToken);
+
+	Task<SpendingByNormalizedDescriptionResult> GetSpendingByNormalizedDescriptionAsync(
+		DateTimeOffset? from,
+		DateTimeOffset? to,
+		CancellationToken cancellationToken);
 }

--- a/src/Application/Models/NormalizedDescriptions/GetOrCreateResult.cs
+++ b/src/Application/Models/NormalizedDescriptions/GetOrCreateResult.cs
@@ -1,0 +1,11 @@
+using Domain.NormalizedDescriptions;
+
+namespace Application.Models.NormalizedDescriptions;
+
+// Returned by INormalizedDescriptionService.GetOrCreateAsync. The resolver (RECEIPTS-578)
+// uses MatchScore to populate ReceiptItem.NormalizedDescriptionMatchScore at the same time
+// it writes the NormalizedDescriptionId FK, so admins can later query threshold-impact
+// aggregates without recomputing embeddings. MatchScore is null when no ANN candidate was
+// above the pending-review floor (a brand-new canonical entry was created) or when the
+// embedding service was unavailable.
+public record GetOrCreateResult(NormalizedDescription Description, double? MatchScore);

--- a/src/Application/Models/NormalizedDescriptions/MatchTestResult.cs
+++ b/src/Application/Models/NormalizedDescriptions/MatchTestResult.cs
@@ -1,0 +1,26 @@
+namespace Application.Models.NormalizedDescriptions;
+
+// Result of INormalizedDescriptionService.TestMatchAsync — the admin-facing "what would happen
+// if I ran GetOrCreate on this description" probe. Candidates are the top-N ANN matches; the
+// simulated outcome tells the admin which branch (auto-accept / pending review / create new)
+// the production resolver would take given the supplied overrides or the live DB thresholds.
+public record MatchTestResult(
+	List<MatchCandidate> Candidates,
+	string SimulatedOutcome,
+	Guid? SimulatedTargetId);
+
+// Simulated outcomes for TestMatchAsync. Kept as string constants so the wire format stays
+// human-readable and stable across refactors.
+public static class MatchTestOutcomes
+{
+	public const string AutoAccept = "AutoAccept";
+	public const string PendingReview = "PendingReview";
+	public const string CreateNew = "CreateNew";
+	public const string EmbeddingUnavailable = "EmbeddingUnavailable";
+}
+
+public record MatchCandidate(
+	Guid NormalizedDescriptionId,
+	string CanonicalName,
+	double CosineSimilarity,
+	string Status);

--- a/src/Application/Models/NormalizedDescriptions/ThresholdImpactPreview.cs
+++ b/src/Application/Models/NormalizedDescriptions/ThresholdImpactPreview.cs
@@ -1,0 +1,19 @@
+namespace Application.Models.NormalizedDescriptions;
+
+// Result of INormalizedDescriptionService.PreviewThresholdImpactAsync. Counts are computed
+// against the live ReceiptItems.NormalizedDescriptionMatchScore column, once with the current
+// DB thresholds and once with the proposed ones. The deltas are an admin-friendly breakdown
+// of how many items would change classification bucket. Items with a NULL score contribute
+// to the Unresolved bucket in both sides.
+public record ThresholdImpactPreview(
+	ClassificationCounts Current,
+	ClassificationCounts Proposed,
+	ReclassificationDeltas Deltas);
+
+public record ClassificationCounts(int AutoAccepted, int PendingReview, int Unresolved);
+
+public record ReclassificationDeltas(
+	int AutoToPending,
+	int PendingToAuto,
+	int UnresolvedToAuto,
+	int UnresolvedToPending);

--- a/src/Application/Models/Reports/SpendingByNormalizedDescriptionResult.cs
+++ b/src/Application/Models/Reports/SpendingByNormalizedDescriptionResult.cs
@@ -1,0 +1,14 @@
+namespace Application.Models.Reports;
+
+public record SpendingByNormalizedDescriptionItem(
+	string CanonicalName,
+	decimal TotalAmount,
+	string Currency,
+	int ItemCount,
+	DateTimeOffset? FirstSeen,
+	DateTimeOffset? LastSeen);
+
+public record SpendingByNormalizedDescriptionResult(
+	List<SpendingByNormalizedDescriptionItem> Items,
+	DateTimeOffset? FromDate,
+	DateTimeOffset? ToDate);

--- a/src/Application/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQuery.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQuery.cs
@@ -1,0 +1,8 @@
+using Application.Interfaces;
+using Application.Models.Reports;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public record GetSpendingByNormalizedDescriptionQuery(
+	DateTimeOffset? From,
+	DateTimeOffset? To) : IQuery<SpendingByNormalizedDescriptionResult>;

--- a/src/Application/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQueryHandler.cs
+++ b/src/Application/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQueryHandler.cs
@@ -1,0 +1,17 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using MediatR;
+
+namespace Application.Queries.Aggregates.Reports;
+
+public class GetSpendingByNormalizedDescriptionQueryHandler(IReportService reportService)
+	: IRequestHandler<GetSpendingByNormalizedDescriptionQuery, SpendingByNormalizedDescriptionResult>
+{
+	public async Task<SpendingByNormalizedDescriptionResult> Handle(GetSpendingByNormalizedDescriptionQuery request, CancellationToken cancellationToken)
+	{
+		return await reportService.GetSpendingByNormalizedDescriptionAsync(
+			request.From,
+			request.To,
+			cancellationToken);
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQuery.cs
@@ -1,0 +1,12 @@
+using Application.Interfaces;
+using Domain.NormalizedDescriptions;
+
+namespace Application.Queries.NormalizedDescription.GetAll;
+
+// Lists canonical normalized-description rows, optionally filtered to a single status.
+// Unlike the Core entity list queries, this isn't paginated — the row count is bounded by
+// the number of unique receipt-item descriptions ever seen, which stays small enough that
+// the admin screen can render the full set without server-side paging for the foreseeable
+// future. When pressure grows we can add offset/limit/sort in a follow-up without changing
+// the existing URL shape.
+public record GetAllNormalizedDescriptionsQuery(NormalizedDescriptionStatus? StatusFilter) : IQuery<List<Domain.NormalizedDescriptions.NormalizedDescription>>;

--- a/src/Application/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQueryHandler.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.GetAll;
+
+public class GetAllNormalizedDescriptionsQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<GetAllNormalizedDescriptionsQuery, List<Domain.NormalizedDescriptions.NormalizedDescription>>
+{
+	public async Task<List<Domain.NormalizedDescriptions.NormalizedDescription>> Handle(GetAllNormalizedDescriptionsQuery request, CancellationToken cancellationToken)
+	{
+		return await service.GetAllAsync(request.StatusFilter, cancellationToken);
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQuery.cs
@@ -1,0 +1,19 @@
+using Application.Interfaces;
+
+namespace Application.Queries.NormalizedDescription.GetById;
+
+public record GetNormalizedDescriptionByIdQuery : IQuery<Domain.NormalizedDescriptions.NormalizedDescription?>
+{
+	public Guid Id { get; }
+	public const string IdCannotBeEmptyExceptionMessage = "NormalizedDescription Id cannot be empty.";
+
+	public GetNormalizedDescriptionByIdQuery(Guid id)
+	{
+		if (id == Guid.Empty)
+		{
+			throw new ArgumentException(IdCannotBeEmptyExceptionMessage, nameof(id));
+		}
+
+		Id = id;
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQueryHandler.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Services;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.GetById;
+
+public class GetNormalizedDescriptionByIdQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<GetNormalizedDescriptionByIdQuery, Domain.NormalizedDescriptions.NormalizedDescription?>
+{
+	public async Task<Domain.NormalizedDescriptions.NormalizedDescription?> Handle(GetNormalizedDescriptionByIdQuery request, CancellationToken cancellationToken)
+	{
+		return await service.GetByIdAsync(request.Id, cancellationToken);
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQuery.cs
@@ -1,0 +1,6 @@
+using Application.Interfaces;
+using Domain.NormalizedDescriptions;
+
+namespace Application.Queries.NormalizedDescription.GetSettings;
+
+public record GetNormalizedDescriptionSettingsQuery : IQuery<NormalizedDescriptionSettings>;

--- a/src/Application/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQueryHandler.cs
@@ -1,0 +1,14 @@
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.GetSettings;
+
+public class GetNormalizedDescriptionSettingsQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<GetNormalizedDescriptionSettingsQuery, NormalizedDescriptionSettings>
+{
+	public async Task<NormalizedDescriptionSettings> Handle(GetNormalizedDescriptionSettingsQuery request, CancellationToken cancellationToken)
+	{
+		return await service.GetSettingsAsync(cancellationToken);
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQuery.cs
@@ -1,0 +1,8 @@
+using Application.Interfaces;
+using Application.Models.NormalizedDescriptions;
+
+namespace Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+
+public record PreviewThresholdImpactQuery(
+	double AutoAcceptThreshold,
+	double PendingReviewThreshold) : IQuery<ThresholdImpactPreview>;

--- a/src/Application/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQueryHandler.cs
@@ -1,0 +1,17 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+
+public class PreviewThresholdImpactQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<PreviewThresholdImpactQuery, ThresholdImpactPreview>
+{
+	public async Task<ThresholdImpactPreview> Handle(PreviewThresholdImpactQuery request, CancellationToken cancellationToken)
+	{
+		return await service.PreviewThresholdImpactAsync(
+			request.AutoAcceptThreshold,
+			request.PendingReviewThreshold,
+			cancellationToken);
+	}
+}

--- a/src/Application/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQuery.cs
+++ b/src/Application/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQuery.cs
@@ -1,0 +1,10 @@
+using Application.Interfaces;
+using Application.Models.NormalizedDescriptions;
+
+namespace Application.Queries.NormalizedDescription.TestMatch;
+
+public record TestNormalizedDescriptionMatchQuery(
+	string Description,
+	int TopN,
+	double? AutoAcceptThresholdOverride,
+	double? PendingReviewThresholdOverride) : IQuery<MatchTestResult>;

--- a/src/Application/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQueryHandler.cs
+++ b/src/Application/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQueryHandler.cs
@@ -1,0 +1,19 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using MediatR;
+
+namespace Application.Queries.NormalizedDescription.TestMatch;
+
+public class TestNormalizedDescriptionMatchQueryHandler(INormalizedDescriptionService service)
+	: IRequestHandler<TestNormalizedDescriptionMatchQuery, MatchTestResult>
+{
+	public async Task<MatchTestResult> Handle(TestNormalizedDescriptionMatchQuery request, CancellationToken cancellationToken)
+	{
+		return await service.TestMatchAsync(
+			request.Description,
+			request.TopN,
+			request.AutoAcceptThresholdOverride,
+			request.PendingReviewThresholdOverride,
+			cancellationToken);
+	}
+}

--- a/src/Domain/Core/ReceiptItem.cs
+++ b/src/Domain/Core/ReceiptItem.cs
@@ -18,6 +18,13 @@ public class ReceiptItem
 	public string? Subcategory { get; set; }
 	public PricingMode PricingMode { get; set; }
 
+	// Resolver-populated fields — readonly from a domain-logic perspective, but public setters
+	// are required so Mapperly can populate them. Not included in the constructor: the
+	// NormalizedDescription resolver (see RECEIPTS-578) writes the FK, and read paths
+	// populate the denormalized name from the entity nav property.
+	public Guid? NormalizedDescriptionId { get; set; }
+	public string? NormalizedDescriptionName { get; set; }
+
 	public const string DescriptionCannotBeEmpty = "Description cannot be empty";
 	public const string QuantityMustBePositive = "Quantity must be positive";
 	public const string CategoryCannotBeEmpty = "Category cannot be empty";

--- a/src/Domain/Core/ReceiptItem.cs
+++ b/src/Domain/Core/ReceiptItem.cs
@@ -20,10 +20,11 @@ public class ReceiptItem
 
 	// Resolver-populated fields — readonly from a domain-logic perspective, but public setters
 	// are required so Mapperly can populate them. Not included in the constructor: the
-	// NormalizedDescription resolver (see RECEIPTS-578) writes the FK, and read paths
-	// populate the denormalized name from the entity nav property.
+	// NormalizedDescription resolver (see RECEIPTS-578) writes the FK, the match score, and
+	// read paths populate the denormalized name from the entity nav property.
 	public Guid? NormalizedDescriptionId { get; set; }
 	public string? NormalizedDescriptionName { get; set; }
+	public double? NormalizedDescriptionMatchScore { get; set; }
 
 	public const string DescriptionCannotBeEmpty = "Description cannot be empty";
 	public const string QuantityMustBePositive = "Quantity must be positive";

--- a/src/Domain/NormalizedDescriptions/NormalizedDescription.cs
+++ b/src/Domain/NormalizedDescriptions/NormalizedDescription.cs
@@ -1,0 +1,24 @@
+namespace Domain.NormalizedDescriptions;
+
+public class NormalizedDescription
+{
+	public Guid Id { get; set; }
+	public string CanonicalName { get; set; }
+	public NormalizedDescriptionStatus Status { get; set; }
+	public DateTimeOffset CreatedAt { get; set; }
+
+	public const string CanonicalNameCannotBeEmpty = "Canonical name cannot be empty";
+
+	public NormalizedDescription(Guid id, string canonicalName, NormalizedDescriptionStatus status, DateTimeOffset createdAt)
+	{
+		if (string.IsNullOrWhiteSpace(canonicalName))
+		{
+			throw new ArgumentException(CanonicalNameCannotBeEmpty, nameof(canonicalName));
+		}
+
+		Id = id;
+		CanonicalName = canonicalName;
+		Status = status;
+		CreatedAt = createdAt;
+	}
+}

--- a/src/Domain/NormalizedDescriptions/NormalizedDescriptionSettings.cs
+++ b/src/Domain/NormalizedDescriptions/NormalizedDescriptionSettings.cs
@@ -1,0 +1,35 @@
+namespace Domain.NormalizedDescriptions;
+
+public class NormalizedDescriptionSettings
+{
+	public Guid Id { get; set; }
+	public double AutoAcceptThreshold { get; set; }
+	public double PendingReviewThreshold { get; set; }
+	public DateTimeOffset UpdatedAt { get; set; }
+
+	public const string ThresholdsMustBeInRange = "Thresholds must satisfy 0 <= pendingReviewThreshold < autoAcceptThreshold <= 1";
+	public const string PendingMustBeLessThanAuto = "pendingReviewThreshold must be strictly less than autoAcceptThreshold";
+
+	public NormalizedDescriptionSettings(Guid id, double autoAcceptThreshold, double pendingReviewThreshold, DateTimeOffset updatedAt)
+	{
+		Validate(autoAcceptThreshold, pendingReviewThreshold);
+
+		Id = id;
+		AutoAcceptThreshold = autoAcceptThreshold;
+		PendingReviewThreshold = pendingReviewThreshold;
+		UpdatedAt = updatedAt;
+	}
+
+	public static void Validate(double autoAcceptThreshold, double pendingReviewThreshold)
+	{
+		if (autoAcceptThreshold < 0 || autoAcceptThreshold > 1 || pendingReviewThreshold < 0 || pendingReviewThreshold > 1)
+		{
+			throw new ArgumentException(ThresholdsMustBeInRange);
+		}
+
+		if (pendingReviewThreshold >= autoAcceptThreshold)
+		{
+			throw new ArgumentException(PendingMustBeLessThanAuto);
+		}
+	}
+}

--- a/src/Domain/NormalizedDescriptions/NormalizedDescriptionStatus.cs
+++ b/src/Domain/NormalizedDescriptions/NormalizedDescriptionStatus.cs
@@ -1,0 +1,7 @@
+namespace Domain.NormalizedDescriptions;
+
+public enum NormalizedDescriptionStatus
+{
+	Active,
+	PendingReview,
+}

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -51,6 +51,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 	public virtual DbSet<ItemTemplateEntity> ItemTemplates { get; set; } = null!;
 	public virtual DbSet<ItemEmbeddingEntity> ItemEmbeddings { get; set; } = null!;
 	public virtual DbSet<NormalizedDescriptionEntity> NormalizedDescriptions { get; set; } = null!;
+	public virtual DbSet<NormalizedDescriptionSettingsEntity> NormalizedDescriptionSettings { get; set; } = null!;
 	public virtual DbSet<DistinctDescriptionEntity> DistinctDescriptions { get; set; } = null!;
 	public virtual DbSet<ItemSimilarityEdgeEntity> ItemSimilarityEdges { get; set; } = null!;
 	public virtual DbSet<AuditLogEntity> AuditLogs { get; set; } = null!;

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -50,6 +50,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 	public virtual DbSet<ApiKeyEntity> ApiKeys { get; set; } = null!;
 	public virtual DbSet<ItemTemplateEntity> ItemTemplates { get; set; } = null!;
 	public virtual DbSet<ItemEmbeddingEntity> ItemEmbeddings { get; set; } = null!;
+	public virtual DbSet<NormalizedDescriptionEntity> NormalizedDescriptions { get; set; } = null!;
 	public virtual DbSet<DistinctDescriptionEntity> DistinctDescriptions { get; set; } = null!;
 	public virtual DbSet<ItemSimilarityEdgeEntity> ItemSimilarityEdges { get; set; } = null!;
 	public virtual DbSet<AuditLogEntity> AuditLogs { get; set; } = null!;
@@ -77,6 +78,13 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 				.HasConversion(
 					v => string.Join(';', v.ToArray()),
 					v => new Pgvector.Vector(v.Split(';').Select(float.Parse).ToArray()));
+
+			modelBuilder.Entity<NormalizedDescriptionEntity>()
+				.Property(e => e.Embedding)
+				.HasColumnType(null)
+				.HasConversion(
+					v => v == null ? null : string.Join(';', v.ToArray()),
+					v => string.IsNullOrEmpty(v) ? null : new Pgvector.Vector(v.Split(';').Select(float.Parse).ToArray()));
 		}
 	}
 

--- a/src/Infrastructure/Configurations/NormalizedDescriptionEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/NormalizedDescriptionEntityConfiguration.cs
@@ -1,0 +1,35 @@
+using Domain.NormalizedDescriptions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Configurations;
+
+public class NormalizedDescriptionEntityConfiguration : IEntityTypeConfiguration<NormalizedDescriptionEntity>
+{
+	public void Configure(EntityTypeBuilder<NormalizedDescriptionEntity> builder)
+	{
+		builder.ToTable("NormalizedDescriptions");
+
+		builder.HasKey(e => e.Id);
+
+		builder.Property(e => e.Id)
+			.IsRequired()
+			.ValueGeneratedOnAdd();
+
+		// Status stored as string via HasConversion, mirroring the ReceiptItemEntity.PricingMode pattern.
+		builder.Property(e => e.Status)
+			.HasConversion(
+				v => v.ToString(),
+				v => Enum.Parse<NormalizedDescriptionStatus>(v, ignoreCase: true))
+			.HasMaxLength(32);
+
+		builder.Property(e => e.Embedding)
+			.HasColumnType($"vector({OnnxEmbeddingService.EmbeddingDimension})");
+
+		// The unique functional index on lower(CanonicalName) and the partial HNSW index on
+		// Embedding are added via raw SQL in the migration — EF cannot natively express
+		// functional indexes or pgvector operator classes.
+	}
+}

--- a/src/Infrastructure/Configurations/NormalizedDescriptionSettingsEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/NormalizedDescriptionSettingsEntityConfiguration.cs
@@ -1,0 +1,44 @@
+using Infrastructure.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Configurations;
+
+public class NormalizedDescriptionSettingsEntityConfiguration : IEntityTypeConfiguration<NormalizedDescriptionSettingsEntity>
+{
+	// Fixed singleton ID for the one-row settings table. All reads and writes target this ID;
+	// HasData seeds a single row on migration so the service can always resolve thresholds.
+	public static readonly Guid SingletonId = new("00000000-0000-0000-0000-000000000001");
+
+	// Initial threshold defaults, mirrored from the (now-legacy) hardcoded constants on
+	// NormalizedDescriptionService. Retained here so the migration seed is self-contained
+	// and can be updated in isolation when we re-calibrate.
+	public const double InitialAutoAcceptThreshold = 0.81;
+	public const double InitialPendingReviewThreshold = 0.68;
+
+	// The seed timestamp is fixed so EF migrations are deterministic (DateTimeOffset.UtcNow
+	// would produce a different SQL on every `migrations add`). Runtime updates overwrite
+	// this value via UpdateSettingsAsync.
+	public static readonly DateTimeOffset SeedUpdatedAt = new(2026, 4, 19, 0, 0, 0, TimeSpan.Zero);
+
+	public void Configure(EntityTypeBuilder<NormalizedDescriptionSettingsEntity> builder)
+	{
+		builder.ToTable("NormalizedDescriptionSettings");
+
+		builder.HasKey(e => e.Id);
+
+		// ValueGeneratedNever — singleton row identity is fixed at seed time.
+		builder.Property(e => e.Id)
+			.IsRequired()
+			.ValueGeneratedNever();
+
+		builder.HasData(
+			new NormalizedDescriptionSettingsEntity
+			{
+				Id = SingletonId,
+				AutoAcceptThreshold = InitialAutoAcceptThreshold,
+				PendingReviewThreshold = InitialPendingReviewThreshold,
+				UpdatedAt = SeedUpdatedAt,
+			});
+	}
+}

--- a/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
@@ -24,6 +24,16 @@ public class ReceiptItemEntityConfiguration : IEntityTypeConfiguration<ReceiptIt
 		builder.Navigation(e => e.Receipt)
 			.AutoInclude();
 
+		builder.HasOne(e => e.NormalizedDescription)
+			.WithMany()
+			.HasForeignKey(e => e.NormalizedDescriptionId)
+			.OnDelete(DeleteBehavior.SetNull);
+
+		builder.Navigation(e => e.NormalizedDescription)
+			.AutoInclude();
+
+		builder.HasIndex(e => e.NormalizedDescriptionId);
+
 		builder.HasQueryFilter(e => e.DeletedAt == null);
 	}
 }

--- a/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
@@ -34,6 +34,12 @@ public class ReceiptItemEntityConfiguration : IEntityTypeConfiguration<ReceiptIt
 
 		builder.HasIndex(e => e.NormalizedDescriptionId);
 
+		// Threshold-impact previews aggregate ReceiptItem counts by bucketing on match score.
+		// An index on NormalizedDescriptionMatchScore keeps those aggregates fast even as the
+		// table grows; the column is populated by the resolver (RECEIPTS-578) with the cosine
+		// similarity at resolve time and remains NULL for unresolved / newly-created items.
+		builder.HasIndex(e => e.NormalizedDescriptionMatchScore);
+
 		builder.HasQueryFilter(e => e.DeletedAt == null);
 	}
 }

--- a/src/Infrastructure/Entities/Core/NormalizedDescriptionEntity.cs
+++ b/src/Infrastructure/Entities/Core/NormalizedDescriptionEntity.cs
@@ -1,0 +1,14 @@
+using Domain.NormalizedDescriptions;
+using Pgvector;
+
+namespace Infrastructure.Entities.Core;
+
+public class NormalizedDescriptionEntity
+{
+	public Guid Id { get; set; }
+	public string CanonicalName { get; set; } = string.Empty;
+	public NormalizedDescriptionStatus Status { get; set; }
+	public Vector? Embedding { get; set; }
+	public string? EmbeddingModelVersion { get; set; }
+	public DateTimeOffset CreatedAt { get; set; }
+}

--- a/src/Infrastructure/Entities/Core/NormalizedDescriptionSettingsEntity.cs
+++ b/src/Infrastructure/Entities/Core/NormalizedDescriptionSettingsEntity.cs
@@ -1,0 +1,9 @@
+namespace Infrastructure.Entities.Core;
+
+public class NormalizedDescriptionSettingsEntity
+{
+	public Guid Id { get; set; }
+	public double AutoAcceptThreshold { get; set; }
+	public double PendingReviewThreshold { get; set; }
+	public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/src/Infrastructure/Entities/Core/ReceiptItemEntity.cs
+++ b/src/Infrastructure/Entities/Core/ReceiptItemEntity.cs
@@ -18,6 +18,7 @@ public class ReceiptItemEntity : ISoftDeletable, IOwnedBy<ReceiptEntity>
 	public string? Subcategory { get; set; }
 	public PricingMode PricingMode { get; set; } = PricingMode.Quantity;
 	public Guid? NormalizedDescriptionId { get; set; }
+	public double? NormalizedDescriptionMatchScore { get; set; }
 	public virtual NormalizedDescriptionEntity? NormalizedDescription { get; set; }
 	public virtual ReceiptEntity? Receipt { get; set; }
 	public DateTimeOffset? DeletedAt { get; set; }

--- a/src/Infrastructure/Entities/Core/ReceiptItemEntity.cs
+++ b/src/Infrastructure/Entities/Core/ReceiptItemEntity.cs
@@ -17,6 +17,8 @@ public class ReceiptItemEntity : ISoftDeletable, IOwnedBy<ReceiptEntity>
 	public string Category { get; set; } = string.Empty;
 	public string? Subcategory { get; set; }
 	public PricingMode PricingMode { get; set; } = PricingMode.Quantity;
+	public Guid? NormalizedDescriptionId { get; set; }
+	public virtual NormalizedDescriptionEntity? NormalizedDescription { get; set; }
 	public virtual ReceiptEntity? Receipt { get; set; }
 	public DateTimeOffset? DeletedAt { get; set; }
 	public string? DeletedByUserId { get; set; }

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Infrastructure.Tests" />
+    <InternalsVisibleTo Include="Infrastructure.IntegrationTests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/Mapping/NormalizedDescriptionMapper.cs
+++ b/src/Infrastructure/Mapping/NormalizedDescriptionMapper.cs
@@ -1,0 +1,17 @@
+using Domain.NormalizedDescriptions;
+using Infrastructure.Entities.Core;
+using Riok.Mapperly.Abstractions;
+
+namespace Infrastructure.Mapping;
+
+[Mapper]
+public partial class NormalizedDescriptionMapper
+{
+	[MapperIgnoreTarget(nameof(NormalizedDescriptionEntity.Embedding))]
+	[MapperIgnoreTarget(nameof(NormalizedDescriptionEntity.EmbeddingModelVersion))]
+	public partial NormalizedDescriptionEntity ToEntity(NormalizedDescription source);
+
+	[MapperIgnoreSource(nameof(NormalizedDescriptionEntity.Embedding))]
+	[MapperIgnoreSource(nameof(NormalizedDescriptionEntity.EmbeddingModelVersion))]
+	public partial NormalizedDescription ToDomain(NormalizedDescriptionEntity source);
+}

--- a/src/Infrastructure/Mapping/NormalizedDescriptionSettingsMapper.cs
+++ b/src/Infrastructure/Mapping/NormalizedDescriptionSettingsMapper.cs
@@ -1,0 +1,13 @@
+using Domain.NormalizedDescriptions;
+using Infrastructure.Entities.Core;
+using Riok.Mapperly.Abstractions;
+
+namespace Infrastructure.Mapping;
+
+[Mapper]
+public partial class NormalizedDescriptionSettingsMapper
+{
+	public partial NormalizedDescriptionSettingsEntity ToEntity(NormalizedDescriptionSettings source);
+
+	public partial NormalizedDescriptionSettings ToDomain(NormalizedDescriptionSettingsEntity source);
+}

--- a/src/Infrastructure/Mapping/ReceiptItemMapper.cs
+++ b/src/Infrastructure/Mapping/ReceiptItemMapper.cs
@@ -14,8 +14,12 @@ public partial class ReceiptItemMapper
 	[MapProperty(nameof(ReceiptItem.TotalAmount.Amount), nameof(ReceiptItemEntity.TotalAmount))]
 	[MapProperty(nameof(ReceiptItem.TotalAmount.Currency), nameof(ReceiptItemEntity.TotalAmountCurrency))]
 	[MapperIgnoreSource(nameof(ReceiptItem.ReceiptId))]
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionId))]
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionName))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.Receipt))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.ReceiptId))]
+	[MapperIgnoreTarget(nameof(ReceiptItemEntity.NormalizedDescription))]
+	[MapperIgnoreTarget(nameof(ReceiptItemEntity.NormalizedDescriptionId))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.DeletedAt))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.DeletedByUserId))]
 	[MapperIgnoreTarget(nameof(ReceiptItemEntity.DeletedByApiKeyId))]
@@ -28,9 +32,21 @@ public partial class ReceiptItemMapper
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.Receipt))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.UnitPriceCurrency))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.TotalAmountCurrency))]
+	[MapperIgnoreSource(nameof(ReceiptItemEntity.NormalizedDescription))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.DeletedAt))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.DeletedByUserId))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.DeletedByApiKeyId))]
 	[MapperIgnoreSource(nameof(ReceiptItemEntity.CascadeDeletedByParentId))]
-	public partial ReceiptItem ToDomain(ReceiptItemEntity source);
+	[MapperIgnoreTarget(nameof(ReceiptItem.NormalizedDescriptionName))]
+	private partial ReceiptItem ToDomainPartial(ReceiptItemEntity source);
+
+	public ReceiptItem ToDomain(ReceiptItemEntity source)
+	{
+		ReceiptItem domain = ToDomainPartial(source);
+		// Denormalize CanonicalName from the nav property for read paths. Mapperly can emit
+		// the direct FK via the partial method above, but the nested path through the
+		// navigation requires a custom projection.
+		domain.NormalizedDescriptionName = source.NormalizedDescription?.CanonicalName;
+		return domain;
+	}
 }

--- a/src/Infrastructure/Migrations/20260420021000_AddNormalizedDescriptions.Designer.cs
+++ b/src/Infrastructure/Migrations/20260420021000_AddNormalizedDescriptions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420021000_AddNormalizedDescriptions")]
+    partial class AddNormalizedDescriptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260420021000_AddNormalizedDescriptions.cs
+++ b/src/Infrastructure/Migrations/20260420021000_AddNormalizedDescriptions.cs
@@ -1,0 +1,92 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pgvector;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddNormalizedDescriptions : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AddColumn<Guid>(
+			name: "NormalizedDescriptionId",
+			table: "ReceiptItems",
+			type: "uuid",
+			nullable: true);
+
+		migrationBuilder.CreateTable(
+			name: "NormalizedDescriptions",
+			columns: table => new
+			{
+				Id = table.Column<Guid>(type: "uuid", nullable: false),
+				CanonicalName = table.Column<string>(type: "text", nullable: false),
+				Status = table.Column<string>(type: "text", maxLength: 32, nullable: false),
+				Embedding = table.Column<Vector>(type: "vector(1024)", nullable: true),
+				EmbeddingModelVersion = table.Column<string>(type: "text", nullable: true),
+				CreatedAt = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false)
+			},
+			constraints: table =>
+			{
+				table.PrimaryKey("PK_NormalizedDescriptions", x => x.Id);
+			});
+
+		migrationBuilder.CreateIndex(
+			name: "IX_ReceiptItems_NormalizedDescriptionId",
+			table: "ReceiptItems",
+			column: "NormalizedDescriptionId");
+
+		migrationBuilder.AddForeignKey(
+			name: "FK_ReceiptItems_NormalizedDescriptions_NormalizedDescriptionId",
+			table: "ReceiptItems",
+			column: "NormalizedDescriptionId",
+			principalTable: "NormalizedDescriptions",
+			principalColumn: "Id",
+			onDelete: ReferentialAction.SetNull);
+
+		// Unique functional index on lower("CanonicalName") — EF does not natively model
+		// functional indexes. Ensures case-insensitive canonical name uniqueness across the
+		// table and supports the service's exact-match short-circuit with an index hit.
+		migrationBuilder.Sql(
+			"""
+			CREATE UNIQUE INDEX "IX_NormalizedDescriptions_CanonicalName_Lower"
+			    ON "NormalizedDescriptions" (lower("CanonicalName"));
+			""");
+
+		// Partial HNSW index for ANN similarity search on rows that have an embedding.
+		// pgvector cosine_ops + a WHERE predicate are not modelable in EF, so raw SQL.
+		migrationBuilder.Sql(
+			"""
+			CREATE INDEX "IX_NormalizedDescriptions_Embedding_hnsw"
+			    ON "NormalizedDescriptions" USING hnsw ("Embedding" vector_cosine_ops)
+			    WITH (m = 16, ef_construction = 64)
+			    WHERE "Embedding" IS NOT NULL;
+			""");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		// Drop raw-SQL indexes first, then let EF drop the foreign key/table/index/column.
+		migrationBuilder.Sql("""DROP INDEX IF EXISTS "IX_NormalizedDescriptions_Embedding_hnsw";""");
+		migrationBuilder.Sql("""DROP INDEX IF EXISTS "IX_NormalizedDescriptions_CanonicalName_Lower";""");
+
+		migrationBuilder.DropForeignKey(
+			name: "FK_ReceiptItems_NormalizedDescriptions_NormalizedDescriptionId",
+			table: "ReceiptItems");
+
+		migrationBuilder.DropTable(
+			name: "NormalizedDescriptions");
+
+		migrationBuilder.DropIndex(
+			name: "IX_ReceiptItems_NormalizedDescriptionId",
+			table: "ReceiptItems");
+
+		migrationBuilder.DropColumn(
+			name: "NormalizedDescriptionId",
+			table: "ReceiptItems");
+	}
+}

--- a/src/Infrastructure/Migrations/20260420024810_AddNormalizedDescriptionSettingsAndMatchScore.Designer.cs
+++ b/src/Infrastructure/Migrations/20260420024810_AddNormalizedDescriptionSettingsAndMatchScore.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420024810_AddNormalizedDescriptionSettingsAndMatchScore")]
+    partial class AddNormalizedDescriptionSettingsAndMatchScore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260420024810_AddNormalizedDescriptionSettingsAndMatchScore.cs
+++ b/src/Infrastructure/Migrations/20260420024810_AddNormalizedDescriptionSettingsAndMatchScore.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddNormalizedDescriptionSettingsAndMatchScore : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AddColumn<double>(
+			name: "NormalizedDescriptionMatchScore",
+			table: "ReceiptItems",
+			type: "double precision",
+			nullable: true);
+
+		migrationBuilder.CreateTable(
+			name: "NormalizedDescriptionSettings",
+			columns: table => new
+			{
+				Id = table.Column<Guid>(type: "uuid", nullable: false),
+				AutoAcceptThreshold = table.Column<double>(type: "double precision", nullable: false),
+				PendingReviewThreshold = table.Column<double>(type: "double precision", nullable: false),
+				UpdatedAt = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false)
+			},
+			constraints: table =>
+			{
+				table.PrimaryKey("PK_NormalizedDescriptionSettings", x => x.Id);
+			});
+
+		migrationBuilder.InsertData(
+			table: "NormalizedDescriptionSettings",
+			columns: new[] { "Id", "AutoAcceptThreshold", "PendingReviewThreshold", "UpdatedAt" },
+			values: new object[] { new Guid("00000000-0000-0000-0000-000000000001"), 0.81000000000000005, 0.68000000000000005, new DateTimeOffset(new DateTime(2026, 4, 19, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)) });
+
+		migrationBuilder.CreateIndex(
+			name: "IX_ReceiptItems_NormalizedDescriptionMatchScore",
+			table: "ReceiptItems",
+			column: "NormalizedDescriptionMatchScore");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropTable(
+			name: "NormalizedDescriptionSettings");
+
+		migrationBuilder.DropIndex(
+			name: "IX_ReceiptItems_NormalizedDescriptionMatchScore",
+			table: "ReceiptItems");
+
+		migrationBuilder.DropColumn(
+			name: "NormalizedDescriptionMatchScore",
+			table: "ReceiptItems");
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -243,7 +243,8 @@ public static class InfrastructureService
 			.AddSingleton<TransactionMapper>()
 			.AddSingleton<AdjustmentMapper>()
 			.AddSingleton<ItemTemplateMapper>()
-			.AddSingleton<NormalizedDescriptionMapper>();
+			.AddSingleton<NormalizedDescriptionMapper>()
+			.AddSingleton<NormalizedDescriptionSettingsMapper>();
 
 		return services;
 	}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -226,6 +226,10 @@ public static class InfrastructureService
 		services.AddSingleton<ItemSimilarityEdgeRefresher>();
 		services.AddHostedService(sp => sp.GetRequiredService<ItemSimilarityEdgeRefresher>());
 
+		// Resolver for RECEIPTS-578 — scans unresolved ReceiptItems, groups by description,
+		// and links each to a NormalizedDescription via NormalizedDescriptionService.
+		services.AddHostedService<NormalizedDescriptionResolutionService>();
+
 		services.AddHealthChecks()
 			.AddCheck<ItemSimilarityRefresherHealthCheck>(
 				"item_similarity_refresher",

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -131,6 +131,7 @@ public static class InfrastructureService
 			.AddScoped<IBackupImportService, BackupImportService>()
 			.AddScoped<IItemTemplateService, ItemTemplateService>()
 			.AddScoped<IItemTemplateSimilarityService, ItemTemplateSimilarityService>()
+			.AddScoped<INormalizedDescriptionService, NormalizedDescriptionService>()
 			.AddScoped<IReceiptRepository, ReceiptRepository>()
 			.AddScoped<IAccountRepository, AccountRepository>()
 			.AddScoped<ICardRepository, CardRepository>()
@@ -241,7 +242,8 @@ public static class InfrastructureService
 			.AddSingleton<ReceiptItemMapper>()
 			.AddSingleton<TransactionMapper>()
 			.AddSingleton<AdjustmentMapper>()
-			.AddSingleton<ItemTemplateMapper>();
+			.AddSingleton<ItemTemplateMapper>()
+			.AddSingleton<NormalizedDescriptionMapper>();
 
 		return services;
 	}

--- a/src/Infrastructure/Services/NormalizedDescriptionResolutionService.cs
+++ b/src/Infrastructure/Services/NormalizedDescriptionResolutionService.cs
@@ -1,0 +1,224 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using Domain.NormalizedDescriptions;
+using Infrastructure.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Services;
+
+// Background resolver that scans unresolved ReceiptItemEntity rows and links each to a
+// NormalizedDescription (RECEIPTS-578). Mirrors EmbeddingGenerationService: 10s initial
+// delay, 30s poll cycle, 50-row batches. Per cycle we group rows by raw description so the
+// same canonical lookup isn't run twice for duplicate text; each unique description hits
+// NormalizedDescriptionService.GetOrCreateAsync exactly once and its (Id, MatchScore) is
+// written onto every row in the group.
+//
+// Signal-driven via IDescriptionChangeSignal — the same channel that dirties
+// ItemSimilarityEdgeRefresher also hints that new ReceiptItems may need normalization.
+// Both consumers are idempotent, so reusing the signal is safe.
+//
+// Errors are logged and the cycle retries next tick — we never surface exceptions past the
+// hosted-service boundary because a resolver crash would otherwise cascade into the host
+// (BackgroundServiceExceptionBehavior.StopHost default).
+public class NormalizedDescriptionResolutionService(
+	IServiceScopeFactory scopeFactory,
+	IDescriptionChangeSignal signal,
+	ILogger<NormalizedDescriptionResolutionService> logger) : BackgroundService
+{
+	internal const int BatchSize = 50;
+	internal const int MinDescriptionLength = 2;
+	internal static readonly TimeSpan Interval = TimeSpan.FromSeconds(30);
+	internal static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(10);
+
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		try
+		{
+			await Task.Delay(InitialDelay, stoppingToken);
+		}
+		catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+		{
+			return;
+		}
+
+		while (!stoppingToken.IsCancellationRequested)
+		{
+			try
+			{
+				await ProcessPendingResolutionsAsync(stoppingToken);
+			}
+			catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+			{
+				break;
+			}
+			catch (Exception ex)
+			{
+				// Per-batch failures are logged and swallowed so the next tick can retry —
+				// we never want a single bad description to crash the host. The resolver is
+				// idempotent (the WHERE clause excludes already-linked rows) so retrying
+				// after a transient failure re-picks the same unresolved set.
+				logger.LogError(ex, "Error during normalized-description resolution cycle");
+			}
+
+			// Drain any dirty signals that arrived while we were processing. We only care
+			// that at least one signal exists to wake us early; excess reads are harmless.
+			while (signal.Reader.TryRead(out _))
+			{
+			}
+
+			try
+			{
+				// Wait for either the next signal or the poll interval, whichever fires first.
+				// Using a linked CTS lets the stop token cancel the wait without racing with
+				// the channel reader.
+				using CancellationTokenSource waitCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+				waitCts.CancelAfter(Interval);
+				try
+				{
+					await signal.Reader.ReadAsync(waitCts.Token);
+				}
+				catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+				{
+					break;
+				}
+				catch (OperationCanceledException)
+				{
+					// Interval elapsed — fall through to the next cycle.
+				}
+			}
+			catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+			{
+				break;
+			}
+		}
+	}
+
+	// Exposed internally so tests can invoke a single cycle directly without spinning the
+	// hosted-service loop (and tolerating the 10-second initial delay). The method is
+	// deliberately side-effect-bounded: either all grouped updates persist and the cycle
+	// returns a summary, or a failure bubbles out and no FKs are written (the SaveChanges
+	// call is single-shot across all items in the batch).
+	internal async Task<ResolutionSummary> ProcessPendingResolutionsAsync(CancellationToken cancellationToken)
+	{
+		using IServiceScope scope = scopeFactory.CreateScope();
+		IEmbeddingService embeddingService = scope.ServiceProvider.GetRequiredService<IEmbeddingService>();
+		INormalizedDescriptionService normalizedDescriptionService =
+			scope.ServiceProvider.GetRequiredService<INormalizedDescriptionService>();
+		IDbContextFactory<ApplicationDbContext> contextFactory =
+			scope.ServiceProvider.GetRequiredService<IDbContextFactory<ApplicationDbContext>>();
+
+		// The whole NormalizedDescriptionService.GetOrCreateAsync flow hinges on the ANN
+		// search — without an embedding service we'd degrade to creating an Active entry
+		// per distinct description, which is cheap but misleading because the downstream
+		// "auto-accept" UX presumes real similarity scoring. Skip the cycle cleanly.
+		if (!embeddingService.IsConfigured)
+		{
+			return ResolutionSummary.Empty;
+		}
+
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		// Candidate set: live ReceiptItems without an FK and with a description long enough
+		// to meaningfully embed. `IgnoreQueryFilters` matches the other background services
+		// (EmbeddingGenerationService): we want full visibility over the hard schema state
+		// rather than relying on soft-delete filters, and the explicit DeletedAt == null
+		// condition keeps the semantics identical. The ordering pin by Id keeps successive
+		// cycles deterministic on an otherwise-arbitrary set and makes test assertions easier.
+		List<ReceiptItemEntity> pending = await context.ReceiptItems
+			.IgnoreQueryFilters()
+			.Where(r =>
+				r.DeletedAt == null &&
+				r.NormalizedDescriptionId == null &&
+				r.Description != string.Empty &&
+				r.Description.Length >= MinDescriptionLength)
+			.OrderBy(r => r.Id)
+			.Take(BatchSize)
+			.ToListAsync(cancellationToken);
+
+		if (pending.Count == 0)
+		{
+			return ResolutionSummary.Empty;
+		}
+
+		// Group by raw description so we only call GetOrCreateAsync once per unique text.
+		// The grouping collapses casing-equivalent duplicates (e.g., "Organic Milk" /
+		// "organic milk") only if they're literally identical — the service itself handles
+		// case-insensitive matching against canonical names when it sees them for the
+		// first time, so the first call in a group that sees "organic MILK" will still
+		// resolve to the same canonical entry as a later call with "ORGANIC milk".
+		var groups = pending
+			.GroupBy(r => r.Description)
+			.ToList();
+
+		int linked = 0;
+		int newEntriesCreated = 0;
+		int skipped = 0;
+
+		foreach (var group in groups)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			GetOrCreateResult? result;
+			try
+			{
+				result = await normalizedDescriptionService.GetOrCreateAsync(group.Key, cancellationToken);
+			}
+			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+			{
+				throw;
+			}
+			catch (Exception ex)
+			{
+				// A single bad description (unexpected embedding failure, DB hiccup while the
+				// normalized service tries to race-insert, etc.) must not poison the rest of
+				// the batch. Count the group as skipped and continue.
+				logger.LogError(
+					ex,
+					"Failed to resolve normalized description for {Count} receipt item(s) with text {Description}",
+					group.Count(),
+					group.Key);
+				skipped += group.Count();
+				continue;
+			}
+
+			// MatchScore == null means GetOrCreateAsync created a brand-new canonical entry
+			// (no candidate above the pending-review floor, or the embedding service went
+			// unavailable mid-call). We still link the items — the FK being present is the
+			// user-visible signal that resolution happened; the null score is a truthful
+			// "we didn't have a similarity to record".
+			if (result.MatchScore is null)
+			{
+				newEntriesCreated++;
+			}
+
+			foreach (ReceiptItemEntity item in group)
+			{
+				item.NormalizedDescriptionId = result.Description.Id;
+				item.NormalizedDescriptionMatchScore = result.MatchScore;
+				linked++;
+			}
+		}
+
+		if (linked > 0)
+		{
+			await context.SaveChangesAsync(cancellationToken);
+		}
+
+		ResolutionSummary summary = new(linked, newEntriesCreated, skipped);
+		logger.LogInformation(
+			"Resolved normalized descriptions: linked={Linked}, newEntriesCreated={NewEntriesCreated}, skipped={Skipped}",
+			summary.Linked,
+			summary.NewEntriesCreated,
+			summary.Skipped);
+
+		return summary;
+	}
+
+	internal readonly record struct ResolutionSummary(int Linked, int NewEntriesCreated, int Skipped)
+	{
+		public static ResolutionSummary Empty { get; } = new(0, 0, 0);
+	}
+}

--- a/src/Infrastructure/Services/NormalizedDescriptionService.cs
+++ b/src/Infrastructure/Services/NormalizedDescriptionService.cs
@@ -1,5 +1,7 @@
 using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
 using Domain.NormalizedDescriptions;
+using Infrastructure.Configurations;
 using Infrastructure.Entities.Core;
 using Infrastructure.Mapping;
 using Microsoft.EntityFrameworkCore;
@@ -10,19 +12,24 @@ namespace Infrastructure.Services;
 public class NormalizedDescriptionService(
 	IDbContextFactory<ApplicationDbContext> contextFactory,
 	IEmbeddingService embeddingService,
-	NormalizedDescriptionMapper mapper) : INormalizedDescriptionService
+	NormalizedDescriptionMapper mapper,
+	NormalizedDescriptionSettingsMapper settingsMapper) : INormalizedDescriptionService
 {
-	// Threshold constants are hardcoded for RECEIPTS-577. A later issue (RECEIPTS-580) moves
-	// them into a DB-backed settings row so they can be tuned without a redeploy. The values
-	// below match the data-driven calibration baseline.
-	public const double AutoAcceptThreshold = 0.81;
-	public const double PendingReviewThreshold = 0.68;
+	// The thresholds used when no settings row exists yet. These match the migration seed so
+	// that pre-migration code paths (tests that don't seed, integration tests spinning up a
+	// fresh schema) still see the same decision boundaries as production would at rest.
+	public const double InitialAutoAcceptThreshold = NormalizedDescriptionSettingsEntityConfiguration.InitialAutoAcceptThreshold;
+	public const double InitialPendingReviewThreshold = NormalizedDescriptionSettingsEntityConfiguration.InitialPendingReviewThreshold;
 
 	public const string ReceiptItemNotFound = "Receipt item not found.";
+	public const string SettingsRowNotFound = "NormalizedDescriptionSettings singleton row is missing.";
+	public const string TestMatchDescriptionRequired = "Test match description must not be empty.";
+	public const string TopNOutOfRange = "topN must be between 1 and 20.";
 
+	private const int MaxTopN = 20;
 	private const string PostgreSQL = "Npgsql.EntityFrameworkCore.PostgreSQL";
 
-	public async Task<NormalizedDescription> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken)
+	public async Task<GetOrCreateResult> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken)
 	{
 		string normalized = (rawDescription ?? string.Empty).Trim();
 		if (string.IsNullOrEmpty(normalized))
@@ -32,18 +39,26 @@ public class NormalizedDescriptionService(
 
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
 
+		// Read thresholds fresh from the DB each call. Call frequency is bounded by the
+		// resolver's 30-second poll cycle, so the latency cost is negligible and admin
+		// updates take effect on the next run without any cache-invalidation plumbing.
+		(double autoAccept, double pendingReview) = await ResolveThresholdsAsync(context, cancellationToken);
+
 		// Step 1: exact case-insensitive match on existing canonical name.
 		NormalizedDescriptionEntity? existing = await FindExactCaseInsensitiveAsync(context, normalized, cancellationToken);
 		if (existing is not null)
 		{
-			return mapper.ToDomain(existing);
+			// An exact-name match is a perfect logical match — surface similarity = 1 so
+			// the resolver can record it on the ReceiptItem without requiring a second
+			// embedding roundtrip.
+			return new GetOrCreateResult(mapper.ToDomain(existing), MatchScore: 1.0);
 		}
 
 		// Step 2: no embedding capability — create Active entry directly with no vector.
 		if (!embeddingService.IsConfigured)
 		{
 			NormalizedDescriptionEntity created = await InsertAsync(context, normalized, NormalizedDescriptionStatus.Active, embedding: null, cancellationToken);
-			return mapper.ToDomain(created);
+			return new GetOrCreateResult(mapper.ToDomain(created), MatchScore: null);
 		}
 
 		// Step 3: generate embedding for the input.
@@ -62,20 +77,20 @@ public class NormalizedDescriptionService(
 
 		if (topMatch is not null && topSimilarity.HasValue)
 		{
-			if (topSimilarity.Value >= AutoAcceptThreshold)
+			if (topSimilarity.Value >= autoAccept)
 			{
-				return mapper.ToDomain(topMatch);
+				return new GetOrCreateResult(mapper.ToDomain(topMatch), topSimilarity.Value);
 			}
 
-			if (topSimilarity.Value >= PendingReviewThreshold)
+			if (topSimilarity.Value >= pendingReview)
 			{
 				NormalizedDescriptionEntity pending = await InsertAsync(context, normalized, NormalizedDescriptionStatus.PendingReview, embeddingVector, cancellationToken);
-				return mapper.ToDomain(pending);
+				return new GetOrCreateResult(mapper.ToDomain(pending), topSimilarity.Value);
 			}
 		}
 
 		NormalizedDescriptionEntity activeCreated = await InsertAsync(context, normalized, NormalizedDescriptionStatus.Active, embeddingVector, cancellationToken);
-		return mapper.ToDomain(activeCreated);
+		return new GetOrCreateResult(mapper.ToDomain(activeCreated), MatchScore: null);
 	}
 
 	public async Task<NormalizedDescription?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
@@ -200,6 +215,276 @@ public class NormalizedDescriptionService(
 		return true;
 	}
 
+	public async Task<NormalizedDescriptionSettings> GetSettingsAsync(CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity entity = await ResolveSettingsEntityAsync(context, cancellationToken);
+		return settingsMapper.ToDomain(entity);
+	}
+
+	public async Task<NormalizedDescriptionSettings> UpdateSettingsAsync(
+		double autoAcceptThreshold,
+		double pendingReviewThreshold,
+		CancellationToken cancellationToken)
+	{
+		// Domain-level validation: prevents malformed bounds (out-of-range, crossed thresholds)
+		// from ever hitting the DB. Mirrors the constructor on NormalizedDescriptionSettings.
+		NormalizedDescriptionSettings.Validate(autoAcceptThreshold, pendingReviewThreshold);
+
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity entity = await ResolveSettingsEntityAsync(context, cancellationToken);
+
+		entity.AutoAcceptThreshold = autoAcceptThreshold;
+		entity.PendingReviewThreshold = pendingReviewThreshold;
+		entity.UpdatedAt = DateTimeOffset.UtcNow;
+
+		await context.SaveChangesAsync(cancellationToken);
+		return settingsMapper.ToDomain(entity);
+	}
+
+	public async Task<MatchTestResult> TestMatchAsync(
+		string description,
+		int topN,
+		double? autoAcceptThresholdOverride,
+		double? pendingReviewThresholdOverride,
+		CancellationToken cancellationToken)
+	{
+		string normalized = (description ?? string.Empty).Trim();
+		if (string.IsNullOrEmpty(normalized))
+		{
+			throw new ArgumentException(TestMatchDescriptionRequired, nameof(description));
+		}
+
+		if (topN < 1 || topN > MaxTopN)
+		{
+			throw new ArgumentException(TopNOutOfRange, nameof(topN));
+		}
+
+		// Validate any thresholds the admin supplied. We accept partial overrides (one or the
+		// other) but still need the combined pair to satisfy the invariant: fall back to the
+		// DB values for the unset side, then validate the resulting pair.
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity settings = await ResolveSettingsEntityAsync(context, cancellationToken);
+
+		double autoAccept = autoAcceptThresholdOverride ?? settings.AutoAcceptThreshold;
+		double pendingReview = pendingReviewThresholdOverride ?? settings.PendingReviewThreshold;
+		NormalizedDescriptionSettings.Validate(autoAccept, pendingReview);
+
+		// If there is an exact case-insensitive match, the resolver would short-circuit
+		// without ever querying embeddings. Mirror that here so the preview is truthful.
+		NormalizedDescriptionEntity? exactMatch = await FindExactCaseInsensitiveAsync(context, normalized, cancellationToken);
+		if (exactMatch is not null)
+		{
+			List<MatchCandidate> exactCandidates =
+			[
+				new MatchCandidate(
+					exactMatch.Id,
+					exactMatch.CanonicalName,
+					1.0,
+					exactMatch.Status.ToString()),
+			];
+			return new MatchTestResult(exactCandidates, MatchTestOutcomes.AutoAccept, exactMatch.Id);
+		}
+
+		if (!embeddingService.IsConfigured)
+		{
+			// No embedding service — the real resolver would create a new Active entry, but
+			// admins still deserve an honest answer: no candidates, and a dedicated outcome
+			// so the UI can surface a banner. SimulatedTargetId is null because the new
+			// entry doesn't exist yet.
+			return new MatchTestResult([], MatchTestOutcomes.EmbeddingUnavailable, SimulatedTargetId: null);
+		}
+
+		float[] embeddingData = await embeddingService.GenerateEmbeddingAsync(normalized, cancellationToken);
+		if (embeddingData.Length == 0)
+		{
+			return new MatchTestResult([], MatchTestOutcomes.EmbeddingUnavailable, SimulatedTargetId: null);
+		}
+
+		Vector queryVector = new(embeddingData);
+		List<MatchCandidate> candidates = await AnnSearchTopNAsync(context, queryVector, topN, cancellationToken);
+
+		// The resolver makes its branch decision against the top-1 candidate, so we do too —
+		// the rest of the candidates are informational only.
+		MatchCandidate? top = candidates.Count > 0 ? candidates[0] : null;
+		if (top is not null)
+		{
+			if (top.CosineSimilarity >= autoAccept)
+			{
+				return new MatchTestResult(candidates, MatchTestOutcomes.AutoAccept, top.NormalizedDescriptionId);
+			}
+
+			if (top.CosineSimilarity >= pendingReview)
+			{
+				// In the real resolver this would create a new PendingReview entry linked in
+				// a neighbourhood of `top`; SimulatedTargetId=null because the row doesn't
+				// exist yet. The caller has the top candidate in `candidates[0]` for context.
+				return new MatchTestResult(candidates, MatchTestOutcomes.PendingReview, SimulatedTargetId: null);
+			}
+		}
+
+		return new MatchTestResult(candidates, MatchTestOutcomes.CreateNew, SimulatedTargetId: null);
+	}
+
+	public async Task<ThresholdImpactPreview> PreviewThresholdImpactAsync(
+		double autoAcceptThreshold,
+		double pendingReviewThreshold,
+		CancellationToken cancellationToken)
+	{
+		NormalizedDescriptionSettings.Validate(autoAcceptThreshold, pendingReviewThreshold);
+
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity settings = await ResolveSettingsEntityAsync(context, cancellationToken);
+
+		// Snapshot the scored live-set once. We bucketise twice (current thresholds and
+		// proposed thresholds) over the same in-memory list to keep the two classifications
+		// strictly comparable — querying twice would risk a race if items were resolved
+		// between the two counts. An item only enters this list if BOTH the FK and the
+		// score are populated; otherwise it's structurally unresolved and no threshold
+		// change can reclassify it. The set is bounded (only resolved items) so memory
+		// cost is modest relative to the total ReceiptItems table.
+		List<double> scored = await context.ReceiptItems
+			.AsNoTracking()
+			.IgnoreAutoIncludes()
+			.Where(r => r.NormalizedDescriptionMatchScore != null && r.NormalizedDescriptionId != null)
+			.Select(r => r.NormalizedDescriptionMatchScore!.Value)
+			.ToListAsync(cancellationToken);
+
+		// Items without a match score or without any linked NormalizedDescription are
+		// counted as structurally unresolved regardless of threshold choice.
+		int unresolvedCount = await context.ReceiptItems
+			.AsNoTracking()
+			.IgnoreAutoIncludes()
+			.CountAsync(r => r.NormalizedDescriptionMatchScore == null || r.NormalizedDescriptionId == null, cancellationToken);
+
+		ClassificationCounts current = Classify(scored, settings.AutoAcceptThreshold, settings.PendingReviewThreshold, unresolvedCount);
+		ClassificationCounts proposed = Classify(scored, autoAcceptThreshold, pendingReviewThreshold, unresolvedCount);
+
+		// Deltas: per-item transitions between the two classification maps. We don't have
+		// item identity here, just a list of scores — so we compute counts by bucket
+		// intersection (e.g., items currently auto-accepted but proposed-pending-review =
+		// scores where current.auto holds but proposed.auto doesn't and proposed.pending
+		// does). Same for Unresolved → {auto, pending}, which falls out of the score nulls:
+		// null-score items never change bucket, so Unresolved→X transitions only apply to
+		// the "scored but currently below pendingReview" sub-slice.
+		int autoToPending = scored.Count(s =>
+			s >= settings.AutoAcceptThreshold &&
+			s >= pendingReviewThreshold && s < autoAcceptThreshold);
+
+		int pendingToAuto = scored.Count(s =>
+			s >= settings.PendingReviewThreshold && s < settings.AutoAcceptThreshold &&
+			s >= autoAcceptThreshold);
+
+		// Unresolved→X deltas describe currently-unresolved-by-threshold items (i.e., scored
+		// but below the current pending-review floor) that would move up under the proposal.
+		// NULL-score items are "structurally unresolved" and cannot move via a threshold change.
+		int unresolvedToAuto = scored.Count(s =>
+			s < settings.PendingReviewThreshold &&
+			s >= autoAcceptThreshold);
+
+		int unresolvedToPending = scored.Count(s =>
+			s < settings.PendingReviewThreshold &&
+			s >= pendingReviewThreshold && s < autoAcceptThreshold);
+
+		ReclassificationDeltas deltas = new(autoToPending, pendingToAuto, unresolvedToAuto, unresolvedToPending);
+		return new ThresholdImpactPreview(current, proposed, deltas);
+	}
+
+	private static ClassificationCounts Classify(
+		List<double> scored,
+		double autoAcceptThreshold,
+		double pendingReviewThreshold,
+		int unresolvedCount)
+	{
+		int autoAccepted = 0;
+		int pendingReview = 0;
+		int belowFloor = 0;
+		foreach (double score in scored)
+		{
+			if (score >= autoAcceptThreshold)
+			{
+				autoAccepted++;
+			}
+			else if (score >= pendingReviewThreshold)
+			{
+				pendingReview++;
+			}
+			else
+			{
+				belowFloor++;
+			}
+		}
+
+		// Unresolved = structurally-unresolved (NULL score) + "scored but below pending-review"
+		// (i.e., the resolver would have created a new canonical entry, so they're still
+		// effectively unresolved against any existing NormalizedDescription).
+		return new ClassificationCounts(autoAccepted, pendingReview, unresolvedCount + belowFloor);
+	}
+
+	private async Task<(double AutoAccept, double PendingReview)> ResolveThresholdsAsync(
+		ApplicationDbContext context,
+		CancellationToken cancellationToken)
+	{
+		NormalizedDescriptionSettingsEntity? entity = await context.NormalizedDescriptionSettings
+			.AsNoTracking()
+			.FirstOrDefaultAsync(e => e.Id == NormalizedDescriptionSettingsEntityConfiguration.SingletonId, cancellationToken);
+
+		if (entity is null)
+		{
+			// Fallback path for contexts that haven't been seeded (unit tests using a fresh
+			// InMemory provider, integration harnesses that skip EF migrations). The initial
+			// constants mirror the seed row so behaviour is identical at rest.
+			return (InitialAutoAcceptThreshold, InitialPendingReviewThreshold);
+		}
+
+		return (entity.AutoAcceptThreshold, entity.PendingReviewThreshold);
+	}
+
+	private async Task<NormalizedDescriptionSettingsEntity> ResolveSettingsEntityAsync(
+		ApplicationDbContext context,
+		CancellationToken cancellationToken)
+	{
+		NormalizedDescriptionSettingsEntity? entity = await context.NormalizedDescriptionSettings
+			.FirstOrDefaultAsync(e => e.Id == NormalizedDescriptionSettingsEntityConfiguration.SingletonId, cancellationToken);
+
+		if (entity is not null)
+		{
+			return entity;
+		}
+
+		// Self-heal path: if the seed row is missing (e.g., migrations were rolled back and
+		// re-applied in a narrow window, or an InMemory test skipped seeding) we bootstrap
+		// the singleton with defaults on first read/write rather than failing loudly. The
+		// fixed SingletonId plus PK means the insert is race-safe: a second concurrent call
+		// would hit a PK violation and reload.
+		entity = new NormalizedDescriptionSettingsEntity
+		{
+			Id = NormalizedDescriptionSettingsEntityConfiguration.SingletonId,
+			AutoAcceptThreshold = InitialAutoAcceptThreshold,
+			PendingReviewThreshold = InitialPendingReviewThreshold,
+			UpdatedAt = DateTimeOffset.UtcNow,
+		};
+		context.NormalizedDescriptionSettings.Add(entity);
+		try
+		{
+			await context.SaveChangesAsync(cancellationToken);
+		}
+		catch (DbUpdateException)
+		{
+			context.Entry(entity).State = EntityState.Detached;
+			NormalizedDescriptionSettingsEntity? winner = await context.NormalizedDescriptionSettings
+				.FirstOrDefaultAsync(e => e.Id == NormalizedDescriptionSettingsEntityConfiguration.SingletonId, cancellationToken);
+			if (winner is null)
+			{
+				throw new InvalidOperationException(SettingsRowNotFound);
+			}
+
+			return winner;
+		}
+
+		return entity;
+	}
+
 	private static async Task<NormalizedDescriptionEntity?> FindExactCaseInsensitiveAsync(
 		ApplicationDbContext context, string canonicalName, CancellationToken cancellationToken)
 	{
@@ -295,6 +580,61 @@ public class NormalizedDescriptionService(
 		NormalizedDescriptionEntity? entity = await context.NormalizedDescriptions
 			.FirstOrDefaultAsync(e => e.Id == row.entity_id, cancellationToken);
 		return (entity, row.similarity);
+	}
+
+	// Virtual so tests can stub an N-row result without pgvector. Callers cap topN at MaxTopN.
+	protected virtual async Task<List<MatchCandidate>> AnnSearchTopNAsync(
+		ApplicationDbContext context,
+		Vector queryVector,
+		int topN,
+		CancellationToken cancellationToken)
+	{
+		if (context.Database.ProviderName != PostgreSQL)
+		{
+			return [];
+		}
+
+		// Same index as AnnSearchTopOneAsync (partial HNSW on Embedding). Raising LIMIT costs
+		// extra index probes but no additional table scans; safe to keep at topN ≤ 20.
+		string sql = """
+			SELECT "Id" AS entity_id,
+			       (1.0 - ("Embedding" <=> {0}::vector)) AS similarity
+			FROM "NormalizedDescriptions"
+			WHERE "Embedding" IS NOT NULL
+			ORDER BY "Embedding" <=> {0}::vector
+			LIMIT {1}
+			""";
+
+		List<AnnSearchRow> rows = await context.Database
+			.SqlQueryRaw<AnnSearchRow>(sql, queryVector, topN)
+			.ToListAsync(cancellationToken);
+
+		if (rows.Count == 0)
+		{
+			return [];
+		}
+
+		List<Guid> ids = [.. rows.Select(r => r.entity_id)];
+		Dictionary<Guid, NormalizedDescriptionEntity> entities = await context.NormalizedDescriptions
+			.Where(e => ids.Contains(e.Id))
+			.ToDictionaryAsync(e => e.Id, cancellationToken);
+
+		List<MatchCandidate> candidates = [];
+		foreach (AnnSearchRow row in rows)
+		{
+			if (!entities.TryGetValue(row.entity_id, out NormalizedDescriptionEntity? entity))
+			{
+				continue;
+			}
+
+			candidates.Add(new MatchCandidate(
+				entity.Id,
+				entity.CanonicalName,
+				row.similarity,
+				entity.Status.ToString()));
+		}
+
+		return candidates;
 	}
 
 	private sealed class AnnSearchRow

--- a/src/Infrastructure/Services/NormalizedDescriptionService.cs
+++ b/src/Infrastructure/Services/NormalizedDescriptionService.cs
@@ -1,0 +1,307 @@
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Mapping;
+using Microsoft.EntityFrameworkCore;
+using Pgvector;
+
+namespace Infrastructure.Services;
+
+public class NormalizedDescriptionService(
+	IDbContextFactory<ApplicationDbContext> contextFactory,
+	IEmbeddingService embeddingService,
+	NormalizedDescriptionMapper mapper) : INormalizedDescriptionService
+{
+	// Threshold constants are hardcoded for RECEIPTS-577. A later issue (RECEIPTS-580) moves
+	// them into a DB-backed settings row so they can be tuned without a redeploy. The values
+	// below match the data-driven calibration baseline.
+	public const double AutoAcceptThreshold = 0.81;
+	public const double PendingReviewThreshold = 0.68;
+
+	public const string ReceiptItemNotFound = "Receipt item not found.";
+
+	private const string PostgreSQL = "Npgsql.EntityFrameworkCore.PostgreSQL";
+
+	public async Task<NormalizedDescription> GetOrCreateAsync(string rawDescription, CancellationToken cancellationToken)
+	{
+		string normalized = (rawDescription ?? string.Empty).Trim();
+		if (string.IsNullOrEmpty(normalized))
+		{
+			throw new ArgumentException(NormalizedDescription.CanonicalNameCannotBeEmpty, nameof(rawDescription));
+		}
+
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		// Step 1: exact case-insensitive match on existing canonical name.
+		NormalizedDescriptionEntity? existing = await FindExactCaseInsensitiveAsync(context, normalized, cancellationToken);
+		if (existing is not null)
+		{
+			return mapper.ToDomain(existing);
+		}
+
+		// Step 2: no embedding capability — create Active entry directly with no vector.
+		if (!embeddingService.IsConfigured)
+		{
+			NormalizedDescriptionEntity created = await InsertAsync(context, normalized, NormalizedDescriptionStatus.Active, embedding: null, cancellationToken);
+			return mapper.ToDomain(created);
+		}
+
+		// Step 3: generate embedding for the input.
+		float[] embeddingData = await embeddingService.GenerateEmbeddingAsync(normalized, cancellationToken);
+		Vector? embeddingVector = embeddingData.Length > 0 ? new Vector(embeddingData) : null;
+
+		// Step 4: ANN top-1 search — only supported on Postgres. On other providers (InMemory tests)
+		// the method is a no-op by default; tests can override AnnSearchTopOneAsync to simulate
+		// specific top-1 matches and exercise each threshold band.
+		double? topSimilarity = null;
+		NormalizedDescriptionEntity? topMatch = null;
+		if (embeddingVector is not null)
+		{
+			(topMatch, topSimilarity) = await AnnSearchTopOneAsync(context, embeddingVector, cancellationToken);
+		}
+
+		if (topMatch is not null && topSimilarity.HasValue)
+		{
+			if (topSimilarity.Value >= AutoAcceptThreshold)
+			{
+				return mapper.ToDomain(topMatch);
+			}
+
+			if (topSimilarity.Value >= PendingReviewThreshold)
+			{
+				NormalizedDescriptionEntity pending = await InsertAsync(context, normalized, NormalizedDescriptionStatus.PendingReview, embeddingVector, cancellationToken);
+				return mapper.ToDomain(pending);
+			}
+		}
+
+		NormalizedDescriptionEntity activeCreated = await InsertAsync(context, normalized, NormalizedDescriptionStatus.Active, embeddingVector, cancellationToken);
+		return mapper.ToDomain(activeCreated);
+	}
+
+	public async Task<NormalizedDescription?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionEntity? entity = await context.NormalizedDescriptions
+			.AsNoTracking()
+			.FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
+		return entity is null ? null : mapper.ToDomain(entity);
+	}
+
+	public async Task<List<NormalizedDescription>> GetAllAsync(NormalizedDescriptionStatus? filter, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		IQueryable<NormalizedDescriptionEntity> query = context.NormalizedDescriptions.AsNoTracking();
+		if (filter.HasValue)
+		{
+			query = query.Where(e => e.Status == filter.Value);
+		}
+
+		List<NormalizedDescriptionEntity> entities = await query
+			.OrderBy(e => e.CanonicalName)
+			.ToListAsync(cancellationToken);
+		return [.. entities.Select(mapper.ToDomain)];
+	}
+
+	public async Task<int> MergeAsync(Guid keepId, Guid discardId, CancellationToken cancellationToken)
+	{
+		if (keepId == discardId)
+		{
+			return 0;
+		}
+
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		NormalizedDescriptionEntity? keep = await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(e => e.Id == keepId, cancellationToken);
+		NormalizedDescriptionEntity? discard = await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(e => e.Id == discardId, cancellationToken);
+
+		if (keep is null || discard is null)
+		{
+			return 0;
+		}
+
+		// Re-link every live ReceiptItem currently pointing at discard to point at keep.
+		// Soft-deleted items are deliberately excluded via the default query filter — re-linking
+		// logically-deleted rows would inflate the returned count and muddy the audit trail.
+		List<ReceiptItemEntity> items = await context.ReceiptItems
+			.IgnoreAutoIncludes()
+			.Where(r => r.NormalizedDescriptionId == discardId)
+			.ToListAsync(cancellationToken);
+
+		foreach (ReceiptItemEntity item in items)
+		{
+			item.NormalizedDescriptionId = keepId;
+		}
+
+		context.NormalizedDescriptions.Remove(discard);
+
+		await context.SaveChangesAsync(cancellationToken);
+		return items.Count;
+	}
+
+	public async Task<NormalizedDescription> SplitAsync(Guid receiptItemId, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		ReceiptItemEntity? item = await context.ReceiptItems
+			.IgnoreAutoIncludes()
+			.FirstOrDefaultAsync(r => r.Id == receiptItemId, cancellationToken);
+		if (item is null)
+		{
+			throw new KeyNotFoundException(ReceiptItemNotFound);
+		}
+
+		// Match the normalization contract from GetOrCreateAsync so that callers can't create
+		// whitespace-divergent duplicates via Split.
+		string canonicalName = (item.Description ?? string.Empty).Trim();
+		if (string.IsNullOrEmpty(canonicalName))
+		{
+			throw new ArgumentException(NormalizedDescription.CanonicalNameCannotBeEmpty, nameof(receiptItemId));
+		}
+
+		// Generate an embedding for the split item's raw description if possible, so the
+		// new entry is consistent with entries produced by GetOrCreateAsync.
+		Vector? embeddingVector = null;
+		if (embeddingService.IsConfigured)
+		{
+			float[] data = await embeddingService.GenerateEmbeddingAsync(canonicalName, cancellationToken);
+			if (data.Length > 0)
+			{
+				embeddingVector = new Vector(data);
+			}
+		}
+
+		NormalizedDescriptionEntity created = await InsertAsync(
+			context,
+			canonicalName,
+			NormalizedDescriptionStatus.Active,
+			embeddingVector,
+			cancellationToken);
+
+		item.NormalizedDescriptionId = created.Id;
+		await context.SaveChangesAsync(cancellationToken);
+
+		return mapper.ToDomain(created);
+	}
+
+	public async Task<bool> UpdateStatusAsync(Guid id, NormalizedDescriptionStatus status, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		NormalizedDescriptionEntity? entity = await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
+		if (entity is null || entity.Status == status)
+		{
+			return false;
+		}
+
+		entity.Status = status;
+		await context.SaveChangesAsync(cancellationToken);
+		return true;
+	}
+
+	private static async Task<NormalizedDescriptionEntity?> FindExactCaseInsensitiveAsync(
+		ApplicationDbContext context, string canonicalName, CancellationToken cancellationToken)
+	{
+		// ToLower() translates to LOWER() on both PostgreSQL and InMemory. Paired with the
+		// unique functional index on lower("CanonicalName") in the migration, this avoids
+		// a sequential scan on Postgres while still working under InMemory for tests.
+		string lowered = canonicalName.ToLowerInvariant();
+		return await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(
+				e => e.CanonicalName.ToLower() == lowered,
+				cancellationToken);
+	}
+
+	private async Task<NormalizedDescriptionEntity> InsertAsync(
+		ApplicationDbContext context,
+		string canonicalName,
+		NormalizedDescriptionStatus status,
+		Vector? embedding,
+		CancellationToken cancellationToken)
+	{
+		// Double-check for a race: between the caller's exact-match lookup and this insert,
+		// another request may have created a row with the same canonical name. The DB has a
+		// unique functional index on lower(CanonicalName), so a second lookup inside this
+		// save path gives us a race-safe compromise without needing a distributed lock.
+		NormalizedDescriptionEntity? preInsert = await FindExactCaseInsensitiveAsync(context, canonicalName, cancellationToken);
+		if (preInsert is not null)
+		{
+			return preInsert;
+		}
+
+		NormalizedDescriptionEntity entity = new()
+		{
+			Id = Guid.NewGuid(),
+			CanonicalName = canonicalName,
+			Status = status,
+			Embedding = embedding,
+			EmbeddingModelVersion = embedding is null ? null : OnnxEmbeddingService.ModelName,
+			CreatedAt = DateTimeOffset.UtcNow,
+		};
+
+		context.NormalizedDescriptions.Add(entity);
+		try
+		{
+			await context.SaveChangesAsync(cancellationToken);
+		}
+		catch (DbUpdateException)
+		{
+			// Another writer raced us to the unique functional index on lower(CanonicalName).
+			// Detach our losing insert, reload the winner, and return it.
+			context.Entry(entity).State = EntityState.Detached;
+			NormalizedDescriptionEntity? winner = await FindExactCaseInsensitiveAsync(context, canonicalName, cancellationToken);
+			if (winner is null)
+			{
+				throw;
+			}
+
+			return winner;
+		}
+
+		return entity;
+	}
+
+	// Virtual so tests can simulate specific top-1 matches without a real Postgres. On providers
+	// that don't support pgvector (e.g., InMemory) the default implementation is a no-op.
+	protected virtual async Task<(NormalizedDescriptionEntity? Match, double? Similarity)> AnnSearchTopOneAsync(
+		ApplicationDbContext context, Vector queryVector, CancellationToken cancellationToken)
+	{
+		if (context.Database.ProviderName != PostgreSQL)
+		{
+			return (null, null);
+		}
+
+		// pgvector's `<=>` operator returns cosine distance (1 - cosine_similarity).
+		// The partial HNSW index covers the WHERE "Embedding" IS NOT NULL clause.
+		string sql = """
+			SELECT "Id" AS entity_id,
+			       (1.0 - ("Embedding" <=> {0}::vector)) AS similarity
+			FROM "NormalizedDescriptions"
+			WHERE "Embedding" IS NOT NULL
+			ORDER BY "Embedding" <=> {0}::vector
+			LIMIT 1
+			""";
+
+		AnnSearchRow? row = await context.Database
+			.SqlQueryRaw<AnnSearchRow>(sql, queryVector)
+			.FirstOrDefaultAsync(cancellationToken);
+
+		if (row is null)
+		{
+			return (null, null);
+		}
+
+		NormalizedDescriptionEntity? entity = await context.NormalizedDescriptions
+			.FirstOrDefaultAsync(e => e.Id == row.entity_id, cancellationToken);
+		return (entity, row.similarity);
+	}
+
+	private sealed class AnnSearchRow
+	{
+#pragma warning disable IDE1006 // Underscore naming matches raw-SQL column aliases.
+		public Guid entity_id { get; set; }
+		public double similarity { get; set; }
+#pragma warning restore IDE1006
+	}
+}

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Application.Interfaces.Services;
 using Application.Models.Reports;
+using Common;
 using Infrastructure.Entities.Core;
 using Microsoft.EntityFrameworkCore;
 
@@ -690,6 +691,86 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 
 		return periods;
 	}
+
+	public async Task<SpendingByNormalizedDescriptionResult> GetSpendingByNormalizedDescriptionAsync(
+		DateTimeOffset? from,
+		DateTimeOffset? to,
+		CancellationToken cancellationToken)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		// Receipt.Date is DateOnly; convert the caller-supplied DateTimeOffset bounds to DateOnly
+		// using the UTC day so filtering is deterministic regardless of the caller's offset.
+		DateOnly? fromDate = from.HasValue ? DateOnly.FromDateTime(from.Value.UtcDateTime) : null;
+		DateOnly? toDate = to.HasValue ? DateOnly.FromDateTime(to.Value.UtcDateTime) : null;
+
+		var receiptsQuery = context.Receipts.AsNoTracking()
+			.Where(r => r.DeletedAt == null);
+
+		if (fromDate.HasValue)
+		{
+			receiptsQuery = receiptsQuery.Where(r => r.Date >= fromDate.Value);
+		}
+
+		if (toDate.HasValue)
+		{
+			receiptsQuery = receiptsQuery.Where(r => r.Date <= toDate.Value);
+		}
+
+		// LEFT JOIN ReceiptItems -> NormalizedDescriptions (via nullable FK).
+		// Soft-deleted receipts already excluded above; exclude soft-deleted items here.
+		// The join via Receipt.Id enforces the date filter on the item side as well.
+		var joined = from ri in context.ReceiptItems.AsNoTracking().Where(ri => ri.DeletedAt == null)
+					 join r in receiptsQuery on ri.ReceiptId equals r.Id
+					 join n in context.NormalizedDescriptions.AsNoTracking() on ri.NormalizedDescriptionId equals n.Id into gj
+					 from n in gj.DefaultIfEmpty()
+					 select new
+					 {
+						 CanonicalName = n != null ? n.CanonicalName : null,
+						 ri.TotalAmount,
+						 ri.TotalAmountCurrency,
+						 r.Date,
+					 };
+
+		var materialized = await joined.ToListAsync(cancellationToken);
+
+		// Group by the canonical name; NULL FK buckets into a synthetic "(Not Normalized)" group.
+		const string NotNormalizedLabel = "(Not Normalized)";
+		List<SpendingByNormalizedDescriptionItem> items = materialized
+			.GroupBy(x => x.CanonicalName ?? NotNormalizedLabel)
+			.Select(g =>
+			{
+				decimal total = g.Sum(x => x.TotalAmount);
+				int count = g.Count();
+				DateOnly minDate = g.Min(x => x.Date);
+				DateOnly maxDate = g.Max(x => x.Date);
+
+				// Dominant currency: most common across the bucket. Ties broken by name asc
+				// (stable via Currency enum ordering). Empty groups fall back to USD.
+				string currency = g
+					.GroupBy(x => x.TotalAmountCurrency)
+					.OrderByDescending(cg => cg.Count())
+					.ThenBy(cg => cg.Key)
+					.Select(cg => cg.Key.ToString())
+					.FirstOrDefault() ?? Currency.USD.ToString();
+
+				return new SpendingByNormalizedDescriptionItem(
+					g.Key,
+					total,
+					currency,
+					count,
+					ToDateTimeOffset(minDate),
+					ToDateTimeOffset(maxDate));
+			})
+			.OrderByDescending(x => x.TotalAmount)
+			.ThenBy(x => x.CanonicalName)
+			.ToList();
+
+		return new SpendingByNormalizedDescriptionResult(items, from, to);
+	}
+
+	private static DateTimeOffset ToDateTimeOffset(DateOnly date) =>
+		new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.Zero);
 
 	public async Task<UncategorizedItemsResult> GetUncategorizedItemsAsync(
 		string sortBy,

--- a/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
+++ b/src/Presentation/API/Controllers/Aggregates/ReportsController.cs
@@ -464,4 +464,36 @@ public class ReportsController(IMediator mediator) : ControllerBase
 			}).ToList()
 		});
 	}
+
+	[HttpGet("spending-by-normalized-description")]
+	[EndpointSummary("Get spending by normalized description report")]
+	[EndpointDescription("Aggregates receipt item spending grouped by normalized description canonical name. Items without a normalized description bucket into a synthetic \"(Not Normalized)\" group.")]
+	public async Task<Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>>> GetSpendingByNormalizedDescription(
+		[FromQuery] DateTimeOffset? from,
+		[FromQuery] DateTimeOffset? to,
+		CancellationToken cancellationToken)
+	{
+		if (from.HasValue && to.HasValue && from.Value > to.Value)
+		{
+			return TypedResults.BadRequest("from must be before or equal to to");
+		}
+
+		GetSpendingByNormalizedDescriptionQuery query = new(from, to);
+		AppReports.SpendingByNormalizedDescriptionResult result = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new SpendingByNormalizedDescriptionResponse
+		{
+			FromDate = result.FromDate,
+			ToDate = result.ToDate,
+			Items = result.Items.Select(i => new SpendingByNormalizedDescriptionItem
+			{
+				CanonicalName = i.CanonicalName,
+				TotalAmount = (double)i.TotalAmount,
+				Currency = i.Currency,
+				ItemCount = i.ItemCount,
+				FirstSeen = i.FirstSeen,
+				LastSeen = i.LastSeen
+			}).ToList()
+		});
+	}
 }

--- a/src/Presentation/API/Controllers/NormalizedDescriptionsController.cs
+++ b/src/Presentation/API/Controllers/NormalizedDescriptionsController.cs
@@ -1,6 +1,11 @@
 using API.Generated.Dtos;
+using Application.Commands.NormalizedDescription.Merge;
+using Application.Commands.NormalizedDescription.Split;
 using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Commands.NormalizedDescription.UpdateStatus;
 using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.GetAll;
+using Application.Queries.NormalizedDescription.GetById;
 using Application.Queries.NormalizedDescription.GetSettings;
 using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
 using Application.Queries.NormalizedDescription.TestMatch;
@@ -10,13 +15,16 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using DomainStatus = Domain.NormalizedDescriptions.NormalizedDescriptionStatus;
+using DtoStatus = API.Generated.Dtos.NormalizedDescriptionStatus;
 
 namespace API.Controllers;
 
-// RECEIPTS-580 scaffolds this controller with the admin settings/test/preview endpoints
-// only; RECEIPTS-579 will extend the same class with merge/split/status/list/get endpoints.
-// All endpoints gate on RequireAdmin — tuning thresholds and probing the classifier are
-// operator tasks, not end-user ones.
+// Admin-only surface for the canonical-descriptions registry. Wired up across two issues:
+// RECEIPTS-580 scaffolds the settings/test/preview endpoints; RECEIPTS-579 extends the class
+// with list/get/merge/split/status endpoints. Every endpoint gates on RequireAdmin because
+// tuning thresholds, probing the classifier, and editing the registry are operator tasks,
+// not end-user ones.
 [ApiVersion("1.0")]
 [ApiController]
 [Route("api/normalized-descriptions")]
@@ -27,6 +35,11 @@ public class NormalizedDescriptionsController(IMediator mediator) : ControllerBa
 	public const string RouteSettings = "settings";
 	public const string RoutePreview = "settings/preview";
 	public const string RouteTest = "test";
+	public const string RouteGetAll = "";
+	public const string RouteGetById = "{id}";
+	public const string RouteMerge = "{id}/merge";
+	public const string RouteSplit = "{id}/split";
+	public const string RouteUpdateStatus = "{id}/status";
 
 	public const string AutoAcceptOutOfRange = "autoAcceptThreshold must be between 0 and 1";
 	public const string PendingReviewOutOfRange = "pendingReviewThreshold must be between 0 and 1";
@@ -34,6 +47,11 @@ public class NormalizedDescriptionsController(IMediator mediator) : ControllerBa
 	public const string DescriptionRequired = "description must not be empty";
 	public const string TopNOutOfRange = "topN must be between 1 and 20";
 	public const string OverrideOutOfRange = "threshold overrides must be between 0 and 1 when provided";
+	public const string IdCannotBeEmpty = "id must not be empty";
+	public const string DiscardIdCannotBeEmpty = "discardId must not be empty";
+	public const string ReceiptItemIdCannotBeEmpty = "receiptItemId must not be empty";
+	public const string MergeIdsMustDiffer = "keep id and discardId must differ";
+	public const string InvalidStatusFilter = "status must be 'Active' or 'PendingReview' when provided";
 
 	[HttpGet(RouteSettings)]
 	[EndpointSummary("Get the current normalized-description threshold settings")]
@@ -146,6 +164,169 @@ public class NormalizedDescriptionsController(IMediator mediator) : ControllerBa
 		ThresholdImpactPreview result = await mediator.Send(query, cancellationToken);
 		return TypedResults.Ok(ToResponse(result));
 	}
+
+	[HttpGet(RouteGetAll)]
+	[EndpointSummary("List normalized descriptions")]
+	[EndpointDescription("Returns all canonical normalized-description rows, optionally filtered by status (Active or PendingReview). Admin-only.")]
+	public async Task<Results<Ok<NormalizedDescriptionListResponse>, BadRequest<string>>> GetAllNormalizedDescriptions(
+		[FromQuery] string? status,
+		CancellationToken cancellationToken)
+	{
+		DomainStatus? filter = null;
+		if (!string.IsNullOrWhiteSpace(status))
+		{
+			// Parse case-insensitively so the URL is tolerant of "active", "Active", "ACTIVE" —
+			// the spec enumerates PascalCase to stay symmetric with the response-body enum,
+			// but query params traditionally flex on case.
+			if (!Enum.TryParse(status, ignoreCase: true, out DomainStatus parsed))
+			{
+				return TypedResults.BadRequest(InvalidStatusFilter);
+			}
+
+			filter = parsed;
+		}
+
+		GetAllNormalizedDescriptionsQuery query = new(filter);
+		List<NormalizedDescription> items = await mediator.Send(query, cancellationToken);
+
+		return TypedResults.Ok(new NormalizedDescriptionListResponse
+		{
+			Items = [.. items.Select(ToResponse)],
+			TotalCount = items.Count,
+		});
+	}
+
+	[HttpGet(RouteGetById)]
+	[EndpointSummary("Get a normalized description by ID")]
+	[EndpointDescription("Returns a single canonical normalized-description row by GUID. Admin-only.")]
+	public async Task<Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>>> GetNormalizedDescriptionById(
+		[FromRoute] Guid id,
+		CancellationToken cancellationToken)
+	{
+		if (id == Guid.Empty)
+		{
+			return TypedResults.BadRequest(IdCannotBeEmpty);
+		}
+
+		GetNormalizedDescriptionByIdQuery query = new(id);
+		NormalizedDescription? result = await mediator.Send(query, cancellationToken);
+		if (result is null)
+		{
+			return TypedResults.NotFound();
+		}
+
+		return TypedResults.Ok(ToResponse(result));
+	}
+
+	[HttpPost(RouteMerge)]
+	[EndpointSummary("Merge two normalized descriptions")]
+	[EndpointDescription("Re-links every live ReceiptItem currently pointing at discardId to the canonical row identified by the path {id}, then deletes the discarded row. Returns the count of re-linked items — zero when either id was missing or the two ids were identical. Admin-only.")]
+	public async Task<Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>>> MergeNormalizedDescriptions(
+		[FromRoute] Guid id,
+		[FromBody] MergeNormalizedDescriptionRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (id == Guid.Empty)
+		{
+			return TypedResults.BadRequest(IdCannotBeEmpty);
+		}
+
+		if (request.DiscardId == Guid.Empty)
+		{
+			return TypedResults.BadRequest(DiscardIdCannotBeEmpty);
+		}
+
+		if (id == request.DiscardId)
+		{
+			return TypedResults.BadRequest(MergeIdsMustDiffer);
+		}
+
+		MergeNormalizedDescriptionsCommand command = new(id, request.DiscardId);
+		int itemsRelinkedCount = await mediator.Send(command, cancellationToken);
+		return TypedResults.Ok(new MergeNormalizedDescriptionsResponse { ItemsRelinkedCount = itemsRelinkedCount });
+	}
+
+	[HttpPost(RouteSplit)]
+	[EndpointSummary("Detach a receipt item from its normalized description")]
+	[EndpointDescription("Creates a new canonical NormalizedDescription row for the supplied ReceiptItem's raw description and re-points the item at it. Used to unpick bad auto-merges. Admin-only.")]
+	public async Task<Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>>> SplitNormalizedDescription(
+		[FromRoute] Guid id,
+		[FromBody] SplitNormalizedDescriptionRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (id == Guid.Empty)
+		{
+			return TypedResults.BadRequest(IdCannotBeEmpty);
+		}
+
+		if (request.ReceiptItemId == Guid.Empty)
+		{
+			return TypedResults.BadRequest(ReceiptItemIdCannotBeEmpty);
+		}
+
+		SplitNormalizedDescriptionCommand command = new(request.ReceiptItemId);
+		try
+		{
+			NormalizedDescription created = await mediator.Send(command, cancellationToken);
+			return TypedResults.Ok(ToResponse(created));
+		}
+		catch (KeyNotFoundException)
+		{
+			// The service throws when the ReceiptItem does not exist — surface it as a 404.
+			// We don't translate every exception type because that would mask genuine server
+			// errors (DB failures, embedding service outages) behind a 404; only this one
+			// maps cleanly to a client-facing 404.
+			return TypedResults.NotFound();
+		}
+	}
+
+	[HttpPatch(RouteUpdateStatus)]
+	[EndpointSummary("Update the status of a normalized description")]
+	[EndpointDescription("Flips a NormalizedDescription between Active and PendingReview. Returns 204 on success and 404 when the row does not exist. Admin-only.")]
+	public async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateNormalizedDescriptionStatus(
+		[FromRoute] Guid id,
+		[FromBody] UpdateNormalizedDescriptionStatusRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (id == Guid.Empty)
+		{
+			return TypedResults.BadRequest(IdCannotBeEmpty);
+		}
+
+		DomainStatus domainStatus = request.Status switch
+		{
+			DtoStatus.Active => DomainStatus.Active,
+			DtoStatus.PendingReview => DomainStatus.PendingReview,
+			_ => throw new InvalidOperationException($"Unhandled status value: {request.Status}"),
+		};
+
+		// The UpdateStatusAsync service returns false for both "row missing" and "row already at
+		// target status". To preserve REST semantics, do an existence check first so we can
+		// reliably return 404 for the missing case and 204 for both a real flip and a no-op.
+		GetNormalizedDescriptionByIdQuery existsQuery = new(id);
+		NormalizedDescription? existing = await mediator.Send(existsQuery, cancellationToken);
+		if (existing is null)
+		{
+			return TypedResults.NotFound();
+		}
+
+		UpdateNormalizedDescriptionStatusCommand command = new(id, domainStatus);
+		await mediator.Send(command, cancellationToken);
+		return TypedResults.NoContent();
+	}
+
+	private static NormalizedDescriptionResponse ToResponse(NormalizedDescription source) => new()
+	{
+		Id = source.Id,
+		CanonicalName = source.CanonicalName,
+		Status = source.Status switch
+		{
+			DomainStatus.Active => DtoStatus.Active,
+			DomainStatus.PendingReview => DtoStatus.PendingReview,
+			_ => throw new InvalidOperationException($"Unhandled status value: {source.Status}"),
+		},
+		CreatedAt = source.CreatedAt,
+	};
 
 	private static NormalizedDescriptionSettingsResponse ToResponse(NormalizedDescriptionSettings settings) => new()
 	{

--- a/src/Presentation/API/Controllers/NormalizedDescriptionsController.cs
+++ b/src/Presentation/API/Controllers/NormalizedDescriptionsController.cs
@@ -1,0 +1,190 @@
+using API.Generated.Dtos;
+using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.GetSettings;
+using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+using Application.Queries.NormalizedDescription.TestMatch;
+using Asp.Versioning;
+using Domain.NormalizedDescriptions;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+// RECEIPTS-580 scaffolds this controller with the admin settings/test/preview endpoints
+// only; RECEIPTS-579 will extend the same class with merge/split/status/list/get endpoints.
+// All endpoints gate on RequireAdmin — tuning thresholds and probing the classifier are
+// operator tasks, not end-user ones.
+[ApiVersion("1.0")]
+[ApiController]
+[Route("api/normalized-descriptions")]
+[Produces("application/json")]
+[Authorize(Policy = "RequireAdmin")]
+public class NormalizedDescriptionsController(IMediator mediator) : ControllerBase
+{
+	public const string RouteSettings = "settings";
+	public const string RoutePreview = "settings/preview";
+	public const string RouteTest = "test";
+
+	public const string AutoAcceptOutOfRange = "autoAcceptThreshold must be between 0 and 1";
+	public const string PendingReviewOutOfRange = "pendingReviewThreshold must be between 0 and 1";
+	public const string PendingMustBeLessThanAuto = "pendingReviewThreshold must be strictly less than autoAcceptThreshold";
+	public const string DescriptionRequired = "description must not be empty";
+	public const string TopNOutOfRange = "topN must be between 1 and 20";
+	public const string OverrideOutOfRange = "threshold overrides must be between 0 and 1 when provided";
+
+	[HttpGet(RouteSettings)]
+	[EndpointSummary("Get the current normalized-description threshold settings")]
+	[EndpointDescription("Returns the live auto-accept and pending-review thresholds used by the resolver. Admin-only.")]
+	public async Task<Ok<NormalizedDescriptionSettingsResponse>> GetSettings(CancellationToken cancellationToken)
+	{
+		NormalizedDescriptionSettings settings = await mediator.Send(new GetNormalizedDescriptionSettingsQuery(), cancellationToken);
+		return TypedResults.Ok(ToResponse(settings));
+	}
+
+	[HttpPatch(RouteSettings)]
+	[EndpointSummary("Update the normalized-description threshold settings")]
+	[EndpointDescription("Both thresholds must satisfy 0 <= pendingReviewThreshold < autoAcceptThreshold <= 1. Admin-only.")]
+	public async Task<Results<Ok<NormalizedDescriptionSettingsResponse>, BadRequest<string>>> UpdateSettings(
+		[FromBody] UpdateNormalizedDescriptionSettingsRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (request.AutoAcceptThreshold < 0 || request.AutoAcceptThreshold > 1)
+		{
+			return TypedResults.BadRequest(AutoAcceptOutOfRange);
+		}
+
+		if (request.PendingReviewThreshold < 0 || request.PendingReviewThreshold > 1)
+		{
+			return TypedResults.BadRequest(PendingReviewOutOfRange);
+		}
+
+		if (request.PendingReviewThreshold >= request.AutoAcceptThreshold)
+		{
+			return TypedResults.BadRequest(PendingMustBeLessThanAuto);
+		}
+
+		UpdateNormalizedDescriptionSettingsCommand command = new(request.AutoAcceptThreshold, request.PendingReviewThreshold);
+		NormalizedDescriptionSettings result = await mediator.Send(command, cancellationToken);
+		return TypedResults.Ok(ToResponse(result));
+	}
+
+	[HttpPost(RouteTest)]
+	[EndpointSummary("Probe the normalized-description classifier for a given description")]
+	[EndpointDescription("Returns the top-N ANN candidates and the classification branch the resolver would take. Admin-only.")]
+	public async Task<Results<Ok<MatchTestResultResponse>, BadRequest<string>>> TestMatch(
+		[FromBody] TestMatchRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(request.Description))
+		{
+			return TypedResults.BadRequest(DescriptionRequired);
+		}
+
+		int topN = request.TopN == 0 ? 5 : request.TopN;
+		if (topN < 1 || topN > 20)
+		{
+			return TypedResults.BadRequest(TopNOutOfRange);
+		}
+
+		if (request.AutoAcceptThresholdOverride is double autoOverride &&
+			(autoOverride < 0 || autoOverride > 1))
+		{
+			return TypedResults.BadRequest(OverrideOutOfRange);
+		}
+
+		if (request.PendingReviewThresholdOverride is double pendingOverride &&
+			(pendingOverride < 0 || pendingOverride > 1))
+		{
+			return TypedResults.BadRequest(OverrideOutOfRange);
+		}
+
+		// If both overrides are supplied, reject a crossed pair up front for the same reason
+		// UpdateSettings does — don't wait for the service to throw.
+		if (request.AutoAcceptThresholdOverride is double autoSet &&
+			request.PendingReviewThresholdOverride is double pendingSet &&
+			pendingSet >= autoSet)
+		{
+			return TypedResults.BadRequest(PendingMustBeLessThanAuto);
+		}
+
+		TestNormalizedDescriptionMatchQuery query = new(
+			request.Description,
+			topN,
+			request.AutoAcceptThresholdOverride,
+			request.PendingReviewThresholdOverride);
+
+		MatchTestResult result = await mediator.Send(query, cancellationToken);
+		return TypedResults.Ok(ToResponse(result));
+	}
+
+	[HttpPost(RoutePreview)]
+	[EndpointSummary("Preview the impact of changing normalized-description thresholds")]
+	[EndpointDescription("Returns current and proposed classification counts with per-bucket deltas. Admin-only.")]
+	public async Task<Results<Ok<ThresholdImpactPreviewResponse>, BadRequest<string>>> PreviewThresholdImpact(
+		[FromBody] PreviewThresholdImpactRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (request.AutoAcceptThreshold < 0 || request.AutoAcceptThreshold > 1)
+		{
+			return TypedResults.BadRequest(AutoAcceptOutOfRange);
+		}
+
+		if (request.PendingReviewThreshold < 0 || request.PendingReviewThreshold > 1)
+		{
+			return TypedResults.BadRequest(PendingReviewOutOfRange);
+		}
+
+		if (request.PendingReviewThreshold >= request.AutoAcceptThreshold)
+		{
+			return TypedResults.BadRequest(PendingMustBeLessThanAuto);
+		}
+
+		PreviewThresholdImpactQuery query = new(request.AutoAcceptThreshold, request.PendingReviewThreshold);
+		ThresholdImpactPreview result = await mediator.Send(query, cancellationToken);
+		return TypedResults.Ok(ToResponse(result));
+	}
+
+	private static NormalizedDescriptionSettingsResponse ToResponse(NormalizedDescriptionSettings settings) => new()
+	{
+		Id = settings.Id,
+		AutoAcceptThreshold = settings.AutoAcceptThreshold,
+		PendingReviewThreshold = settings.PendingReviewThreshold,
+		UpdatedAt = settings.UpdatedAt,
+	};
+
+	private static MatchTestResultResponse ToResponse(MatchTestResult result) => new()
+	{
+		SimulatedOutcome = result.SimulatedOutcome,
+		SimulatedTargetId = result.SimulatedTargetId,
+		Candidates = [.. result.Candidates.Select(c => new MatchCandidateDto
+		{
+			NormalizedDescriptionId = c.NormalizedDescriptionId,
+			CanonicalName = c.CanonicalName,
+			CosineSimilarity = c.CosineSimilarity,
+			Status = c.Status,
+		})],
+	};
+
+	private static ThresholdImpactPreviewResponse ToResponse(ThresholdImpactPreview preview) => new()
+	{
+		Current = ToResponse(preview.Current),
+		Proposed = ToResponse(preview.Proposed),
+		Deltas = new ReclassificationDeltasDto
+		{
+			AutoToPending = preview.Deltas.AutoToPending,
+			PendingToAuto = preview.Deltas.PendingToAuto,
+			UnresolvedToAuto = preview.Deltas.UnresolvedToAuto,
+			UnresolvedToPending = preview.Deltas.UnresolvedToPending,
+		},
+	};
+
+	private static ClassificationCountsDto ToResponse(ClassificationCounts counts) => new()
+	{
+		AutoAccepted = counts.AutoAccepted,
+		PendingReview = counts.PendingReview,
+		Unresolved = counts.Unresolved,
+	};
+}

--- a/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
+++ b/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
@@ -12,12 +12,6 @@ public partial class ReceiptItemMapper
 	[MapProperty(nameof(ReceiptItem.UnitPrice.Amount), nameof(ReceiptItemResponse.UnitPrice))]
 	[MapperIgnoreSource(nameof(ReceiptItem.TotalAmount))]
 	[MapperIgnoreSource(nameof(ReceiptItem.PricingMode))]
-	// NormalizedDescription FK, name, and match score are deliberately not exposed on the API
-	// response here — RECEIPTS-583 will add them. Ignore them so Mapperly does not flag the
-	// unmapped members.
-	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionId))]
-	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionName))]
-	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionMatchScore))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.AdditionalProperties))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.PricingMode))]
 	private partial ReceiptItemResponse ToResponsePartial(ReceiptItem source);

--- a/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
+++ b/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
@@ -12,10 +12,12 @@ public partial class ReceiptItemMapper
 	[MapProperty(nameof(ReceiptItem.UnitPrice.Amount), nameof(ReceiptItemResponse.UnitPrice))]
 	[MapperIgnoreSource(nameof(ReceiptItem.TotalAmount))]
 	[MapperIgnoreSource(nameof(ReceiptItem.PricingMode))]
-	// NormalizedDescription FK and name are deliberately not exposed on the API response here —
-	// RECEIPTS-583 will add them. Ignore them so Mapperly does not flag the unmapped members.
+	// NormalizedDescription FK, name, and match score are deliberately not exposed on the API
+	// response here — RECEIPTS-583 will add them. Ignore them so Mapperly does not flag the
+	// unmapped members.
 	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionId))]
 	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionName))]
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionMatchScore))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.AdditionalProperties))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.PricingMode))]
 	private partial ReceiptItemResponse ToResponsePartial(ReceiptItem source);

--- a/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
+++ b/src/Presentation/API/Mapping/Core/ReceiptItemMapper.cs
@@ -12,6 +12,10 @@ public partial class ReceiptItemMapper
 	[MapProperty(nameof(ReceiptItem.UnitPrice.Amount), nameof(ReceiptItemResponse.UnitPrice))]
 	[MapperIgnoreSource(nameof(ReceiptItem.TotalAmount))]
 	[MapperIgnoreSource(nameof(ReceiptItem.PricingMode))]
+	// NormalizedDescription FK and name are deliberately not exposed on the API response here —
+	// RECEIPTS-583 will add them. Ignore them so Mapperly does not flag the unmapped members.
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionId))]
+	[MapperIgnoreSource(nameof(ReceiptItem.NormalizedDescriptionName))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.AdditionalProperties))]
 	[MapperIgnoreTarget(nameof(ReceiptItemResponse.PricingMode))]
 	private partial ReceiptItemResponse ToResponsePartial(ReceiptItem source);

--- a/src/client/src/components/ReceiptItemsCard.test.tsx
+++ b/src/client/src/components/ReceiptItemsCard.test.tsx
@@ -342,6 +342,81 @@ describe("ReceiptItemsCard", () => {
     expect(submitButton).toBeInTheDocument();
   });
 
+  it("renders 'normalized as' label when normalizedDescriptionName is present and differs from description", () => {
+    const itemsWithNormalized = [
+      {
+        id: "item-norm-1",
+        receiptItemCode: "ITEM-NORM-1",
+        description: "Red Seedless Grapes 2LB",
+        quantity: 1,
+        unitPrice: 5.99,
+        category: "Groceries",
+        subcategory: "Produce",
+        pricingMode: "quantity",
+        normalizedDescriptionName: "Grapes",
+      },
+    ];
+    renderWithQueryClient(
+      <ReceiptItemsCard
+        receiptId="receipt-1"
+        items={itemsWithNormalized}
+        subtotal={5.99}
+      />,
+    );
+    expect(screen.getByText("Red Seedless Grapes 2LB")).toBeInTheDocument();
+    expect(screen.getByText(/normalized as Grapes/i)).toBeInTheDocument();
+  });
+
+  it("does not render 'normalized as' label when normalizedDescriptionName is null", () => {
+    const itemsWithoutNormalized = [
+      {
+        id: "item-plain-1",
+        receiptItemCode: "ITEM-PLAIN-1",
+        description: "Eggs",
+        quantity: 1,
+        unitPrice: 3.49,
+        category: "Groceries",
+        subcategory: "Dairy",
+        pricingMode: "quantity",
+        normalizedDescriptionName: null,
+      },
+    ];
+    renderWithQueryClient(
+      <ReceiptItemsCard
+        receiptId="receipt-1"
+        items={itemsWithoutNormalized}
+        subtotal={3.49}
+      />,
+    );
+    expect(screen.getByText("Eggs")).toBeInTheDocument();
+    expect(screen.queryByText(/normalized as/i)).not.toBeInTheDocument();
+  });
+
+  it("does not render 'normalized as' label when normalizedDescriptionName equals description", () => {
+    const itemsWithSameNormalized = [
+      {
+        id: "item-same-1",
+        receiptItemCode: "ITEM-SAME-1",
+        description: "Milk",
+        quantity: 1,
+        unitPrice: 4.29,
+        category: "Groceries",
+        subcategory: "Dairy",
+        pricingMode: "quantity",
+        normalizedDescriptionName: "Milk",
+      },
+    ];
+    renderWithQueryClient(
+      <ReceiptItemsCard
+        receiptId="receipt-1"
+        items={itemsWithSameNormalized}
+        subtotal={4.29}
+      />,
+    );
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+    expect(screen.queryByText(/normalized as/i)).not.toBeInTheDocument();
+  });
+
   it("cancels delete dialog without deleting", async () => {
     const { useDeleteReceiptItems } = await import(
       "@/hooks/useReceiptItems"

--- a/src/client/src/components/ReceiptItemsCard.tsx
+++ b/src/client/src/components/ReceiptItemsCard.tsx
@@ -48,6 +48,7 @@ interface ReceiptItem {
   category: string;
   subcategory?: string | null;
   pricingMode?: string | null;
+  normalizedDescriptionName?: string | null;
 }
 
 interface ReceiptItemsCardProps {
@@ -221,7 +222,19 @@ export function ReceiptItemsCard({
                       <TableCell className="font-mono">
                         {item.receiptItemCode ?? ""}
                       </TableCell>
-                      <TableCell>{item.description}</TableCell>
+                      <TableCell>
+                        <div>{item.description}</div>
+                        {item.normalizedDescriptionName &&
+                          item.normalizedDescriptionName !==
+                            item.description && (
+                            <div
+                              className="text-xs text-muted-foreground"
+                              data-testid={`normalized-as-${item.id}`}
+                            >
+                              normalized as {item.normalizedDescriptionName}
+                            </div>
+                          )}
+                      </TableCell>
                       <TableCell className="text-right">
                         {item.quantity}
                       </TableCell>

--- a/src/client/src/components/reports/NormalizedDescriptions.test.tsx
+++ b/src/client/src/components/reports/NormalizedDescriptions.test.tsx
@@ -1,0 +1,491 @@
+import { screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "@/test/test-utils";
+import { mockMutationResult, mockQueryResult } from "@/test/mock-hooks";
+import NormalizedDescriptions from "./NormalizedDescriptions";
+
+vi.mock("@/hooks/useNormalizedDescriptions", () => ({
+  useNormalizedDescriptions: vi.fn(),
+  useNormalizedDescription: vi.fn(),
+}));
+
+vi.mock("@/hooks/useNormalizedDescriptionActions", () => ({
+  useMergeMutation: vi.fn(() => mockMutationResult()),
+  useSplitMutation: vi.fn(() => mockMutationResult()),
+  useUpdateStatusMutation: vi.fn(() => mockMutationResult()),
+}));
+
+vi.mock("@/hooks/useNormalizedDescriptionSettings", () => ({
+  useSettings: vi.fn(),
+  useUpdateSettingsMutation: vi.fn(() => mockMutationResult()),
+  useTestMatchMutation: vi.fn(() => mockMutationResult()),
+  usePreviewImpactMutation: vi.fn(() => mockMutationResult()),
+}));
+
+vi.mock("@/hooks/useReceiptItems", () => ({
+  useReceiptItems: vi.fn(() => ({
+    data: [],
+    total: 0,
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/hooks/usePermission", () => ({
+  usePermission: vi.fn(() => ({
+    roles: ["Admin"],
+    hasRole: (role: string) => role === "Admin",
+    isAdmin: () => true,
+  })),
+}));
+
+import { useNormalizedDescriptions } from "@/hooks/useNormalizedDescriptions";
+import {
+  useMergeMutation,
+  useSplitMutation,
+  useUpdateStatusMutation,
+} from "@/hooks/useNormalizedDescriptionActions";
+import {
+  useSettings,
+  useUpdateSettingsMutation,
+  useTestMatchMutation,
+  usePreviewImpactMutation,
+} from "@/hooks/useNormalizedDescriptionSettings";
+import { useReceiptItems } from "@/hooks/useReceiptItems";
+import { usePermission } from "@/hooks/usePermission";
+
+const pendingItems = [
+  {
+    id: "p-1",
+    canonicalName: "Strawberry Preserves",
+    status: "pendingReview" as const,
+    createdAt: "2025-03-01T00:00:00Z",
+  },
+  {
+    id: "p-2",
+    canonicalName: "Organic Milk",
+    status: "pendingReview" as const,
+    createdAt: "2025-03-02T00:00:00Z",
+  },
+];
+
+const activeItems = [
+  {
+    id: "a-1",
+    canonicalName: "Apples",
+    status: "active" as const,
+    createdAt: "2025-02-01T00:00:00Z",
+  },
+  {
+    id: "a-2",
+    canonicalName: "Milk",
+    status: "active" as const,
+    createdAt: "2025-02-02T00:00:00Z",
+  },
+];
+
+function mockList(status: string | undefined) {
+  if (status === "PendingReview") {
+    return mockQueryResult({
+      data: { items: pendingItems, totalCount: pendingItems.length },
+      isLoading: false,
+      isSuccess: true,
+      isPending: false,
+      status: "success",
+    });
+  }
+  if (status === "Active") {
+    return mockQueryResult({
+      data: { items: activeItems, totalCount: activeItems.length },
+      isLoading: false,
+      isSuccess: true,
+      isPending: false,
+      status: "success",
+    });
+  }
+  return mockQueryResult({
+    data: { items: [], totalCount: 0 },
+    isLoading: false,
+    isSuccess: true,
+    isPending: false,
+    status: "success",
+  });
+}
+
+const liveSettings = {
+  id: "00000000-0000-0000-0000-000000000001",
+  autoAcceptThreshold: 0.9,
+  pendingReviewThreshold: 0.75,
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+function wireDefaults() {
+  vi.mocked(useNormalizedDescriptions).mockImplementation((status) =>
+    mockList(status),
+  );
+  vi.mocked(useSettings).mockReturnValue(
+    mockQueryResult({
+      data: liveSettings,
+      isLoading: false,
+      isSuccess: true,
+      isPending: false,
+      status: "success",
+    }),
+  );
+  vi.mocked(useMergeMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useSplitMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useUpdateStatusMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useUpdateSettingsMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useTestMatchMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(usePreviewImpactMutation).mockReturnValue(mockMutationResult());
+  vi.mocked(useReceiptItems).mockReturnValue({
+    data: [],
+    total: 0,
+    isLoading: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  vi.mocked(usePermission).mockReturnValue({
+    roles: ["Admin"],
+    hasRole: (role: string) => role === "Admin",
+    isAdmin: () => true,
+  });
+}
+
+describe("NormalizedDescriptions review queue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wireDefaults();
+  });
+
+  it("renders pending-review rows by default", async () => {
+    renderWithQueryClient(<NormalizedDescriptions />);
+    expect(
+      await screen.findByText("Strawberry Preserves"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Organic Milk")).toBeInTheDocument();
+  });
+
+  it("shows empty state when queue is empty", () => {
+    vi.mocked(useNormalizedDescriptions).mockImplementation((status) => {
+      if (status === "PendingReview") {
+        return mockQueryResult({
+          data: { items: [], totalCount: 0 },
+          isLoading: false,
+          isSuccess: true,
+          isPending: false,
+          status: "success",
+        });
+      }
+      return mockList(status);
+    });
+    renderWithQueryClient(<NormalizedDescriptions />);
+    expect(screen.getByText("Review Queue Empty")).toBeInTheDocument();
+  });
+
+  it("approve button calls status update mutation", async () => {
+    const mutate = vi.fn();
+    vi.mocked(useUpdateStatusMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    const row = (await screen.findByText("Strawberry Preserves")).closest(
+      "tr",
+    )!;
+    const approveBtn = within(row).getByRole("button", { name: "Approve" });
+    await user.click(approveBtn);
+    expect(mutate).toHaveBeenCalledWith({ id: "p-1", status: "active" });
+  });
+
+  it("opens merge dialog when Merge is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    const row = (await screen.findByText("Strawberry Preserves")).closest(
+      "tr",
+    )!;
+    await user.click(within(row).getByRole("button", { name: "Merge" }));
+    expect(screen.getByText("Merge Into Active Entry")).toBeInTheDocument();
+    expect(screen.getByText("Apples")).toBeInTheDocument();
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+  });
+
+  it("confirm merge calls mutation with discard and target ids", async () => {
+    const mutate = vi.fn((_vars, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+    vi.mocked(useMergeMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    const row = (await screen.findByText("Strawberry Preserves")).closest(
+      "tr",
+    )!;
+    await user.click(within(row).getByRole("button", { name: "Merge" }));
+
+    // Select target
+    const dialog = screen.getByRole("dialog");
+    const appleLabel = within(dialog).getByText("Apples").closest("label")!;
+    const appleRadio = within(appleLabel).getByRole("radio");
+    await user.click(appleRadio);
+    await user.click(within(dialog).getByRole("button", { name: "Merge" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { id: "a-1", discardId: "p-1" },
+      expect.any(Object),
+    );
+  });
+
+  it("opens split dialog and confirms with receipt item id", async () => {
+    const mutate = vi.fn((_vars, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+    vi.mocked(useSplitMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+    vi.mocked(useReceiptItems).mockReturnValue({
+      data: [
+        {
+          id: "ri-1",
+          description: "STRAWBERRY PRESERVES",
+          normalizedDescriptionId: "p-1",
+          normalizedDescriptionName: "Strawberry Preserves",
+        },
+        {
+          id: "ri-2",
+          description: "OTHER",
+          normalizedDescriptionId: "different",
+        },
+      ],
+      total: 2,
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    const row = (await screen.findByText("Strawberry Preserves")).closest(
+      "tr",
+    )!;
+    await user.click(within(row).getByRole("button", { name: "Split" }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByText("Split Out a Receipt Item"),
+    ).toBeInTheDocument();
+    const label = within(dialog)
+      .getByText("STRAWBERRY PRESERVES")
+      .closest("label")!;
+    const radio = within(label).getByRole("radio");
+    await user.click(radio);
+    await user.click(within(dialog).getByRole("button", { name: "Split" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { id: "p-1", receiptItemId: "ri-1" },
+      expect.any(Object),
+    );
+  });
+});
+
+describe("NormalizedDescriptions registry tab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wireDefaults();
+  });
+
+  it("shows active entries when registry tab is selected", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Registry" }));
+    expect(await screen.findByText("Apples")).toBeInTheDocument();
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+  });
+
+  it("filters by search box", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Registry" }));
+    const input = await screen.findByLabelText("Search");
+    await user.type(input, "apple");
+    await waitFor(() => {
+      expect(screen.getByText("Apples")).toBeInTheDocument();
+      expect(screen.queryByText("Milk")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("NormalizedDescriptions settings tab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wireDefaults();
+  });
+
+  it("renders settings tab for admins and hydrates from live settings", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    const pendingInput = screen.getByLabelText(
+      "Pending-Review Threshold",
+    ) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+    expect(pendingInput.value).toBe("0.75");
+  });
+
+  it("hides settings tab for non-admins", () => {
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["User"],
+      hasRole: (role: string) => role === "User",
+      isAdmin: () => false,
+    });
+    renderWithQueryClient(<NormalizedDescriptions />);
+    expect(
+      screen.queryByRole("tab", { name: "Settings" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("save triggers update mutation with parsed thresholds", async () => {
+    const mutate = vi.fn();
+    vi.mocked(useUpdateSettingsMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(mutate).toHaveBeenCalledWith({
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.75,
+    });
+  });
+
+  it("shows validation error when pending >= auto", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    const pendingInput = (await screen.findByLabelText(
+      "Pending-Review Threshold",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+
+    await user.clear(autoInput);
+    await user.type(autoInput, "0.5");
+    await user.clear(pendingInput);
+    await user.type(pendingInput, "0.8");
+
+    expect(
+      await screen.findByTestId("threshold-validation-error"),
+    ).toHaveTextContent(/strictly less than the auto-accept threshold/i);
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("shows validation error when a value is out of range", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+
+    await user.clear(autoInput);
+    await user.type(autoInput, "2");
+
+    expect(
+      await screen.findByTestId("threshold-validation-error"),
+    ).toHaveTextContent(/between 0 and 1/i);
+  });
+
+  it("preview impact shows panel with deltas", async () => {
+    vi.mocked(usePreviewImpactMutation).mockReturnValue(
+      mockMutationResult({
+        data: {
+          current: { autoAccepted: 5, pendingReview: 2, unresolved: 1 },
+          proposed: { autoAccepted: 6, pendingReview: 1, unresolved: 1 },
+          deltas: {
+            autoToPending: 0,
+            pendingToAuto: 1,
+            unresolvedToAuto: 0,
+            unresolvedToPending: 0,
+          },
+        },
+        isSuccess: true,
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    expect(
+      await screen.findByTestId("preview-impact-panel"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/pending-to-auto: 1/i)).toBeInTheDocument();
+  });
+
+  it("preview impact button calls mutation with current edited thresholds", async () => {
+    const mutate = vi.fn();
+    vi.mocked(usePreviewImpactMutation).mockReturnValue(
+      mockMutationResult({ mutate }),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const autoInput = (await screen.findByLabelText(
+      "Auto-Accept Threshold",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(autoInput.value).toBe("0.9"));
+    await user.click(
+      screen.getByRole("button", { name: /preview impact/i }),
+    );
+    expect(mutate).toHaveBeenCalledWith({
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.75,
+    });
+  });
+
+  it("test description box renders candidates and outcome", async () => {
+    const mutate = vi.fn();
+    vi.mocked(useTestMatchMutation).mockReturnValue(
+      mockMutationResult({
+        mutate,
+        data: {
+          candidates: [
+            {
+              normalizedDescriptionId: "a-1",
+              canonicalName: "Apples",
+              cosineSimilarity: 0.87,
+              status: "Active",
+            },
+          ],
+          simulatedOutcome: "AutoAccept",
+        },
+        isSuccess: true,
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithQueryClient(<NormalizedDescriptions />);
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+
+    const testInput = await screen.findByLabelText("Description");
+    await user.type(testInput, "apples");
+    await user.click(screen.getByRole("button", { name: "Test" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "apples", topN: 5 }),
+    );
+
+    const panel = await screen.findByTestId("test-match-panel");
+    expect(within(panel).getByText("AutoAccept")).toBeInTheDocument();
+    expect(within(panel).getByText("Apples")).toBeInTheDocument();
+    expect(within(panel).getByText("0.8700")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/reports/NormalizedDescriptions.tsx
+++ b/src/client/src/components/reports/NormalizedDescriptions.tsx
@@ -1,0 +1,806 @@
+import { useMemo, useState } from "react";
+import { useNormalizedDescriptions } from "@/hooks/useNormalizedDescriptions";
+import {
+  useMergeMutation,
+  useSplitMutation,
+  useUpdateStatusMutation,
+} from "@/hooks/useNormalizedDescriptionActions";
+import {
+  useSettings,
+  useUpdateSettingsMutation,
+  useTestMatchMutation,
+  usePreviewImpactMutation,
+} from "@/hooks/useNormalizedDescriptionSettings";
+import { useReceiptItems } from "@/hooks/useReceiptItems";
+import { usePermission } from "@/hooks/usePermission";
+import { formatDecimal } from "@/lib/format";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { components } from "@/generated/api";
+
+type NormalizedDescription =
+  components["schemas"]["NormalizedDescriptionResponse"];
+
+type ReceiptItem = {
+  id: string;
+  description: string;
+  normalizedDescriptionId?: string | null;
+  normalizedDescriptionName?: string | null;
+};
+
+type TabKey = "review" | "registry" | "settings";
+
+export default function NormalizedDescriptions() {
+  const { isAdmin } = usePermission();
+  const [tab, setTab] = useState<TabKey>("review");
+
+  return (
+    <Tabs
+      value={tab}
+      onValueChange={(v) => setTab(v as TabKey)}
+      className="space-y-4"
+    >
+      <TabsList>
+        <TabsTrigger value="review">Review Queue</TabsTrigger>
+        <TabsTrigger value="registry">Registry</TabsTrigger>
+        {isAdmin() && <TabsTrigger value="settings">Settings</TabsTrigger>}
+      </TabsList>
+      <TabsContent value="review">
+        <ReviewQueueTab />
+      </TabsContent>
+      <TabsContent value="registry">
+        <RegistryTab />
+      </TabsContent>
+      {isAdmin() && (
+        <TabsContent value="settings">
+          <SettingsTab />
+        </TabsContent>
+      )}
+    </Tabs>
+  );
+}
+
+function ReviewQueueTab() {
+  const { data: pendingData, isLoading, isError } = useNormalizedDescriptions(
+    "PendingReview",
+  );
+  const { data: activeData } = useNormalizedDescriptions("Active");
+  const updateStatus = useUpdateStatusMutation();
+  const [mergeTarget, setMergeTarget] = useState<NormalizedDescription | null>(
+    null,
+  );
+  const [splitTarget, setSplitTarget] = useState<NormalizedDescription | null>(
+    null,
+  );
+
+  const pending = useMemo(() => {
+    const items = pendingData?.items ?? [];
+    return [...items].sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+  }, [pendingData?.items]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">Failed to load review queue.</p>
+      </div>
+    );
+  }
+
+  if (pending.length === 0) {
+    return (
+      <div className="rounded-lg border p-6 text-center">
+        <h2 className="text-lg font-semibold">Review Queue Empty</h2>
+        <p className="mt-2 text-muted-foreground">
+          No descriptions are awaiting review right now.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-6 rounded-lg border p-4">
+        <div>
+          <p className="text-sm text-muted-foreground">Pending Review</p>
+          <p className="text-2xl font-bold">
+            {pendingData?.totalCount ?? pending.length}
+          </p>
+        </div>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Canonical Name</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Created</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {pending.map((row) => (
+            <TableRow key={row.id}>
+              <TableCell className="font-medium">{row.canonicalName}</TableCell>
+              <TableCell>
+                <Badge variant="secondary">Pending Review</Badge>
+              </TableCell>
+              <TableCell>
+                <span className="text-sm text-muted-foreground">
+                  {new Date(row.createdAt).toLocaleDateString()}
+                </span>
+              </TableCell>
+              <TableCell className="text-right space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={updateStatus.isPending}
+                  onClick={() =>
+                    updateStatus.mutate({ id: row.id, status: "active" })
+                  }
+                >
+                  Approve
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setMergeTarget(row)}
+                >
+                  Merge
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setSplitTarget(row)}
+                >
+                  Split
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <MergeDialog
+        source={mergeTarget}
+        candidates={activeData?.items ?? []}
+        onClose={() => setMergeTarget(null)}
+      />
+      <SplitDialog
+        source={splitTarget}
+        onClose={() => setSplitTarget(null)}
+      />
+    </div>
+  );
+}
+
+interface MergeDialogProps {
+  source: NormalizedDescription | null;
+  candidates: NormalizedDescription[];
+  onClose: () => void;
+}
+
+function MergeDialog({ source, candidates, onClose }: MergeDialogProps) {
+  const merge = useMergeMutation();
+  const [targetId, setTargetId] = useState<string | undefined>();
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const list = candidates.filter((c) => c.id !== source?.id);
+    if (!q) return list.slice(0, 50);
+    return list
+      .filter((c) => c.canonicalName.toLowerCase().includes(q))
+      .slice(0, 50);
+  }, [candidates, search, source?.id]);
+
+  function handleClose() {
+    setTargetId(undefined);
+    setSearch("");
+    onClose();
+  }
+
+  function handleConfirm() {
+    if (!source || !targetId) return;
+    merge.mutate(
+      { id: targetId, discardId: source.id },
+      { onSuccess: () => handleClose() },
+    );
+  }
+
+  return (
+    <Dialog
+      open={source !== null}
+      onOpenChange={(open) => {
+        if (!open) handleClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Merge Into Active Entry</DialogTitle>
+          <DialogDescription>
+            Pick the canonical row to keep. All receipt items currently linked
+            to &quot;{source?.canonicalName}&quot; will be re-pointed at the
+            chosen row, and this pending-review entry will be deleted.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div>
+            <Label htmlFor="merge-search">Search active entries</Label>
+            <Input
+              id="merge-search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Start typing a canonical name…"
+              className="mt-1"
+            />
+          </div>
+          <div className="max-h-64 overflow-y-auto rounded border">
+            {filtered.length === 0 ? (
+              <p className="p-4 text-sm text-muted-foreground">
+                No matching active entries.
+              </p>
+            ) : (
+              <ul className="divide-y">
+                {filtered.map((c) => (
+                  <li key={c.id}>
+                    <label className="flex cursor-pointer items-center gap-2 p-2 text-sm hover:bg-muted/50">
+                      <input
+                        type="radio"
+                        name="merge-target"
+                        value={c.id}
+                        checked={targetId === c.id}
+                        onChange={() => setTargetId(c.id)}
+                      />
+                      <span className="font-medium">{c.canonicalName}</span>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={!targetId || merge.isPending}
+          >
+            {merge.isPending ? "Merging…" : "Merge"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface SplitDialogProps {
+  source: NormalizedDescription | null;
+  onClose: () => void;
+}
+
+function SplitDialog({ source, onClose }: SplitDialogProps) {
+  const split = useSplitMutation();
+  const [selectedItemId, setSelectedItemId] = useState<string | undefined>();
+  // Pull a broad page of receipt items and filter client-side by normalized
+  // description id. The list endpoint doesn't expose a dedicated filter today,
+  // so this keeps the dialog functional without requiring a new API.
+  const { data: items, isLoading } = useReceiptItems(0, 200);
+
+  const linked = useMemo(() => {
+    if (!source || !items) return [] as ReceiptItem[];
+    return (items as ReceiptItem[]).filter(
+      (i) => i.normalizedDescriptionId === source.id,
+    );
+  }, [items, source]);
+
+  function handleClose() {
+    setSelectedItemId(undefined);
+    onClose();
+  }
+
+  function handleConfirm() {
+    if (!source || !selectedItemId) return;
+    split.mutate(
+      { id: source.id, receiptItemId: selectedItemId },
+      { onSuccess: () => handleClose() },
+    );
+  }
+
+  return (
+    <Dialog
+      open={source !== null}
+      onOpenChange={(open) => {
+        if (!open) handleClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Split Out a Receipt Item</DialogTitle>
+          <DialogDescription>
+            Pick a receipt item currently linked to &quot;
+            {source?.canonicalName}&quot;. It will be detached into a brand-new
+            normalized description that keeps the item&apos;s raw description.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          {isLoading ? (
+            <Skeleton className="h-24 w-full rounded" />
+          ) : linked.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No linked receipt items found in the most recent 200 items. Split
+              from the receipt detail page if the item is older.
+            </p>
+          ) : (
+            <ul className="max-h-64 overflow-y-auto divide-y rounded border">
+              {linked.map((item) => (
+                <li key={item.id}>
+                  <label className="flex cursor-pointer items-center gap-2 p-2 text-sm hover:bg-muted/50">
+                    <input
+                      type="radio"
+                      name="split-target"
+                      value={item.id}
+                      checked={selectedItemId === item.id}
+                      onChange={() => setSelectedItemId(item.id)}
+                    />
+                    <span>{item.description}</span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={!selectedItemId || split.isPending}
+          >
+            {split.isPending ? "Splitting…" : "Split"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RegistryTab() {
+  const { data, isLoading, isError } = useNormalizedDescriptions("Active");
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    const items = data?.items ?? [];
+    const q = search.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((i) => i.canonicalName.toLowerCase().includes(q));
+  }, [data?.items, search]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">Failed to load registry.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-end gap-4">
+        <div className="flex-1 max-w-md">
+          <Label htmlFor="registry-search">Search</Label>
+          <Input
+            id="registry-search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Filter by canonical name…"
+            className="mt-1"
+          />
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-muted-foreground">Active Entries</p>
+          <p className="text-2xl font-bold">{data?.totalCount ?? 0}</p>
+        </div>
+      </div>
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border p-6 text-center">
+          <p className="text-muted-foreground">
+            {search
+              ? "No active entries match your search."
+              : "No active entries yet."}
+          </p>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Canonical Name</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell className="font-medium">
+                  {row.canonicalName}
+                </TableCell>
+                <TableCell>
+                  <span className="text-sm text-muted-foreground">
+                    {new Date(row.createdAt).toLocaleDateString()}
+                  </span>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}
+
+function SettingsTab() {
+  const settings = useSettings();
+
+  if (settings.isLoading) {
+    return <Skeleton className="h-48 w-full rounded-lg" />;
+  }
+
+  if (settings.isError || !settings.data) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">Failed to load settings.</p>
+      </div>
+    );
+  }
+
+  return (
+    <SettingsForm
+      initialAutoAccept={settings.data.autoAcceptThreshold}
+      initialPendingReview={settings.data.pendingReviewThreshold}
+    />
+  );
+}
+
+interface SettingsFormProps {
+  initialAutoAccept: number;
+  initialPendingReview: number;
+}
+
+function SettingsForm({
+  initialAutoAccept,
+  initialPendingReview,
+}: SettingsFormProps) {
+  const updateSettings = useUpdateSettingsMutation();
+  const previewImpact = usePreviewImpactMutation();
+  const testMatch = useTestMatchMutation();
+
+  const [autoAccept, setAutoAccept] = useState(() => String(initialAutoAccept));
+  const [pendingReview, setPendingReview] = useState(() =>
+    String(initialPendingReview),
+  );
+  const [testDescription, setTestDescription] = useState("");
+  const [topN, setTopN] = useState(5);
+
+  const autoVal = parseFloat(autoAccept);
+  const pendingVal = parseFloat(pendingReview);
+  const autoValid = Number.isFinite(autoVal) && autoVal >= 0 && autoVal <= 1;
+  const pendingValid =
+    Number.isFinite(pendingVal) && pendingVal >= 0 && pendingVal <= 1;
+  const orderValid = autoValid && pendingValid && pendingVal < autoVal;
+  const canSubmit = autoValid && pendingValid && orderValid;
+
+  function validationMessage() {
+    if (!autoValid || !pendingValid) {
+      return "Thresholds must be numbers between 0 and 1.";
+    }
+    if (!orderValid) {
+      return "Pending-review threshold must be strictly less than the auto-accept threshold.";
+    }
+    return null;
+  }
+
+  function handleSave() {
+    if (!canSubmit) return;
+    updateSettings.mutate({
+      autoAcceptThreshold: autoVal,
+      pendingReviewThreshold: pendingVal,
+    });
+  }
+
+  function handlePreview() {
+    if (!canSubmit) return;
+    previewImpact.mutate({
+      autoAcceptThreshold: autoVal,
+      pendingReviewThreshold: pendingVal,
+    });
+  }
+
+  function handleTest() {
+    const trimmed = testDescription.trim();
+    if (!trimmed) return;
+    testMatch.mutate({
+      description: trimmed,
+      topN,
+      autoAcceptThresholdOverride: autoValid ? autoVal : undefined,
+      pendingReviewThresholdOverride: pendingValid ? pendingVal : undefined,
+    });
+  }
+
+  const validationError = validationMessage();
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Thresholds</CardTitle>
+          <CardDescription>
+            Auto-accept is the similarity score at which the resolver re-uses an
+            existing canonical entry. Pending-review is the floor for flagging a
+            new description for admin review. Both are between 0 and 1, and
+            pending-review must be strictly less than auto-accept.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="auto-accept-input">Auto-Accept Threshold</Label>
+              <Input
+                id="auto-accept-input"
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={autoAccept}
+                onChange={(e) => setAutoAccept(e.target.value)}
+                className="mt-1"
+                aria-invalid={!autoValid}
+              />
+            </div>
+            <div>
+              <Label htmlFor="pending-review-input">
+                Pending-Review Threshold
+              </Label>
+              <Input
+                id="pending-review-input"
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={pendingReview}
+                onChange={(e) => setPendingReview(e.target.value)}
+                className="mt-1"
+                aria-invalid={!pendingValid || !orderValid}
+              />
+            </div>
+          </div>
+          {validationError && (
+            <p
+              role="alert"
+              className="text-sm text-destructive"
+              data-testid="threshold-validation-error"
+            >
+              {validationError}
+            </p>
+          )}
+          <div className="flex gap-2">
+            <Button
+              onClick={handleSave}
+              disabled={!canSubmit || updateSettings.isPending}
+            >
+              {updateSettings.isPending ? "Saving…" : "Save"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handlePreview}
+              disabled={!canSubmit || previewImpact.isPending}
+            >
+              {previewImpact.isPending ? "Computing…" : "Preview impact"}
+            </Button>
+          </div>
+          {previewImpact.data && (
+            <div
+              className="rounded border p-3 text-sm"
+              data-testid="preview-impact-panel"
+            >
+              <h3 className="font-semibold">Projected impact</h3>
+              <div className="mt-2 grid grid-cols-3 gap-4">
+                <div>
+                  <p className="text-xs text-muted-foreground">Auto-accepted</p>
+                  <p>
+                    <span>{previewImpact.data.current.autoAccepted}</span>
+                    {" \u2192 "}
+                    <strong>{previewImpact.data.proposed.autoAccepted}</strong>
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">
+                    Pending review
+                  </p>
+                  <p>
+                    <span>{previewImpact.data.current.pendingReview}</span>
+                    {" \u2192 "}
+                    <strong>{previewImpact.data.proposed.pendingReview}</strong>
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Unresolved</p>
+                  <p>
+                    <span>{previewImpact.data.current.unresolved}</span>
+                    {" \u2192 "}
+                    <strong>{previewImpact.data.proposed.unresolved}</strong>
+                  </p>
+                </div>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Auto-to-pending: {previewImpact.data.deltas.autoToPending} |
+                Pending-to-auto: {previewImpact.data.deltas.pendingToAuto} |
+                Unresolved-to-auto: {previewImpact.data.deltas.unresolvedToAuto}{" "}
+                | Unresolved-to-pending:{" "}
+                {previewImpact.data.deltas.unresolvedToPending}
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Test a Description</CardTitle>
+          <CardDescription>
+            Run any description through the classifier with the currently-edited
+            thresholds (or the live values when the inputs are blank) to see
+            which canonical rows would match.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="flex-1 min-w-[220px]">
+              <Label htmlFor="test-description-input">Description</Label>
+              <Input
+                id="test-description-input"
+                value={testDescription}
+                onChange={(e) => setTestDescription(e.target.value)}
+                placeholder="e.g. banana"
+                className="mt-1"
+              />
+            </div>
+            <div className="w-28">
+              <Label htmlFor="test-topn-input">Top N</Label>
+              <Select
+                value={String(topN)}
+                onValueChange={(v) => setTopN(Number(v))}
+              >
+                <SelectTrigger
+                  id="test-topn-input"
+                  className="mt-1 w-full"
+                  aria-label="Top N candidates"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {[3, 5, 10, 20].map((n) => (
+                    <SelectItem key={n} value={String(n)}>
+                      {n}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              onClick={handleTest}
+              disabled={!testDescription.trim() || testMatch.isPending}
+            >
+              {testMatch.isPending ? "Testing…" : "Test"}
+            </Button>
+          </div>
+          {testMatch.data && (
+            <div
+              className="rounded border p-3 text-sm"
+              data-testid="test-match-panel"
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-semibold">Simulated outcome:</span>
+                <Badge variant="secondary">
+                  {testMatch.data.simulatedOutcome}
+                </Badge>
+              </div>
+              {testMatch.data.candidates.length === 0 ? (
+                <p className="mt-2 text-muted-foreground">
+                  No candidates returned.
+                </p>
+              ) : (
+                <Table className="mt-2">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Canonical Name</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead className="text-right">Similarity</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {testMatch.data.candidates.map((c) => (
+                      <TableRow key={c.normalizedDescriptionId}>
+                        <TableCell className="font-medium">
+                          {c.canonicalName}
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              c.status === "Active" ? "default" : "secondary"
+                            }
+                          >
+                            {c.status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatDecimal(c.cosineSimilarity, 4)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/client/src/components/reports/SpendingByNormalizedDescription.test.tsx
+++ b/src/client/src/components/reports/SpendingByNormalizedDescription.test.tsx
@@ -1,0 +1,93 @@
+import { screen } from "@testing-library/react";
+import { renderWithQueryClient } from "@/test/test-utils";
+import SpendingByNormalizedDescription from "./SpendingByNormalizedDescription";
+
+vi.mock("@/hooks/useSpendingByNormalizedDescription", () => ({
+  useSpendingByNormalizedDescription: vi.fn(),
+}));
+
+vi.mock("@/components/dashboard/DateRangeSelector", () => ({
+  DateRangeSelector: () => <div data-testid="date-range-selector" />,
+}));
+
+vi.mock("@/components/charts", () => ({
+  ChartCard: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="chart-card">{children}</div>
+  ),
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+import { useSpendingByNormalizedDescription } from "@/hooks/useSpendingByNormalizedDescription";
+const mockHook = vi.mocked(useSpendingByNormalizedDescription);
+
+const sampleItems = [
+  {
+    canonicalName: "Apples",
+    totalAmount: 12.5,
+    currency: "USD",
+    itemCount: 3,
+    firstSeen: null,
+    lastSeen: null,
+  },
+  {
+    canonicalName: "Bananas",
+    totalAmount: 40,
+    currency: "USD",
+    itemCount: 5,
+    firstSeen: null,
+    lastSeen: null,
+  },
+];
+
+function setupMock(overrides: Record<string, unknown> = {}) {
+  mockHook.mockReturnValue({
+    data: { items: sampleItems },
+    isLoading: false,
+    isError: false,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+describe("SpendingByNormalizedDescription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton", () => {
+    setupMock({ isLoading: true, data: undefined });
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    const skeletons = document.querySelectorAll("[data-slot='skeleton']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state", () => {
+    setupMock({ isError: true, data: undefined });
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    expect(
+      screen.getByText(/failed to load spending by normalized description/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no items", () => {
+    setupMock({ data: { items: [] } });
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    expect(screen.getByText("No Data")).toBeInTheDocument();
+  });
+
+  it("renders items sorted by total desc", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    const table = screen.getByRole("table");
+    const rows = table.querySelectorAll("tbody tr");
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent).toContain("Bananas");
+    expect(rows[1].textContent).toContain("Apples");
+  });
+
+  it("formats totals as currency and sums grand total", () => {
+    setupMock();
+    renderWithQueryClient(<SpendingByNormalizedDescription />);
+    expect(screen.getByText("$52.50")).toBeInTheDocument();
+  });
+});

--- a/src/client/src/components/reports/SpendingByNormalizedDescription.tsx
+++ b/src/client/src/components/reports/SpendingByNormalizedDescription.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useMemo, useState } from "react";
+import { format, subMonths } from "date-fns";
+import { useSpendingByNormalizedDescription } from "@/hooks/useSpendingByNormalizedDescription";
+import { formatCurrency } from "@/lib/format";
+import { DateRangeSelector } from "@/components/dashboard/DateRangeSelector";
+import type { DateRange } from "@/hooks/useDashboard";
+import { ChartCard, BarChart } from "@/components/charts";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function getDefaultRange(): DateRange {
+  const now = new Date();
+  return {
+    startDate: format(subMonths(now, 1), "yyyy-MM-dd"),
+    endDate: format(now, "yyyy-MM-dd"),
+  };
+}
+
+export default function SpendingByNormalizedDescription() {
+  const [dateRange, setDateRange] = useState<DateRange>(getDefaultRange);
+
+  const handleDateRangeChange = useCallback((range: DateRange) => {
+    setDateRange(range);
+  }, []);
+
+  const { data, isLoading, isError } = useSpendingByNormalizedDescription({
+    from: dateRange.startDate,
+    to: dateRange.endDate,
+  });
+
+  const sorted = useMemo(() => {
+    const items = data?.items ?? [];
+    return [...items].sort((a, b) => (b.totalAmount ?? 0) - (a.totalAmount ?? 0));
+  }, [data?.items]);
+
+  const grandTotal = useMemo(
+    () => sorted.reduce((sum, item) => sum + (item.totalAmount ?? 0), 0),
+    [sorted],
+  );
+
+  const chartData = useMemo(
+    () =>
+      sorted.slice(0, 10).map((item) => ({
+        name: item.canonicalName,
+        value: Number(item.totalAmount ?? 0),
+      })),
+    [sorted],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-full rounded-lg" />
+        <Skeleton className="h-20 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-6 text-center">
+        <p className="text-destructive">
+          Failed to load spending by normalized description report.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data || sorted.length === 0) {
+    return (
+      <div className="space-y-4">
+        <div className="flex justify-end">
+          <DateRangeSelector
+            value={dateRange}
+            onChange={handleDateRangeChange}
+          />
+        </div>
+        <div className="rounded-lg border p-6 text-center">
+          <h2 className="text-lg font-semibold">No Data</h2>
+          <p className="mt-2 text-muted-foreground">
+            No spending data found for the selected date range.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex gap-6">
+          <div>
+            <p className="text-sm text-muted-foreground">Descriptions</p>
+            <p className="text-2xl font-bold">{sorted.length}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Total Spending</p>
+            <p className="text-2xl font-bold">{formatCurrency(grandTotal)}</p>
+          </div>
+        </div>
+        <DateRangeSelector
+          value={dateRange}
+          onChange={handleDateRangeChange}
+        />
+      </div>
+
+      <ChartCard
+        title="Top Normalized Descriptions by Spending"
+        empty={chartData.length === 0}
+      >
+        <BarChart
+          data={chartData}
+          layout="horizontal"
+          height={Math.max(200, chartData.length * 40)}
+          formatValue={formatCurrency}
+        />
+      </ChartCard>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Canonical Name</TableHead>
+            <TableHead className="text-right">Items</TableHead>
+            <TableHead className="text-right">Total</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map((item) => (
+            <TableRow key={item.canonicalName}>
+              <TableCell className="font-medium">
+                {item.canonicalName}
+              </TableCell>
+              <TableCell className="text-right">{item.itemCount}</TableCell>
+              <TableCell className="text-right">
+                {formatCurrency(Number(item.totalAmount ?? 0))}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -3212,6 +3212,18 @@ export interface components {
             subcategory?: string | null;
             /** @description Pricing mode: 'quantity' (qty x unit price) or 'flat' (single flat price) */
             pricingMode: string;
+            /**
+             * Format: uuid
+             * @description FK to the canonical NormalizedDescription. Null until the resolver links this item.
+             */
+            normalizedDescriptionId?: string | null;
+            /** @description Denormalized CanonicalName from the linked NormalizedDescription for display. */
+            normalizedDescriptionName?: string | null;
+            /**
+             * Format: double
+             * @description Cosine similarity captured when the resolver linked this item; null for unresolved or no-match-created items.
+             */
+            normalizedDescriptionMatchScore?: number | null;
         };
         ReceiptItemListResponse: {
             data: components["schemas"]["ReceiptItemResponse"][];

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -491,6 +491,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/normalized-descriptions/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the current normalized-description threshold settings
+         * @description Returns the live auto-accept and pending-review thresholds used by the
+         *     resolver when classifying new receipt item descriptions. Admin-only.
+         */
+        get: operations["GetNormalizedDescriptionSettings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update the normalized-description threshold settings
+         * @description Updates the auto-accept and pending-review thresholds. Both values must
+         *     satisfy `0 <= pendingReviewThreshold < autoAcceptThreshold <= 1`. Admin-only.
+         */
+        patch: operations["UpdateNormalizedDescriptionSettings"];
+        trace?: never;
+    };
+    "/api/normalized-descriptions/settings/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview the impact of changing threshold settings
+         * @description Returns current vs. proposed classification counts (auto-accepted,
+         *     pending-review, unresolved) and the reclassification deltas that a
+         *     threshold change would produce, computed against the live
+         *     `NormalizedDescriptionMatchScore` column on receipt items. Admin-only.
+         */
+        post: operations["PreviewNormalizedDescriptionThresholdImpact"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Probe the classifier for a given description
+         * @description Returns the top-N ANN candidates for the supplied description along with
+         *     the classification branch the production resolver would take under the
+         *     supplied threshold overrides (or the live DB settings when absent).
+         *     Admin-only.
+         */
+        post: operations["TestNormalizedDescriptionMatch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/receipts/{id}": {
         parameters: {
             query?: never;
@@ -2664,6 +2736,114 @@ export interface components {
              * @description Number of similar items with this category
              */
             occurrenceCount: number;
+        };
+        NormalizedDescriptionSettingsResponse: {
+            /**
+             * Format: uuid
+             * @description Fixed singleton identifier for the settings row.
+             */
+            id: string;
+            /**
+             * Format: double
+             * @description Cosine-similarity floor at which the resolver re-uses an existing canonical entry.
+             */
+            autoAcceptThreshold: number;
+            /**
+             * Format: double
+             * @description Cosine-similarity floor at which the resolver creates a PendingReview entry instead of a new Active one.
+             */
+            pendingReviewThreshold: number;
+            /**
+             * Format: date-time
+             * @description When the settings were last changed.
+             */
+            updatedAt: string;
+        };
+        UpdateNormalizedDescriptionSettingsRequest: {
+            /** Format: double */
+            autoAcceptThreshold: number;
+            /** Format: double */
+            pendingReviewThreshold: number;
+        };
+        TestMatchRequest: {
+            /** @description Description to classify. Must be non-empty after trim. */
+            description: string;
+            /**
+             * Format: int32
+             * @description Number of ANN candidates to return (ranked by cosine similarity).
+             * @default 5
+             */
+            topN: number;
+            /**
+             * Format: double
+             * @description Override the live auto-accept threshold for simulation. Falls back to DB settings when null.
+             */
+            autoAcceptThresholdOverride?: number | null;
+            /**
+             * Format: double
+             * @description Override the live pending-review threshold for simulation. Falls back to DB settings when null.
+             */
+            pendingReviewThresholdOverride?: number | null;
+        };
+        MatchTestResultResponse: {
+            candidates: components["schemas"]["MatchCandidateDto"][];
+            /** @description One of: AutoAccept, PendingReview, CreateNew, EmbeddingUnavailable. */
+            simulatedOutcome: string;
+            /**
+             * Format: uuid
+             * @description ID of the normalized-description row the resolver would reuse (AutoAccept) or null for CreateNew / PendingReview / EmbeddingUnavailable.
+             */
+            simulatedTargetId?: string | null;
+        };
+        MatchCandidateDto: {
+            /** Format: uuid */
+            normalizedDescriptionId: string;
+            canonicalName: string;
+            /** Format: double */
+            cosineSimilarity: number;
+            /** @description Active or PendingReview. */
+            status: string;
+        };
+        PreviewThresholdImpactRequest: {
+            /** Format: double */
+            autoAcceptThreshold: number;
+            /** Format: double */
+            pendingReviewThreshold: number;
+        };
+        ThresholdImpactPreviewResponse: {
+            current: components["schemas"]["ClassificationCountsDto"];
+            proposed: components["schemas"]["ClassificationCountsDto"];
+            deltas: components["schemas"]["ReclassificationDeltasDto"];
+        };
+        ClassificationCountsDto: {
+            /** Format: int32 */
+            autoAccepted: number;
+            /** Format: int32 */
+            pendingReview: number;
+            /** Format: int32 */
+            unresolved: number;
+        };
+        ReclassificationDeltasDto: {
+            /**
+             * Format: int32
+             * @description Items currently auto-accepted that would fall back to pending-review under the proposal.
+             */
+            autoToPending: number;
+            /**
+             * Format: int32
+             * @description Items currently pending-review that would be auto-accepted under the proposal.
+             */
+            pendingToAuto: number;
+            /**
+             * Format: int32
+             * @description Items currently unresolved (below pending-review threshold) that would be auto-accepted under the proposal.
+             */
+            unresolvedToAuto: number;
+            /**
+             * Format: int32
+             * @description Items currently unresolved (below pending-review threshold) that would move up to pending-review under the proposal.
+             */
+            unresolvedToPending: number;
         };
         CreateReceiptRequest: {
             location: string;
@@ -4905,6 +5085,125 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    GetNormalizedDescriptionSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionSettingsResponse"];
+                };
+            };
+        };
+    };
+    UpdateNormalizedDescriptionSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateNormalizedDescriptionSettingsRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionSettingsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    PreviewNormalizedDescriptionThresholdImpact: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PreviewThresholdImpactRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThresholdImpactPreviewResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    TestNormalizedDescriptionMatch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TestMatchRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchTestResultResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
             };
         };
     };

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -1793,6 +1793,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/reports/spending-by-normalized-description": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get spending by normalized description report
+         * @description Aggregates receipt item spending grouped by normalized description canonical name. Items without a normalized description bucket into a synthetic "(Not Normalized)" group.
+         */
+        get: operations["GetSpendingByNormalizedDescriptionReport"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/dashboard/summary": {
         parameters: {
             query?: never;
@@ -2541,6 +2561,45 @@ export interface components {
             category: string;
             subcategory?: string | null;
             pricingMode: string;
+        };
+        SpendingByNormalizedDescriptionResponse: {
+            items: components["schemas"]["SpendingByNormalizedDescriptionItem"][];
+            /**
+             * Format: date-time
+             * @description Inclusive lower bound on receipt date, echoed from the request.
+             */
+            fromDate?: string | null;
+            /**
+             * Format: date-time
+             * @description Inclusive upper bound on receipt date, echoed from the request.
+             */
+            toDate?: string | null;
+        };
+        SpendingByNormalizedDescriptionItem: {
+            /** @description Canonical name of the normalized description, or "(Not Normalized)" for receipt items without a normalized description. */
+            canonicalName: string;
+            /**
+             * Format: double
+             * @description Sum of ReceiptItem.TotalAmount for items in this bucket.
+             */
+            totalAmount: number;
+            /** @description Dominant currency across the items in this bucket. */
+            currency: string;
+            /**
+             * Format: int32
+             * @description Number of receipt items in this bucket.
+             */
+            itemCount: number;
+            /**
+             * Format: date-time
+             * @description Earliest receipt date among items in this bucket.
+             */
+            firstSeen?: string | null;
+            /**
+             * Format: date-time
+             * @description Latest receipt date among items in this bucket.
+             */
+            lastSeen?: string | null;
         };
         DashboardSummaryResponse: {
             /** Format: int32 */
@@ -7978,6 +8037,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UncategorizedItemsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    GetSpendingByNormalizedDescriptionReport: {
+        parameters: {
+            query?: {
+                /** @description Inclusive lower bound on receipt date (ISO 8601 date-time string). Defaults to all time when omitted. */
+                from?: string;
+                /** @description Inclusive upper bound on receipt date (ISO 8601 date-time string). Defaults to all time when omitted. */
+                to?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SpendingByNormalizedDescriptionResponse"];
                 };
             };
             /** @description Bad Request */

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -563,6 +563,116 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/normalized-descriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List normalized descriptions
+         * @description Returns all canonical normalized-description rows, optionally filtered by
+         *     status. Not paginated — the row count is bounded by the number of unique
+         *     receipt-item descriptions ever seen. Admin-only.
+         */
+        get: operations["GetAllNormalizedDescriptions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a normalized description by ID
+         * @description Returns a single canonical normalized-description row by GUID. Admin-only.
+         */
+        get: operations["GetNormalizedDescriptionById"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/{id}/merge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Merge two normalized descriptions
+         * @description Re-links every ReceiptItem currently pointing at `discardId` to the
+         *     canonical row identified by the path `{id}` ("keep"), then deletes the
+         *     discarded row. Returns the count of re-linked items — zero when either
+         *     id was missing or the two ids were identical. Admin-only.
+         */
+        post: operations["MergeNormalizedDescriptions"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/{id}/split": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Detach a receipt item from its normalized description
+         * @description Creates a new canonical row for the supplied ReceiptItem's raw description
+         *     and re-points the item at it. Used to unpick bad auto-merges. The path
+         *     `{id}` is the current NormalizedDescription the item is being split away
+         *     from; the body identifies the specific ReceiptItem to isolate. Admin-only.
+         */
+        post: operations["SplitNormalizedDescription"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/normalized-descriptions/{id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update the status of a normalized description
+         * @description Flips a NormalizedDescription between Active and PendingReview. Returns
+         *     204 when the status was changed and 404 when the row does not exist or
+         *     already has the requested status. Admin-only.
+         */
+        patch: operations["UpdateNormalizedDescriptionStatus"];
+        trace?: never;
+    };
     "/api/receipts/{id}": {
         parameters: {
             query?: never;
@@ -2844,6 +2954,52 @@ export interface components {
              * @description Items currently unresolved (below pending-review threshold) that would move up to pending-review under the proposal.
              */
             unresolvedToPending: number;
+        };
+        /**
+         * @description Active rows are confidently-classified and re-used as-is by the resolver; pendingReview rows are flagged for admin review before being promoted.
+         * @enum {string}
+         */
+        NormalizedDescriptionStatus: "active" | "pendingReview";
+        NormalizedDescriptionResponse: {
+            /** Format: uuid */
+            id: string;
+            /** @description The canonical name shared by every receipt item linked to this row. */
+            canonicalName: string;
+            status: components["schemas"]["NormalizedDescriptionStatus"];
+            /** Format: date-time */
+            createdAt: string;
+        };
+        NormalizedDescriptionListResponse: {
+            items: components["schemas"]["NormalizedDescriptionResponse"][];
+            /**
+             * Format: int32
+             * @description Total number of rows returned. Matches the length of `items` since the endpoint is not paginated.
+             */
+            totalCount: number;
+        };
+        MergeNormalizedDescriptionRequest: {
+            /**
+             * Format: uuid
+             * @description ID of the NormalizedDescription to merge away. All ReceiptItems pointing at this row will be re-linked to the kept row.
+             */
+            discardId: string;
+        };
+        SplitNormalizedDescriptionRequest: {
+            /**
+             * Format: uuid
+             * @description ID of the ReceiptItem to detach from its current NormalizedDescription.
+             */
+            receiptItemId: string;
+        };
+        UpdateNormalizedDescriptionStatusRequest: {
+            status: components["schemas"]["NormalizedDescriptionStatus"];
+        };
+        MergeNormalizedDescriptionsResponse: {
+            /**
+             * Format: int32
+             * @description Number of ReceiptItems that were re-linked from the discarded row to the kept row. Zero when either id was missing or the two ids were identical.
+             */
+            itemsRelinkedCount: number;
         };
         CreateReceiptRequest: {
             location: string;
@@ -5204,6 +5360,195 @@ export interface operations {
                 content: {
                     "application/json": string;
                 };
+            };
+        };
+    };
+    GetAllNormalizedDescriptions: {
+        parameters: {
+            query?: {
+                /** @description Optional status filter. When absent, returns rows of both statuses. Matching is case-insensitive. */
+                status?: "Active" | "PendingReview";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionListResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    GetNormalizedDescriptionById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    MergeNormalizedDescriptions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the canonical row to keep (all items from `discardId` move here). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MergeNormalizedDescriptionRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MergeNormalizedDescriptionsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    SplitNormalizedDescription: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the NormalizedDescription the item is being split away from. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SplitNormalizedDescriptionRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NormalizedDescriptionResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UpdateNormalizedDescriptionStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateNormalizedDescriptionStatusRequest"];
+            };
+        };
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/src/client/src/hooks/useNormalizedDescriptionActions.test.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionActions.test.ts
@@ -1,0 +1,158 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import {
+  useMergeMutation,
+  useSplitMutation,
+  useUpdateStatusMutation,
+} from "./useNormalizedDescriptionActions";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    POST: vi.fn(),
+    PATCH: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useMergeMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("merges with path and body", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: { itemsRelinkedCount: 4 },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useMergeMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({ id: "keep-1", discardId: "drop-1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/{id}/merge",
+      {
+        params: { path: { id: "keep-1" } },
+        body: { discardId: "drop-1" },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: undefined,
+      error: { message: "nope" },
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { result } = renderHook(() => useMergeMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+    result.current.mutate({ id: "a", discardId: "b" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useSplitMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("splits with path and body", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: {
+        id: "new-id",
+        canonicalName: "Banana",
+        status: "active",
+        createdAt: "2025-01-01T00:00:00Z",
+      },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSplitMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({ id: "src-1", receiptItemId: "item-1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/{id}/split",
+      {
+        params: { path: { id: "src-1" } },
+        body: { receiptItemId: "item-1" },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: undefined,
+      error: { message: "nope" },
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { result } = renderHook(() => useSplitMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+    result.current.mutate({ id: "a", receiptItemId: "b" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useUpdateStatusMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("patches with status", async () => {
+    mockClient.PATCH.mockResolvedValue({
+      data: undefined,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useUpdateStatusMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({ id: "n-1", status: "active" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.PATCH).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/{id}/status",
+      {
+        params: { path: { id: "n-1" } },
+        body: { status: "active" },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    mockClient.PATCH.mockResolvedValue({
+      data: undefined,
+      error: { message: "nope" },
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { result } = renderHook(() => useUpdateStatusMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+    result.current.mutate({ id: "a", status: "pendingReview" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/client/src/hooks/useNormalizedDescriptionActions.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionActions.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+import { toast } from "sonner";
+import type { components } from "@/generated/api";
+
+type NormalizedDescriptionStatus =
+  components["schemas"]["NormalizedDescriptionStatus"];
+
+export function useMergeMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      discardId,
+    }: {
+      id: string;
+      discardId: string;
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/normalized-descriptions/{id}/merge",
+        {
+          params: { path: { id } },
+          body: { discardId },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["normalized-descriptions"] });
+      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
+      const count = data?.itemsRelinkedCount ?? 0;
+      if (count > 0) {
+        toast.success(`Merged — ${count} items re-linked`);
+      } else {
+        toast.success("Merge completed");
+      }
+    },
+    onError: () => {
+      toast.error("Failed to merge normalized descriptions");
+    },
+  });
+}
+
+export function useSplitMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      receiptItemId,
+    }: {
+      id: string;
+      receiptItemId: string;
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/normalized-descriptions/{id}/split",
+        {
+          params: { path: { id } },
+          body: { receiptItemId },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["normalized-descriptions"] });
+      queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
+      toast.success("Receipt item split into a new normalized description");
+    },
+    onError: () => {
+      toast.error("Failed to split normalized description");
+    },
+  });
+}
+
+export function useUpdateStatusMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      status,
+    }: {
+      id: string;
+      status: NormalizedDescriptionStatus;
+    }) => {
+      const { error } = await client.PATCH(
+        "/api/normalized-descriptions/{id}/status",
+        {
+          params: { path: { id } },
+          body: { status },
+        },
+      );
+      if (error) throw error;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["normalized-descriptions"] });
+      toast.success(
+        variables.status === "active"
+          ? "Approved as active"
+          : "Moved to pending review",
+      );
+    },
+    onError: () => {
+      toast.error("Failed to update status");
+    },
+  });
+}

--- a/src/client/src/hooks/useNormalizedDescriptionSettings.test.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionSettings.test.ts
@@ -1,0 +1,222 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import {
+  useSettings,
+  useUpdateSettingsMutation,
+  useTestMatchMutation,
+  usePreviewImpactMutation,
+} from "./useNormalizedDescriptionSettings";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PATCH: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches live settings", async () => {
+    const mockData = {
+      id: "00000000-0000-0000-0000-000000000001",
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.75,
+      updatedAt: "2025-01-01T00:00:00Z",
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSettings(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/settings",
+    );
+  });
+});
+
+describe("useUpdateSettingsMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("patches settings with thresholds", async () => {
+    mockClient.PATCH.mockResolvedValue({
+      data: {
+        id: "n-1",
+        autoAcceptThreshold: 0.95,
+        pendingReviewThreshold: 0.7,
+        updatedAt: "2025-01-01T00:00:00Z",
+      },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useUpdateSettingsMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({
+      autoAcceptThreshold: 0.95,
+      pendingReviewThreshold: 0.7,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.PATCH).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/settings",
+      {
+        body: {
+          autoAcceptThreshold: 0.95,
+          pendingReviewThreshold: 0.7,
+        },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    mockClient.PATCH.mockResolvedValue({
+      data: undefined,
+      error: { message: "nope" },
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { result } = renderHook(() => useUpdateSettingsMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+    result.current.mutate({
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.7,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useTestMatchMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts test description with defaults", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: { candidates: [], simulatedOutcome: "CreateNew" },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useTestMatchMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({ description: "apples" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/test",
+      {
+        body: {
+          description: "apples",
+          topN: 5,
+          autoAcceptThresholdOverride: undefined,
+          pendingReviewThresholdOverride: undefined,
+        },
+      },
+    );
+  });
+
+  it("passes overrides", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: { candidates: [], simulatedOutcome: "AutoAccept" },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useTestMatchMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({
+      description: "apples",
+      topN: 10,
+      autoAcceptThresholdOverride: 0.8,
+      pendingReviewThresholdOverride: 0.6,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/test",
+      {
+        body: {
+          description: "apples",
+          topN: 10,
+          autoAcceptThresholdOverride: 0.8,
+          pendingReviewThresholdOverride: 0.6,
+        },
+      },
+    );
+  });
+});
+
+describe("usePreviewImpactMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts threshold preview", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: {
+        current: { autoAccepted: 1, pendingReview: 2, unresolved: 3 },
+        proposed: { autoAccepted: 2, pendingReview: 2, unresolved: 2 },
+        deltas: {
+          autoToPending: 0,
+          pendingToAuto: 1,
+          unresolvedToAuto: 0,
+          unresolvedToPending: 0,
+        },
+      },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => usePreviewImpactMutation(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    result.current.mutate({
+      autoAcceptThreshold: 0.9,
+      pendingReviewThreshold: 0.7,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/settings/preview",
+      {
+        body: {
+          autoAcceptThreshold: 0.9,
+          pendingReviewThreshold: 0.7,
+        },
+      },
+    );
+  });
+});

--- a/src/client/src/hooks/useNormalizedDescriptionSettings.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionSettings.ts
@@ -1,0 +1,106 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+import { toast } from "sonner";
+
+export function useSettings() {
+  return useQuery({
+    queryKey: ["normalized-descriptions", "settings"],
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/normalized-descriptions/settings",
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useUpdateSettingsMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      autoAcceptThreshold,
+      pendingReviewThreshold,
+    }: {
+      autoAcceptThreshold: number;
+      pendingReviewThreshold: number;
+    }) => {
+      const { data, error } = await client.PATCH(
+        "/api/normalized-descriptions/settings",
+        {
+          body: { autoAcceptThreshold, pendingReviewThreshold },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["normalized-descriptions", "settings"],
+      });
+      toast.success("Settings saved");
+    },
+    onError: () => {
+      toast.error("Failed to save settings");
+    },
+  });
+}
+
+export function useTestMatchMutation() {
+  return useMutation({
+    mutationFn: async ({
+      description,
+      topN = 5,
+      autoAcceptThresholdOverride,
+      pendingReviewThresholdOverride,
+    }: {
+      description: string;
+      topN?: number;
+      autoAcceptThresholdOverride?: number | null;
+      pendingReviewThresholdOverride?: number | null;
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/normalized-descriptions/test",
+        {
+          body: {
+            description,
+            topN,
+            autoAcceptThresholdOverride:
+              autoAcceptThresholdOverride ?? undefined,
+            pendingReviewThresholdOverride:
+              pendingReviewThresholdOverride ?? undefined,
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onError: () => {
+      toast.error("Failed to test description");
+    },
+  });
+}
+
+export function usePreviewImpactMutation() {
+  return useMutation({
+    mutationFn: async ({
+      autoAcceptThreshold,
+      pendingReviewThreshold,
+    }: {
+      autoAcceptThreshold: number;
+      pendingReviewThreshold: number;
+    }) => {
+      const { data, error } = await client.POST(
+        "/api/normalized-descriptions/settings/preview",
+        {
+          body: { autoAcceptThreshold, pendingReviewThreshold },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onError: () => {
+      toast.error("Failed to preview impact");
+    },
+  });
+}

--- a/src/client/src/hooks/useNormalizedDescriptions.test.ts
+++ b/src/client/src/hooks/useNormalizedDescriptions.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import {
+  useNormalizedDescriptions,
+  useNormalizedDescription,
+} from "./useNormalizedDescriptions";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useNormalizedDescriptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches list with no filter", async () => {
+    const mockData = {
+      items: [
+        {
+          id: "n-1",
+          canonicalName: "Apples",
+          status: "active",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      ],
+      totalCount: 1,
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useNormalizedDescriptions(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/normalized-descriptions",
+      { params: { query: { status: undefined } } },
+    );
+  });
+
+  it("fetches list with PendingReview filter", async () => {
+    mockClient.GET.mockResolvedValue({
+      data: { items: [], totalCount: 0 },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () => useNormalizedDescriptions("PendingReview"),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/normalized-descriptions",
+      { params: { query: { status: "PendingReview" } } },
+    );
+  });
+
+  it("propagates API errors", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useNormalizedDescriptions(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});
+
+describe("useNormalizedDescription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not fetch when id is null", () => {
+    const { result } = renderHook(() => useNormalizedDescription(null), {
+      wrapper: createQueryWrapper(),
+    });
+    expect(result.current.isPending).toBe(true);
+    expect(mockClient.GET).not.toHaveBeenCalled();
+  });
+
+  it("fetches by id", async () => {
+    const mockData = {
+      id: "n-1",
+      canonicalName: "Apples",
+      status: "active",
+      createdAt: "2025-01-01T00:00:00Z",
+    };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useNormalizedDescription("n-1"), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/normalized-descriptions/{id}",
+      { params: { path: { id: "n-1" } } },
+    );
+  });
+});

--- a/src/client/src/hooks/useNormalizedDescriptions.ts
+++ b/src/client/src/hooks/useNormalizedDescriptions.ts
@@ -1,0 +1,35 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export type NormalizedDescriptionStatusFilter = "Active" | "PendingReview";
+
+export function useNormalizedDescriptions(
+  statusFilter?: NormalizedDescriptionStatusFilter,
+) {
+  return useQuery({
+    queryKey: ["normalized-descriptions", "list", statusFilter],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/normalized-descriptions", {
+        params: { query: { status: statusFilter } },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+export function useNormalizedDescription(id: string | null) {
+  return useQuery({
+    queryKey: ["normalized-descriptions", id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/normalized-descriptions/{id}",
+        { params: { path: { id: id! } } },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/src/client/src/hooks/useSpendingByNormalizedDescription.test.ts
+++ b/src/client/src/hooks/useSpendingByNormalizedDescription.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper } from "@/test/test-utils";
+import { useSpendingByNormalizedDescription } from "./useSpendingByNormalizedDescription";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    GET: vi.fn(),
+  },
+}));
+
+import client from "@/lib/api-client";
+const mockClient = vi.mocked(client);
+
+describe("useSpendingByNormalizedDescription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches report with no params", async () => {
+    const mockData = { items: [] };
+    mockClient.GET.mockResolvedValue({
+      data: mockData,
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSpendingByNormalizedDescription(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockData);
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/spending-by-normalized-description",
+      {
+        params: {
+          query: {
+            from: undefined,
+            to: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("passes from/to params", async () => {
+    mockClient.GET.mockResolvedValue({
+      data: { items: [] },
+      error: undefined,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useSpendingByNormalizedDescription({
+          from: "2025-01-01",
+          to: "2025-12-31",
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/api/reports/spending-by-normalized-description",
+      {
+        params: {
+          query: {
+            from: "2025-01-01",
+            to: "2025-12-31",
+          },
+        },
+      },
+    );
+  });
+
+  it("propagates errors", async () => {
+    const apiError = { message: "Server error" };
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: apiError,
+      response: {} as Response,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { result } = renderHook(() => useSpendingByNormalizedDescription(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/src/client/src/hooks/useSpendingByNormalizedDescription.ts
+++ b/src/client/src/hooks/useSpendingByNormalizedDescription.ts
@@ -1,0 +1,36 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+export interface SpendingByNormalizedDescriptionParams {
+  from?: string;
+  to?: string;
+}
+
+export function useSpendingByNormalizedDescription(
+  params: SpendingByNormalizedDescriptionParams = {},
+) {
+  return useQuery({
+    queryKey: [
+      "reports",
+      "spending-by-normalized-description",
+      params.from,
+      params.to,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/reports/spending-by-normalized-description",
+        {
+          params: {
+            query: {
+              from: params.from,
+              to: params.to,
+            },
+          },
+        },
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -180,6 +180,7 @@ function ReceiptDetail() {
               category: i.category,
               subcategory: i.subcategory,
               pricingMode: i.pricingMode,
+              normalizedDescriptionName: i.normalizedDescriptionName,
             }))}
             subtotal={subtotal}
             location={trip.receipt.receipt.location}

--- a/src/client/src/pages/Reports.test.tsx
+++ b/src/client/src/pages/Reports.test.tsx
@@ -1,6 +1,24 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@/test/test-utils";
 import Reports, { REPORTS, DEFAULT_REPORT } from "./Reports";
+
+// jsdom polyfills required by Radix UI Select (used for the report picker).
+beforeAll(() => {
+  if (
+    !(Element.prototype as unknown as { hasPointerCapture?: unknown })
+      .hasPointerCapture
+  ) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.releasePointerCapture = () => {};
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (
+    !(Element.prototype as unknown as { scrollIntoView?: unknown }).scrollIntoView
+  ) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
 
 vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
@@ -46,7 +64,40 @@ vi.mock("@/components/reports/UncategorizedItems", () => ({
   ),
 }));
 
+vi.mock("@/components/reports/SpendingByNormalizedDescription", () => ({
+  default: () => (
+    <div data-testid="report-spending-by-normalized-description">
+      Spending by Normalized Description
+    </div>
+  ),
+}));
+
+vi.mock("@/components/reports/NormalizedDescriptions", () => ({
+  default: () => (
+    <div data-testid="report-normalized-descriptions">
+      Normalized Descriptions
+    </div>
+  ),
+}));
+
+vi.mock("@/hooks/usePermission", () => ({
+  usePermission: vi.fn(() => ({
+    roles: ["User"],
+    hasRole: (role: string) => role === "User",
+    isAdmin: () => false,
+  })),
+}));
+
 describe("Reports", () => {
+  beforeEach(async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["User"],
+      hasRole: (role: string) => role === "User",
+      isAdmin: () => false,
+    });
+  });
+
   it("renders the page heading", () => {
     renderWithProviders(<Reports />, { route: "/reports" });
     expect(
@@ -104,10 +155,43 @@ describe("Reports", () => {
   });
 
   it("exports REPORTS config with correct number of reports", () => {
-    expect(REPORTS).toHaveLength(7);
+    expect(REPORTS).toHaveLength(9);
   });
 
   it("exports DEFAULT_REPORT as out-of-balance", () => {
     expect(DEFAULT_REPORT).toBe("out-of-balance");
+  });
+
+  it("hides admin-only reports for non-admin users", async () => {
+    renderWithProviders(<Reports />, { route: "/reports" });
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+    expect(
+      screen.queryByRole("option", { name: /normalized descriptions/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows admin-only reports for admin users", async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue({
+      roles: ["Admin"],
+      hasRole: (role: string) => role === "Admin",
+      isAdmin: () => true,
+    });
+    renderWithProviders(<Reports />, { route: "/reports" });
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+    expect(
+      screen.getByRole("option", { name: /normalized descriptions/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to default when admin-only slug is used by non-admin", async () => {
+    renderWithProviders(<Reports />, {
+      route: "/reports?report=normalized-descriptions",
+    });
+    expect(
+      await screen.findByTestId("report-out-of-balance"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/client/src/pages/Reports.tsx
+++ b/src/client/src/pages/Reports.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { usePermission } from "@/hooks/usePermission";
 import {
   Select,
   SelectContent,
@@ -14,6 +15,7 @@ interface ReportConfig {
   slug: string;
   name: string;
   component: React.LazyExoticComponent<React.ComponentType>;
+  adminOnly?: boolean;
 }
 
 const REPORTS: ReportConfig[] = [
@@ -38,6 +40,13 @@ const REPORTS: ReportConfig[] = [
     component: lazy(() => import("@/components/reports/SpendingByLocation")),
   },
   {
+    slug: "spending-by-normalized-description",
+    name: "Spending by Normalized Description",
+    component: lazy(
+      () => import("@/components/reports/SpendingByNormalizedDescription"),
+    ),
+  },
+  {
     slug: "category-trends",
     name: "Category Trends",
     component: lazy(() => import("@/components/reports/CategoryTrends")),
@@ -52,10 +61,15 @@ const REPORTS: ReportConfig[] = [
     name: "Uncategorized Items",
     component: lazy(() => import("@/components/reports/UncategorizedItems")),
   },
+  {
+    slug: "normalized-descriptions",
+    name: "Normalized Descriptions",
+    component: lazy(() => import("@/components/reports/NormalizedDescriptions")),
+    adminOnly: true,
+  },
 ];
 
 const DEFAULT_REPORT = REPORTS[0].slug;
-const VALID_SLUGS = new Set(REPORTS.map((r) => r.slug));
 
 function ReportFallback() {
   return <Skeleton className="h-32 w-full rounded-lg" />;
@@ -63,13 +77,25 @@ function ReportFallback() {
 
 function Reports() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { isAdmin } = usePermission();
+
+  const availableReports = useMemo(
+    () => REPORTS.filter((r) => !r.adminOnly || isAdmin()),
+    [isAdmin],
+  );
+  const validSlugs = useMemo(
+    () => new Set(availableReports.map((r) => r.slug)),
+    [availableReports],
+  );
+
   const rawReport = searchParams.get("report");
   const activeSlug =
-    rawReport && VALID_SLUGS.has(rawReport) ? rawReport : DEFAULT_REPORT;
+    rawReport && validSlugs.has(rawReport) ? rawReport : DEFAULT_REPORT;
 
   const activeReport = useMemo(
-    () => REPORTS.find((r) => r.slug === activeSlug)!,
-    [activeSlug],
+    () =>
+      availableReports.find((r) => r.slug === activeSlug) ?? availableReports[0],
+    [activeSlug, availableReports],
   );
 
   usePageTitle(`Reports - ${activeReport.name}`);
@@ -85,12 +111,12 @@ function Reports() {
     <div className="space-y-6">
       <div className="flex items-center gap-4">
         <h1 className="text-2xl font-bold tracking-tight">Reports</h1>
-        <Select value={activeSlug} onValueChange={handleReportChange}>
-          <SelectTrigger className="w-[220px]" aria-label="Select report">
+        <Select value={activeReport.slug} onValueChange={handleReportChange}>
+          <SelectTrigger className="w-[260px]" aria-label="Select report">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {REPORTS.map((report) => (
+            {availableReports.map((report) => (
               <SelectItem key={report.slug} value={report.slug}>
                 {report.name}
               </SelectItem>

--- a/tests/Application.Tests/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/NormalizedDescription/Merge/MergeNormalizedDescriptionsCommandHandlerTests.cs
@@ -1,0 +1,53 @@
+using Application.Commands.NormalizedDescription.Merge;
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.NormalizedDescription.Merge;
+
+public class MergeNormalizedDescriptionsCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsIdsToServiceAndReturnsRelinkCount()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid keepId = Guid.NewGuid();
+		Guid discardId = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.MergeAsync(keepId, discardId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(7);
+
+		MergeNormalizedDescriptionsCommandHandler handler = new(mockService.Object);
+		MergeNormalizedDescriptionsCommand command = new(keepId, discardId);
+
+		// Act
+		int result = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().Be(7);
+		mockService.Verify(s => s.MergeAsync(keepId, discardId, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_MissingRowReturnsZero_ReflectsServiceContract()
+	{
+		// The service returns 0 when either id is missing or both ids are equal. The handler
+		// just forwards that count — it's the controller's job to validate inputs before call.
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid keepId = Guid.NewGuid();
+		Guid discardId = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.MergeAsync(keepId, discardId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(0);
+
+		MergeNormalizedDescriptionsCommandHandler handler = new(mockService.Object);
+		MergeNormalizedDescriptionsCommand command = new(keepId, discardId);
+
+		int result = await handler.Handle(command, CancellationToken.None);
+
+		result.Should().Be(0);
+	}
+}

--- a/tests/Application.Tests/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/NormalizedDescription/Split/SplitNormalizedDescriptionCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using Application.Commands.NormalizedDescription.Split;
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.NormalizedDescription.Split;
+
+public class SplitNormalizedDescriptionCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsReceiptItemIdAndReturnsCreated()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid receiptItemId = Guid.NewGuid();
+		Domain.NormalizedDescriptions.NormalizedDescription expected = new(
+			Guid.NewGuid(),
+			"cherry cola",
+			NormalizedDescriptionStatus.Active,
+			new DateTimeOffset(2026, 4, 19, 12, 0, 0, TimeSpan.Zero));
+
+		mockService
+			.Setup(s => s.SplitAsync(receiptItemId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		SplitNormalizedDescriptionCommandHandler handler = new(mockService.Object);
+		SplitNormalizedDescriptionCommand command = new(receiptItemId);
+
+		// Act
+		Domain.NormalizedDescriptions.NormalizedDescription actual = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.SplitAsync(receiptItemId, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ServicePropagatesKeyNotFound()
+	{
+		// The service throws KeyNotFoundException when the receipt item is missing; the
+		// handler should propagate rather than swallow so controller/test callers can map
+		// it to a 404.
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid missing = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.SplitAsync(missing, It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new KeyNotFoundException("Receipt item not found."));
+
+		SplitNormalizedDescriptionCommandHandler handler = new(mockService.Object);
+		SplitNormalizedDescriptionCommand command = new(missing);
+
+		Func<Task> act = () => handler.Handle(command, CancellationToken.None);
+		await act.Should().ThrowAsync<KeyNotFoundException>();
+	}
+}

--- a/tests/Application.Tests/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/NormalizedDescription/UpdateSettings/UpdateNormalizedDescriptionSettingsCommandHandlerTests.cs
@@ -1,0 +1,36 @@
+using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.NormalizedDescription.UpdateSettings;
+
+public class UpdateNormalizedDescriptionSettingsCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsThresholdsToServiceAndReturnsResult()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		NormalizedDescriptionSettings expected = new(
+			Guid.NewGuid(),
+			autoAcceptThreshold: 0.9,
+			pendingReviewThreshold: 0.5,
+			updatedAt: new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		mockService
+			.Setup(s => s.UpdateSettingsAsync(0.9, 0.5, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		UpdateNormalizedDescriptionSettingsCommandHandler handler = new(mockService.Object);
+		UpdateNormalizedDescriptionSettingsCommand command = new(0.9, 0.5);
+
+		// Act
+		NormalizedDescriptionSettings actual = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.UpdateSettingsAsync(0.9, 0.5, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/NormalizedDescription/UpdateStatus/UpdateNormalizedDescriptionStatusCommandHandlerTests.cs
@@ -1,0 +1,53 @@
+using Application.Commands.NormalizedDescription.UpdateStatus;
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.NormalizedDescription.UpdateStatus;
+
+public class UpdateNormalizedDescriptionStatusCommandHandlerTests
+{
+	[Fact]
+	public async Task Handle_StatusChanged_ReturnsTrue()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid id = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		UpdateNormalizedDescriptionStatusCommandHandler handler = new(mockService.Object);
+		UpdateNormalizedDescriptionStatusCommand command = new(id, NormalizedDescriptionStatus.Active);
+
+		// Act
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().BeTrue();
+		mockService.Verify(s => s.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_RowMissingOrAlreadyAtStatus_ReturnsFalse()
+	{
+		// The service returns false for both "row missing" and "row already at target" cases.
+		// The handler forwards without distinguishing — it's the controller's job to do an
+		// existence check first to distinguish 404 from idempotent no-op.
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid id = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.UpdateStatusAsync(id, NormalizedDescriptionStatus.PendingReview, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		UpdateNormalizedDescriptionStatusCommandHandler handler = new(mockService.Object);
+		UpdateNormalizedDescriptionStatusCommand command = new(id, NormalizedDescriptionStatus.PendingReview);
+
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Application.Tests/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Aggregates/Reports/GetSpendingByNormalizedDescriptionQueryHandlerTests.cs
@@ -1,0 +1,94 @@
+using Application.Interfaces.Services;
+using Application.Models.Reports;
+using Application.Queries.Aggregates.Reports;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.Aggregates.Reports;
+
+public class GetSpendingByNormalizedDescriptionQueryHandlerTests
+{
+	private readonly Mock<IReportService> _reportServiceMock;
+	private readonly GetSpendingByNormalizedDescriptionQueryHandler _handler;
+
+	public GetSpendingByNormalizedDescriptionQueryHandlerTests()
+	{
+		_reportServiceMock = new Mock<IReportService>();
+		_handler = new GetSpendingByNormalizedDescriptionQueryHandler(_reportServiceMock.Object);
+	}
+
+	[Fact]
+	public async Task Handle_DelegatesToReportService_WithNullDates()
+	{
+		// Arrange
+		GetSpendingByNormalizedDescriptionQuery query = new(null, null);
+		SpendingByNormalizedDescriptionResult expectedResult = new([], null, null);
+
+		_reportServiceMock
+			.Setup(s => s.GetSpendingByNormalizedDescriptionAsync(null, null, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expectedResult);
+		_reportServiceMock.Verify(
+			s => s.GetSpendingByNormalizedDescriptionAsync(null, null, It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PassesDateRangeToService()
+	{
+		// Arrange
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 12, 31, 23, 59, 59, TimeSpan.Zero);
+		GetSpendingByNormalizedDescriptionQuery query = new(from, to);
+		SpendingByNormalizedDescriptionResult expectedResult = new([], from, to);
+
+		_reportServiceMock
+			.Setup(s => s.GetSpendingByNormalizedDescriptionAsync(from, to, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		_reportServiceMock.Verify(
+			s => s.GetSpendingByNormalizedDescriptionAsync(from, to, It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsServiceResult()
+	{
+		// Arrange
+		GetSpendingByNormalizedDescriptionQuery query = new(null, null);
+		SpendingByNormalizedDescriptionItem item = new(
+			"Bananas",
+			42.50m,
+			"USD",
+			5,
+			new DateTimeOffset(2025, 1, 5, 0, 0, 0, TimeSpan.Zero),
+			new DateTimeOffset(2025, 3, 15, 0, 0, 0, TimeSpan.Zero));
+		SpendingByNormalizedDescriptionResult expectedResult = new([item], null, null);
+
+		_reportServiceMock
+			.Setup(s => s.GetSpendingByNormalizedDescriptionAsync(
+				It.IsAny<DateTimeOffset?>(),
+				It.IsAny<DateTimeOffset?>(),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expectedResult);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		result.Items[0].CanonicalName.Should().Be("Bananas");
+		result.Items[0].TotalAmount.Should().Be(42.50m);
+		result.Items[0].Currency.Should().Be("USD");
+		result.Items[0].ItemCount.Should().Be(5);
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/GetAll/GetAllNormalizedDescriptionsQueryHandlerTests.cs
@@ -1,0 +1,74 @@
+using Application.Interfaces.Services;
+using Application.Queries.NormalizedDescription.GetAll;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.GetAll;
+
+public class GetAllNormalizedDescriptionsQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_NoFilter_ReturnsAllFromService()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		List<Domain.NormalizedDescriptions.NormalizedDescription> expected =
+		[
+			new(Guid.NewGuid(), "coffee beans", NormalizedDescriptionStatus.Active, DateTimeOffset.UtcNow),
+			new(Guid.NewGuid(), "whole milk", NormalizedDescriptionStatus.PendingReview, DateTimeOffset.UtcNow),
+		];
+
+		mockService
+			.Setup(s => s.GetAllAsync(null, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetAllNormalizedDescriptionsQueryHandler handler = new(mockService.Object);
+		GetAllNormalizedDescriptionsQuery query = new(StatusFilter: null);
+
+		// Act
+		List<Domain.NormalizedDescriptions.NormalizedDescription> actual = await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetAllAsync(null, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_WithFilter_ForwardsToService()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		List<Domain.NormalizedDescriptions.NormalizedDescription> expected =
+		[
+			new(Guid.NewGuid(), "whole milk", NormalizedDescriptionStatus.PendingReview, DateTimeOffset.UtcNow),
+		];
+
+		mockService
+			.Setup(s => s.GetAllAsync(NormalizedDescriptionStatus.PendingReview, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetAllNormalizedDescriptionsQueryHandler handler = new(mockService.Object);
+		GetAllNormalizedDescriptionsQuery query = new(NormalizedDescriptionStatus.PendingReview);
+
+		List<Domain.NormalizedDescriptions.NormalizedDescription> actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetAllAsync(NormalizedDescriptionStatus.PendingReview, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_EmptyResult_ReturnsEmptyList()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		mockService
+			.Setup(s => s.GetAllAsync(It.IsAny<NormalizedDescriptionStatus?>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+
+		GetAllNormalizedDescriptionsQueryHandler handler = new(mockService.Object);
+		GetAllNormalizedDescriptionsQuery query = new(NormalizedDescriptionStatus.Active);
+
+		List<Domain.NormalizedDescriptions.NormalizedDescription> actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeEmpty();
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/GetById/GetNormalizedDescriptionByIdQueryHandlerTests.cs
@@ -1,0 +1,64 @@
+using Application.Interfaces.Services;
+using Application.Queries.NormalizedDescription.GetById;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.GetById;
+
+public class GetNormalizedDescriptionByIdQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_Found_ReturnsEntityFromService()
+	{
+		// Arrange
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid id = Guid.NewGuid();
+		Domain.NormalizedDescriptions.NormalizedDescription expected = new(
+			id,
+			"cherry cola",
+			NormalizedDescriptionStatus.Active,
+			new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		mockService
+			.Setup(s => s.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetNormalizedDescriptionByIdQueryHandler handler = new(mockService.Object);
+		GetNormalizedDescriptionByIdQuery query = new(id);
+
+		// Act
+		Domain.NormalizedDescriptions.NormalizedDescription? actual = await handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetByIdAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_NotFound_ReturnsNull()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		Guid id = Guid.NewGuid();
+
+		mockService
+			.Setup(s => s.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Domain.NormalizedDescriptions.NormalizedDescription?)null);
+
+		GetNormalizedDescriptionByIdQueryHandler handler = new(mockService.Object);
+		GetNormalizedDescriptionByIdQuery query = new(id);
+
+		Domain.NormalizedDescriptions.NormalizedDescription? actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeNull();
+	}
+
+	[Fact]
+	public void Query_EmptyGuid_ThrowsArgumentException()
+	{
+		// The query rejects Guid.Empty up-front so a malformed request never reaches the service.
+		Action act = () => _ = new GetNormalizedDescriptionByIdQuery(Guid.Empty);
+		act.Should().Throw<ArgumentException>()
+			.WithMessage(GetNormalizedDescriptionByIdQuery.IdCannotBeEmptyExceptionMessage + "*");
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/GetSettings/GetNormalizedDescriptionSettingsQueryHandlerTests.cs
@@ -1,0 +1,33 @@
+using Application.Interfaces.Services;
+using Application.Queries.NormalizedDescription.GetSettings;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.GetSettings;
+
+public class GetNormalizedDescriptionSettingsQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ReturnsSettingsFromService()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		NormalizedDescriptionSettings expected = new(
+			Guid.NewGuid(),
+			autoAcceptThreshold: 0.81,
+			pendingReviewThreshold: 0.68,
+			updatedAt: new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		mockService
+			.Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		GetNormalizedDescriptionSettingsQueryHandler handler = new(mockService.Object);
+		GetNormalizedDescriptionSettingsQuery query = new();
+
+		NormalizedDescriptionSettings actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/PreviewThresholdImpact/PreviewThresholdImpactQueryHandlerTests.cs
@@ -1,0 +1,32 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.PreviewThresholdImpact;
+
+public class PreviewThresholdImpactQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsThresholdsToServiceAndReturnsResult()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		ThresholdImpactPreview expected = new(
+			Current: new ClassificationCounts(10, 5, 2),
+			Proposed: new ClassificationCounts(12, 3, 2),
+			Deltas: new ReclassificationDeltas(AutoToPending: 0, PendingToAuto: 2, UnresolvedToAuto: 0, UnresolvedToPending: 0));
+
+		mockService
+			.Setup(s => s.PreviewThresholdImpactAsync(0.75, 0.5, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		PreviewThresholdImpactQueryHandler handler = new(mockService.Object);
+		PreviewThresholdImpactQuery query = new(0.75, 0.5);
+
+		ThresholdImpactPreview actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.PreviewThresholdImpactAsync(0.75, 0.5, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Application.Tests/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/NormalizedDescription/TestMatch/TestNormalizedDescriptionMatchQueryHandlerTests.cs
@@ -1,0 +1,32 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.TestMatch;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Queries.NormalizedDescription.TestMatch;
+
+public class TestNormalizedDescriptionMatchQueryHandlerTests
+{
+	[Fact]
+	public async Task Handle_ForwardsParametersToServiceAndReturnsResult()
+	{
+		Mock<INormalizedDescriptionService> mockService = new();
+		MatchTestResult expected = new(
+			Candidates: [new MatchCandidate(Guid.NewGuid(), "Milk", 0.92, "Active")],
+			SimulatedOutcome: MatchTestOutcomes.AutoAccept,
+			SimulatedTargetId: Guid.NewGuid());
+
+		mockService
+			.Setup(s => s.TestMatchAsync("whole milk", 3, 0.85, 0.55, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		TestNormalizedDescriptionMatchQueryHandler handler = new(mockService.Object);
+		TestNormalizedDescriptionMatchQuery query = new("whole milk", 3, 0.85, 0.55);
+
+		MatchTestResult actual = await handler.Handle(query, CancellationToken.None);
+
+		actual.Should().BeSameAs(expected);
+		mockService.Verify(s => s.TestMatchAsync("whole milk", 3, 0.85, 0.55, It.IsAny<CancellationToken>()), Times.Once);
+	}
+}

--- a/tests/Domain.Tests/NormalizedDescriptions/NormalizedDescriptionSettingsTests.cs
+++ b/tests/Domain.Tests/NormalizedDescriptions/NormalizedDescriptionSettingsTests.cs
@@ -1,0 +1,53 @@
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+
+namespace Domain.Tests.NormalizedDescriptions;
+
+public class NormalizedDescriptionSettingsTests
+{
+	private static readonly DateTimeOffset NowTimestamp = new(2026, 4, 19, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public void Constructor_ValidThresholds_AssignsProperties()
+	{
+		Guid id = Guid.NewGuid();
+		NormalizedDescriptionSettings settings = new(id, autoAcceptThreshold: 0.9, pendingReviewThreshold: 0.5, updatedAt: NowTimestamp);
+
+		settings.Id.Should().Be(id);
+		settings.AutoAcceptThreshold.Should().Be(0.9);
+		settings.PendingReviewThreshold.Should().Be(0.5);
+		settings.UpdatedAt.Should().Be(NowTimestamp);
+	}
+
+	[Theory]
+	[InlineData(0.0, 0.0)] // pending == auto — pending must be strictly less
+	[InlineData(1.0, 1.0)]
+	[InlineData(0.5, 0.8)] // pending > auto
+	[InlineData(0.81, 0.81)]
+	public void Constructor_PendingNotStrictlyLessThanAuto_Throws(double autoAccept, double pendingReview)
+	{
+		Action act = () => _ = new NormalizedDescriptionSettings(Guid.NewGuid(), autoAccept, pendingReview, NowTimestamp);
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(-0.01, 0.5)]
+	[InlineData(1.01, 0.5)]
+	[InlineData(0.8, -0.01)]
+	[InlineData(0.8, 1.01)]
+	public void Constructor_ThresholdOutOfRange_Throws(double autoAccept, double pendingReview)
+	{
+		Action act = () => _ = new NormalizedDescriptionSettings(Guid.NewGuid(), autoAccept, pendingReview, NowTimestamp);
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(0.81, 0.68)] // the canonical baseline
+	[InlineData(1.0, 0.0)]   // boundary values both allowed
+	[InlineData(0.5, 0.499)] // tight spread
+	public void Validate_ValidPairs_DoesNotThrow(double autoAccept, double pendingReview)
+	{
+		Action act = () => NormalizedDescriptionSettings.Validate(autoAccept, pendingReview);
+		act.Should().NotThrow();
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/Services/NormalizedDescriptionResolutionServiceTests.cs
+++ b/tests/Infrastructure.IntegrationTests/Services/NormalizedDescriptionResolutionServiceTests.cs
@@ -1,0 +1,335 @@
+using Application.Interfaces.Services;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Infrastructure.Mapping;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests.Services;
+
+// Real-Postgres exercise of NormalizedDescriptionResolutionService (RECEIPTS-578). The tests
+// pre-seed NormalizedDescription rows so GetOrCreateAsync hits the exact-match short-circuit
+// (step 1 inside the service) and never needs the pgvector ANN pathway — that lets us verify
+// the resolver's end-to-end persistence, grouping, and filtering semantics without depending
+// on the ONNX embedding model.
+//
+// The ANN-match and below-threshold-create branches of GetOrCreateAsync are covered by the
+// unit tests against the InMemory provider (TestableNormalizedDescriptionService overrides
+// AnnSearchTopOneAsync for each threshold band).
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class NormalizedDescriptionResolutionServiceTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_LinksItems_ViaExactMatch_PopulatesFkAndScore()
+	{
+		// Arrange — pre-seed canonical entries so the resolver routes every description
+		// through the exact-case-insensitive short-circuit inside NormalizedDescriptionService.
+		await ResetTablesAsync();
+
+		Guid milkId = Guid.NewGuid();
+		Guid bananaId = Guid.NewGuid();
+
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		ReceiptItemEntity first = WithDescription(receipt.Id, "Organic Milk");
+		ReceiptItemEntity second = WithDescription(receipt.Id, "organic milk");
+		ReceiptItemEntity third = WithDescription(receipt.Id, "Bananas");
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.AddRange(
+				new NormalizedDescriptionEntity
+				{
+					Id = milkId,
+					CanonicalName = "Organic Milk",
+					Status = NormalizedDescriptionStatus.Active,
+					CreatedAt = DateTimeOffset.UtcNow,
+				},
+				new NormalizedDescriptionEntity
+				{
+					Id = bananaId,
+					CanonicalName = "Bananas",
+					Status = NormalizedDescriptionStatus.Active,
+					CreatedAt = DateTimeOffset.UtcNow,
+				});
+			setup.Receipts.Add(receipt);
+			setup.ReceiptItems.AddRange(first, second, third);
+			await setup.SaveChangesAsync();
+		}
+
+		NoOpEmbeddingService embeddingService = new();
+		ServiceProvider provider = BuildProvider(embeddingService);
+
+		NormalizedDescriptionResolutionService resolver = new(
+			provider.GetRequiredService<IServiceScopeFactory>(),
+			provider.GetRequiredService<IDescriptionChangeSignal>(),
+			NullLogger<NormalizedDescriptionResolutionService>.Instance);
+
+		// Act
+		var summary = await resolver.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert — all three items were linked with the exact-match short-circuit's
+		// perfect score of 1.0.
+		summary.Linked.Should().Be(3);
+		summary.NewEntriesCreated.Should().Be(0, "each description hit an existing canonical entry");
+
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+		List<ReceiptItemEntity> items = await verify.ReceiptItems.AsNoTracking().ToListAsync();
+		items.Should().HaveCount(3);
+
+		ReceiptItemEntity persistedFirst = items.Single(i => i.Id == first.Id);
+		ReceiptItemEntity persistedSecond = items.Single(i => i.Id == second.Id);
+		ReceiptItemEntity persistedThird = items.Single(i => i.Id == third.Id);
+
+		// Both casing variants resolve to the same canonical entry.
+		persistedFirst.NormalizedDescriptionId.Should().Be(milkId);
+		persistedSecond.NormalizedDescriptionId.Should().Be(milkId);
+		persistedThird.NormalizedDescriptionId.Should().Be(bananaId);
+
+		// Exact-match short-circuit surfaces similarity = 1.0 — the resolver must persist
+		// that score alongside the FK so the downstream preview / admin reports don't have
+		// to re-compute embeddings.
+		persistedFirst.NormalizedDescriptionMatchScore.Should().Be(1.0);
+		persistedSecond.NormalizedDescriptionMatchScore.Should().Be(1.0);
+		persistedThird.NormalizedDescriptionMatchScore.Should().Be(1.0);
+
+		// The resolver must not invent new canonical entries when exact matches exist.
+		int canonicalCount = await verify.NormalizedDescriptions.AsNoTracking().CountAsync();
+		canonicalCount.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_Batch_GroupsDuplicateDescriptions_IntoSingleGetOrCreateCall()
+	{
+		// Arrange — three rows with the same text should all resolve to the same FK.
+		await ResetTablesAsync();
+
+		Guid canonicalId = Guid.NewGuid();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		ReceiptItemEntity a = WithDescription(receipt.Id, "Eggs Large");
+		ReceiptItemEntity b = WithDescription(receipt.Id, "Eggs Large");
+		ReceiptItemEntity c = WithDescription(receipt.Id, "Eggs Large");
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = canonicalId,
+				CanonicalName = "Eggs Large",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			setup.Receipts.Add(receipt);
+			setup.ReceiptItems.AddRange(a, b, c);
+			await setup.SaveChangesAsync();
+		}
+
+		// A counting embedding service lets us assert the dedup behaviour is real — no need
+		// for embedding data since we pre-seeded the canonical rows.
+		NoOpEmbeddingService embeddingService = new();
+		ServiceProvider provider = BuildProvider(embeddingService);
+
+		NormalizedDescriptionResolutionService resolver = new(
+			provider.GetRequiredService<IServiceScopeFactory>(),
+			provider.GetRequiredService<IDescriptionChangeSignal>(),
+			NullLogger<NormalizedDescriptionResolutionService>.Instance);
+
+		// Act
+		var summary = await resolver.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert — all three rows got linked to the same canonical entry.
+		summary.Linked.Should().Be(3);
+
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+		List<ReceiptItemEntity> items = await verify.ReceiptItems.AsNoTracking().ToListAsync();
+		items.Should().OnlyContain(i => i.NormalizedDescriptionId == canonicalId);
+		items.Should().OnlyContain(i => i.NormalizedDescriptionMatchScore == 1.0);
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_IsIdempotent_WhenRunTwice()
+	{
+		// Arrange
+		await ResetTablesAsync();
+
+		Guid canonicalId = Guid.NewGuid();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		ReceiptItemEntity item = WithDescription(receipt.Id, "Sourdough Bread");
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = canonicalId,
+				CanonicalName = "Sourdough Bread",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			setup.Receipts.Add(receipt);
+			setup.ReceiptItems.Add(item);
+			await setup.SaveChangesAsync();
+		}
+
+		NoOpEmbeddingService embeddingService = new();
+		ServiceProvider provider = BuildProvider(embeddingService);
+		NormalizedDescriptionResolutionService resolver = new(
+			provider.GetRequiredService<IServiceScopeFactory>(),
+			provider.GetRequiredService<IDescriptionChangeSignal>(),
+			NullLogger<NormalizedDescriptionResolutionService>.Instance);
+
+		// Act — first run links the item; second run should see zero candidates.
+		var first = await resolver.ProcessPendingResolutionsAsync(CancellationToken.None);
+		var second = await resolver.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert
+		first.Linked.Should().Be(1);
+		second.Linked.Should().Be(0);
+
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+		int canonicalCount = await verify.NormalizedDescriptions.AsNoTracking().CountAsync();
+		canonicalCount.Should().Be(1, "the second cycle must not create a duplicate canonical entry");
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_ExcludesAlreadyLinkedAndSoftDeleted()
+	{
+		// Arrange — mix of states that should be filtered out vs resolved.
+		await ResetTablesAsync();
+
+		Guid existingCanonicalId = Guid.NewGuid();
+		Guid newCanonicalId = Guid.NewGuid();
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.AddRange(
+				new NormalizedDescriptionEntity
+				{
+					Id = existingCanonicalId,
+					CanonicalName = "Pre-existing",
+					Status = NormalizedDescriptionStatus.Active,
+					CreatedAt = DateTimeOffset.UtcNow,
+				},
+				new NormalizedDescriptionEntity
+				{
+					Id = newCanonicalId,
+					CanonicalName = "Unresolved",
+					Status = NormalizedDescriptionStatus.Active,
+					CreatedAt = DateTimeOffset.UtcNow,
+				});
+
+			ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+			setup.Receipts.Add(receipt);
+
+			// Already-linked: the resolver must not re-touch this row.
+			ReceiptItemEntity linked = WithDescription(receipt.Id, "Pre-existing");
+			linked.NormalizedDescriptionId = existingCanonicalId;
+			linked.NormalizedDescriptionMatchScore = 0.42;
+
+			// Soft-deleted: the resolver must skip it.
+			ReceiptItemEntity deleted = WithDescription(receipt.Id, "Unresolved");
+			deleted.DeletedAt = DateTimeOffset.UtcNow;
+
+			// Too-short: filtered out by the length predicate.
+			ReceiptItemEntity tooShort = WithDescription(receipt.Id, "X");
+
+			// The only row that should actually get resolved.
+			ReceiptItemEntity target = WithDescription(receipt.Id, "Unresolved");
+
+			setup.ReceiptItems.AddRange(linked, deleted, tooShort, target);
+			await setup.SaveChangesAsync();
+		}
+
+		NoOpEmbeddingService embeddingService = new();
+		ServiceProvider provider = BuildProvider(embeddingService);
+		NormalizedDescriptionResolutionService resolver = new(
+			provider.GetRequiredService<IServiceScopeFactory>(),
+			provider.GetRequiredService<IDescriptionChangeSignal>(),
+			NullLogger<NormalizedDescriptionResolutionService>.Instance);
+
+		// Act
+		var summary = await resolver.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert — only the one valid, unresolved row was linked.
+		summary.Linked.Should().Be(1);
+
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+		// The already-linked row retains its prior score (resolver did not overwrite).
+		ReceiptItemEntity persistedLinked = await verify.ReceiptItems
+			.AsNoTracking()
+			.SingleAsync(i => i.Description == "Pre-existing");
+		persistedLinked.NormalizedDescriptionId.Should().Be(existingCanonicalId);
+		persistedLinked.NormalizedDescriptionMatchScore.Should().Be(0.42);
+
+		// The soft-deleted row is still unresolved.
+		ReceiptItemEntity persistedDeleted = await verify.ReceiptItems
+			.IgnoreQueryFilters()
+			.AsNoTracking()
+			.SingleAsync(i => i.DeletedAt != null);
+		persistedDeleted.NormalizedDescriptionId.Should().BeNull();
+
+		// The too-short row is still unresolved.
+		ReceiptItemEntity persistedTooShort = await verify.ReceiptItems
+			.AsNoTracking()
+			.SingleAsync(i => i.Description == "X");
+		persistedTooShort.NormalizedDescriptionId.Should().BeNull();
+
+		// The target was linked to the pre-seeded "Unresolved" canonical entry with a
+		// perfect exact-match score.
+		ReceiptItemEntity persistedTarget = await verify.ReceiptItems
+			.AsNoTracking()
+			.SingleAsync(i => i.Description == "Unresolved" && i.DeletedAt == null);
+		persistedTarget.NormalizedDescriptionId.Should().Be(newCanonicalId);
+		persistedTarget.NormalizedDescriptionMatchScore.Should().Be(1.0);
+	}
+
+	private ServiceProvider BuildProvider(IEmbeddingService embeddingService)
+	{
+		ServiceCollection services = new();
+		services.AddSingleton<IEmbeddingService>(embeddingService);
+		services.AddSingleton<NormalizedDescriptionMapper>();
+		services.AddSingleton<NormalizedDescriptionSettingsMapper>();
+		services.AddSingleton<IDbContextFactory<ApplicationDbContext>>(new FixtureDbContextFactory(fixture));
+		services.AddScoped<INormalizedDescriptionService, NormalizedDescriptionService>();
+		services.AddSingleton<IDescriptionChangeSignal, DescriptionChangeSignal>();
+		return services.BuildServiceProvider();
+	}
+
+	// Hand-written embedding stub — the integration test project doesn't reference Moq. This
+	// stub reports IsConfigured=true so the resolver proceeds past its short-circuit, but
+	// never has to actually supply an embedding because every test pre-seeds the canonical
+	// entry that the exact-match path will find first.
+	private sealed class NoOpEmbeddingService : IEmbeddingService
+	{
+		public bool IsConfigured => true;
+		public Task<float[]> GenerateEmbeddingAsync(string text, CancellationToken cancellationToken)
+			=> Task.FromResult(Array.Empty<float>());
+		public Task<List<float[]>> GenerateEmbeddingsAsync(List<string> texts, CancellationToken cancellationToken)
+			=> Task.FromResult(texts.Select(_ => Array.Empty<float>()).ToList());
+	}
+
+	private static ReceiptItemEntity WithDescription(Guid receiptId, string description)
+	{
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receiptId);
+		item.Description = description;
+		return item;
+	}
+
+	private async Task ResetTablesAsync()
+	{
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		// Reset every table the resolver touches or depends on. DistinctDescriptions is
+		// reconciled by the DbContext SaveChanges hook so it needs a clean slate too.
+		await context.Database.ExecuteSqlRawAsync(
+			"""TRUNCATE "ReceiptItems", "Receipts", "NormalizedDescriptions", "DistinctDescriptions" RESTART IDENTITY CASCADE;""");
+	}
+
+	private sealed class FixtureDbContextFactory(PostgresFixture fixture) : IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => fixture.CreateDbContext();
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/Services/ReportServiceSpendingByNormalizedDescriptionTests.cs
+++ b/tests/Infrastructure.IntegrationTests/Services/ReportServiceSpendingByNormalizedDescriptionTests.cs
@@ -1,0 +1,201 @@
+using Application.Models.Reports;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests.Services;
+
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class ReportServiceSpendingByNormalizedDescriptionTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_AggregatesByCanonicalName_AndBucketsNullFk()
+	{
+		// Arrange
+		await ResetTablesAsync();
+
+		Guid normalizedId = Guid.NewGuid();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Organic Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			setup.Receipts.Add(receipt);
+
+			ReceiptItemEntity linked1 = ReceiptItemEntityGenerator.Generate(receipt.Id);
+			linked1.Description = "organic milk";
+			linked1.TotalAmount = 4.00m;
+			linked1.NormalizedDescriptionId = normalizedId;
+
+			ReceiptItemEntity linked2 = ReceiptItemEntityGenerator.Generate(receipt.Id);
+			linked2.Description = "ORGANIC MILK";
+			linked2.TotalAmount = 5.50m;
+			linked2.NormalizedDescriptionId = normalizedId;
+
+			ReceiptItemEntity unlinked = ReceiptItemEntityGenerator.Generate(receipt.Id);
+			unlinked.Description = "mystery item";
+			unlinked.TotalAmount = 2.00m;
+			unlinked.NormalizedDescriptionId = null;
+
+			setup.ReceiptItems.AddRange(linked1, linked2, unlinked);
+			await setup.SaveChangesAsync();
+		}
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(from: null, to: null, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().HaveCount(2);
+
+		SpendingByNormalizedDescriptionItem milk = result.Items.Single(i => i.CanonicalName == "Organic Milk");
+		milk.TotalAmount.Should().Be(9.50m);
+		milk.ItemCount.Should().Be(2);
+		milk.Currency.Should().Be("USD");
+		milk.FirstSeen.Should().NotBeNull();
+		milk.LastSeen.Should().NotBeNull();
+
+		SpendingByNormalizedDescriptionItem notNormalized = result.Items.Single(i => i.CanonicalName == "(Not Normalized)");
+		notNormalized.TotalAmount.Should().Be(2.00m);
+		notNormalized.ItemCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_FiltersByDateRange()
+	{
+		// Arrange
+		await ResetTablesAsync();
+
+		Guid normalizedId = Guid.NewGuid();
+
+		ReceiptEntity receiptInRange = ReceiptEntityGenerator.Generate();
+		receiptInRange.Date = new DateOnly(2025, 6, 15);
+
+		ReceiptEntity receiptOutOfRange = ReceiptEntityGenerator.Generate();
+		receiptOutOfRange.Date = new DateOnly(2024, 1, 1);
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Bananas",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			setup.Receipts.AddRange(receiptInRange, receiptOutOfRange);
+
+			ReceiptItemEntity inRange = ReceiptItemEntityGenerator.Generate(receiptInRange.Id);
+			inRange.Description = "bananas";
+			inRange.TotalAmount = 1.50m;
+			inRange.NormalizedDescriptionId = normalizedId;
+
+			ReceiptItemEntity outOfRange = ReceiptItemEntityGenerator.Generate(receiptOutOfRange.Id);
+			outOfRange.Description = "bananas";
+			outOfRange.TotalAmount = 99.99m;
+			outOfRange.NormalizedDescriptionId = normalizedId;
+
+			setup.ReceiptItems.AddRange(inRange, outOfRange);
+			await setup.SaveChangesAsync();
+		}
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(from, to, CancellationToken.None);
+
+		// Assert — only the receipt within the range contributed
+		result.Items.Should().ContainSingle();
+		result.Items[0].CanonicalName.Should().Be("Bananas");
+		result.Items[0].TotalAmount.Should().Be(1.50m);
+		result.Items[0].ItemCount.Should().Be(1);
+		result.FromDate.Should().Be(from);
+		result.ToDate.Should().Be(to);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_IgnoresSoftDeletedItemsAndReceipts()
+	{
+		// Arrange
+		await ResetTablesAsync();
+
+		Guid normalizedId = Guid.NewGuid();
+		ReceiptEntity live = ReceiptEntityGenerator.Generate();
+		ReceiptEntity deleted = ReceiptEntityGenerator.Generate();
+		deleted.DeletedAt = DateTimeOffset.UtcNow;
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Eggs",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			setup.Receipts.AddRange(live, deleted);
+
+			ReceiptItemEntity liveItem = ReceiptItemEntityGenerator.Generate(live.Id);
+			liveItem.Description = "eggs";
+			liveItem.TotalAmount = 3.00m;
+			liveItem.NormalizedDescriptionId = normalizedId;
+
+			ReceiptItemEntity softDeletedItem = ReceiptItemEntityGenerator.Generate(live.Id);
+			softDeletedItem.Description = "eggs";
+			softDeletedItem.TotalAmount = 100.00m;
+			softDeletedItem.NormalizedDescriptionId = normalizedId;
+			softDeletedItem.DeletedAt = DateTimeOffset.UtcNow;
+
+			ReceiptItemEntity itemOnDeletedReceipt = ReceiptItemEntityGenerator.Generate(deleted.Id);
+			itemOnDeletedReceipt.Description = "eggs";
+			itemOnDeletedReceipt.TotalAmount = 50.00m;
+			itemOnDeletedReceipt.NormalizedDescriptionId = normalizedId;
+
+			setup.ReceiptItems.AddRange(liveItem, softDeletedItem, itemOnDeletedReceipt);
+			await setup.SaveChangesAsync();
+		}
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(null, null, CancellationToken.None);
+
+		// Assert — only the live item on the live receipt counted
+		result.Items.Should().ContainSingle();
+		result.Items[0].CanonicalName.Should().Be("Eggs");
+		result.Items[0].TotalAmount.Should().Be(3.00m);
+		result.Items[0].ItemCount.Should().Be(1);
+	}
+
+	private async Task ResetTablesAsync()
+	{
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		await context.Database.ExecuteSqlRawAsync(
+			"""TRUNCATE "ReceiptItems", "Receipts", "NormalizedDescriptions", "DistinctDescriptions" RESTART IDENTITY CASCADE;""");
+	}
+
+	private sealed class FixtureDbContextFactory(PostgresFixture fixture) : IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => fixture.CreateDbContext();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/NormalizedDescriptionResolutionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/NormalizedDescriptionResolutionServiceTests.cs
@@ -1,0 +1,427 @@
+using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Services;
+using Infrastructure.Tests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Infrastructure.Tests.Services;
+
+[Trait("Category", "Unit")]
+public class NormalizedDescriptionResolutionServiceTests
+{
+	private readonly Mock<IEmbeddingService> _embeddingServiceMock;
+	private readonly Mock<INormalizedDescriptionService> _normalizedServiceMock;
+	private readonly Mock<IDescriptionChangeSignal> _signalMock;
+	private readonly Mock<ILogger<NormalizedDescriptionResolutionService>> _loggerMock;
+	private readonly Mock<IServiceScopeFactory> _scopeFactoryMock;
+	private readonly Mock<IServiceScope> _scopeMock;
+	private readonly Mock<IServiceProvider> _serviceProviderMock;
+	private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+
+	public NormalizedDescriptionResolutionServiceTests()
+	{
+		_embeddingServiceMock = new Mock<IEmbeddingService>();
+		_normalizedServiceMock = new Mock<INormalizedDescriptionService>();
+		_signalMock = new Mock<IDescriptionChangeSignal>();
+		_loggerMock = new Mock<ILogger<NormalizedDescriptionResolutionService>>();
+		_scopeFactoryMock = new Mock<IServiceScopeFactory>();
+		_scopeMock = new Mock<IServiceScope>();
+		_serviceProviderMock = new Mock<IServiceProvider>();
+
+		(_contextFactory, MockCurrentUserAccessor accessor) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		accessor.UserId = "test-user";
+
+		_serviceProviderMock
+			.Setup(sp => sp.GetService(typeof(IEmbeddingService)))
+			.Returns(_embeddingServiceMock.Object);
+		_serviceProviderMock
+			.Setup(sp => sp.GetService(typeof(INormalizedDescriptionService)))
+			.Returns(_normalizedServiceMock.Object);
+		_serviceProviderMock
+			.Setup(sp => sp.GetService(typeof(IDbContextFactory<ApplicationDbContext>)))
+			.Returns(_contextFactory);
+		_scopeMock
+			.Setup(s => s.ServiceProvider)
+			.Returns(_serviceProviderMock.Object);
+		_scopeFactoryMock
+			.Setup(f => f.CreateScope())
+			.Returns(_scopeMock.Object);
+	}
+
+	private NormalizedDescriptionResolutionService CreateService() => new(
+		_scopeFactoryMock.Object,
+		_signalMock.Object,
+		_loggerMock.Object);
+
+	private async Task SeedReceiptAndItemsAsync(params ReceiptItemEntity[] items)
+	{
+		using ApplicationDbContext seed = _contextFactory.CreateDbContext();
+		// Use a single ReceiptEntity for FK consistency — the resolver only reads from
+		// ReceiptItems and doesn't care about the receipt, but EF's relationship graph
+		// rejects orphan items on SaveChangesAsync.
+		Guid receiptId = Guid.NewGuid();
+		foreach (ReceiptItemEntity item in items)
+		{
+			item.ReceiptId = receiptId;
+		}
+
+		seed.Receipts.Add(new ReceiptEntity
+		{
+			Id = receiptId,
+			Date = new DateOnly(2026, 4, 19),
+			Location = "Test",
+			TaxAmount = 0m,
+			TaxAmountCurrency = Common.Currency.USD,
+		});
+		seed.ReceiptItems.AddRange(items);
+		await seed.SaveChangesAsync();
+	}
+
+	private static ReceiptItemEntity BuildItem(string description, Guid? receiptId = null, DateTimeOffset? deletedAt = null)
+	{
+		return new ReceiptItemEntity
+		{
+			Id = Guid.NewGuid(),
+			ReceiptId = receiptId ?? Guid.NewGuid(),
+			Description = description,
+			Quantity = 1m,
+			UnitPrice = 1m,
+			UnitPriceCurrency = Common.Currency.USD,
+			TotalAmount = 1m,
+			TotalAmountCurrency = Common.Currency.USD,
+			Category = "Test",
+			DeletedAt = deletedAt,
+		};
+	}
+
+	private static GetOrCreateResult NewResult(string canonicalName, double? matchScore)
+	{
+		NormalizedDescription domain = new(
+			Guid.NewGuid(),
+			canonicalName,
+			NormalizedDescriptionStatus.Active,
+			DateTimeOffset.UtcNow);
+		return new GetOrCreateResult(domain, matchScore);
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_BatchDedup_OneCallPerUniqueDescription()
+	{
+		// Arrange — two items share a description; a third has its own.
+		Guid receiptId = Guid.NewGuid();
+		ReceiptItemEntity dup1 = BuildItem("Organic Milk", receiptId);
+		ReceiptItemEntity dup2 = BuildItem("Organic Milk", receiptId);
+		ReceiptItemEntity other = BuildItem("Bananas", receiptId);
+		await SeedReceiptAndItemsAsync(dup1, dup2, other);
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+
+		GetOrCreateResult milkResult = NewResult("Organic Milk", 0.95);
+		GetOrCreateResult bananaResult = NewResult("Bananas", null);
+
+		_normalizedServiceMock
+			.Setup(s => s.GetOrCreateAsync("Organic Milk", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(milkResult);
+		_normalizedServiceMock
+			.Setup(s => s.GetOrCreateAsync("Bananas", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(bananaResult);
+
+		NormalizedDescriptionResolutionService service = CreateService();
+
+		// Act
+		var summary = await service.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert — one call per unique description.
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync("Organic Milk", It.IsAny<CancellationToken>()),
+			Times.Once);
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync("Bananas", It.IsAny<CancellationToken>()),
+			Times.Once);
+
+		summary.Linked.Should().Be(3);
+		summary.NewEntriesCreated.Should().Be(1, "the Bananas result had no match score, indicating a new canonical entry");
+
+		// Both dup items point at the same NormalizedDescriptionId; the banana item at its own.
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		List<ReceiptItemEntity> items = await verify.ReceiptItems.AsNoTracking().ToListAsync();
+		items.Should().HaveCount(3);
+
+		ReceiptItemEntity rDup1 = items.Single(i => i.Id == dup1.Id);
+		ReceiptItemEntity rDup2 = items.Single(i => i.Id == dup2.Id);
+		ReceiptItemEntity rOther = items.Single(i => i.Id == other.Id);
+
+		rDup1.NormalizedDescriptionId.Should().Be(milkResult.Description.Id);
+		rDup2.NormalizedDescriptionId.Should().Be(milkResult.Description.Id);
+		rOther.NormalizedDescriptionId.Should().Be(bananaResult.Description.Id);
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_WritesMatchScore_AlongsideFk()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		ReceiptItemEntity matched = BuildItem("Eggs Large", receiptId);
+		ReceiptItemEntity fresh = BuildItem("Mystery Widget", receiptId);
+		await SeedReceiptAndItemsAsync(matched, fresh);
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+
+		GetOrCreateResult matchedResult = NewResult("Eggs", 0.87);
+		GetOrCreateResult freshResult = NewResult("Mystery Widget", null);
+
+		_normalizedServiceMock
+			.Setup(s => s.GetOrCreateAsync("Eggs Large", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(matchedResult);
+		_normalizedServiceMock
+			.Setup(s => s.GetOrCreateAsync("Mystery Widget", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(freshResult);
+
+		NormalizedDescriptionResolutionService service = CreateService();
+
+		// Act
+		await service.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		ReceiptItemEntity persistedMatched = await verify.ReceiptItems.AsNoTracking().SingleAsync(i => i.Id == matched.Id);
+		ReceiptItemEntity persistedFresh = await verify.ReceiptItems.AsNoTracking().SingleAsync(i => i.Id == fresh.Id);
+
+		persistedMatched.NormalizedDescriptionId.Should().Be(matchedResult.Description.Id);
+		persistedMatched.NormalizedDescriptionMatchScore.Should().Be(0.87);
+
+		// null MatchScore signals "brand-new canonical entry" — we still link the FK but
+		// don't invent a score.
+		persistedFresh.NormalizedDescriptionId.Should().Be(freshResult.Description.Id);
+		persistedFresh.NormalizedDescriptionMatchScore.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_SkipsCycle_WhenEmbeddingServiceNotConfigured()
+	{
+		// Arrange
+		await SeedReceiptAndItemsAsync(BuildItem("Would Be Resolved"));
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
+
+		NormalizedDescriptionResolutionService service = CreateService();
+
+		// Act
+		var summary = await service.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert
+		summary.Linked.Should().Be(0);
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_FiltersOutShortDescriptions()
+	{
+		// Arrange — "X" is below MinDescriptionLength; empty is filtered separately.
+		ReceiptItemEntity tooShort = BuildItem("X");
+		ReceiptItemEntity empty = BuildItem(string.Empty);
+		ReceiptItemEntity good = BuildItem("Bread");
+		await SeedReceiptAndItemsAsync(tooShort, empty, good);
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_normalizedServiceMock
+			.Setup(s => s.GetOrCreateAsync("Bread", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(NewResult("Bread", 0.99));
+
+		NormalizedDescriptionResolutionService service = CreateService();
+
+		// Act
+		var summary = await service.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert — only the valid row was processed.
+		summary.Linked.Should().Be(1);
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync("X", It.IsAny<CancellationToken>()),
+			Times.Never);
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync(string.Empty, It.IsAny<CancellationToken>()),
+			Times.Never);
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync("Bread", It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_ExcludesSoftDeletedItems()
+	{
+		// Arrange
+		ReceiptItemEntity deleted = BuildItem("Soft Deleted", deletedAt: DateTimeOffset.UtcNow);
+		ReceiptItemEntity live = BuildItem("Live Item");
+		await SeedReceiptAndItemsAsync(deleted, live);
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_normalizedServiceMock
+			.Setup(s => s.GetOrCreateAsync("Live Item", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(NewResult("Live Item", 0.9));
+
+		NormalizedDescriptionResolutionService service = CreateService();
+
+		// Act
+		await service.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert — soft-deleted item was never offered to the normalized service.
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync("Soft Deleted", It.IsAny<CancellationToken>()),
+			Times.Never);
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync("Live Item", It.IsAny<CancellationToken>()),
+			Times.Once);
+
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		ReceiptItemEntity persistedDeleted = await verify.ReceiptItems
+			.IgnoreQueryFilters()
+			.AsNoTracking()
+			.SingleAsync(i => i.Id == deleted.Id);
+		persistedDeleted.NormalizedDescriptionId.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_ExcludesItemsWithFkAlreadySet()
+	{
+		// Arrange — already-linked rows must not be re-processed.
+		Guid existingFk = Guid.NewGuid();
+
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = existingFk,
+				CanonicalName = "Pre-linked",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		ReceiptItemEntity alreadyLinked = BuildItem("Already Linked");
+		alreadyLinked.NormalizedDescriptionId = existingFk;
+		ReceiptItemEntity unresolved = BuildItem("Unresolved");
+		await SeedReceiptAndItemsAsync(alreadyLinked, unresolved);
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_normalizedServiceMock
+			.Setup(s => s.GetOrCreateAsync("Unresolved", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(NewResult("Unresolved", 0.85));
+
+		NormalizedDescriptionResolutionService service = CreateService();
+
+		// Act
+		await service.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync("Already Linked", It.IsAny<CancellationToken>()),
+			Times.Never);
+		_normalizedServiceMock.Verify(
+			s => s.GetOrCreateAsync("Unresolved", It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task ProcessPendingResolutionsAsync_ExceptionInGetOrCreate_LogsAndContinues()
+	{
+		// Arrange — one group throws, the other succeeds.
+		Guid receiptId = Guid.NewGuid();
+		ReceiptItemEntity bad = BuildItem("Problematic", receiptId);
+		ReceiptItemEntity good = BuildItem("Works Fine", receiptId);
+		await SeedReceiptAndItemsAsync(bad, good);
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_normalizedServiceMock
+			.Setup(s => s.GetOrCreateAsync("Problematic", It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("boom"));
+		_normalizedServiceMock
+			.Setup(s => s.GetOrCreateAsync("Works Fine", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(NewResult("Works Fine", 0.9));
+
+		NormalizedDescriptionResolutionService service = CreateService();
+
+		// Act
+		var summary = await service.ProcessPendingResolutionsAsync(CancellationToken.None);
+
+		// Assert — the exception is logged, not rethrown; the good group persisted.
+		summary.Linked.Should().Be(1);
+		summary.Skipped.Should().Be(1);
+
+		_loggerMock.Verify(
+			x => x.Log(
+				LogLevel.Error,
+				It.IsAny<EventId>(),
+				It.IsAny<It.IsAnyType>(),
+				It.IsAny<Exception>(),
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			Times.AtLeastOnce);
+
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		ReceiptItemEntity persistedBad = await verify.ReceiptItems.AsNoTracking().SingleAsync(i => i.Id == bad.Id);
+		ReceiptItemEntity persistedGood = await verify.ReceiptItems.AsNoTracking().SingleAsync(i => i.Id == good.Id);
+
+		persistedBad.NormalizedDescriptionId.Should().BeNull("the failing group must not leave partial state");
+		persistedGood.NormalizedDescriptionId.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task ExecuteAsync_StopsGracefully_OnCancellation()
+	{
+		// Arrange — cancel immediately so the 10-second initial delay is interrupted.
+		NormalizedDescriptionResolutionService service = CreateService();
+		using CancellationTokenSource cts = new();
+
+		// Act
+		await service.StartAsync(cts.Token);
+		cts.Cancel();
+		Func<Task> act = async () => await service.StopAsync(CancellationToken.None);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public async Task ExecuteAsync_DoesNotThrow_WhenScopeFactoryThrows()
+	{
+		// Arrange — a repeated per-cycle exception must be swallowed and logged,
+		// not propagated up through the BackgroundService host.
+		TaskCompletionSource invoked = new();
+		Mock<IServiceScopeFactory> throwingFactory = new();
+		throwingFactory
+			.Setup(f => f.CreateScope())
+			.Callback(() => invoked.TrySetResult())
+			.Throws(new InvalidOperationException("scope creation failed"));
+
+		NormalizedDescriptionResolutionService service = new(
+			throwingFactory.Object,
+			_signalMock.Object,
+			_loggerMock.Object);
+
+		using CancellationTokenSource cts = new();
+
+		// Act — start the service, wait for the first scope attempt (which throws), then cancel.
+		await service.StartAsync(cts.Token);
+		await invoked.Task.WaitAsync(TimeSpan.FromSeconds(15));
+		cts.Cancel();
+		Func<Task> act = async () => await service.StopAsync(CancellationToken.None);
+
+		// Assert — the service's try/catch absorbed the exception.
+		await act.Should().NotThrowAsync();
+		_loggerMock.Verify(
+			x => x.Log(
+				LogLevel.Error,
+				It.IsAny<EventId>(),
+				It.IsAny<It.IsAnyType>(),
+				It.IsAny<Exception>(),
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			Times.AtLeastOnce);
+	}
+}

--- a/tests/Infrastructure.Tests/Services/NormalizedDescriptionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/NormalizedDescriptionServiceTests.cs
@@ -1,0 +1,450 @@
+using Application.Interfaces.Services;
+using Common;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Mapping;
+using Infrastructure.Services;
+using Infrastructure.Tests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Pgvector;
+
+namespace Infrastructure.Tests.Services;
+
+[Trait("Category", "Unit")]
+public class NormalizedDescriptionServiceTests
+{
+	private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+	private readonly Mock<IEmbeddingService> _embeddingServiceMock;
+	private readonly NormalizedDescriptionMapper _mapper;
+
+	public NormalizedDescriptionServiceTests()
+	{
+		(_contextFactory, MockCurrentUserAccessor accessor) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		accessor.UserId = "test-user";
+		_embeddingServiceMock = new Mock<IEmbeddingService>();
+		_mapper = new NormalizedDescriptionMapper();
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_ExactCaseInsensitiveMatch_ReturnsExisting()
+	{
+		// Arrange — seed an existing canonical entry.
+		Guid existingId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = existingId,
+				CanonicalName = "Organic Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act — query with different casing; it should short-circuit without generating an embedding.
+		NormalizedDescription result = await service.GetOrCreateAsync("organic MILK", CancellationToken.None);
+
+		// Assert
+		result.Id.Should().Be(existingId);
+		result.CanonicalName.Should().Be("Organic Milk");
+		_embeddingServiceMock.Verify(
+			e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_EmbeddingServiceUnavailable_CreatesActiveEntryWithNoEmbedding()
+	{
+		// Arrange
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		NormalizedDescription result = await service.GetOrCreateAsync("New Item", CancellationToken.None);
+
+		// Assert — a new Active row was created, and no embedding was generated.
+		result.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		result.CanonicalName.Should().Be("New Item");
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		NormalizedDescriptionEntity stored = await verify.NormalizedDescriptions.SingleAsync(e => e.Id == result.Id);
+		stored.Embedding.Should().BeNull();
+		stored.EmbeddingModelVersion.Should().BeNull();
+		_embeddingServiceMock.Verify(
+			e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_AboveAutoAcceptThreshold_ReturnsAnnMatchWithoutInserting()
+	{
+		// Arrange — seed an existing Active entry that the fake ANN will return as the top-1.
+		Guid matchedId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = matchedId,
+				CanonicalName = "Gallon of Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync("Whole Milk", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory,
+			_embeddingServiceMock.Object,
+			_mapper,
+			matchedId,
+			similarity: NormalizedDescriptionService.AutoAcceptThreshold + 0.01);
+
+		// Act
+		NormalizedDescription result = await service.GetOrCreateAsync("Whole Milk", CancellationToken.None);
+
+		// Assert — returned the ANN match; no new row inserted.
+		result.Id.Should().Be(matchedId);
+		result.CanonicalName.Should().Be("Gallon of Milk");
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		int count = await verify.NormalizedDescriptions.CountAsync();
+		count.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_BetweenThresholds_CreatesPendingReviewWithInputText()
+	{
+		// Arrange — seed a close-but-not-exact match that the fake ANN will return.
+		Guid matchedId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = matchedId,
+				CanonicalName = "Gallon of Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync("Milky Thing", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		double between = (NormalizedDescriptionService.AutoAcceptThreshold + NormalizedDescriptionService.PendingReviewThreshold) / 2;
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory,
+			_embeddingServiceMock.Object,
+			_mapper,
+			matchedId,
+			similarity: between);
+
+		// Act
+		NormalizedDescription result = await service.GetOrCreateAsync("Milky Thing", CancellationToken.None);
+
+		// Assert — a new PendingReview row was created with the input text as canonical name.
+		result.Status.Should().Be(NormalizedDescriptionStatus.PendingReview);
+		result.CanonicalName.Should().Be("Milky Thing");
+		result.Id.Should().NotBe(matchedId);
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		int count = await verify.NormalizedDescriptions.CountAsync();
+		count.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_BelowPendingReviewThreshold_CreatesActiveEntry()
+	{
+		// Arrange — seed an unrelated Active entry that the fake ANN will return as the top-1 match
+		// but with a similarity below the PendingReview threshold.
+		Guid matchedId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = matchedId,
+				CanonicalName = "Unrelated Item",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync("Totally Different", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory,
+			_embeddingServiceMock.Object,
+			_mapper,
+			matchedId,
+			similarity: NormalizedDescriptionService.PendingReviewThreshold - 0.1);
+
+		// Act
+		NormalizedDescription result = await service.GetOrCreateAsync("Totally Different", CancellationToken.None);
+
+		// Assert — a new Active entry was created with the input text as canonical.
+		result.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		result.CanonicalName.Should().Be("Totally Different");
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		int count = await verify.NormalizedDescriptions.CountAsync();
+		count.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task GetOrCreateAsync_EmptyOrWhitespace_Throws()
+	{
+		// Arrange
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act + Assert
+		await service.Invoking(s => s.GetOrCreateAsync("   ", CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Fact]
+	public async Task MergeAsync_ReLinksReceiptItemsAndDeletesDiscard()
+	{
+		// Arrange — two NormalizedDescriptions plus two ReceiptItems pointing at the discard entry.
+		Guid keepId = Guid.NewGuid();
+		Guid discardId = Guid.NewGuid();
+		Guid itemAId = Guid.NewGuid();
+		Guid itemBId = Guid.NewGuid();
+		Guid receiptId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.AddRange(
+				new NormalizedDescriptionEntity { Id = keepId, CanonicalName = "Milk", Status = NormalizedDescriptionStatus.Active, CreatedAt = DateTimeOffset.UtcNow },
+				new NormalizedDescriptionEntity { Id = discardId, CanonicalName = "Mlik", Status = NormalizedDescriptionStatus.Active, CreatedAt = DateTimeOffset.UtcNow });
+			seed.ReceiptItems.AddRange(
+				BuildReceiptItem(itemAId, receiptId, "Mlik", discardId),
+				BuildReceiptItem(itemBId, receiptId, "Mlik", discardId));
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		int moved = await service.MergeAsync(keepId, discardId, CancellationToken.None);
+
+		// Assert
+		moved.Should().Be(2);
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		(await verify.NormalizedDescriptions.AnyAsync(e => e.Id == discardId)).Should().BeFalse();
+		(await verify.NormalizedDescriptions.AnyAsync(e => e.Id == keepId)).Should().BeTrue();
+		List<Guid?> linkedIds = await verify.ReceiptItems
+			.IgnoreAutoIncludes()
+			.Where(r => r.Id == itemAId || r.Id == itemBId)
+			.Select(r => r.NormalizedDescriptionId)
+			.ToListAsync();
+		linkedIds.Should().OnlyContain(id => id == keepId);
+	}
+
+	[Fact]
+	public async Task SplitAsync_CreatesNewActiveEntryAndRepointsReceiptItem()
+	{
+		// Arrange — an existing NormalizedDescription shared by a ReceiptItem.
+		Guid sharedId = Guid.NewGuid();
+		Guid itemId = Guid.NewGuid();
+		Guid receiptId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = sharedId,
+				CanonicalName = "Shared Name",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			seed.ReceiptItems.Add(BuildReceiptItem(itemId, receiptId, "Specific Raw Text", sharedId));
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		NormalizedDescription created = await service.SplitAsync(itemId, CancellationToken.None);
+
+		// Assert — a new Active entry was created with the ReceiptItem's raw text, and the
+		// ReceiptItem now points at the new entry.
+		created.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		created.CanonicalName.Should().Be("Specific Raw Text");
+		created.Id.Should().NotBe(sharedId);
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		ReceiptItemEntity updatedItem = await verify.ReceiptItems
+			.IgnoreAutoIncludes()
+			.SingleAsync(r => r.Id == itemId);
+		updatedItem.NormalizedDescriptionId.Should().Be(created.Id);
+	}
+
+	[Fact]
+	public async Task UpdateStatusAsync_ChangesPendingReviewToActive()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = id,
+				CanonicalName = "Pending Entry",
+				Status = NormalizedDescriptionStatus.PendingReview,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		bool changed = await service.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, CancellationToken.None);
+
+		// Assert
+		changed.Should().BeTrue();
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		NormalizedDescriptionEntity stored = await verify.NormalizedDescriptions.SingleAsync(e => e.Id == id);
+		stored.Status.Should().Be(NormalizedDescriptionStatus.Active);
+	}
+
+	[Fact]
+	public async Task UpdateStatusAsync_NoChange_ReturnsFalse()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = id,
+				CanonicalName = "Already Active",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		bool changed = await service.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, CancellationToken.None);
+
+		// Assert
+		changed.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task GetByIdAsync_ReturnsEntity_WhenPresent()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = id,
+				CanonicalName = "Findable",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		NormalizedDescription? result = await service.GetByIdAsync(id, CancellationToken.None);
+
+		// Assert
+		result.Should().NotBeNull();
+		result!.CanonicalName.Should().Be("Findable");
+	}
+
+	[Fact]
+	public async Task GetAllAsync_FilterByStatus_ReturnsOnlyMatching()
+	{
+		// Arrange
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.AddRange(
+				new NormalizedDescriptionEntity { Id = Guid.NewGuid(), CanonicalName = "Active A", Status = NormalizedDescriptionStatus.Active, CreatedAt = DateTimeOffset.UtcNow },
+				new NormalizedDescriptionEntity { Id = Guid.NewGuid(), CanonicalName = "Pending B", Status = NormalizedDescriptionStatus.PendingReview, CreatedAt = DateTimeOffset.UtcNow },
+				new NormalizedDescriptionEntity { Id = Guid.NewGuid(), CanonicalName = "Active C", Status = NormalizedDescriptionStatus.Active, CreatedAt = DateTimeOffset.UtcNow });
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+
+		// Act
+		List<NormalizedDescription> pending = await service.GetAllAsync(NormalizedDescriptionStatus.PendingReview, CancellationToken.None);
+		List<NormalizedDescription> all = await service.GetAllAsync(null, CancellationToken.None);
+
+		// Assert
+		pending.Should().ContainSingle();
+		pending[0].CanonicalName.Should().Be("Pending B");
+		all.Should().HaveCount(3);
+	}
+
+	private static ReceiptItemEntity BuildReceiptItem(Guid id, Guid receiptId, string description, Guid? normalizedId)
+	{
+		return new ReceiptItemEntity
+		{
+			Id = id,
+			ReceiptId = receiptId,
+			Description = description,
+			Quantity = 1,
+			UnitPrice = 1,
+			UnitPriceCurrency = Currency.USD,
+			TotalAmount = 1,
+			TotalAmountCurrency = Currency.USD,
+			Category = "Groceries",
+			NormalizedDescriptionId = normalizedId,
+		};
+	}
+
+	private static float[] CreateFakeEmbedding()
+	{
+		float[] embedding = new float[OnnxEmbeddingService.EmbeddingDimension];
+		Random rng = new(42);
+		for (int i = 0; i < embedding.Length; i++)
+		{
+			embedding[i] = (float)(rng.NextDouble() * 2 - 1);
+		}
+
+		return embedding;
+	}
+
+	// Test subclass that overrides the ANN search to deterministically return a seeded match.
+	// This lets us exercise the threshold-band logic against InMemory, which cannot run the
+	// pgvector `<=>` operator.
+	private sealed class TestableNormalizedDescriptionService(
+		IDbContextFactory<ApplicationDbContext> contextFactory,
+		IEmbeddingService embeddingService,
+		NormalizedDescriptionMapper mapper,
+		Guid matchId,
+		double similarity) : NormalizedDescriptionService(contextFactory, embeddingService, mapper)
+	{
+		private readonly Guid _matchId = matchId;
+		private readonly double _similarity = similarity;
+
+		protected override async Task<(NormalizedDescriptionEntity? Match, double? Similarity)> AnnSearchTopOneAsync(
+			ApplicationDbContext context, Vector queryVector, CancellationToken cancellationToken)
+		{
+			NormalizedDescriptionEntity? match = await context.NormalizedDescriptions
+				.FirstOrDefaultAsync(e => e.Id == _matchId, cancellationToken);
+			return (match, _similarity);
+		}
+	}
+}

--- a/tests/Infrastructure.Tests/Services/NormalizedDescriptionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/NormalizedDescriptionServiceTests.cs
@@ -1,4 +1,5 @@
 using Application.Interfaces.Services;
+using Application.Models.NormalizedDescriptions;
 using Common;
 using Domain.NormalizedDescriptions;
 using FluentAssertions;
@@ -18,6 +19,7 @@ public class NormalizedDescriptionServiceTests
 	private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
 	private readonly Mock<IEmbeddingService> _embeddingServiceMock;
 	private readonly NormalizedDescriptionMapper _mapper;
+	private readonly NormalizedDescriptionSettingsMapper _settingsMapper;
 
 	public NormalizedDescriptionServiceTests()
 	{
@@ -25,6 +27,7 @@ public class NormalizedDescriptionServiceTests
 		accessor.UserId = "test-user";
 		_embeddingServiceMock = new Mock<IEmbeddingService>();
 		_mapper = new NormalizedDescriptionMapper();
+		_settingsMapper = new NormalizedDescriptionSettingsMapper();
 	}
 
 	[Fact]
@@ -45,14 +48,17 @@ public class NormalizedDescriptionServiceTests
 		}
 
 		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act — query with different casing; it should short-circuit without generating an embedding.
-		NormalizedDescription result = await service.GetOrCreateAsync("organic MILK", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("organic MILK", CancellationToken.None);
 
 		// Assert
-		result.Id.Should().Be(existingId);
-		result.CanonicalName.Should().Be("Organic Milk");
+		result.Description.Id.Should().Be(existingId);
+		result.Description.CanonicalName.Should().Be("Organic Milk");
+		// Exact-match short-circuit surfaces a perfect similarity score so the resolver
+		// can persist it on the ReceiptItem without a second embedding roundtrip.
+		result.MatchScore.Should().Be(1.0);
 		_embeddingServiceMock.Verify(
 			e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
 			Times.Never);
@@ -63,16 +69,18 @@ public class NormalizedDescriptionServiceTests
 	{
 		// Arrange
 		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
-		NormalizedDescription result = await service.GetOrCreateAsync("New Item", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("New Item", CancellationToken.None);
 
 		// Assert — a new Active row was created, and no embedding was generated.
-		result.Status.Should().Be(NormalizedDescriptionStatus.Active);
-		result.CanonicalName.Should().Be("New Item");
+		result.Description.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		result.Description.CanonicalName.Should().Be("New Item");
+		// No embedding → no ANN search → no MatchScore to surface.
+		result.MatchScore.Should().BeNull();
 		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
-		NormalizedDescriptionEntity stored = await verify.NormalizedDescriptions.SingleAsync(e => e.Id == result.Id);
+		NormalizedDescriptionEntity stored = await verify.NormalizedDescriptions.SingleAsync(e => e.Id == result.Description.Id);
 		stored.Embedding.Should().BeNull();
 		stored.EmbeddingModelVersion.Should().BeNull();
 		_embeddingServiceMock.Verify(
@@ -106,15 +114,18 @@ public class NormalizedDescriptionServiceTests
 			_contextFactory,
 			_embeddingServiceMock.Object,
 			_mapper,
+			_settingsMapper,
 			matchedId,
-			similarity: NormalizedDescriptionService.AutoAcceptThreshold + 0.01);
+			similarity: NormalizedDescriptionService.InitialAutoAcceptThreshold + 0.01);
 
 		// Act
-		NormalizedDescription result = await service.GetOrCreateAsync("Whole Milk", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("Whole Milk", CancellationToken.None);
 
 		// Assert — returned the ANN match; no new row inserted.
-		result.Id.Should().Be(matchedId);
-		result.CanonicalName.Should().Be("Gallon of Milk");
+		result.Description.Id.Should().Be(matchedId);
+		result.Description.CanonicalName.Should().Be("Gallon of Milk");
+		// AutoAccept branch returns the ANN similarity so the resolver can persist it.
+		result.MatchScore.Should().Be(NormalizedDescriptionService.InitialAutoAcceptThreshold + 0.01);
 		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
 		int count = await verify.NormalizedDescriptions.CountAsync();
 		count.Should().Be(1);
@@ -142,21 +153,23 @@ public class NormalizedDescriptionServiceTests
 			.Setup(e => e.GenerateEmbeddingAsync("Milky Thing", It.IsAny<CancellationToken>()))
 			.ReturnsAsync(CreateFakeEmbedding());
 
-		double between = (NormalizedDescriptionService.AutoAcceptThreshold + NormalizedDescriptionService.PendingReviewThreshold) / 2;
+		double between = (NormalizedDescriptionService.InitialAutoAcceptThreshold + NormalizedDescriptionService.InitialPendingReviewThreshold) / 2;
 		TestableNormalizedDescriptionService service = new(
 			_contextFactory,
 			_embeddingServiceMock.Object,
 			_mapper,
+			_settingsMapper,
 			matchedId,
 			similarity: between);
 
 		// Act
-		NormalizedDescription result = await service.GetOrCreateAsync("Milky Thing", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("Milky Thing", CancellationToken.None);
 
 		// Assert — a new PendingReview row was created with the input text as canonical name.
-		result.Status.Should().Be(NormalizedDescriptionStatus.PendingReview);
-		result.CanonicalName.Should().Be("Milky Thing");
-		result.Id.Should().NotBe(matchedId);
+		result.Description.Status.Should().Be(NormalizedDescriptionStatus.PendingReview);
+		result.Description.CanonicalName.Should().Be("Milky Thing");
+		result.Description.Id.Should().NotBe(matchedId);
+		result.MatchScore.Should().Be(between);
 		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
 		int count = await verify.NormalizedDescriptions.CountAsync();
 		count.Should().Be(2);
@@ -189,15 +202,18 @@ public class NormalizedDescriptionServiceTests
 			_contextFactory,
 			_embeddingServiceMock.Object,
 			_mapper,
+			_settingsMapper,
 			matchedId,
-			similarity: NormalizedDescriptionService.PendingReviewThreshold - 0.1);
+			similarity: NormalizedDescriptionService.InitialPendingReviewThreshold - 0.1);
 
 		// Act
-		NormalizedDescription result = await service.GetOrCreateAsync("Totally Different", CancellationToken.None);
+		GetOrCreateResult result = await service.GetOrCreateAsync("Totally Different", CancellationToken.None);
 
 		// Assert — a new Active entry was created with the input text as canonical.
-		result.Status.Should().Be(NormalizedDescriptionStatus.Active);
-		result.CanonicalName.Should().Be("Totally Different");
+		result.Description.Status.Should().Be(NormalizedDescriptionStatus.Active);
+		result.Description.CanonicalName.Should().Be("Totally Different");
+		// Below pending-review floor → a brand-new canonical entry; no similarity to persist.
+		result.MatchScore.Should().BeNull();
 		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
 		int count = await verify.NormalizedDescriptions.CountAsync();
 		count.Should().Be(2);
@@ -207,7 +223,7 @@ public class NormalizedDescriptionServiceTests
 	public async Task GetOrCreateAsync_EmptyOrWhitespace_Throws()
 	{
 		// Arrange
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act + Assert
 		await service.Invoking(s => s.GetOrCreateAsync("   ", CancellationToken.None))
@@ -234,7 +250,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		int moved = await service.MergeAsync(keepId, discardId, CancellationToken.None);
@@ -273,7 +289,7 @@ public class NormalizedDescriptionServiceTests
 		}
 
 		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		NormalizedDescription created = await service.SplitAsync(itemId, CancellationToken.None);
@@ -307,7 +323,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		bool changed = await service.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, CancellationToken.None);
@@ -336,7 +352,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		bool changed = await service.UpdateStatusAsync(id, NormalizedDescriptionStatus.Active, CancellationToken.None);
@@ -362,7 +378,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		NormalizedDescription? result = await service.GetByIdAsync(id, CancellationToken.None);
@@ -385,7 +401,7 @@ public class NormalizedDescriptionServiceTests
 			await seed.SaveChangesAsync();
 		}
 
-		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
 
 		// Act
 		List<NormalizedDescription> pending = await service.GetAllAsync(NormalizedDescriptionStatus.PendingReview, CancellationToken.None);
@@ -395,6 +411,312 @@ public class NormalizedDescriptionServiceTests
 		pending.Should().ContainSingle();
 		pending[0].CanonicalName.Should().Be("Pending B");
 		all.Should().HaveCount(3);
+	}
+
+	// ── RECEIPTS-580: settings / test-match / threshold-impact ─────────────────
+
+	[Fact]
+	public async Task GetSettingsAsync_NoRow_BootstrapsSingletonWithInitialDefaults()
+	{
+		// Arrange — no seed row. On InMemory we hit the self-heal path.
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		// Act
+		NormalizedDescriptionSettings result = await service.GetSettingsAsync(CancellationToken.None);
+
+		// Assert — initial values are the same as the migration seed defaults.
+		result.AutoAcceptThreshold.Should().Be(NormalizedDescriptionService.InitialAutoAcceptThreshold);
+		result.PendingReviewThreshold.Should().Be(NormalizedDescriptionService.InitialPendingReviewThreshold);
+		result.Id.Should().Be(new Guid("00000000-0000-0000-0000-000000000001"));
+	}
+
+	[Fact]
+	public async Task GetSettingsAsync_WithSeededRow_ReturnsStoredValues()
+	{
+		// Arrange
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptionSettings.Add(new NormalizedDescriptionSettingsEntity
+			{
+				Id = new Guid("00000000-0000-0000-0000-000000000001"),
+				AutoAcceptThreshold = 0.9,
+				PendingReviewThreshold = 0.5,
+				UpdatedAt = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero),
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		// Act
+		NormalizedDescriptionSettings result = await service.GetSettingsAsync(CancellationToken.None);
+
+		// Assert
+		result.AutoAcceptThreshold.Should().Be(0.9);
+		result.PendingReviewThreshold.Should().Be(0.5);
+	}
+
+	[Fact]
+	public async Task UpdateSettingsAsync_ValidBounds_PersistsAndReturnsNewValues()
+	{
+		// Arrange
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+		DateTimeOffset before = DateTimeOffset.UtcNow.AddSeconds(-1);
+
+		// Act
+		NormalizedDescriptionSettings updated = await service.UpdateSettingsAsync(0.95, 0.5, CancellationToken.None);
+
+		// Assert — returned values match input, UpdatedAt advanced, row was persisted.
+		updated.AutoAcceptThreshold.Should().Be(0.95);
+		updated.PendingReviewThreshold.Should().Be(0.5);
+		updated.UpdatedAt.Should().BeAfter(before);
+
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		NormalizedDescriptionSettingsEntity stored = await verify.NormalizedDescriptionSettings.SingleAsync();
+		stored.AutoAcceptThreshold.Should().Be(0.95);
+		stored.PendingReviewThreshold.Should().Be(0.5);
+	}
+
+	[Theory]
+	[InlineData(-0.01, 0.5)]
+	[InlineData(1.01, 0.5)]
+	[InlineData(0.8, -0.01)]
+	[InlineData(0.8, 1.01)]
+	[InlineData(0.5, 0.8)] // pending >= auto
+	[InlineData(0.8, 0.8)] // pending == auto (must be strictly less)
+	public async Task UpdateSettingsAsync_InvalidBounds_Throws(double autoAccept, double pendingReview)
+	{
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		await service.Invoking(s => s.UpdateSettingsAsync(autoAccept, pendingReview, CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_ExactCaseInsensitiveMatch_ReturnsAutoAcceptWithTarget()
+	{
+		// Arrange
+		Guid existingId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = existingId,
+				CanonicalName = "Whole Milk",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		// Act — lowercase variant should short-circuit via exact-match path.
+		MatchTestResult result = await service.TestMatchAsync("whole milk", topN: 5, null, null, CancellationToken.None);
+
+		// Assert — exact match collapses to a single synthetic candidate with similarity = 1.
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.AutoAccept);
+		result.SimulatedTargetId.Should().Be(existingId);
+		result.Candidates.Should().ContainSingle();
+		result.Candidates[0].CosineSimilarity.Should().Be(1.0);
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_EmbeddingUnavailable_ReturnsEmbeddingUnavailableOutcome()
+	{
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(false);
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		MatchTestResult result = await service.TestMatchAsync("Brand New Item", topN: 5, null, null, CancellationToken.None);
+
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.EmbeddingUnavailable);
+		result.SimulatedTargetId.Should().BeNull();
+		result.Candidates.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_AutoAcceptBranch_WithOverride()
+	{
+		// Arrange — seed a candidate the fake ANN returns at similarity = 0.9.
+		Guid topId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = topId,
+				CanonicalName = "Similar Thing",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper, topId, similarity: 0.9);
+
+		// Override auto-accept to 0.85 → 0.9 is above, so auto-accept wins.
+		MatchTestResult result = await service.TestMatchAsync(
+			"Fresh Input",
+			topN: 5,
+			autoAcceptThresholdOverride: 0.85,
+			pendingReviewThresholdOverride: 0.5,
+			CancellationToken.None);
+
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.AutoAccept);
+		result.SimulatedTargetId.Should().Be(topId);
+		result.Candidates.Should().ContainSingle();
+		result.Candidates[0].CosineSimilarity.Should().Be(0.9);
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_PendingReviewBranch_ReturnsPendingWithNullTarget()
+	{
+		Guid topId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = topId,
+				CanonicalName = "Near Match",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper, topId, similarity: 0.75);
+
+		// Default DB settings (0.81 / 0.68) → 0.75 lands between the thresholds.
+		MatchTestResult result = await service.TestMatchAsync(
+			"Something Close",
+			topN: 5,
+			autoAcceptThresholdOverride: null,
+			pendingReviewThresholdOverride: null,
+			CancellationToken.None);
+
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.PendingReview);
+		result.SimulatedTargetId.Should().BeNull();
+		result.Candidates.Should().ContainSingle();
+	}
+
+	[Fact]
+	public async Task TestMatchAsync_BelowPendingFloor_ReturnsCreateNewOutcome()
+	{
+		Guid topId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = topId,
+				CanonicalName = "Distant Thing",
+				Status = NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		_embeddingServiceMock.Setup(e => e.IsConfigured).Returns(true);
+		_embeddingServiceMock
+			.Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(CreateFakeEmbedding());
+
+		TestableNormalizedDescriptionService service = new(
+			_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper, topId, similarity: 0.3);
+
+		MatchTestResult result = await service.TestMatchAsync("Very Different", topN: 5, null, null, CancellationToken.None);
+
+		result.SimulatedOutcome.Should().Be(MatchTestOutcomes.CreateNew);
+		result.SimulatedTargetId.Should().BeNull();
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	public async Task TestMatchAsync_EmptyInput_Throws(string input)
+	{
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		await service.Invoking(s => s.TestMatchAsync(input, topN: 5, null, null, CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(21)]
+	[InlineData(-1)]
+	public async Task TestMatchAsync_TopNOutOfRange_Throws(int topN)
+	{
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		await service.Invoking(s => s.TestMatchAsync("desc", topN, null, null, CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Fact]
+	public async Task PreviewThresholdImpactAsync_CountsItemsByScore()
+	{
+		// Arrange — seed receipt items across all threshold bands plus a below-floor scored
+		// row AND a structurally-unresolved row. Default settings: auto = 0.81, pending = 0.68.
+		Guid receiptId = Guid.NewGuid();
+		Guid linkedId = Guid.NewGuid();
+		using (ApplicationDbContext seed = _contextFactory.CreateDbContext())
+		{
+			seed.ReceiptItems.AddRange(
+				BuildReceiptItemWithScore(receiptId, "A", score: 0.95, normalizedId: Guid.NewGuid()), // auto-accepted (current)
+				BuildReceiptItemWithScore(receiptId, "B", score: 0.82, normalizedId: Guid.NewGuid()), // auto-accepted (current)
+				BuildReceiptItemWithScore(receiptId, "C", score: 0.70, normalizedId: Guid.NewGuid()), // pending-review (current)
+				BuildReceiptItemWithScore(receiptId, "D", score: 0.50, normalizedId: linkedId),        // below-floor scored → "unresolved-by-threshold" (current)
+				BuildReceiptItemWithScore(receiptId, "E", score: null, normalizedId: null));           // structurally unresolved
+			await seed.SaveChangesAsync();
+		}
+
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		// Act — propose lowering both thresholds so some items shift bucket.
+		ThresholdImpactPreview preview = await service.PreviewThresholdImpactAsync(
+			autoAcceptThreshold: 0.6,
+			pendingReviewThreshold: 0.4,
+			CancellationToken.None);
+
+		// Assert current classification: A(0.95) + B(0.82) auto; C(0.70) pending; D below
+		// floor + E null FK → both unresolved.
+		preview.Current.AutoAccepted.Should().Be(2);
+		preview.Current.PendingReview.Should().Be(1);
+		preview.Current.Unresolved.Should().Be(2);
+
+		// Under proposed (0.6 / 0.4): A(0.95) B(0.82) C(0.70) all auto; D(0.50) pending-review
+		// (scored and ≥ 0.4); E still structurally unresolved.
+		preview.Proposed.AutoAccepted.Should().Be(3);
+		preview.Proposed.PendingReview.Should().Be(1);
+		preview.Proposed.Unresolved.Should().Be(1);
+
+		// Deltas: C moves pending → auto; D moves unresolved-by-threshold → pending. A/B stay
+		// auto, E stays structurally unresolved.
+		preview.Deltas.PendingToAuto.Should().Be(1);
+		preview.Deltas.UnresolvedToPending.Should().Be(1);
+		preview.Deltas.AutoToPending.Should().Be(0);
+		preview.Deltas.UnresolvedToAuto.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task PreviewThresholdImpactAsync_InvalidBounds_Throws()
+	{
+		NormalizedDescriptionService service = new(_contextFactory, _embeddingServiceMock.Object, _mapper, _settingsMapper);
+
+		await service.Invoking(s => s.PreviewThresholdImpactAsync(0.5, 0.5, CancellationToken.None))
+			.Should().ThrowAsync<ArgumentException>();
 	}
 
 	private static ReceiptItemEntity BuildReceiptItem(Guid id, Guid receiptId, string description, Guid? normalizedId)
@@ -411,6 +733,24 @@ public class NormalizedDescriptionServiceTests
 			TotalAmountCurrency = Currency.USD,
 			Category = "Groceries",
 			NormalizedDescriptionId = normalizedId,
+		};
+	}
+
+	private static ReceiptItemEntity BuildReceiptItemWithScore(Guid receiptId, string description, double? score, Guid? normalizedId)
+	{
+		return new ReceiptItemEntity
+		{
+			Id = Guid.NewGuid(),
+			ReceiptId = receiptId,
+			Description = description,
+			Quantity = 1,
+			UnitPrice = 1,
+			UnitPriceCurrency = Currency.USD,
+			TotalAmount = 1,
+			TotalAmountCurrency = Currency.USD,
+			Category = "Groceries",
+			NormalizedDescriptionId = normalizedId,
+			NormalizedDescriptionMatchScore = score,
 		};
 	}
 
@@ -433,8 +773,9 @@ public class NormalizedDescriptionServiceTests
 		IDbContextFactory<ApplicationDbContext> contextFactory,
 		IEmbeddingService embeddingService,
 		NormalizedDescriptionMapper mapper,
+		NormalizedDescriptionSettingsMapper settingsMapper,
 		Guid matchId,
-		double similarity) : NormalizedDescriptionService(contextFactory, embeddingService, mapper)
+		double similarity) : NormalizedDescriptionService(contextFactory, embeddingService, mapper, settingsMapper)
 	{
 		private readonly Guid _matchId = matchId;
 		private readonly double _similarity = similarity;
@@ -445,6 +786,19 @@ public class NormalizedDescriptionServiceTests
 			NormalizedDescriptionEntity? match = await context.NormalizedDescriptions
 				.FirstOrDefaultAsync(e => e.Id == _matchId, cancellationToken);
 			return (match, _similarity);
+		}
+
+		protected override async Task<List<MatchCandidate>> AnnSearchTopNAsync(
+			ApplicationDbContext context, Vector queryVector, int topN, CancellationToken cancellationToken)
+		{
+			NormalizedDescriptionEntity? match = await context.NormalizedDescriptions
+				.FirstOrDefaultAsync(e => e.Id == _matchId, cancellationToken);
+			if (match is null)
+			{
+				return [];
+			}
+
+			return [new MatchCandidate(match.Id, match.CanonicalName, _similarity, match.Status.ToString())];
 		}
 	}
 }

--- a/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
@@ -649,4 +649,349 @@ public class ReportServiceTests
 
 		contextFactory.ResetDatabase();
 	}
+
+	// ── GetSpendingByNormalizedDescriptionAsync ──────────────────────────────
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_GroupsByCanonicalName_AndBucketsNullFk()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid receiptId = Guid.NewGuid();
+		Guid normalizedId = Guid.NewGuid();
+		DateOnly date = new(2025, 3, 1);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Organic Milk",
+				Status = Domain.NormalizedDescriptions.NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			context.Receipts.Add(new ReceiptEntity
+			{
+				Id = receiptId,
+				Location = "Store A",
+				Date = date,
+				TaxAmount = 0m,
+			});
+
+			// Two items linked to "Organic Milk"
+			context.ReceiptItems.AddRange(
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptId,
+					Description = "organic milk",
+					Quantity = 1,
+					UnitPrice = 4.00m,
+					TotalAmount = 4.00m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+				},
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptId,
+					Description = "ORGANIC MILK",
+					Quantity = 1,
+					UnitPrice = 5.50m,
+					TotalAmount = 5.50m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+				},
+				// One item with no normalized description
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptId,
+					Description = "Mystery Item",
+					Quantity = 1,
+					UnitPrice = 2.00m,
+					TotalAmount = 2.00m,
+					Category = "Uncategorized",
+					NormalizedDescriptionId = null,
+				});
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(from: null, to: null, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().HaveCount(2);
+		result.FromDate.Should().BeNull();
+		result.ToDate.Should().BeNull();
+
+		SpendingByNormalizedDescriptionItem milkBucket = result.Items.Single(i => i.CanonicalName == "Organic Milk");
+		milkBucket.TotalAmount.Should().Be(9.50m);
+		milkBucket.ItemCount.Should().Be(2);
+		milkBucket.Currency.Should().Be("USD");
+		milkBucket.FirstSeen.Should().NotBeNull();
+		milkBucket.LastSeen.Should().NotBeNull();
+
+		SpendingByNormalizedDescriptionItem notNormalizedBucket = result.Items.Single(i => i.CanonicalName == "(Not Normalized)");
+		notNormalizedBucket.TotalAmount.Should().Be(2.00m);
+		notNormalizedBucket.ItemCount.Should().Be(1);
+
+		// Ordered by total desc
+		result.Items[0].CanonicalName.Should().Be("Organic Milk");
+		result.Items[1].CanonicalName.Should().Be("(Not Normalized)");
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_FiltersByDateRange()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid normalizedId = Guid.NewGuid();
+
+		Guid receiptInRange = Guid.NewGuid();
+		Guid receiptOutOfRange = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Bananas",
+				Status = Domain.NormalizedDescriptions.NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			context.Receipts.AddRange(
+				new ReceiptEntity
+				{
+					Id = receiptInRange,
+					Location = "Store",
+					Date = new DateOnly(2025, 6, 15),
+					TaxAmount = 0m,
+				},
+				new ReceiptEntity
+				{
+					Id = receiptOutOfRange,
+					Location = "Store",
+					Date = new DateOnly(2024, 1, 1),
+					TaxAmount = 0m,
+				});
+
+			context.ReceiptItems.AddRange(
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptInRange,
+					Description = "bananas",
+					Quantity = 1,
+					UnitPrice = 1.50m,
+					TotalAmount = 1.50m,
+					Category = "Produce",
+					NormalizedDescriptionId = normalizedId,
+				},
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = receiptOutOfRange,
+					Description = "bananas",
+					Quantity = 1,
+					UnitPrice = 99.99m,
+					TotalAmount = 99.99m,
+					Category = "Produce",
+					NormalizedDescriptionId = normalizedId,
+				});
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(from, to, CancellationToken.None);
+
+		// Assert — only the receipt in range contributed
+		result.Items.Should().ContainSingle();
+		result.Items[0].TotalAmount.Should().Be(1.50m);
+		result.Items[0].ItemCount.Should().Be(1);
+		result.FromDate.Should().Be(from);
+		result.ToDate.Should().Be(to);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_IgnoresSoftDeletedItemsAndReceipts()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid normalizedId = Guid.NewGuid();
+		Guid liveReceipt = Guid.NewGuid();
+		Guid deletedReceipt = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Eggs",
+				Status = Domain.NormalizedDescriptions.NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			context.Receipts.AddRange(
+				new ReceiptEntity
+				{
+					Id = liveReceipt,
+					Location = "Store",
+					Date = new DateOnly(2025, 3, 1),
+					TaxAmount = 0m,
+				},
+				new ReceiptEntity
+				{
+					Id = deletedReceipt,
+					Location = "Store",
+					Date = new DateOnly(2025, 3, 1),
+					TaxAmount = 0m,
+					DeletedAt = DateTimeOffset.UtcNow,
+				});
+
+			context.ReceiptItems.AddRange(
+				// Live item on live receipt — counted
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = liveReceipt,
+					Description = "eggs",
+					Quantity = 1,
+					UnitPrice = 3.00m,
+					TotalAmount = 3.00m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+				},
+				// Soft-deleted item on live receipt — excluded
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = liveReceipt,
+					Description = "eggs",
+					Quantity = 1,
+					UnitPrice = 100.00m,
+					TotalAmount = 100.00m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+					DeletedAt = DateTimeOffset.UtcNow,
+				},
+				// Live item on deleted receipt — excluded (because receipt is deleted)
+				new ReceiptItemEntity
+				{
+					Id = Guid.NewGuid(),
+					ReceiptId = deletedReceipt,
+					Description = "eggs",
+					Quantity = 1,
+					UnitPrice = 50.00m,
+					TotalAmount = 50.00m,
+					Category = "Dairy",
+					NormalizedDescriptionId = normalizedId,
+				});
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(null, null, CancellationToken.None);
+
+		// Assert — only the live item on the live receipt survives
+		result.Items.Should().ContainSingle();
+		result.Items[0].CanonicalName.Should().Be("Eggs");
+		result.Items[0].TotalAmount.Should().Be(3.00m);
+		result.Items[0].ItemCount.Should().Be(1);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_ReturnsEmpty_WhenNoItems()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		ReportService service = new(contextFactory);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(null, null, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().BeEmpty();
+		result.FromDate.Should().BeNull();
+		result.ToDate.Should().BeNull();
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescriptionAsync_UsesFirstAndLastSeenDates()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid normalizedId = Guid.NewGuid();
+		Guid r1 = Guid.NewGuid();
+		Guid r2 = Guid.NewGuid();
+		Guid r3 = Guid.NewGuid();
+
+		DateOnly day1 = new(2025, 1, 5);
+		DateOnly day2 = new(2025, 6, 20);
+		DateOnly day3 = new(2025, 11, 30);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normalizedId,
+				CanonicalName = "Coffee",
+				Status = Domain.NormalizedDescriptions.NormalizedDescriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow,
+			});
+
+			context.Receipts.AddRange(
+				new ReceiptEntity { Id = r1, Location = "S", Date = day1, TaxAmount = 0m },
+				new ReceiptEntity { Id = r2, Location = "S", Date = day2, TaxAmount = 0m },
+				new ReceiptEntity { Id = r3, Location = "S", Date = day3, TaxAmount = 0m });
+
+			context.ReceiptItems.AddRange(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = r1, Description = "coffee", Quantity = 1, UnitPrice = 4m, TotalAmount = 4m, Category = "Beverages", NormalizedDescriptionId = normalizedId },
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = r2, Description = "coffee", Quantity = 1, UnitPrice = 4m, TotalAmount = 4m, Category = "Beverages", NormalizedDescriptionId = normalizedId },
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = r3, Description = "coffee", Quantity = 1, UnitPrice = 4m, TotalAmount = 4m, Category = "Beverages", NormalizedDescriptionId = normalizedId });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		SpendingByNormalizedDescriptionResult result = await service
+			.GetSpendingByNormalizedDescriptionAsync(null, null, CancellationToken.None);
+
+		// Assert
+		result.Items.Should().ContainSingle();
+		SpendingByNormalizedDescriptionItem bucket = result.Items[0];
+		bucket.ItemCount.Should().Be(3);
+		bucket.FirstSeen.Should().Be(new DateTimeOffset(day1.Year, day1.Month, day1.Day, 0, 0, 0, TimeSpan.Zero));
+		bucket.LastSeen.Should().Be(new DateTimeOffset(day3.Year, day3.Month, day3.Day, 0, 0, 0, TimeSpan.Zero));
+
+		contextFactory.ResetDatabase();
+	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Aggregates/ReportsControllerTests.cs
@@ -720,4 +720,173 @@ public class ReportsControllerTests
 		receipt.Date.Should().Be(date);
 		receipt.TransactionTotal.Should().Be(42.99);
 	}
+
+	// ── GetSpendingByNormalizedDescription ─────────────────
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_ReturnsOkResult_WithDefaultParameters()
+	{
+		// Arrange
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new([], null, null);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == null && q.To == null),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(null, null, CancellationToken.None);
+
+		// Assert
+		Ok<SpendingByNormalizedDescriptionResponse> okResult = Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+		okResult.Value!.Items.Should().BeEmpty();
+		okResult.Value!.FromDate.Should().BeNull();
+		okResult.Value!.ToDate.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_PassesDateRangeToMediator()
+	{
+		// Arrange
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new([], from, to);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == from && q.To == to),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(from, to, CancellationToken.None);
+
+		// Assert
+		Ok<SpendingByNormalizedDescriptionResponse> okResult = Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+		okResult.Value!.FromDate.Should().Be(from);
+		okResult.Value!.ToDate.Should().Be(to);
+
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == from && q.To == to),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_ReturnsBadRequest_WhenFromAfterTo()
+	{
+		// Arrange
+		DateTimeOffset from = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset to = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(from, to, CancellationToken.None);
+
+		// Assert
+		BadRequest<string> badResult = Assert.IsType<BadRequest<string>>(result.Result);
+		badResult.Value.Should().Contain("from must be before or equal to to");
+		_mediatorMock.Verify(
+			m => m.Send(It.IsAny<GetSpendingByNormalizedDescriptionQuery>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_MapsResponseFieldsCorrectly()
+	{
+		// Arrange
+		DateTimeOffset firstSeen = new(2025, 1, 5, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset lastSeen = new(2025, 11, 30, 0, 0, 0, TimeSpan.Zero);
+
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new(
+		[
+			new AppReports.SpendingByNormalizedDescriptionItem("Organic Milk", 42.50m, "USD", 5, firstSeen, lastSeen),
+			new AppReports.SpendingByNormalizedDescriptionItem("(Not Normalized)", 12.00m, "USD", 2, null, null),
+		], null, null);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<GetSpendingByNormalizedDescriptionQuery>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(null, null, CancellationToken.None);
+
+		// Assert
+		Ok<SpendingByNormalizedDescriptionResponse> okResult = Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+		SpendingByNormalizedDescriptionResponse response = okResult.Value!;
+		response.Items.Should().HaveCount(2);
+
+		SpendingByNormalizedDescriptionItem first = response.Items.First(i => i.CanonicalName == "Organic Milk");
+		first.TotalAmount.Should().Be(42.50);
+		first.Currency.Should().Be("USD");
+		first.ItemCount.Should().Be(5);
+		first.FirstSeen.Should().Be(firstSeen);
+		first.LastSeen.Should().Be(lastSeen);
+
+		SpendingByNormalizedDescriptionItem notNormalized = response.Items.First(i => i.CanonicalName == "(Not Normalized)");
+		notNormalized.TotalAmount.Should().Be(12.00);
+		notNormalized.ItemCount.Should().Be(2);
+		notNormalized.FirstSeen.Should().BeNull();
+		notNormalized.LastSeen.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_AcceptsOnlyFromSet()
+	{
+		// Arrange
+		DateTimeOffset from = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new([], from, null);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == from && q.To == null),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(from, null, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetSpendingByNormalizedDescription_AcceptsOnlyToSet()
+	{
+		// Arrange
+		DateTimeOffset to = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+		AppReports.SpendingByNormalizedDescriptionResult reportResult = new([], null, to);
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetSpendingByNormalizedDescriptionQuery>(q => q.From == null && q.To == to),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(reportResult);
+
+		// Act
+		Results<Ok<SpendingByNormalizedDescriptionResponse>, BadRequest<string>> result =
+			await _controller.GetSpendingByNormalizedDescription(null, to, CancellationToken.None);
+
+		// Assert
+		Assert.IsType<Ok<SpendingByNormalizedDescriptionResponse>>(result.Result);
+	}
+
+	[Fact]
+	public void GetSpendingByNormalizedDescription_RequiresAuthorization()
+	{
+		// Assert — the ReportsController-level [Authorize] attribute applies to this action.
+		System.Reflection.MethodInfo method = typeof(ReportsController)
+			.GetMethod(nameof(ReportsController.GetSpendingByNormalizedDescription))!;
+
+		bool classAttribute = typeof(ReportsController)
+			.GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), inherit: true)
+			.Length > 0;
+		bool methodAllowsAnonymous = method
+			.GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute), inherit: true)
+			.Length > 0;
+
+		classAttribute.Should().BeTrue("ReportsController requires authentication at the class level");
+		methodAllowsAnonymous.Should().BeFalse("GetSpendingByNormalizedDescription should not bypass authorization");
+	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptItemsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptItemsControllerTests.cs
@@ -635,4 +635,52 @@ public class ReceiptItemsControllerTests
 		// Assert
 		await act.Should().ThrowAsync<Exception>();
 	}
+
+	[Fact]
+	public async Task GetReceiptItemById_IncludesNormalizedDescriptionFields_WhenPopulated()
+	{
+		// Arrange - RECEIPTS-583: normalized description fields surface on the response
+		Guid normalizedId = Guid.NewGuid();
+		ReceiptItem mediatorReturn = ReceiptItemGenerator.Generate();
+		mediatorReturn.NormalizedDescriptionId = normalizedId;
+		mediatorReturn.NormalizedDescriptionName = "Grapes";
+		mediatorReturn.NormalizedDescriptionMatchScore = 0.87;
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetReceiptItemByIdQuery>(q => q.Id == mediatorReturn.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(mediatorReturn);
+
+		// Act
+		Results<Ok<ReceiptItemResponse>, NotFound> result = await _controller.GetReceiptItemById(mediatorReturn.Id);
+
+		// Assert
+		Ok<ReceiptItemResponse> okResult = Assert.IsType<Ok<ReceiptItemResponse>>(result.Result);
+		ReceiptItemResponse response = Assert.IsType<ReceiptItemResponse>(okResult.Value);
+		response.NormalizedDescriptionId.Should().Be(normalizedId);
+		response.NormalizedDescriptionName.Should().Be("Grapes");
+		response.NormalizedDescriptionMatchScore.Should().Be(0.87);
+	}
+
+	[Fact]
+	public async Task GetReceiptItemById_NormalizedDescriptionFieldsAreNull_WhenUnresolved()
+	{
+		// Arrange - RECEIPTS-583: unresolved items expose null normalized fields
+		ReceiptItem mediatorReturn = ReceiptItemGenerator.Generate();
+
+		_mediatorMock.Setup(m => m.Send(
+			It.Is<GetReceiptItemByIdQuery>(q => q.Id == mediatorReturn.Id),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(mediatorReturn);
+
+		// Act
+		Results<Ok<ReceiptItemResponse>, NotFound> result = await _controller.GetReceiptItemById(mediatorReturn.Id);
+
+		// Assert
+		Ok<ReceiptItemResponse> okResult = Assert.IsType<Ok<ReceiptItemResponse>>(result.Result);
+		ReceiptItemResponse response = Assert.IsType<ReceiptItemResponse>(okResult.Value);
+		response.NormalizedDescriptionId.Should().BeNull();
+		response.NormalizedDescriptionName.Should().BeNull();
+		response.NormalizedDescriptionMatchScore.Should().BeNull();
+	}
 }

--- a/tests/Presentation.API.Tests/Controllers/NormalizedDescriptionsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/NormalizedDescriptionsControllerTests.cs
@@ -1,7 +1,12 @@
 using API.Controllers;
 using API.Generated.Dtos;
+using Application.Commands.NormalizedDescription.Merge;
+using Application.Commands.NormalizedDescription.Split;
 using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Commands.NormalizedDescription.UpdateStatus;
 using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.GetAll;
+using Application.Queries.NormalizedDescription.GetById;
 using Application.Queries.NormalizedDescription.GetSettings;
 using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
 using Application.Queries.NormalizedDescription.TestMatch;
@@ -10,6 +15,8 @@ using FluentAssertions;
 using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Moq;
+using DomainStatus = Domain.NormalizedDescriptions.NormalizedDescriptionStatus;
+using DtoStatus = API.Generated.Dtos.NormalizedDescriptionStatus;
 
 namespace Presentation.API.Tests.Controllers;
 
@@ -278,5 +285,330 @@ public class NormalizedDescriptionsControllerTests
 		bad.Value.Should().Be(expectedMessage);
 
 		_mediatorMock.Verify(m => m.Send(It.IsAny<PreviewThresholdImpactQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── GET list ─────────────────────────────────────────────────
+
+	[Fact]
+	public async Task GetAllNormalizedDescriptions_NoFilter_ReturnsOkWithAllItems()
+	{
+		List<NormalizedDescription> items =
+		[
+			new(Guid.NewGuid(), "coffee beans", DomainStatus.Active, new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero)),
+			new(Guid.NewGuid(), "whole milk", DomainStatus.PendingReview, new DateTimeOffset(2026, 4, 2, 0, 0, 0, TimeSpan.Zero)),
+		];
+
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetAllNormalizedDescriptionsQuery>(q => q.StatusFilter == null), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(items);
+
+		Results<Ok<NormalizedDescriptionListResponse>, BadRequest<string>> result =
+			await _controller.GetAllNormalizedDescriptions(status: null, CancellationToken.None);
+
+		Ok<NormalizedDescriptionListResponse> ok = Assert.IsType<Ok<NormalizedDescriptionListResponse>>(result.Result);
+		ok.Value!.Items.Should().HaveCount(2);
+		ok.Value.TotalCount.Should().Be(2);
+		ok.Value.Items.First().CanonicalName.Should().Be("coffee beans");
+	}
+
+	[Theory]
+	[InlineData("Active", DomainStatus.Active)]
+	[InlineData("PendingReview", DomainStatus.PendingReview)]
+	[InlineData("active", DomainStatus.Active)]
+	[InlineData("pendingreview", DomainStatus.PendingReview)]
+	public async Task GetAllNormalizedDescriptions_WithStatusFilter_ForwardsToQuery(string status, DomainStatus expected)
+	{
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetAllNormalizedDescriptionsQuery>(q => q.StatusFilter == expected), It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+
+		Results<Ok<NormalizedDescriptionListResponse>, BadRequest<string>> result =
+			await _controller.GetAllNormalizedDescriptions(status, CancellationToken.None);
+
+		Ok<NormalizedDescriptionListResponse> ok = Assert.IsType<Ok<NormalizedDescriptionListResponse>>(result.Result);
+		ok.Value!.Items.Should().BeEmpty();
+		ok.Value.TotalCount.Should().Be(0);
+		_mediatorMock.Verify(m => m.Send(It.Is<GetAllNormalizedDescriptionsQuery>(q => q.StatusFilter == expected), It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetAllNormalizedDescriptions_InvalidStatusFilter_ReturnsBadRequest()
+	{
+		Results<Ok<NormalizedDescriptionListResponse>, BadRequest<string>> result =
+			await _controller.GetAllNormalizedDescriptions(status: "archived", CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.InvalidStatusFilter);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<GetAllNormalizedDescriptionsQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── GET by id ────────────────────────────────────────────────
+
+	[Fact]
+	public async Task GetNormalizedDescriptionById_Found_ReturnsOkWithMappedResponse()
+	{
+		Guid id = Guid.NewGuid();
+		NormalizedDescription item = new(
+			id,
+			"cherry cola",
+			DomainStatus.PendingReview,
+			new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(item);
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.GetNormalizedDescriptionById(id, CancellationToken.None);
+
+		Ok<NormalizedDescriptionResponse> ok = Assert.IsType<Ok<NormalizedDescriptionResponse>>(result.Result);
+		ok.Value!.Id.Should().Be(id);
+		ok.Value.CanonicalName.Should().Be("cherry cola");
+		ok.Value.Status.Should().Be(DtoStatus.PendingReview);
+		ok.Value.CreatedAt.Should().Be(item.CreatedAt);
+	}
+
+	[Fact]
+	public async Task GetNormalizedDescriptionById_NotFound_ReturnsNotFound()
+	{
+		Guid id = Guid.NewGuid();
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((NormalizedDescription?)null);
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.GetNormalizedDescriptionById(id, CancellationToken.None);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task GetNormalizedDescriptionById_EmptyGuid_ReturnsBadRequest()
+	{
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.GetNormalizedDescriptionById(Guid.Empty, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.IdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<GetNormalizedDescriptionByIdQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── POST merge ───────────────────────────────────────────────
+
+	[Fact]
+	public async Task MergeNormalizedDescriptions_ValidRequest_ReturnsOkWithRelinkCount()
+	{
+		Guid keepId = Guid.NewGuid();
+		Guid discardId = Guid.NewGuid();
+		MergeNormalizedDescriptionRequest request = new() { DiscardId = discardId };
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<MergeNormalizedDescriptionsCommand>(c => c.KeepId == keepId && c.DiscardId == discardId),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(12);
+
+		Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.MergeNormalizedDescriptions(keepId, request, CancellationToken.None);
+
+		Ok<MergeNormalizedDescriptionsResponse> ok = Assert.IsType<Ok<MergeNormalizedDescriptionsResponse>>(result.Result);
+		ok.Value!.ItemsRelinkedCount.Should().Be(12);
+	}
+
+	[Fact]
+	public async Task MergeNormalizedDescriptions_EmptyKeepId_ReturnsBadRequest()
+	{
+		MergeNormalizedDescriptionRequest request = new() { DiscardId = Guid.NewGuid() };
+
+		Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.MergeNormalizedDescriptions(Guid.Empty, request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.IdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<MergeNormalizedDescriptionsCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task MergeNormalizedDescriptions_EmptyDiscardId_ReturnsBadRequest()
+	{
+		MergeNormalizedDescriptionRequest request = new() { DiscardId = Guid.Empty };
+
+		Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.MergeNormalizedDescriptions(Guid.NewGuid(), request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.DiscardIdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<MergeNormalizedDescriptionsCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task MergeNormalizedDescriptions_SameKeepAndDiscard_ReturnsBadRequest()
+	{
+		Guid id = Guid.NewGuid();
+		MergeNormalizedDescriptionRequest request = new() { DiscardId = id };
+
+		Results<Ok<MergeNormalizedDescriptionsResponse>, BadRequest<string>> result =
+			await _controller.MergeNormalizedDescriptions(id, request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.MergeIdsMustDiffer);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<MergeNormalizedDescriptionsCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── POST split ───────────────────────────────────────────────
+
+	[Fact]
+	public async Task SplitNormalizedDescription_ValidRequest_ReturnsOkWithNewResource()
+	{
+		Guid currentId = Guid.NewGuid();
+		Guid receiptItemId = Guid.NewGuid();
+		Guid newId = Guid.NewGuid();
+		SplitNormalizedDescriptionRequest request = new() { ReceiptItemId = receiptItemId };
+
+		NormalizedDescription created = new(
+			newId,
+			"reese cup",
+			DomainStatus.Active,
+			new DateTimeOffset(2026, 4, 19, 12, 0, 0, TimeSpan.Zero));
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<SplitNormalizedDescriptionCommand>(c => c.ReceiptItemId == receiptItemId),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(created);
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.SplitNormalizedDescription(currentId, request, CancellationToken.None);
+
+		Ok<NormalizedDescriptionResponse> ok = Assert.IsType<Ok<NormalizedDescriptionResponse>>(result.Result);
+		ok.Value!.Id.Should().Be(newId);
+		ok.Value.CanonicalName.Should().Be("reese cup");
+		ok.Value.Status.Should().Be(DtoStatus.Active);
+	}
+
+	[Fact]
+	public async Task SplitNormalizedDescription_ReceiptItemMissing_ReturnsNotFound()
+	{
+		Guid currentId = Guid.NewGuid();
+		Guid missingReceiptItemId = Guid.NewGuid();
+		SplitNormalizedDescriptionRequest request = new() { ReceiptItemId = missingReceiptItemId };
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<SplitNormalizedDescriptionCommand>(c => c.ReceiptItemId == missingReceiptItemId),
+				It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new KeyNotFoundException("Receipt item not found."));
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.SplitNormalizedDescription(currentId, request, CancellationToken.None);
+
+		Assert.IsType<NotFound>(result.Result);
+	}
+
+	[Fact]
+	public async Task SplitNormalizedDescription_EmptyId_ReturnsBadRequest()
+	{
+		SplitNormalizedDescriptionRequest request = new() { ReceiptItemId = Guid.NewGuid() };
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.SplitNormalizedDescription(Guid.Empty, request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.IdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<SplitNormalizedDescriptionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task SplitNormalizedDescription_EmptyReceiptItemId_ReturnsBadRequest()
+	{
+		SplitNormalizedDescriptionRequest request = new() { ReceiptItemId = Guid.Empty };
+
+		Results<Ok<NormalizedDescriptionResponse>, NotFound, BadRequest<string>> result =
+			await _controller.SplitNormalizedDescription(Guid.NewGuid(), request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.ReceiptItemIdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<SplitNormalizedDescriptionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── PATCH status ─────────────────────────────────────────────
+
+	[Fact]
+	public async Task UpdateNormalizedDescriptionStatus_ExistingRow_ReturnsNoContent()
+	{
+		Guid id = Guid.NewGuid();
+		UpdateNormalizedDescriptionStatusRequest request = new() { Status = DtoStatus.PendingReview };
+
+		NormalizedDescription existing = new(id, "whole milk", DomainStatus.Active, DateTimeOffset.UtcNow);
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(existing);
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<UpdateNormalizedDescriptionStatusCommand>(c => c.Id == id && c.Status == DomainStatus.PendingReview),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound, BadRequest<string>> result =
+			await _controller.UpdateNormalizedDescriptionStatus(id, request, CancellationToken.None);
+
+		Assert.IsType<NoContent>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<UpdateNormalizedDescriptionStatusCommand>(c => c.Id == id && c.Status == DomainStatus.PendingReview),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task UpdateNormalizedDescriptionStatus_ActiveStatus_MapsToDomainCorrectly()
+	{
+		Guid id = Guid.NewGuid();
+		UpdateNormalizedDescriptionStatusRequest request = new() { Status = DtoStatus.Active };
+
+		NormalizedDescription existing = new(id, "whole milk", DomainStatus.PendingReview, DateTimeOffset.UtcNow);
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(existing);
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<UpdateNormalizedDescriptionStatusCommand>(c => c.Id == id && c.Status == DomainStatus.Active),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		Results<NoContent, NotFound, BadRequest<string>> result =
+			await _controller.UpdateNormalizedDescriptionStatus(id, request, CancellationToken.None);
+
+		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task UpdateNormalizedDescriptionStatus_MissingRow_ReturnsNotFound()
+	{
+		Guid id = Guid.NewGuid();
+		UpdateNormalizedDescriptionStatusRequest request = new() { Status = DtoStatus.Active };
+
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<GetNormalizedDescriptionByIdQuery>(q => q.Id == id), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((NormalizedDescription?)null);
+
+		Results<NoContent, NotFound, BadRequest<string>> result =
+			await _controller.UpdateNormalizedDescriptionStatus(id, request, CancellationToken.None);
+
+		Assert.IsType<NotFound>(result.Result);
+		// Should never reach the update command when the existence check fails.
+		_mediatorMock.Verify(m => m.Send(It.IsAny<UpdateNormalizedDescriptionStatusCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task UpdateNormalizedDescriptionStatus_EmptyId_ReturnsBadRequest()
+	{
+		UpdateNormalizedDescriptionStatusRequest request = new() { Status = DtoStatus.Active };
+
+		Results<NoContent, NotFound, BadRequest<string>> result =
+			await _controller.UpdateNormalizedDescriptionStatus(Guid.Empty, request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.IdCannotBeEmpty);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<GetNormalizedDescriptionByIdQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+		_mediatorMock.Verify(m => m.Send(It.IsAny<UpdateNormalizedDescriptionStatusCommand>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/NormalizedDescriptionsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/NormalizedDescriptionsControllerTests.cs
@@ -1,0 +1,282 @@
+using API.Controllers;
+using API.Generated.Dtos;
+using Application.Commands.NormalizedDescription.UpdateSettings;
+using Application.Models.NormalizedDescriptions;
+using Application.Queries.NormalizedDescription.GetSettings;
+using Application.Queries.NormalizedDescription.PreviewThresholdImpact;
+using Application.Queries.NormalizedDescription.TestMatch;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+
+namespace Presentation.API.Tests.Controllers;
+
+public class NormalizedDescriptionsControllerTests
+{
+	private readonly Mock<IMediator> _mediatorMock;
+	private readonly NormalizedDescriptionsController _controller;
+
+	public NormalizedDescriptionsControllerTests()
+	{
+		_mediatorMock = new Mock<IMediator>();
+		_controller = new NormalizedDescriptionsController(_mediatorMock.Object);
+	}
+
+	// ── GET settings ────────────────────────────────────────────
+
+	[Fact]
+	public async Task GetSettings_ReturnsOkWithMappedResponse()
+	{
+		NormalizedDescriptionSettings settings = new(
+			Guid.NewGuid(), 0.81, 0.68,
+			new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<GetNormalizedDescriptionSettingsQuery>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(settings);
+
+		Ok<NormalizedDescriptionSettingsResponse> result = await _controller.GetSettings(CancellationToken.None);
+
+		result.Value!.Id.Should().Be(settings.Id);
+		result.Value.AutoAcceptThreshold.Should().Be(0.81);
+		result.Value.PendingReviewThreshold.Should().Be(0.68);
+	}
+
+	// ── PATCH settings ──────────────────────────────────────────
+
+	[Fact]
+	public async Task UpdateSettings_ValidRequest_ReturnsOkWithUpdatedValues()
+	{
+		UpdateNormalizedDescriptionSettingsRequest request = new()
+		{
+			AutoAcceptThreshold = 0.9,
+			PendingReviewThreshold = 0.5,
+		};
+
+		NormalizedDescriptionSettings updated = new(
+			Guid.NewGuid(), 0.9, 0.5,
+			new DateTimeOffset(2026, 4, 19, 0, 0, 0, TimeSpan.Zero));
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<UpdateNormalizedDescriptionSettingsCommand>(c => c.AutoAcceptThreshold == 0.9 && c.PendingReviewThreshold == 0.5),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(updated);
+
+		Results<Ok<NormalizedDescriptionSettingsResponse>, BadRequest<string>> result =
+			await _controller.UpdateSettings(request, CancellationToken.None);
+
+		Ok<NormalizedDescriptionSettingsResponse> ok = Assert.IsType<Ok<NormalizedDescriptionSettingsResponse>>(result.Result);
+		ok.Value!.AutoAcceptThreshold.Should().Be(0.9);
+		ok.Value.PendingReviewThreshold.Should().Be(0.5);
+	}
+
+	[Theory]
+	[InlineData(-0.01, 0.5, NormalizedDescriptionsController.AutoAcceptOutOfRange)]
+	[InlineData(1.01, 0.5, NormalizedDescriptionsController.AutoAcceptOutOfRange)]
+	[InlineData(0.8, -0.01, NormalizedDescriptionsController.PendingReviewOutOfRange)]
+	[InlineData(0.8, 1.01, NormalizedDescriptionsController.PendingReviewOutOfRange)]
+	[InlineData(0.5, 0.6, NormalizedDescriptionsController.PendingMustBeLessThanAuto)]
+	[InlineData(0.5, 0.5, NormalizedDescriptionsController.PendingMustBeLessThanAuto)]
+	public async Task UpdateSettings_InvalidRequest_ReturnsBadRequest(double autoAccept, double pendingReview, string expectedMessage)
+	{
+		UpdateNormalizedDescriptionSettingsRequest request = new()
+		{
+			AutoAcceptThreshold = autoAccept,
+			PendingReviewThreshold = pendingReview,
+		};
+
+		Results<Ok<NormalizedDescriptionSettingsResponse>, BadRequest<string>> result =
+			await _controller.UpdateSettings(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(expectedMessage);
+
+		// Should short-circuit without invoking the mediator.
+		_mediatorMock.Verify(m => m.Send(It.IsAny<UpdateNormalizedDescriptionSettingsCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// ── POST test ───────────────────────────────────────────────
+
+	[Fact]
+	public async Task TestMatch_ValidRequest_ReturnsOkWithCandidates()
+	{
+		TestMatchRequest request = new()
+		{
+			Description = "whole milk",
+			TopN = 3,
+			AutoAcceptThresholdOverride = 0.85,
+			PendingReviewThresholdOverride = 0.55,
+		};
+
+		Guid candidateId = Guid.NewGuid();
+		MatchTestResult serviceResult = new(
+			Candidates: [new MatchCandidate(candidateId, "Whole Milk", 0.92, "Active")],
+			SimulatedOutcome: MatchTestOutcomes.AutoAccept,
+			SimulatedTargetId: candidateId);
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<TestNormalizedDescriptionMatchQuery>(q =>
+					q.Description == "whole milk" &&
+					q.TopN == 3 &&
+					q.AutoAcceptThresholdOverride == 0.85 &&
+					q.PendingReviewThresholdOverride == 0.55),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(serviceResult);
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		Ok<MatchTestResultResponse> ok = Assert.IsType<Ok<MatchTestResultResponse>>(result.Result);
+		ok.Value!.SimulatedOutcome.Should().Be("AutoAccept");
+		ok.Value.SimulatedTargetId.Should().Be(candidateId);
+		ok.Value.Candidates.Should().ContainSingle();
+		MatchCandidateDto first = ok.Value.Candidates.First();
+		first.CanonicalName.Should().Be("Whole Milk");
+		first.CosineSimilarity.Should().Be(0.92);
+	}
+
+	[Fact]
+	public async Task TestMatch_ZeroTopN_DefaultsToFive()
+	{
+		// The generated DTO has TopN default = 5, but JSON deserialization from a client
+		// that omits TopN (or sends topN=0 explicitly) can set it to 0. The controller
+		// coerces 0 → 5 as a defensive fallback.
+		TestMatchRequest request = new()
+		{
+			Description = "milk",
+			TopN = 0,
+		};
+
+		_mediatorMock
+			.Setup(m => m.Send(It.Is<TestNormalizedDescriptionMatchQuery>(q => q.TopN == 5), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new MatchTestResult([], MatchTestOutcomes.CreateNew, null));
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		Assert.IsType<Ok<MatchTestResultResponse>>(result.Result);
+		_mediatorMock.Verify(m => m.Send(It.Is<TestNormalizedDescriptionMatchQuery>(q => q.TopN == 5), It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Theory]
+	[InlineData("", NormalizedDescriptionsController.DescriptionRequired)]
+	[InlineData("   ", NormalizedDescriptionsController.DescriptionRequired)]
+	public async Task TestMatch_EmptyDescription_ReturnsBadRequest(string description, string expectedMessage)
+	{
+		TestMatchRequest request = new() { Description = description, TopN = 5 };
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(expectedMessage);
+	}
+
+	[Theory]
+	[InlineData(-1)]
+	[InlineData(21)]
+	public async Task TestMatch_TopNOutOfRange_ReturnsBadRequest(int topN)
+	{
+		TestMatchRequest request = new() { Description = "milk", TopN = topN };
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.TopNOutOfRange);
+	}
+
+	[Fact]
+	public async Task TestMatch_OverrideOutOfRange_ReturnsBadRequest()
+	{
+		TestMatchRequest request = new()
+		{
+			Description = "milk",
+			TopN = 5,
+			AutoAcceptThresholdOverride = 1.5,
+		};
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.OverrideOutOfRange);
+	}
+
+	[Fact]
+	public async Task TestMatch_CrossedOverrides_ReturnsBadRequest()
+	{
+		TestMatchRequest request = new()
+		{
+			Description = "milk",
+			TopN = 5,
+			AutoAcceptThresholdOverride = 0.5,
+			PendingReviewThresholdOverride = 0.8,
+		};
+
+		Results<Ok<MatchTestResultResponse>, BadRequest<string>> result =
+			await _controller.TestMatch(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(NormalizedDescriptionsController.PendingMustBeLessThanAuto);
+	}
+
+	// ── POST settings/preview ────────────────────────────────────
+
+	[Fact]
+	public async Task PreviewThresholdImpact_ValidRequest_ReturnsOkWithMappedCounts()
+	{
+		PreviewThresholdImpactRequest request = new()
+		{
+			AutoAcceptThreshold = 0.75,
+			PendingReviewThreshold = 0.4,
+		};
+
+		ThresholdImpactPreview preview = new(
+			Current: new ClassificationCounts(10, 5, 3),
+			Proposed: new ClassificationCounts(15, 2, 1),
+			Deltas: new ReclassificationDeltas(AutoToPending: 0, PendingToAuto: 3, UnresolvedToAuto: 2, UnresolvedToPending: 0));
+
+		_mediatorMock
+			.Setup(m => m.Send(
+				It.Is<PreviewThresholdImpactQuery>(q => q.AutoAcceptThreshold == 0.75 && q.PendingReviewThreshold == 0.4),
+				It.IsAny<CancellationToken>()))
+			.ReturnsAsync(preview);
+
+		Results<Ok<ThresholdImpactPreviewResponse>, BadRequest<string>> result =
+			await _controller.PreviewThresholdImpact(request, CancellationToken.None);
+
+		Ok<ThresholdImpactPreviewResponse> ok = Assert.IsType<Ok<ThresholdImpactPreviewResponse>>(result.Result);
+		ok.Value!.Current.AutoAccepted.Should().Be(10);
+		ok.Value.Proposed.AutoAccepted.Should().Be(15);
+		ok.Value.Deltas.PendingToAuto.Should().Be(3);
+		ok.Value.Deltas.UnresolvedToAuto.Should().Be(2);
+	}
+
+	[Theory]
+	[InlineData(-0.1, 0.5, NormalizedDescriptionsController.AutoAcceptOutOfRange)]
+	[InlineData(1.1, 0.5, NormalizedDescriptionsController.AutoAcceptOutOfRange)]
+	[InlineData(0.8, -0.1, NormalizedDescriptionsController.PendingReviewOutOfRange)]
+	[InlineData(0.8, 1.1, NormalizedDescriptionsController.PendingReviewOutOfRange)]
+	[InlineData(0.5, 0.6, NormalizedDescriptionsController.PendingMustBeLessThanAuto)]
+	public async Task PreviewThresholdImpact_InvalidRequest_ReturnsBadRequest(double autoAccept, double pendingReview, string expectedMessage)
+	{
+		PreviewThresholdImpactRequest request = new()
+		{
+			AutoAcceptThreshold = autoAccept,
+			PendingReviewThreshold = pendingReview,
+		};
+
+		Results<Ok<ThresholdImpactPreviewResponse>, BadRequest<string>> result =
+			await _controller.PreviewThresholdImpact(request, CancellationToken.None);
+
+		BadRequest<string> bad = Assert.IsType<BadRequest<string>>(result.Result);
+		bad.Value.Should().Be(expectedMessage);
+
+		_mediatorMock.Verify(m => m.Send(It.IsAny<PreviewThresholdImpactQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+}

--- a/tests/Presentation.API.Tests/Mapping/Core/ReceiptItemMapperTests.cs
+++ b/tests/Presentation.API.Tests/Mapping/Core/ReceiptItemMapperTests.cs
@@ -425,4 +425,60 @@ public class ReceiptItemMapperTests
 		// Assert
 		Assert.Equal(PricingMode.Quantity, actual.PricingMode);
 	}
+
+	[Fact]
+	public void ToResponse_MapsNormalizedDescriptionFields_WhenPopulated()
+	{
+		// Arrange
+		Guid expectedId = Guid.NewGuid();
+		Guid expectedNormalizedId = Guid.NewGuid();
+		ReceiptItem item = new(
+			expectedId,
+			"ITEM-NORM-001",
+			"Red Seedless Grapes 2LB",
+			1.0m,
+			new Money(5.99m, Currency.USD),
+			new Money(5.99m, Currency.USD),
+			"Groceries",
+			"Produce"
+		)
+		{
+			NormalizedDescriptionId = expectedNormalizedId,
+			NormalizedDescriptionName = "Grapes",
+			NormalizedDescriptionMatchScore = 0.92
+		};
+
+		// Act
+		ReceiptItemResponse actual = _mapper.ToResponse(item);
+
+		// Assert
+		Assert.Equal(expectedNormalizedId, actual.NormalizedDescriptionId);
+		Assert.Equal("Grapes", actual.NormalizedDescriptionName);
+		Assert.Equal(0.92, actual.NormalizedDescriptionMatchScore);
+	}
+
+	[Fact]
+	public void ToResponse_MapsNullNormalizedDescriptionFields_WhenUnresolved()
+	{
+		// Arrange
+		Guid expectedId = Guid.NewGuid();
+		ReceiptItem item = new(
+			expectedId,
+			"ITEM-NORM-002",
+			"Unresolved Item",
+			1.0m,
+			new Money(1.00m, Currency.USD),
+			new Money(1.00m, Currency.USD),
+			"Test",
+			"Unresolved"
+		);
+
+		// Act
+		ReceiptItemResponse actual = _mapper.ToResponse(item);
+
+		// Assert
+		Assert.Null(actual.NormalizedDescriptionId);
+		Assert.Null(actual.NormalizedDescriptionName);
+		Assert.Null(actual.NormalizedDescriptionMatchScore);
+	}
 }


### PR DESCRIPTION
## Summary

Full implementation of the normalized description registry for receipt items. Raw `description` is preserved (it carries useful detail — "red vs green grapes", "28oz vs 14.5oz cans"); a new `NormalizedDescription` entity gives reports a canonical grouping dimension + admin override controls. Matching is done via pgvector ANN search against the registry.

91 files, +12,799/-135 lines across 8 squashed child PRs:

| PR | Scope |
|---|---|
| [#448](https://github.com/mggarofalo/receipts/pull/448) RECEIPTS-585 | Upgrade ONNX embedding model all-MiniLM-L6-v2 (384-dim, mean pool) → BGE-large-en-v1.5 (1024-dim, CLS pool). Calibrated thresholds: within-cluster MIN rose 0.45 → 0.62, unlocking usable auto-accept/pending-review defaults of 0.81/0.68. |
| [#449](https://github.com/mggarofalo/receipts/pull/449) RECEIPTS-577 | Domain entity, EF schema (vector(1024) + partial HNSW + unique lower(CanonicalName)), service with pgvector `<=>` matching, nullable FK on ReceiptItem. |
| [#450](https://github.com/mggarofalo/receipts/pull/450) RECEIPTS-580 | DB-backed settings singleton (thresholds runtime-tunable), match tester, threshold-impact preview, `NormalizedDescriptionMatchScore` column. |
| [#453](https://github.com/mggarofalo/receipts/pull/453) RECEIPTS-579 | MediatR commands/queries + admin controller endpoints for list/get/merge/split/status. |
| [#455](https://github.com/mggarofalo/receipts/pull/455) RECEIPTS-581 | `GET /api/reports/spending-by-normalized-description` aggregating by canonical name; unresolved items bucket to "(Not Normalized)". |
| [#456](https://github.com/mggarofalo/receipts/pull/456) RECEIPTS-583 | Expose `normalizedDescriptionId` / `Name` / `MatchScore` on `ReceiptItemResponse`; receipt detail UI shows "normalized as {name}" secondary line. |
| [#457](https://github.com/mggarofalo/receipts/pull/457) RECEIPTS-578 | Background resolver `BackgroundService` (mirrors `EmbeddingGenerationService`): 30s poll, batch of 50, signal-driven via `IDescriptionChangeSignal`, batch dedup by description, transactional per batch. |
| [#458](https://github.com/mggarofalo/receipts/pull/458) RECEIPTS-582 | React admin UI at `/reports?report=normalized-descriptions` with tabs: Review Queue, Registry, Settings (threshold form + preview + test box) + spending-by-normalized-description chart report. |

## Architectural highlights

- **Canonical entity resolution via semantic similarity** — well-worn pattern from product catalogs and medical-term normalization. Reuses existing ONNX + pgvector infra.
- **Async resolution, never blocking** — resolver populates the FK on a 30s cadence so item creation stays fast
- **Thresholds administratively settable** — DB-backed singleton row, tunable at runtime without redeploy. Calibration test in the tree regenerates threshold recommendations on demand.
- **Preview-before-change tooling** — admins can test a description or preview a threshold change before saving
- **Match score persisted** — enables O(1) impact previews on existing data without re-running ANN
- **Coexists with existing cluster-based similarity report** — the old report is the discovery tool; the registry is the persisted decision
- **Admin-only writes** — all registry mutation endpoints gated on `RequireAdmin`; read access on `ReceiptItemResponse` is open to all authenticated users
- **Model-rotation ready** — `EmbeddingModelVersion` on each registry row

## Test evidence

- Full unit suite across all projects: **2,388 + 1,963 = 4,351 tests, 0 failures**
- Integration tests for migration + resolver exist (run via CI Postgres)
- Calibration integration test committed + data-driven result artifact (`calibration-results.md`)
- `dotnet format --verify-no-changes` + `tsc --noEmit` + `npm run lint` clean

## Known limitations (documented in child PRs)

- Embedding model produces some cross-cluster confounders on grocery descriptions (e.g., "Red Grapes" vs "Red Delicious Apples" = 0.78). This is why thresholds are tunable and the pending-review queue exists.
- ~7% of true equivalents fall below both thresholds and create new entries; admin can Merge them later.
- Docker-dependent integration tests were skipped locally (Docker Desktop offline during author sessions); CI exercises them.

## Deployment notes

- One-time: `scripts/download-onnx-model.cs` pulls BGE-large (~1.34 GB). Developer setup and CI cold-start are slower; worth caching in CI if it becomes painful.
- EF migrations apply cleanly on fresh DB and on a DB with existing ReceiptItems. Existing items get `NormalizedDescriptionId = NULL`; the background resolver backfills at 30s poll, batch 50 (~100 min for 10k items).
- `ItemEmbeddings` table is truncated by the model-swap migration; `EmbeddingGenerationService` re-embeds on next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)