### PR TITLE
fix(infrastructure): repair failing integration tests (RECEIPTS-586)

### DIFF
--- a/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
+++ b/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
@@ -68,17 +68,21 @@ public class ColumnTypeMappingTests(PostgresFixture fixture)
 	[Fact]
 	public async Task TransactionEntity_RoundTrips_WithForeignKeys()
 	{
-		// Arrange — FK to Receipt and Account
-		// Transaction.AccountId references the Accounts table (post-RECEIPTS-543),
-		// so seed an AccountEntity — not just a Card — before inserting the Transaction.
+		// Arrange — FK to Receipt, Account, and Card.
+		// Transaction.AccountId references Accounts (post-RECEIPTS-543);
+		// Transaction.CardId is now NOT NULL and references Cards (post-RECEIPTS-574).
+		// Card.AccountId is also required and references Accounts (post-RECEIPTS-575).
 		await using ApplicationDbContext context = fixture.CreateDbContext();
 		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
 		AccountEntity account = AccountEntityGenerator.Generate();
+		CardEntity card = CardEntityGenerator.Generate();
+		card.AccountId = account.Id;
 		context.Receipts.Add(receipt);
 		context.Accounts.Add(account);
+		context.Cards.Add(card);
 		await context.SaveChangesAsync();
 
-		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id, card.Id);
 
 		// Act
 		context.Transactions.Add(transaction);
@@ -91,6 +95,7 @@ public class ColumnTypeMappingTests(PostgresFixture fixture)
 		loaded.Should().NotBeNull();
 		loaded!.ReceiptId.Should().Be(receipt.Id);
 		loaded.AccountId.Should().Be(account.Id);
+		loaded.CardId.Should().Be(card.Id);
 		loaded.Amount.Should().Be(transaction.Amount);
 		loaded.AmountCurrency.Should().Be(Currency.USD);
 		loaded.Date.Should().Be(transaction.Date);

--- a/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
+++ b/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
@@ -17,23 +17,30 @@ public class ColumnTypeMappingTests(PostgresFixture fixture)
 	[Fact]
 	public async Task CardEntity_RoundTrips_AllColumnTypes()
 	{
-		// Arrange — uuid, text, boolean
+		// Arrange — uuid, text, boolean, nullable-uuid FK. AccountId is nullable,
+		// so the row inserts without a parent Account, but that leaves the FK column
+		// untested. Seed a parent AccountEntity and populate AccountId so every
+		// column on CardEntity round-trips.
 		await using ApplicationDbContext context = fixture.CreateDbContext();
-		CardEntity account = CardEntityGenerator.Generate();
+		AccountEntity parent = AccountEntityGenerator.Generate();
+		CardEntity card = CardEntityGenerator.Generate();
+		card.AccountId = parent.Id;
 
 		// Act
-		context.Cards.Add(account);
+		context.Accounts.Add(parent);
+		context.Cards.Add(card);
 		await context.SaveChangesAsync();
 
 		// Assert
 		await using ApplicationDbContext readContext = fixture.CreateDbContext();
-		CardEntity? loaded = await readContext.Cards.FirstOrDefaultAsync(a => a.Id == account.Id);
+		CardEntity? loaded = await readContext.Cards.FirstOrDefaultAsync(a => a.Id == card.Id);
 
 		loaded.Should().NotBeNull();
-		loaded!.Id.Should().Be(account.Id);
-		loaded.CardCode.Should().Be(account.CardCode);
-		loaded.Name.Should().Be(account.Name);
-		loaded.IsActive.Should().Be(account.IsActive);
+		loaded!.Id.Should().Be(card.Id);
+		loaded.CardCode.Should().Be(card.CardCode);
+		loaded.Name.Should().Be(card.Name);
+		loaded.IsActive.Should().Be(card.IsActive);
+		loaded.AccountId.Should().Be(parent.Id);
 	}
 
 	[Fact]

--- a/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
+++ b/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
@@ -62,11 +62,13 @@ public class ColumnTypeMappingTests(PostgresFixture fixture)
 	public async Task TransactionEntity_RoundTrips_WithForeignKeys()
 	{
 		// Arrange — FK to Receipt and Account
+		// Transaction.AccountId references the Accounts table (post-RECEIPTS-543),
+		// so seed an AccountEntity — not just a Card — before inserting the Transaction.
 		await using ApplicationDbContext context = fixture.CreateDbContext();
 		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
-		CardEntity account = CardEntityGenerator.Generate();
+		AccountEntity account = AccountEntityGenerator.Generate();
 		context.Receipts.Add(receipt);
-		context.Cards.Add(account);
+		context.Accounts.Add(account);
 		await context.SaveChangesAsync();
 
 		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);

--- a/tests/Infrastructure.IntegrationTests/Fixtures/PostgresFixture.cs
+++ b/tests/Infrastructure.IntegrationTests/Fixtures/PostgresFixture.cs
@@ -21,9 +21,17 @@ public class PostgresFixture : IAsyncLifetime
 		dataSourceBuilder.UseVector();
 		_dataSource = dataSourceBuilder.Build();
 
-		// Run migrations to create the schema
-		await using ApplicationDbContext context = CreateDbContext();
-		await context.Database.MigrateAsync();
+		// Run migrations to create the schema. The first connection caches
+		// npgsql's type info before the pgvector extension exists, so
+		// UseVector()'s vector mapping can't resolve. Reload types after
+		// migrations so the cache picks up the newly-created extension.
+		await using (ApplicationDbContext context = CreateDbContext())
+		{
+			await context.Database.MigrateAsync();
+		}
+
+		await using NpgsqlConnection reloadConnection = await _dataSource.OpenConnectionAsync();
+		await reloadConnection.ReloadTypesAsync();
 	}
 
 	public ApplicationDbContext CreateDbContext()


### PR DESCRIPTION
## Summary

Fixes 2 pre-existing integration test failures in `tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs` that were hidden by the `--filter "Category!=Integration"` filter in CI.

- **`TransactionEntity_RoundTrips_WithForeignKeys`** — now seeds an `AccountEntity` + `CardEntity` (with proper parent Account) and passes the card id, matching the post-RECEIPTS-543 / -574 / -575 schema.
- **`ItemEmbeddingEntity_RoundTrips_VectorColumn`** — `PostgresFixture` now calls `ReloadTypesAsync()` after `MigrateAsync()`. The data source was previously built with `UseVector()` before the pgvector extension existed, so the npgsql type cache never saw the `vector` type.
- **`CardEntity_RoundTrips_AllColumnTypes`** — was passing trivially because `AccountId` was never populated; now exercises the FK column.

## Scope & follow-ups

Scope is limited to these 3 tests. Running the full integration suite surfaced 12 additional pre-existing failures outside this fix, tracked separately:

- RECEIPTS-587 — AuditLog + SoftDelete failures (7 tests)
- RECEIPTS-588 — ItemSimilarity `ProcessedAt` NULL type mismatch (4 tests)
- RECEIPTS-589 — test isolation issue
- RECEIPTS-590 — enable integration tests in CI (blocked on above)

## Test plan

- [x] `dotnet test tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj --filter "FullyQualifiedName~ColumnTypeMapping"` — 8/8 pass locally
- [x] Unit suite unaffected (no runtime code changed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)