### PR TITLE
fix(infrastructure): repair AuditLog + SoftDelete tests post Account→Card rename (RECEIPTS-587)

### DIFF
--- a/tests/Infrastructure.IntegrationTests/AuditLogTests.cs
+++ b/tests/Infrastructure.IntegrationTests/AuditLogTests.cs
@@ -14,9 +14,12 @@ public class AuditLogTests(PostgresFixture fixture)
 	[Fact]
 	public async Task Create_Entity_GeneratesAuditLog()
 	{
-		// Arrange
+		// Arrange — Cards now require a valid parent Account (RECEIPTS-575).
 		await using ApplicationDbContext context = fixture.CreateDbContext();
+		AccountEntity parent = AccountEntityGenerator.Generate();
 		CardEntity account = CardEntityGenerator.Generate();
+		account.AccountId = parent.Id;
+		context.Accounts.Add(parent);
 
 		// Act
 		context.Cards.Add(account);
@@ -27,7 +30,7 @@ public class AuditLogTests(PostgresFixture fixture)
 		AuditLogEntity? auditLog = await readContext.AuditLogs
 			.OrderByDescending(a => a.ChangedAt)
 			.FirstOrDefaultAsync(a => a.EntityId == account.Id.ToString()
-				&& a.EntityType == "Account");
+				&& a.EntityType == "Card");
 
 		auditLog.Should().NotBeNull();
 		auditLog!.Action.Should().Be(AuditAction.Create);
@@ -41,9 +44,12 @@ public class AuditLogTests(PostgresFixture fixture)
 	[Fact]
 	public async Task Update_Entity_GeneratesAuditLogWithFieldChanges()
 	{
-		// Arrange
+		// Arrange — Cards now require a valid parent Account (RECEIPTS-575).
 		await using ApplicationDbContext context = fixture.CreateDbContext();
+		AccountEntity parent = AccountEntityGenerator.Generate();
 		CardEntity account = CardEntityGenerator.Generate();
+		account.AccountId = parent.Id;
+		context.Accounts.Add(parent);
 		context.Cards.Add(account);
 		await context.SaveChangesAsync();
 
@@ -56,7 +62,7 @@ public class AuditLogTests(PostgresFixture fixture)
 		AuditLogEntity? auditLog = await readContext.AuditLogs
 			.OrderByDescending(a => a.ChangedAt)
 			.FirstOrDefaultAsync(a => a.EntityId == account.Id.ToString()
-				&& a.EntityType == "Account"
+				&& a.EntityType == "Card"
 				&& a.Action == AuditAction.Update);
 
 		auditLog.Should().NotBeNull();
@@ -92,9 +98,13 @@ public class AuditLogTests(PostgresFixture fixture)
 	[Fact]
 	public async Task AuditLog_Excludes_AuditLogEntities()
 	{
-		// Arrange — the audit system should not audit itself
+		// Arrange — the audit system should not audit itself.
+		// Cards now require a valid parent Account (RECEIPTS-575).
 		await using ApplicationDbContext context = fixture.CreateDbContext();
+		AccountEntity parent = AccountEntityGenerator.Generate();
 		CardEntity account = CardEntityGenerator.Generate();
+		account.AccountId = parent.Id;
+		context.Accounts.Add(parent);
 
 		// Act — create an entity (which triggers audit log creation)
 		context.Cards.Add(account);

--- a/tests/Infrastructure.IntegrationTests/SoftDeleteTests.cs
+++ b/tests/Infrastructure.IntegrationTests/SoftDeleteTests.cs
@@ -40,18 +40,22 @@ public class SoftDeleteTests(PostgresFixture fixture)
 	[Fact]
 	public async Task SoftDelete_Receipt_CascadesToTransactions()
 	{
-		// Arrange — receipt with a child transaction, saved on one context
+		// Arrange — receipt with a child transaction, saved on one context.
+		// Transaction now requires both AccountId and CardId FKs (RECEIPTS-574/575).
 		Guid receiptId;
 		Guid transactionId;
 		{
 			await using ApplicationDbContext setupContext = fixture.CreateDbContext();
 			ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
-			CardEntity account = CardEntityGenerator.Generate();
+			AccountEntity account = AccountEntityGenerator.Generate();
+			CardEntity card = CardEntityGenerator.Generate();
+			card.AccountId = account.Id;
 			setupContext.Receipts.Add(receipt);
-			setupContext.Cards.Add(account);
+			setupContext.Accounts.Add(account);
+			setupContext.Cards.Add(card);
 			await setupContext.SaveChangesAsync();
 
-			TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+			TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id, card.Id);
 			setupContext.Transactions.Add(transaction);
 			await setupContext.SaveChangesAsync();
 
@@ -59,10 +63,13 @@ public class SoftDeleteTests(PostgresFixture fixture)
 			transactionId = transaction.Id;
 		}
 
-		// Act — soft-delete the receipt on a fresh context (children not in ChangeTracker)
+		// Act — soft-delete the receipt after loading owned children so the
+		// cascade in HandleSoftDelete can see them (matches ReceiptRepository.DeleteAsync).
 		{
 			await using ApplicationDbContext deleteContext = fixture.CreateDbContext();
 			ReceiptEntity receiptToDelete = await deleteContext.Receipts.FirstAsync(r => r.Id == receiptId);
+			await deleteContext.Transactions.IgnoreAutoIncludes()
+				.Where(t => t.ReceiptId == receiptId).LoadAsync();
 			deleteContext.Receipts.Remove(receiptToDelete);
 			await deleteContext.SaveChangesAsync();
 		}
@@ -101,10 +108,13 @@ public class SoftDeleteTests(PostgresFixture fixture)
 			itemId = item.Id;
 		}
 
-		// Act — soft-delete the receipt on a fresh context (children not in ChangeTracker)
+		// Act — soft-delete the receipt after loading owned children so the
+		// cascade in HandleSoftDelete can see them (matches ReceiptRepository.DeleteAsync).
 		{
 			await using ApplicationDbContext deleteContext = fixture.CreateDbContext();
 			ReceiptEntity receiptToDelete = await deleteContext.Receipts.FirstAsync(r => r.Id == receiptId);
+			await deleteContext.ReceiptItems.IgnoreAutoIncludes()
+				.Where(i => i.ReceiptId == receiptId).LoadAsync();
 			deleteContext.Receipts.Remove(receiptToDelete);
 			await deleteContext.SaveChangesAsync();
 		}
@@ -144,10 +154,13 @@ public class SoftDeleteTests(PostgresFixture fixture)
 			adjustmentId = adjustment.Id;
 		}
 
