### PR TITLE
feat(infra): add Ollama + GLM-OCR container to Aspire and docker-compose (RECEIPTS-617)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,54 @@ services:
         max-size: "50m"
         max-file: "3"
 
+  # VLM OCR: Ollama container serving glm-ocr:q8_0 for receipt extraction (RECEIPTS-616 epic).
+  # Named volume persists the model cache so the first-run ~1 GB pull only happens once.
+  vlm-ocr:
+    image: ollama/ollama:latest
+    container_name: receipts-vlm-ocr
+    restart: unless-stopped
+    volumes:
+      - vlm-ocr-models:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2"
+    networks:
+      - receipts-net
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "3"
+
+  # One-shot sidecar: pulls glm-ocr:q8_0 if it is not already cached, then exits.
+  # Idempotent — subsequent runs find the model present and skip the download.
+  vlm-ocr-pull:
+    image: ollama/ollama:latest
+    container_name: receipts-vlm-ocr-pull
+    restart: "no"
+    depends_on:
+      vlm-ocr:
+        condition: service_healthy
+    entrypoint: ["/bin/sh"]
+    command: ["-c", "ollama list | grep -q 'glm-ocr:q8_0' || ollama pull glm-ocr:q8_0"]
+    environment:
+      - OLLAMA_HOST=http://vlm-ocr:11434
+    networks:
+      - receipts-net
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "2"
+
   app:
     image: ghcr.io/mggarofalo/receipts:${IMAGE_TAG:-latest}
     container_name: receipts-app
@@ -105,12 +153,15 @@ services:
       - AdminSeed__Email=admin@example.com
       - AdminSeed__FirstName=Admin
       - AdminSeed__LastName=User
+      - Ollama__BaseUrl=http://vlm-ocr:11434
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_SERVICE_NAME=receipts-api
       - SENTRY_DSN=${SENTRY_DSN:-}
       - SENTRY_BACKEND_DSN=${SENTRY_BACKEND_DSN:-}
     depends_on:
       db:
+        condition: service_healthy
+      vlm-ocr:
         condition: service_healthy
       otel-collector:
         condition: service_started
@@ -280,6 +331,7 @@ volumes:
   secrets:
   db-data:
   app-data:
+  vlm-ocr-models:
   tempo-data:
   loki-data:
   prometheus-data:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,6 +85,16 @@ The system uses pgvector for semantic similarity search on item names and descri
 - **`EmbeddingGenerationService`** — Background service that polls every 30s, generates embeddings for new/changed ItemTemplates and ReceiptItems in batches of 50
 - **`ItemTemplateSimilarityService`** — Hybrid search combining trigram similarity (0.4 weight) and cosine vector similarity (0.6 weight) with HNSW indexing
 
+## VLM OCR (GLM-OCR via Ollama)
+
+Receipt OCR + JSON extraction runs against a local vision-language model hosted in an Ollama container (epic **RECEIPTS-616**). This issue (**RECEIPTS-617**) wires the container into Aspire and docker-compose and adds a startup smoke test; the extraction service itself lands in RECEIPTS-618.
+
+- **Container** — `ollama/ollama:latest`, named `vlm-ocr` in both Aspire (`src/Receipts.AppHost/AppHost.cs`) and docker-compose (`docker-compose.yml`), exposing port 11434.
+- **Model** — `glm-ocr:q8_0` (~1 GB). Pulled on first run by the one-shot `vlm-ocr-pull` sidecar; skipped on subsequent runs.
+- **Model cache** — persistent named volume `vlm-ocr-models` mounted at `/root/.ollama`. Survives container restarts so the pull is a one-time cost.
+- **Configuration** — the API reads `Ollama:BaseUrl` (env var `Ollama__BaseUrl`). Aspire injects this automatically; docker-compose sets it to `http://vlm-ocr:11434`.
+- **Smoke test** — `src/Presentation/API/Services/VlmOcrSmokeTest.cs` runs once on `ApplicationStarted`: hits `GET /api/tags`, logs Information if `glm-ocr` is present, Warning otherwise. Log-only — never blocks startup or fails the process.
+
 ## Test Project Structure
 
 Tests mirror src structure. `SampleData` project provides shared test fixtures across test projects.

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,6 +53,9 @@ VS Code will automatically open the **Aspire Dashboard** in your browser.
 | API (HTTPS) | https://localhost:5001 | REST API (HTTPS) |
 | API Docs (Scalar) | http://localhost:5000/scalar | Interactive API documentation |
 | PgAdmin | auto-assigned | PostgreSQL admin UI |
