### PR TITLE
fix(infrastructure): self-heal orphan Cards in RequireAccountIdOnCards (RECEIPTS-604)

### DIFF
--- a/src/Infrastructure/Migrations/20260420111011_RequireAccountIdOnCards.cs
+++ b/src/Infrastructure/Migrations/20260420111011_RequireAccountIdOnCards.cs
@@ -14,18 +14,18 @@ public partial class RequireAccountIdOnCards : Migration
 	/// <inheritdoc />
 	protected override void Up(MigrationBuilder migrationBuilder)
 	{
-		// Fail loud if any orphan rows remain — the prior IntroduceAccountAggregate
-		// migration seeded AccountId for every existing card, so this should be zero
-		// in any migrated environment.
+		// Self-heal any orphan Cards (AccountId IS NULL). Mirrors the 1:1 backfill
+		// in IntroduceAccountAggregate: create a matching Account with the same Id,
+		// then point the Card at it. Covers Cards that were inserted between the
+		// two migrations (e.g., via backup restore or data sync paths that bypassed
+		// the application-layer validators). The ON CONFLICT guards the edge case
+		// where an Account row with the target Id already exists.
 		migrationBuilder.Sql("""
-			DO $$
-			DECLARE orphan_count INTEGER;
-			BEGIN
-				SELECT COUNT(*) INTO orphan_count FROM "Cards" WHERE "AccountId" IS NULL;
-				IF orphan_count > 0 THEN
-					RAISE EXCEPTION 'RequireAccountIdOnCards: % card(s) have NULL AccountId. Backfill before running this migration.', orphan_count;
-				END IF;
-			END $$;
+			INSERT INTO "Accounts" ("Id", "Name", "IsActive")
+			SELECT "Id", "Name", "IsActive" FROM "Cards" WHERE "AccountId" IS NULL
+			ON CONFLICT ("Id") DO NOTHING;
+
+			UPDATE "Cards" SET "AccountId" = "Id" WHERE "AccountId" IS NULL;
 			""");
 
 		migrationBuilder.DropForeignKey(

--- a/tests/Infrastructure.IntegrationTests/MigrationSafetyTests.cs
+++ b/tests/Infrastructure.IntegrationTests/MigrationSafetyTests.cs
@@ -66,4 +66,51 @@ public class MigrationSafetyTests(PostgresFixture fixture)
 		await context.Database.ExecuteSqlRawAsync("""DELETE FROM "Accounts" WHERE "Id" = {0};""", accountId);
 		await migrator.MigrateAsync();
 	}
+
+	// RECEIPTS-604: RequireAccountIdOnCards self-heals orphan Cards (AccountId IS
+	// NULL) by creating a 1:1 Account with the same Id — mirroring
+	// IntroduceAccountAggregate's original backfill. This covers Cards that
+	// slipped in between the two migrations (e.g., via backup restore or other
+	// paths that bypassed the application-layer validators).
+	[Fact]
+	public async Task RequireAccountIdOnCards_WithOrphanCard_BackfillsMatchingAccount()
+	{
+		const string priorMigration = "20260419022200_AddCardIdToTransactions";
+
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		IMigrator migrator = context.GetInfrastructure().GetRequiredService<IMigrator>();
+
+		// Roll back to a state where Cards.AccountId is nullable.
+		await migrator.MigrateAsync(priorMigration);
+
+		// Insert an orphan Card directly — no matching Account, AccountId NULL.
+		Guid cardId = Guid.NewGuid();
+		await context.Database.ExecuteSqlRawAsync(
+			"""
+			INSERT INTO "Cards" ("Id", "CardCode", "Name", "IsActive", "AccountId")
+				VALUES ({0}, 'ORPHAN', 'Orphan Card', true, NULL);
+			""",
+			cardId);
+
+		// Re-apply all migrations. The self-heal should run before the NOT NULL
+		// alter, so the alter sees no NULLs and succeeds.
+		await migrator.MigrateAsync();
+
+		// Orphan Card should now point at a matching Account with its own Id.
+		Guid? backfilledAccountId = await context.Cards
+			.IgnoreQueryFilters()
+			.Where(c => c.Id == cardId)
+			.Select(c => (Guid?)c.AccountId)
+			.FirstOrDefaultAsync();
+		backfilledAccountId.Should().Be(cardId);
+
+		bool accountExists = await context.Accounts
+			.IgnoreQueryFilters()
+			.AnyAsync(a => a.Id == cardId);
+		accountExists.Should().BeTrue();
+
+		// Clean up: Card first (FK Restrict on AccountId), then the paired Account.
+		await context.Database.ExecuteSqlRawAsync("""DELETE FROM "Cards" WHERE "Id" = {0};""", cardId);
+		await context.Database.ExecuteSqlRawAsync("""DELETE FROM "Accounts" WHERE "Id" = {0};""", cardId);
+	}
 }


### PR DESCRIPTION
## Summary

Prod DbMigrator crash-loops on `0.4.0` because the preflight `RAISE` in `RequireAccountIdOnCards` aborts when any Card has `AccountId IS NULL`. At least one such Card exists in production — likely inserted between `IntroduceAccountAggregate` (Apr 15) and `RequireAccountIdOnCards` (Apr 20) via backup restore or a data-sync path that bypassed the application-layer validators.

## Fix

Replaces the preflight `RAISE` with the same 1:1 backfill pattern `IntroduceAccountAggregate` used:

```sql
INSERT INTO "Accounts" ("Id", "Name", "IsActive")
SELECT "Id", "Name", "IsActive" FROM "Cards" WHERE "AccountId" IS NULL
ON CONFLICT ("Id") DO NOTHING;

UPDATE "Cards" SET "AccountId" = "Id" WHERE "AccountId" IS NULL;
```

- Creates a matching `Account` (same `Id`) for each orphan Card.
- Sets `Cards.AccountId = Cards.Id`.
- `ON CONFLICT ("Id") DO NOTHING` guards the edge case where an `Account` with the target `Id` already exists.
- The subsequent `ALTER COLUMN ... NOT NULL` then sees zero NULL rows and succeeds.

## Test plan

- [x] New integration test `MigrationSafetyTests.RequireAccountIdOnCards_WithOrphanCard_BackfillsMatchingAccount` rolls the DB back to `20260419022200_AddCardIdToTransactions`, inserts an orphan `Card` via raw SQL, re-applies migrations, and asserts the Card ends up pointing at a new 1:1 `Account`. Passes locally.
- [x] Existing `PromoteTransactionCardIdNotNull_WithNullCardIdRow_AbortsWithGuardError` still passes — the self-heal SQL is a no-op when there are no orphan Cards.
- [x] Pre-commit hook ran 1842 tests, all passed.
- [ ] On merge to `main`, release-please will cut `0.4.1`; verify prod DbMigrator succeeds on the 0.4.1 image.

Plane: [RECEIPTS-604](https://plane.wallingford.me/dev/browse/RECEIPTS-604/) (hotfix, urgent)
Follow-up to: RECEIPTS-575 (which shipped the crashing migration in 0.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)