### PR TITLE
fix(infrastructure): exclude id-less entities from audit collector (RECEIPTS-591)

### DIFF
--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -304,7 +304,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
 	private List<AuditEntry> CollectAuditEntries()
 	{
-		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity), typeof(SeedHistoryEntry), typeof(YnabSyncRecordEntity), typeof(YnabSelectedBudgetEntity), typeof(YnabAccountMappingEntity), typeof(YnabCategoryMappingEntity), typeof(YnabServerKnowledgeEntity)];
+		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity), typeof(SeedHistoryEntry), typeof(YnabSyncRecordEntity), typeof(YnabSelectedBudgetEntity), typeof(YnabAccountMappingEntity), typeof(YnabCategoryMappingEntity), typeof(YnabServerKnowledgeEntity), typeof(DistinctDescriptionEntity), typeof(ItemSimilarityEdgeEntity)];
 		List<AuditEntry> auditEntries = [];
 		DateTimeOffset now = DateTimeOffset.UtcNow;
 

--- a/tests/Infrastructure.Tests/Audit/AuditLogCaptureTests.cs
+++ b/tests/Infrastructure.Tests/Audit/AuditLogCaptureTests.cs
@@ -222,6 +222,61 @@ public class AuditLogCaptureTests
 	}
 
 	[Fact]
+	public async Task SaveChanges_DistinctDescriptionEntity_NotAudited()
+	{
+		// DistinctDescription uses Description (string) as its PK, so an EF-tracked
+		// save without excluding this type would crash CollectAuditEntries() on the
+		// `entry.Property("Id")` lookup.
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		DistinctDescriptionEntity entity = new() { Description = "COCA COLA", ProcessedAt = null };
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.DistinctDescriptions.AddAsync(entity);
+			Func<Task> act = async () => await context.SaveChangesAsync();
+			await act.Should().NotThrowAsync();
+		}
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs.ToListAsync();
+			auditLogs.Should().BeEmpty("DistinctDescription is infrastructure data, not a user-observable entity");
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task SaveChanges_ItemSimilarityEdgeEntity_NotAudited()
+	{
+		// ItemSimilarityEdge has a composite PK {DescA, DescB} and no `Id` column,
+		// so an EF-tracked save without excluding this type would crash CollectAuditEntries().
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		ItemSimilarityEdgeEntity entity = new()
+		{
+			DescA = "COCA COLA",
+			DescB = "COCA-COLA",
+			Score = 0.95,
+			ComputedAt = DateTimeOffset.UtcNow,
+		};
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.ItemSimilarityEdges.AddAsync(entity);
+			Func<Task> act = async () => await context.SaveChangesAsync();
+			await act.Should().NotThrowAsync();
+		}
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			List<AuditLogEntity> auditLogs = await context.AuditLogs.ToListAsync();
+			auditLogs.Should().BeEmpty("ItemSimilarityEdge is derived data, not a user-observable entity");
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
 	public async Task SaveChanges_MultipleEntities_ProducesMultipleAuditLogs()
 	{
 		// Arrange


### PR DESCRIPTION
## Summary

- Adds `DistinctDescriptionEntity` and `ItemSimilarityEdgeEntity` to the `excludedTypes` set in `CollectAuditEntries()`. Both entities lack an `Id` column (PKs are `Description` and `{DescA, DescB}` respectively), which crashed `entry.Property("Id").CurrentValue` with `InvalidOperationException`.
- Latent in production today because both tables are only mutated via raw SQL (`ReconcileDistinctDescriptionsAsync`, `ItemSimilarityEdgeRefresher.RefreshAsync`); any EF-tracked write path would trip it. Caught during RECEIPTS-588 investigation.
- Adds two regression tests. Without the `excludedTypes` change they fail with exactly the reported `InvalidOperationException`.

Fix follows the precedent already established for `SeedHistoryEntry` and `YnabServerKnowledgeEntity` — two other id-less infrastructure entities excluded via the same mechanism.

Resolves RECEIPTS-591

## Test plan

- [x] `dotnet test tests/Infrastructure.Tests/Infrastructure.Tests.csproj --filter "FullyQualifiedName~AuditLogCaptureTests"` — 12/12 pass
- [x] Verified the two new tests fail with the reported exception when the fix is removed
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2378/2378 pass
- [x] Pre-commit hook (dotnet format + full unit suite) — pass