+| VLM OCR (Ollama) | http://localhost:11434 | `glm-ocr:q8_0` for receipt extraction (RECEIPTS-616 epic) |
+
+> **First-run download:** The `vlm-ocr-pull` sidecar downloads `glm-ocr:q8_0` (~1 GB) on the first `aspire run`. The model is cached in the `vlm-ocr-models` named volume, so subsequent starts are fast. Watch the `vlm-ocr-pull` resource in the Aspire Dashboard to see progress. The API logs `VLM OCR: glm-ocr model available at ...` once the model is loaded.
 
 > **Note:** Aspire assigns dynamic ports and the defaults above may differ. Check the **Aspire Dashboard → Resources** view for the actual URLs assigned to each service in your session.
 
@@ -89,6 +92,9 @@ export POSTGRES_PORT=5432
 export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=yourpassword
 export POSTGRES_DB=receiptsdb
+
+# Optional: point at an existing Ollama instance if you want the receipt-scan pipeline to work
+export Ollama__BaseUrl=http://localhost:11434
 
 # Apply migrations and seed the database (required before first run)
 dotnet run --project src/Tools/DbMigrator/DbMigrator.csproj

--- a/src/Common/ConfigurationVariables.cs
+++ b/src/Common/ConfigurationVariables.cs
@@ -27,6 +27,9 @@ public static class ConfigurationVariables
 	public const string OcrTimeoutSeconds = "Ocr:TimeoutSeconds";
 	public const string OcrMaxImageBytes = "Ocr:MaxImageBytes";
 
+	// Ollama host for the VLM-based receipt extraction pipeline (RECEIPTS-616 epic).
+	public const string OllamaBaseUrl = "Ollama:BaseUrl";
+
 	public const string YnabPat = "YNAB_PAT";
 }
 

--- a/src/Presentation/API/Program.cs
+++ b/src/Presentation/API/Program.cs
@@ -105,7 +105,10 @@ if (!app.Environment.IsDevelopment())
 }
 
 // VLM OCR startup smoke test (RECEIPTS-616 epic): log-only, does not block startup.
-// Runs once after the host is ready; swallows failures and warns.
+// Runs once after the host is ready. The outer try/catch guards against exceptions that
+// escape VlmOcrSmokeTest.RunAsync (e.g. UriFormatException from a malformed URL, or
+// InvalidOperationException from a scheme-less one) which would otherwise become silent
+// unobserved task exceptions.
 string? ollamaBaseUrl = builder.Configuration[Common.ConfigurationVariables.OllamaBaseUrl];
 if (!string.IsNullOrWhiteSpace(ollamaBaseUrl))
 {
@@ -114,12 +117,19 @@ if (!string.IsNullOrWhiteSpace(ollamaBaseUrl))
 		_ = Task.Run(async () =>
 		{
 			ILogger<Program> smokeLogger = app.Services.GetRequiredService<ILogger<Program>>();
-			using HttpClient http = new()
+			try
 			{
-				BaseAddress = new Uri(ollamaBaseUrl),
-				Timeout = TimeSpan.FromSeconds(10),
-			};
-			await API.Services.VlmOcrSmokeTest.RunAsync(http, smokeLogger, CancellationToken.None);
+				using HttpClient http = new()
+				{
+					BaseAddress = new Uri(ollamaBaseUrl),
+					Timeout = TimeSpan.FromSeconds(10),
+				};
+				await API.Services.VlmOcrSmokeTest.RunAsync(http, smokeLogger, CancellationToken.None);
+			}
+			catch (Exception ex)
+			{
+				smokeLogger.LogWarning(ex, "VLM OCR: unexpected error during smoke test for {Url}", ollamaBaseUrl);
+			}
 		});
 	});
 }

