### PR TITLE
fix(infrastructure): make ReportServiceItemSimilarityTests pass on pg17 (RECEIPTS-588)

### DIFF
--- a/tests/Infrastructure.IntegrationTests/Services/ReportServiceItemSimilarityTests.cs
+++ b/tests/Infrastructure.IntegrationTests/Services/ReportServiceItemSimilarityTests.cs
@@ -157,13 +157,13 @@ public class ReportServiceItemSimilarityTests(PostgresFixture fixture)
 		(await EdgeCountAsync()).Should().BeGreaterThan(0);
 
 		// Remove one description entirely — should cascade-delete edges referencing it.
+		// Raw SQL (not EF): DistinctDescriptions has no Id column, so EF change tracking
+		// on delete trips code paths that assume every tracked entity has an Id property.
 		await using (ApplicationDbContext remove = fixture.CreateDbContext())
 		{
-			DistinctDescriptionEntity? toRemove = await remove.DistinctDescriptions
-				.FirstOrDefaultAsync(d => d.Description == "ORANGE");
-			toRemove.Should().NotBeNull();
-			remove.DistinctDescriptions.Remove(toRemove!);
-			await remove.SaveChangesAsync();
+			int rowsDeleted = await remove.Database.ExecuteSqlInterpolatedAsync(
+				$"""DELETE FROM "DistinctDescriptions" WHERE "Description" = {"ORANGE"};""");
+			rowsDeleted.Should().Be(1, "the ORANGE description must exist before the cascade test");
 		}
 
 		// Assert — edges involving ORANGE are gone (FK ON DELETE CASCADE)
@@ -184,7 +184,7 @@ public class ReportServiceItemSimilarityTests(PostgresFixture fixture)
 		await context.Database.ExecuteSqlRawAsync(
 			"""
 			INSERT INTO "DistinctDescriptions" ("Description", "ProcessedAt")
-			SELECT DISTINCT "Description", NULL
+			SELECT DISTINCT "Description", NULL::timestamptz
 			FROM "ReceiptItems"
 			WHERE "DeletedAt" IS NULL
 			ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

- Types the bare `NULL` in `SeedDistinctDescriptionsFromReceiptItemsAsync` as `NULL::timestamptz` — Postgres was inferring it as `text`, which won't implicitly cast to `timestamptz` (error 42804). This alone unblocks 3 of the 4 tests.
- Switches the `CascadeDeletion` test's DELETE to raw SQL. `DistinctDescriptionEntity` has no `Id` column, so EF-based `SaveChangesAsync` trips code paths that assume every tracked entity has an `Id`. Production code for this table already uses raw SQL; the test now matches.

Two stacked pre-existing bugs — the SQL fix unmasked the second. The description-less Id-assumption issue is latent in production today because `DistinctDescriptions` and `ItemSimilarityEdges` are only touched via raw SQL; flagging as a follow-up for separate tracking.

Resolves RECEIPTS-588

## Test plan

- [x] `dotnet test tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj --filter "FullyQualifiedName~ReportServiceItemSimilarityTests"` — 4/4 pass
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2376/2376 pass
- [x] Pre-commit hook (dotnet format + full unit suite) — pass