### PR TITLE
fix(infrastructure): isolate CategoryEntityGenerator across integration runs

### DIFF
--- a/tests/SampleData/Entities/CategoryEntityGenerator.cs
+++ b/tests/SampleData/Entities/CategoryEntityGenerator.cs
@@ -9,7 +9,7 @@ public static class CategoryEntityGenerator
 		return new CategoryEntity
 		{
 			Id = Guid.NewGuid(),
-			Name = "Test Category",
+			Name = $"Test Category_{Guid.NewGuid():N}",
 			Description = "Test Description",
 			IsActive = true
 		};


### PR DESCRIPTION
## Summary

- `CategoryEntityGenerator.Generate()` now emits a unique `Name` per call (`$"Test Category_{Guid.NewGuid():N}"`), matching the pattern already used by `ItemTemplateEntityGenerator`.
- Eliminates the cross-test collision on `CategoryEntity`'s unique partial index (`UNIQUE (Name) WHERE DeletedAt IS NULL`).
- `ColumnTypeMappingTests.CategoryAndSubcategory_RoundTrip_WithForeignKey` now passes reliably in the full integration suite, not just in isolation.

Resolves RECEIPTS-589.

## Root cause

`PostgresFixture` is a shared `ICollectionFixture`, so the same Postgres container serves every test in `PostgresCollection`. `PurgeTrashServiceTests.PurgeAllDeletedAsync_...` seeds both an active and a deleted Category — both named "Test Category". Only the deleted row is purged; the active row persists. When `CategoryAndSubcategory_RoundTrip_WithForeignKey` runs afterward and tries to insert another "Test Category" row, the unique partial index rejects it.

## Test plan

- [x] `dotnet build tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj` — succeeds.
- [x] `dotnet test tests/Infrastructure.IntegrationTests --filter "FullyQualifiedName~CategoryAndSubcategory" --no-build` — passes.
- [x] `dotnet test tests/Infrastructure.IntegrationTests --filter "Category=Integration" --no-build` — `CategoryAndSubcategory_RoundTrip_WithForeignKey` moves from FAIL → PASS. Remaining 16 failures are unrelated (pgvector + Transaction FK), tracked by RECEIPTS-586.
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — all 2394 unit tests pass.
- [x] `PurgeTrashServiceTests` still passes as before — its assertions check by `Id`, not `Name`.