--- a/src/Presentation/API/Program.cs
+++ b/src/Presentation/API/Program.cs
@@ -104,5 +104,25 @@ if (!app.Environment.IsDevelopment())
 	app.MapFallbackToFile("index.html");
 }
 
+// VLM OCR startup smoke test (RECEIPTS-616 epic): log-only, does not block startup.
+// Runs once after the host is ready; swallows failures and warns.
+string? ollamaBaseUrl = builder.Configuration[Common.ConfigurationVariables.OllamaBaseUrl];
+if (!string.IsNullOrWhiteSpace(ollamaBaseUrl))
+{
+	app.Lifetime.ApplicationStarted.Register(() =>
+	{
+		_ = Task.Run(async () =>
+		{
+			ILogger<Program> smokeLogger = app.Services.GetRequiredService<ILogger<Program>>();
+			using HttpClient http = new()
+			{
+				BaseAddress = new Uri(ollamaBaseUrl),
+				Timeout = TimeSpan.FromSeconds(10),
+			};
+			await API.Services.VlmOcrSmokeTest.RunAsync(http, smokeLogger, CancellationToken.None);
+		});
+	});
+}
+
 // Run application
 await app.RunAsync();

--- a/src/Presentation/API/Services/VlmOcrSmokeTest.cs
+++ b/src/Presentation/API/Services/VlmOcrSmokeTest.cs
@@ -1,0 +1,46 @@
+namespace API.Services;
+
+/// <summary>
+/// Startup log-only check that the configured Ollama instance is reachable and has
+/// the glm-ocr model loaded. Used by <c>Program.cs</c> to surface VLM provisioning
+/// problems early without blocking API startup (RECEIPTS-616 epic).
+/// </summary>
+public static class VlmOcrSmokeTest
+{
+	private const string ExpectedModel = "glm-ocr";
+	private const string TagsEndpoint = "/api/tags";
+
+	public static async Task RunAsync(HttpClient http, ILogger logger, CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(http);
+		ArgumentNullException.ThrowIfNull(logger);
+
+		try
+		{
+			using HttpResponseMessage response = await http.GetAsync(TagsEndpoint, cancellationToken);
+			if (!response.IsSuccessStatusCode)
+			{
+				logger.LogWarning(
+					"VLM OCR: {Endpoint} returned {StatusCode} from {Url}",
+					TagsEndpoint, (int)response.StatusCode, http.BaseAddress);
+				return;
+			}
+
+			string body = await response.Content.ReadAsStringAsync(cancellationToken);
+			if (body.Contains(ExpectedModel, StringComparison.OrdinalIgnoreCase))
+			{
+				logger.LogInformation("VLM OCR: glm-ocr model available at {Url}", http.BaseAddress);
+			}
+			else
+			{
+				logger.LogWarning(
+					"VLM OCR: reachable at {Url} but glm-ocr not in model list — run \"ollama pull glm-ocr:q8_0\" on the VLM host",
+					http.BaseAddress);
+			}
+		}
+		catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+		{
+			logger.LogWarning(ex, "VLM OCR: failed to reach {Url}", http.BaseAddress);
+		}
+	}
+}

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -24,10 +24,26 @@ IResourceBuilder<ProjectResource> seeder = builder.AddProject<Projects.DbSeeder>
 	.WithEnvironment("AdminSeed__FirstName", "Admin")
 	.WithEnvironment("AdminSeed__LastName", "User");
 
-// API: starts after seeder completes
+// VLM OCR: Ollama container serving glm-ocr:q8_0 for receipt extraction (RECEIPTS-616 epic).
+// Named volume persists the model cache across restarts so the first-run ~1 GB pull happens once.
+IResourceBuilder<ContainerResource> vlmOcr = builder.AddContainer("vlm-ocr", "ollama/ollama", "latest")
+	.WithVolume("vlm-ocr-models", "/root/.ollama")
+	.WithHttpEndpoint(port: 11434, targetPort: 11434, name: "http");
+
+// One-shot sidecar that pulls glm-ocr:q8_0 if it is not already cached in the shared volume,
+// then exits. Idempotent — subsequent runs find the model present and skip the download.
+builder.AddContainer("vlm-ocr-pull", "ollama/ollama", "latest")
+	.WithEntrypoint("/bin/sh")
+	.WithArgs("-c", "ollama list | grep -q 'glm-ocr:q8_0' || ollama pull glm-ocr:q8_0")
+	.WithEnvironment("OLLAMA_HOST", "http://vlm-ocr:11434")
+	.WaitFor(vlmOcr);
+
+// API: starts after seeder completes; Ollama URL injected for the smoke test and future extraction service
 IResourceBuilder<ProjectResource> api = builder.AddProject<Projects.API>("api")
 	.WithReference(db)