-		// Act — soft-delete the receipt on a fresh context (children not in ChangeTracker)
+		// Act — soft-delete the receipt after loading owned children so the
+		// cascade in HandleSoftDelete can see them (matches ReceiptRepository.DeleteAsync).
 		{
 			await using ApplicationDbContext deleteContext = fixture.CreateDbContext();
 			ReceiptEntity receiptToDelete = await deleteContext.Receipts.FirstAsync(r => r.Id == receiptId);
+			await deleteContext.Adjustments.IgnoreAutoIncludes()
+				.Where(a => a.ReceiptId == receiptId).LoadAsync();
 			deleteContext.Receipts.Remove(receiptToDelete);
 			await deleteContext.SaveChangesAsync();
 		}
@@ -217,18 +230,22 @@ public class SoftDeleteTests(PostgresFixture fixture)
 	[Fact]
 	public async Task SoftDelete_Transaction_CascadesToYnabSyncRecords()
 	{
-		// Arrange — transaction with a child YnabSyncRecord
+		// Arrange — transaction with a child YnabSyncRecord.
+		// Transaction now requires both AccountId and CardId FKs (RECEIPTS-574/575).
 		Guid transactionId;
 		Guid syncRecordId;
 		{
 			await using ApplicationDbContext setupContext = fixture.CreateDbContext();
 			ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
-			CardEntity account = CardEntityGenerator.Generate();
+			AccountEntity account = AccountEntityGenerator.Generate();
+			CardEntity card = CardEntityGenerator.Generate();
+			card.AccountId = account.Id;
 			setupContext.Receipts.Add(receipt);
-			setupContext.Cards.Add(account);
+			setupContext.Accounts.Add(account);
+			setupContext.Cards.Add(card);
 			await setupContext.SaveChangesAsync();
 
-			TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+			TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id, card.Id);
 			setupContext.Transactions.Add(transaction);
 			await setupContext.SaveChangesAsync();
 
@@ -240,10 +257,13 @@ public class SoftDeleteTests(PostgresFixture fixture)
 			syncRecordId = syncRecord.Id;
 		}
 
