### PR TITLE
fix(infra): raise app container memory limit to 3G for BGE-large model (RECEIPTS-606)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          # BGE-large ONNX model (~1.34 GB) is mmap'd into the singleton
+          # InferenceSession; keep headroom for .NET runtime + request load.
+          memory: 3G
           cpus: "2"
     cap_drop:
       - ALL


### PR DESCRIPTION
## Summary

The 1 GB app container memory limit in `docker-compose.yml` was set before #448 upgraded the embedding model from `all-MiniLM-L6-v2` (~90 MB) to `BGE-large-en-v1.5` (~1.34 GB). The model alone exceeds the cgroup ceiling, causing a restart loop on production.

## Diagnosis

From `docker stats receipts-app --no-stream` on the live container:

| Metric | Value |
| --- | --- |
| MEM | **1GiB / 1GiB (100.00%)** |
| CPU | 114% |
| BLOCK I/O | **150GB read / 146GB written in 14 min** |
| PIDS | 25 |

From `docker inspect`:

```json
{"Status":"running","ExitCode":0,"OOMKilled":false,...}
```

From `docker events --since=10m`: **no external restart trigger** in the window.

The 150 GB read in 14 minutes (~180 MB/s sustained) is page-thrash against the mmap'd ONNX file. `OnnxEmbeddingService` loads the model as a singleton `InferenceSession` ([src/Infrastructure/Services/OnnxEmbeddingService.cs:45](../blob/fix/receipts-606-app-memory-limit/src/Infrastructure/Services/OnnxEmbeddingService.cs#L45)). When the cgroup ceiling is reached, managed `OutOfMemoryException` propagates through `await app.RunAsync()` as a graceful host shutdown — exit 0, `OOMKilled=false`, no Serilog "Application is shutting down…" banner because the runtime is too memory-starved to flush before exit.

Variable lifetime (seconds → minutes) is consistent with this: the container survives until something (a real request, a BackgroundService cycle resolving `IEmbeddingService`, GC compacting) triggers enough allocation to breach the ceiling.

## Change

Bump `services.app.deploy.resources.limits.memory` from `1G` to `3G`. 3 GB gives headroom for the 1.34 GB model plus .NET runtime, ASP.NET Core, EF Core, SignalR, request overhead, and normal GC slack. CPU limit unchanged.

## Test plan

- [ ] Pull image, redeploy stack with new limit
- [ ] `docker stats receipts-app --no-stream` shows MEM well below 3 GiB under normal load
- [ ] Container does not restart on its own for ≥ 30 minutes under typical traffic
- [ ] `/api/health` and `/health` continue to respond 200 / "Healthy"

Closes RECEIPTS-606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)