-	.WaitForCompletion(seeder);
+	.WithEnvironment("Ollama__BaseUrl", vlmOcr.GetEndpoint("http"))
+	.WaitForCompletion(seeder)
+	.WaitFor(vlmOcr);
 
 builder.AddViteApp("frontend", "../client")
 	.WithReference(api)

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -26,9 +26,12 @@ IResourceBuilder<ProjectResource> seeder = builder.AddProject<Projects.DbSeeder>
 
 // VLM OCR: Ollama container serving glm-ocr:q8_0 for receipt extraction (RECEIPTS-616 epic).
 // Named volume persists the model cache across restarts so the first-run ~1 GB pull happens once.
+// Host port is left unset so Aspire picks a free one — Ollama's default 11434 is frequently
+// already bound on developer machines running the native Ollama daemon, which would wedge Aspire
+// startup since the API below does .WaitFor(vlmOcr).
 IResourceBuilder<ContainerResource> vlmOcr = builder.AddContainer("vlm-ocr", "ollama/ollama", "latest")
 	.WithVolume("vlm-ocr-models", "/root/.ollama")
-	.WithHttpEndpoint(port: 11434, targetPort: 11434, name: "http");
+	.WithHttpEndpoint(targetPort: 11434, name: "http");
 
 // One-shot sidecar that pulls glm-ocr:q8_0 if it is not already cached in the shared volume,
 // then exits. Idempotent — subsequent runs find the model present and skip the download.

--- a/tests/Presentation.API.Tests/Services/VlmOcrSmokeTestTests.cs
+++ b/tests/Presentation.API.Tests/Services/VlmOcrSmokeTestTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using API.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+namespace Presentation.API.Tests.Services;
+
+public class VlmOcrSmokeTestTests
+{
+	private const string BaseUrl = "http://vlm-ocr:11434";
+	private static readonly string TagsJsonWithModel = """
+	{
+	  "models": [
+	    {"name": "glm-ocr:q8_0", "size": 987654321}
+	  ]
+	}
+	""";
+	private static readonly string TagsJsonWithoutModel = """
+	{
+	  "models": [
+	    {"name": "llama3:8b", "size": 5000000000}
+	  ]
+	}
+	""";
+
+	[Fact]
+	public async Task RunAsync_ReachableWithModel_LogsInformation()
+	{
+		Mock<ILogger> logger = new();
+		HttpClient http = CreateHttpClient(HttpStatusCode.OK, TagsJsonWithModel);
+
+		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+
+		VerifyLogged(logger, LogLevel.Information, Times.Once());
+		VerifyLogged(logger, LogLevel.Warning, Times.Never());
+	}
+
+	[Fact]
+	public async Task RunAsync_ReachableButModelMissing_LogsWarning()
+	{
+		Mock<ILogger> logger = new();
+		HttpClient http = CreateHttpClient(HttpStatusCode.OK, TagsJsonWithoutModel);
+
+		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+
+		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "glm-ocr not in model list");
+		VerifyLogged(logger, LogLevel.Information, Times.Never());
+	}
+
+	[Fact]
+	public async Task RunAsync_NonSuccessStatusCode_LogsWarning()
+	{
+		Mock<ILogger> logger = new();
+		HttpClient http = CreateHttpClient(HttpStatusCode.ServiceUnavailable, "");
+
+		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+
+		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "503");
+		VerifyLogged(logger, LogLevel.Information, Times.Never());
+	}
+
+	[Fact]
+	public async Task RunAsync_TransportFailure_LogsWarningAndSwallowsException()
+	{
+		Mock<ILogger> logger = new();
+		HttpClient http = CreateThrowingHttpClient(new HttpRequestException("connection refused"));
+
+		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+
+		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "failed to reach");
+		VerifyLogged(logger, LogLevel.Information, Times.Never());
+	}
+
+	[Fact]
+	public async Task RunAsync_Timeout_LogsWarningAndSwallowsException()
+	{
+		Mock<ILogger> logger = new();
+		HttpClient http = CreateThrowingHttpClient(new TaskCanceledException("timeout", new TimeoutException()));
+
+		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+
+		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "failed to reach");
+		VerifyLogged(logger, LogLevel.Information, Times.Never());
+	}
+
+	private static HttpClient CreateHttpClient(HttpStatusCode status, string body)
+	{
+		Mock<HttpMessageHandler> handler = new();
+		handler.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.ReturnsAsync(new HttpResponseMessage
+			{
+				StatusCode = status,
+				Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+			});
+
+		return new HttpClient(handler.Object) { BaseAddress = new Uri(BaseUrl) };
+	}
+
+	private static HttpClient CreateThrowingHttpClient(Exception exception)
+	{
+		Mock<HttpMessageHandler> handler = new();
+		handler.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.ThrowsAsync(exception);
+
+		return new HttpClient(handler.Object) { BaseAddress = new Uri(BaseUrl) };
+	}
+
+	private static void VerifyLogged(Mock<ILogger> logger, LogLevel level, Times times, string? containing = null)
+	{
+		logger.Verify(
+			x => x.Log(
+				level,
+				It.IsAny<EventId>(),
+				It.Is<It.IsAnyType>((state, _) => containing == null || state.ToString()!.Contains(containing)),
+				It.IsAny<Exception?>(),
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			times);
+	}
+}


