### PR TITLE
fix(infrastructure): symlink libdl.so for Tesseract on Ubuntu Noble (RECEIPTS-605)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,10 @@ COPY --from=api-build /app/publish .
 # The Tesseract NuGet package probes for libraries in a platform-specific
 # subdirectory (e.g. x64/libleptonica-1.82.0.so). Ubuntu Noble ships the
 # shared objects under /usr/lib/<triple>, so we symlink them into place.
+#
+# Ubuntu Noble (glibc 2.39) ships only libdl.so.2 — the standalone libdl.so
+# was absorbed into libc in glibc 2.34. Tesseract's InteropDotNet loader
+# calls dlopen("libdl"), so we also symlink libdl.so → libdl.so.2.
 ARG TARGETARCH
 RUN case ${TARGETARCH} in \
       amd64) ARCH_DIR=x64   ; TRIPLE=x86_64-linux-gnu ;; \
@@ -120,7 +124,8 @@ RUN case ${TARGETARCH} in \
     esac && \
     mkdir -p ${ARCH_DIR} && \
     ln -sf /usr/lib/${TRIPLE}/liblept.so.5   ${ARCH_DIR}/libleptonica-1.82.0.so && \
-    ln -sf /usr/lib/${TRIPLE}/libtesseract.so.5 ${ARCH_DIR}/libtesseract50.so
+    ln -sf /usr/lib/${TRIPLE}/libtesseract.so.5 ${ARCH_DIR}/libtesseract50.so && \
+    ln -sf /usr/lib/${TRIPLE}/libdl.so.2 /usr/lib/${TRIPLE}/libdl.so
 
 # Copy CLI tools
 COPY --from=api-build /app/tools ./tools/


### PR DESCRIPTION
## Summary

- Fixes `DllNotFoundException: Unable to load shared library 'libdl'` that was breaking `POST /api/receipts/scan` in containers.
- Ubuntu Noble (glibc 2.39) ships only `libdl.so.2`; the standalone `libdl.so` was absorbed into `libc` in glibc 2.34. Tesseract's `InteropDotNet` loader calls `dlopen("libdl")` when constructing `TesseractEngine`, so the load fails.
- Adds one `ln -sf /usr/lib/${TRIPLE}/libdl.so.2 /usr/lib/${TRIPLE}/libdl.so` to the existing arch-aware Tesseract symlink block, covering both amd64 and arm64.

Plane: [RECEIPTS-605](https://plane.wallingford.me/dev/browse/RECEIPTS-605/)

## Test plan

- [ ] `docker build .` succeeds for both amd64 and arm64
- [ ] Container boots and `libdl.so` exists at `/usr/lib/x86_64-linux-gnu/libdl.so` (or `/usr/lib/aarch64-linux-gnu/libdl.so`)
- [ ] `POST /api/receipts/scan` with a JPEG/PNG returns 200 (not 500) and yields OCR output
- [ ] `TesseractOcrEngine` constructor logs `Tesseract OCR engine initialized with tessdata from ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)