-		// Act — soft-delete the transaction on a fresh context
+		// Act — soft-delete the transaction after loading owned children so the
+		// cascade in HandleSoftDelete can see them.
 		{
 			await using ApplicationDbContext deleteContext = fixture.CreateDbContext();
 			TransactionEntity txToDelete = await deleteContext.Transactions.FirstAsync(t => t.Id == transactionId);
+			await deleteContext.YnabSyncRecords.IgnoreAutoIncludes()
+				.Where(s => s.LocalTransactionId == transactionId).LoadAsync();
 			deleteContext.Transactions.Remove(txToDelete);
 			await deleteContext.SaveChangesAsync();
 		}
@@ -267,17 +287,21 @@ public class SoftDeleteTests(PostgresFixture fixture)
 	public async Task SoftDelete_YnabSyncRecord_AllowsReCreationAfterSoftDelete()
 	{
 		// Arrange — this test validates the filtered unique index on (LocalTransactionId, SyncType)
-		// against a real PostgreSQL instance where unique indexes are enforced
+		// against a real PostgreSQL instance where unique indexes are enforced.
+		// Transaction now requires both AccountId and CardId FKs (RECEIPTS-574/575).
 		Guid transactionId;
 		{
 			await using ApplicationDbContext setupContext = fixture.CreateDbContext();
 			ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
-			CardEntity account = CardEntityGenerator.Generate();
+			AccountEntity account = AccountEntityGenerator.Generate();
+			CardEntity card = CardEntityGenerator.Generate();
+			card.AccountId = account.Id;
 			setupContext.Receipts.Add(receipt);
-			setupContext.Cards.Add(account);
+			setupContext.Accounts.Add(account);
+			setupContext.Cards.Add(card);
 			await setupContext.SaveChangesAsync();
 
-			TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+			TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id, card.Id);
 			setupContext.Transactions.Add(transaction);
 			await setupContext.SaveChangesAsync();
 


### PR DESCRIPTION
## Summary

- Updated `AuditLogTests` (2 tests) to filter `EntityType == \"Card\"` instead of `\"Account\"` — matches the audit interceptor, which derives EntityType from the CLR class name after the RECEIPTS-543 rename.
- Updated `SoftDeleteTests` (5 tests): 3 tests now seed an `AccountEntity` (post-RECEIPTS-543, `Transaction.AccountId` FKs to the new logical `Accounts` table, not `Cards`); 4 cascade tests now eagerly load owned children into the `ChangeTracker` before `Remove`, matching the `ReceiptRepository.DeleteAsync` production pattern. `HandleSoftDelete` only cascades to tracked entities.
- Tests-only change; no production code modified.

Resolves RECEIPTS-587

## Test plan

- [x] `dotnet test tests/Infrastructure.IntegrationTests --filter \"FullyQualifiedName~AuditLogTests|FullyQualifiedName~SoftDeleteTests\"` — all 12 pass locally (previously 7 failing).
- [x] Full unit suite (`Category!=Integration`): **2238/2238 pass**.
- [ ] CI runs unit suite on PR.

## Out of scope

Running the full integration suite surfaces 7 other pre-existing failures not caused by this change:
- 2 in `ColumnTypeMappingTests` (`TransactionEntity_RoundTrips_WithForeignKeys`, `ItemEmbeddingEntity_RoundTrips_VectorColumn`) — already tracked in RECEIPTS-586.
- 4 in `ReportServiceItemSimilarityTests` and 1 in `ColumnTypeMappingTests.CategoryAndSubcategory_RoundTrip_WithForeignKey` fail with `column "ProcessedAt" is of type timestamp with time zone but expression is of type text` — likely the same pgvector/type-cache root cause as the second RECEIPTS-586 bug, but different surface. Worth filing a follow-up if RECEIPTS-586's fix doesn't cover them.