### PR DESCRIPTION
## Summary
- Stands up a self-hosted Ollama container running `glm-ocr:q8_0` in both Aspire (dev) and docker-compose (prod), with a persistent model-cache volume so the first-run ~1 GB pull only happens once.
- Adds a one-shot `vlm-ocr-pull` sidecar that pulls the model on first startup (idempotent — skips if cached).
- Wires `Ollama__BaseUrl` into the API via Aspire `WithEnvironment`/`GetEndpoint` and via a docker-compose env var, plus a new `ConfigurationVariables.OllamaBaseUrl` constant.
- Adds a Program.cs startup log-only smoke test (`VlmOcrSmokeTest`) that hits `/api/tags` and logs whether `glm-ocr` is present. Never blocks startup; exceptions are caught and logged as Warning.
- 5 unit tests cover reachable+present, reachable+missing, non-success status, transport failure, and timeout.
- Docs: new "VLM OCR" section in `docs/architecture.md`, table row + note in `docs/development.md`.

Child A of epic [RECEIPTS-616](https://plane.wallingford.me/receipts/projects/aaac8dc9-bc4c-42db-ac99-eee7864c78e9/issues/71b8c101-433d-4a05-8f37-3cfb647c57d5/). Targets the parent branch `feat/receipts-616-vlm-receipt-extraction`.

**Out of scope** (tracked in sibling issues):
- `IReceiptExtractionService` / `OllamaReceiptExtractionService` → RECEIPTS-618
- `ScanReceiptCommandHandler` rewrite → RECEIPTS-619
- Removing Tesseract/PaddleOCR → RECEIPTS-620
- VLM accuracy regression suite → RECEIPTS-621

Resolves RECEIPTS-617

## Test plan

- [x] `dotnet build Receipts.slnx` — clean, warnings-as-errors
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2,415 tests pass (including 5 new)
- [x] Pre-commit hook full pipeline (format, drift, tests, tsc, eslint) — green
- [ ] Manual: `aspire run` → Aspire Dashboard shows `vlm-ocr`, `vlm-ocr-pull`, API. API logs `VLM OCR: glm-ocr model available at ...` once the pull completes.
- [ ] Manual: `docker compose up` → `vlm-ocr-pull` exits cleanly after pulling, app logs show the smoke test result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)