### PR TITLE
feat(infrastructure): Ollama-backed IReceiptExtractionService (RECEIPTS-618)

### DIFF
--- a/src/Application/Interfaces/Services/IReceiptExtractionService.cs
+++ b/src/Application/Interfaces/Services/IReceiptExtractionService.cs
@@ -1,0 +1,8 @@
+using Application.Models.Ocr;
+
+namespace Application.Interfaces.Services;
+
+public interface IReceiptExtractionService
+{
+	Task<ParsedReceipt> ExtractAsync(byte[] imageBytes, string contentType, CancellationToken cancellationToken);
+}

--- a/src/Common/ConfigurationVariables.cs
+++ b/src/Common/ConfigurationVariables.cs
@@ -30,6 +30,13 @@ public static class ConfigurationVariables
 	// Ollama host for the VLM-based receipt extraction pipeline (RECEIPTS-616 epic).
 	public const string OllamaBaseUrl = "Ollama:BaseUrl";
 
+	// VLM-based receipt extraction (RECEIPTS-618). Explicit override of the Ollama base URL,
+	// the model tag, and the per-call timeout.
+	public const string OcrVlmOllamaUrl = "Ocr:Vlm:OllamaUrl";
+	public const string OcrVlmModel = "Ocr:Vlm:Model";
+	public const string OcrVlmTimeoutSeconds = "Ocr:Vlm:TimeoutSeconds";
+	public const string OcrVlmSection = "Ocr:Vlm";
+
 	public const string YnabPat = "YNAB_PAT";
 }
 

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -209,6 +209,8 @@ public static class InfrastructureService
 			});
 		});
 
+		RegisterReceiptExtractionService(services, configuration);
+
 		// Singleton AI/ML services (local models — always available)
 		services.AddSingleton<IEmbeddingService, OnnxEmbeddingService>();
 		RegisterOcrEngine(services, configuration);
@@ -269,5 +271,67 @@ public static class InfrastructureService
 		{
 			services.AddSingleton<IOcrEngine, TesseractOcrEngine>();
 		}
+	}
+
+	/// <summary>
+	/// Registers the Ollama-backed <see cref="IReceiptExtractionService"/> with resilience
+	/// (retry + circuit breaker) matching the YNAB client pattern. URL resolves from
+	/// <c>Ocr:Vlm:OllamaUrl</c>, then <c>Ollama:BaseUrl</c> (Aspire-injected), then localhost default.
+	/// </summary>
+	internal static void RegisterReceiptExtractionService(IServiceCollection services, IConfiguration configuration)
+	{
+		VlmOcrOptions options = new();
+		configuration.GetSection(ConfigurationVariables.OcrVlmSection).Bind(options);
+
+		if (string.IsNullOrWhiteSpace(options.OllamaUrl))
+		{
+			options.OllamaUrl = configuration[ConfigurationVariables.OllamaBaseUrl]
+				?? "http://localhost:11434";
+		}
+
+		services.AddSingleton(options);
+
+		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
+		{
+			client.BaseAddress = new Uri(options.OllamaUrl!.TrimEnd('/') + "/");
+			// The per-call CancellationTokenSource inside the service owns the timeout.
+			client.Timeout = Timeout.InfiniteTimeSpan;
+		})
+		.AddResilienceHandler("vlm-ocr", ConfigureVlmOcrResilience);
+	}
+
+	/// <summary>
+	/// Resilience policy for VLM OCR HTTP calls: 3 retries with exponential backoff + jitter,
+	/// circuit breaker on sustained failure. Matches the YNAB client pattern.
+	/// </summary>
+	internal static void ConfigureVlmOcrResilience(ResiliencePipelineBuilder<HttpResponseMessage> builder)
+	{
+		builder.AddRetry(new HttpRetryStrategyOptions
+		{
+			MaxRetryAttempts = 3,
+			BackoffType = DelayBackoffType.Exponential,
+			UseJitter = true,
+			ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+				.Handle<HttpRequestException>()
+				.HandleResult(r => r.StatusCode is System.Net.HttpStatusCode.TooManyRequests
+					or System.Net.HttpStatusCode.ServiceUnavailable
+					or System.Net.HttpStatusCode.GatewayTimeout),
+			DelayGenerator = args =>
+			{
+				if (args.Outcome.Result?.Headers.RetryAfter?.Delta is TimeSpan delta)
+				{
+					return ValueTask.FromResult<TimeSpan?>(delta);
+				}
+
+				return ValueTask.FromResult<TimeSpan?>(null);
+			},
+		});
+		builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
+		{
+			SamplingDuration = TimeSpan.FromSeconds(30),
+			FailureRatio = 0.5,
+			MinimumThroughput = 5,
+			BreakDuration = TimeSpan.FromSeconds(60),
+		});
 	}
 }

--- a/src/Infrastructure/Services/OllamaGenerateRequest.cs
+++ b/src/Infrastructure/Services/OllamaGenerateRequest.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Infrastructure.Services;
+
+internal sealed record OllamaGenerateRequest(
+	[property: JsonPropertyName("model")] string Model,
+	[property: JsonPropertyName("prompt")] string Prompt,
+	[property: JsonPropertyName("images")] IReadOnlyList<string> Images,
+	[property: JsonPropertyName("format")] string Format = "json",
+	[property: JsonPropertyName("stream")] bool Stream = false
+);

--- a/src/Infrastructure/Services/OllamaGenerateResponse.cs
+++ b/src/Infrastructure/Services/OllamaGenerateResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Infrastructure.Services;
+
+internal sealed record OllamaGenerateResponse(
+	[property: JsonPropertyName("model")] string? Model,
+	[property: JsonPropertyName("response")] string? Response,
+	[property: JsonPropertyName("done")] bool Done
+);

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -49,26 +49,20 @@ public sealed class OllamaReceiptExtractionService : IReceiptExtractionService
 		using CancellationTokenSource timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 		timeoutSource.CancelAfter(TimeSpan.FromSeconds(_options.TimeoutSeconds));
 
-		HttpResponseMessage httpResponse;
+		OllamaGenerateResponse? generateResponse;
 		try
 		{
-			httpResponse = await _httpClient.PostAsJsonAsync("api/generate", request, JsonOptions, timeoutSource.Token);
+			using HttpResponseMessage httpResponse = await _httpClient.PostAsJsonAsync(
+				"api/generate", request, JsonOptions, timeoutSource.Token);
+
+			httpResponse.EnsureSuccessStatusCode();
+
+			generateResponse = await httpResponse.Content.ReadFromJsonAsync<OllamaGenerateResponse>(
+				JsonOptions, timeoutSource.Token);
 		}
 		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
 		{
 			throw new TimeoutException($"Ollama VLM call timed out after {_options.TimeoutSeconds}s.");
-		}
-
-		httpResponse.EnsureSuccessStatusCode();
-
-		OllamaGenerateResponse? generateResponse;
-		try
-		{
-			generateResponse = await httpResponse.Content.ReadFromJsonAsync<OllamaGenerateResponse>(JsonOptions, timeoutSource.Token);
-		}
-		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-		{
-			throw new TimeoutException($"Ollama VLM response read timed out after {_options.TimeoutSeconds}s.");
 		}
 
 		if (generateResponse is null || string.IsNullOrWhiteSpace(generateResponse.Response))

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -1,0 +1,162 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Application.Interfaces.Services;
+using Application.Models.Ocr;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Services;
+
+public sealed class OllamaReceiptExtractionService : IReceiptExtractionService
+{
+	private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+	{
+		NumberHandling = JsonNumberHandling.AllowReadingFromString,
+	};
+
+	private readonly HttpClient _httpClient;
+	private readonly VlmOcrOptions _options;
+	private readonly ILogger<OllamaReceiptExtractionService> _logger;
+
+	public OllamaReceiptExtractionService(
+		HttpClient httpClient,
+		VlmOcrOptions options,
+		ILogger<OllamaReceiptExtractionService> logger)
+	{
+		_httpClient = httpClient;
+		_options = options;
+		_logger = logger;
+	}
+
+	public async Task<ParsedReceipt> ExtractAsync(byte[] imageBytes, string contentType, CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(imageBytes);
+		if (imageBytes.Length == 0)
+		{
+			throw new ArgumentException("Image bytes cannot be empty.", nameof(imageBytes));
+		}
+
+		_logger.LogDebug(
+			"Extracting receipt via Ollama VLM (model={Model}, bytes={Bytes}, contentType={ContentType})",
+			_options.Model, imageBytes.Length, contentType);
+
+		string base64 = Convert.ToBase64String(imageBytes);
+		OllamaGenerateRequest request = new(
+			Model: _options.Model,
+			Prompt: ReceiptExtractionPrompt.Current,
+			Images: [base64]);
+
+		using CancellationTokenSource timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		timeoutSource.CancelAfter(TimeSpan.FromSeconds(_options.TimeoutSeconds));
+
+		HttpResponseMessage httpResponse;
+		try
+		{
+			httpResponse = await _httpClient.PostAsJsonAsync("api/generate", request, JsonOptions, timeoutSource.Token);
+		}
+		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+		{
+			throw new TimeoutException($"Ollama VLM call timed out after {_options.TimeoutSeconds}s.");
+		}
+
+		httpResponse.EnsureSuccessStatusCode();
+
+		OllamaGenerateResponse? generateResponse;
+		try
+		{
+			generateResponse = await httpResponse.Content.ReadFromJsonAsync<OllamaGenerateResponse>(JsonOptions, timeoutSource.Token);
+		}
+		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+		{
+			throw new TimeoutException($"Ollama VLM response read timed out after {_options.TimeoutSeconds}s.");
+		}
+
+		if (generateResponse is null || string.IsNullOrWhiteSpace(generateResponse.Response))
+		{
+			throw new InvalidOperationException("Ollama VLM returned an empty response.");
+		}
+
+		_logger.LogDebug("Ollama VLM raw response: {Response}", generateResponse.Response);
+
+		VlmReceiptPayload payload;
+		try
+		{
+			payload = JsonSerializer.Deserialize<VlmReceiptPayload>(generateResponse.Response, JsonOptions)
+				?? throw new InvalidOperationException("Ollama VLM produced a null receipt payload.");
+		}
+		catch (JsonException ex)
+		{
+			throw new InvalidOperationException(
+				$"Failed to parse Ollama VLM response as JSON. Raw response: {generateResponse.Response}", ex);
+		}
+
+		return MapToParsedReceipt(payload);
+	}
+
+	private static ParsedReceipt MapToParsedReceipt(VlmReceiptPayload payload)
+	{
+		FieldConfidence<string> storeName = !string.IsNullOrWhiteSpace(payload.Store)
+			? FieldConfidence<string>.High(payload.Store)
+			: FieldConfidence<string>.None();
+
+		FieldConfidence<DateOnly> date = payload.Date is { } d
+			? FieldConfidence<DateOnly>.High(d)
+			: FieldConfidence<DateOnly>.None();
+
+		List<ParsedReceiptItem> items = (payload.Items ?? []).Select(MapItem).ToList();
+
+		FieldConfidence<decimal> subtotal = payload.Subtotal is { } s
+			? FieldConfidence<decimal>.High(s)
+			: FieldConfidence<decimal>.None();
+
+		List<ParsedTaxLine> taxLines = (payload.TaxLines ?? []).Select(MapTaxLine).ToList();
+
+		FieldConfidence<decimal> total = payload.Total is { } t
+			? FieldConfidence<decimal>.High(t)
+			: FieldConfidence<decimal>.None();
+
+		FieldConfidence<string?> paymentMethod = !string.IsNullOrWhiteSpace(payload.PaymentMethod)
+			? FieldConfidence<string?>.High(payload.PaymentMethod)
+			: FieldConfidence<string?>.None();
+
+		return new ParsedReceipt(storeName, date, items, subtotal, taxLines, total, paymentMethod);
+	}
+
+	private static ParsedReceiptItem MapItem(VlmReceiptItem item)
+	{
+		FieldConfidence<string?> code = !string.IsNullOrWhiteSpace(item.Code)
+			? FieldConfidence<string?>.High(item.Code)
+			: FieldConfidence<string?>.None();
+
+		FieldConfidence<string> description = !string.IsNullOrWhiteSpace(item.Description)
+			? FieldConfidence<string>.High(item.Description)
+			: FieldConfidence<string>.None();
+
+		FieldConfidence<decimal> quantity = item.Quantity is { } q
+			? FieldConfidence<decimal>.High(q)
+			: FieldConfidence<decimal>.None();
+
+		FieldConfidence<decimal> unitPrice = item.UnitPrice is { } u
+			? FieldConfidence<decimal>.High(u)
+			: FieldConfidence<decimal>.None();
+
+		FieldConfidence<decimal> totalPrice = item.TotalPrice is { } t
+			? FieldConfidence<decimal>.High(t)
+			: FieldConfidence<decimal>.None();
+
+		return new ParsedReceiptItem(code, description, quantity, unitPrice, totalPrice);
+	}
+
+	private static ParsedTaxLine MapTaxLine(VlmTaxLine tax)
+	{
+		FieldConfidence<string> label = !string.IsNullOrWhiteSpace(tax.Label)
+			? FieldConfidence<string>.High(tax.Label)
+			: FieldConfidence<string>.None();
+
+		FieldConfidence<decimal> amount = tax.Amount is { } a
+			? FieldConfidence<decimal>.High(a)
+			: FieldConfidence<decimal>.None();
+
+		return new ParsedTaxLine(label, amount);
+	}
+}

--- a/src/Infrastructure/Services/ReceiptExtractionPrompt.cs
+++ b/src/Infrastructure/Services/ReceiptExtractionPrompt.cs
@@ -1,0 +1,40 @@
+namespace Infrastructure.Services;
+
+public static class ReceiptExtractionPrompt
+{
+	public const string V1 = """
+		You are a receipt data extraction assistant. Read the receipt image carefully and return a single JSON object with the purchase details.
+
+		Output schema (all fields are optional — omit any field you cannot read from the receipt):
+		{
+		  "store": string,              // Merchant name
+		  "date": string,               // Purchase date, ISO-8601 YYYY-MM-DD
+		  "items": [
+		    {
+		      "code": string | null,    // UPC / SKU / internal code if printed
+		      "description": string,    // Item description as printed
+		      "quantity": number,       // Numeric quantity (use 1 when not explicit)
+		      "unitPrice": number,      // Price per unit
+		      "totalPrice": number      // Line total
+		    }
+		  ],
+		  "subtotal": number,           // Pre-tax total
+		  "taxLines": [
+		    {
+		      "label": string,          // Tax description (e.g. "Sales Tax", "GST")
+		      "amount": number
+		    }
+		  ],
+		  "total": number,              // Grand total charged
+		  "paymentMethod": string | null // e.g. "MASTERCARD", "VISA", "CASH"
+		}
+
+		Rules:
+		- Output ONLY the JSON object. No markdown fences, no prose, no "```json" markers.
+		- Use `.` as the decimal separator.
+		- Emit numbers as JSON numbers, not strings.
+		- Do not invent data. If a field is not visible on the receipt, omit it entirely.
+		""";
+
+	public const string Current = V1;
+}

--- a/src/Infrastructure/Services/VlmOcrOptions.cs
+++ b/src/Infrastructure/Services/VlmOcrOptions.cs
@@ -1,0 +1,10 @@
+namespace Infrastructure.Services;
+
+public sealed class VlmOcrOptions
+{
+	public string? OllamaUrl { get; set; }
+
+	public string Model { get; set; } = "glm-ocr:q8_0";
+
+	public int TimeoutSeconds { get; set; } = 120;
+}

--- a/src/Infrastructure/Services/VlmReceiptPayload.cs
+++ b/src/Infrastructure/Services/VlmReceiptPayload.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace Infrastructure.Services;
+
+internal sealed class VlmReceiptPayload
+{
+	[JsonPropertyName("store")]
+	public string? Store { get; set; }
+
+	[JsonPropertyName("date")]
+	public DateOnly? Date { get; set; }
+
+	[JsonPropertyName("items")]
+	public List<VlmReceiptItem>? Items { get; set; }
+
+	[JsonPropertyName("subtotal")]
+	public decimal? Subtotal { get; set; }
+
+	[JsonPropertyName("taxLines")]
+	public List<VlmTaxLine>? TaxLines { get; set; }
+
+	[JsonPropertyName("total")]
+	public decimal? Total { get; set; }
+
+	[JsonPropertyName("paymentMethod")]
+	public string? PaymentMethod { get; set; }
+}
+
+internal sealed class VlmReceiptItem
+{
+	[JsonPropertyName("code")]
+	public string? Code { get; set; }
+
+	[JsonPropertyName("description")]
+	public string? Description { get; set; }
+
+	[JsonPropertyName("quantity")]
+	public decimal? Quantity { get; set; }
+
+	[JsonPropertyName("unitPrice")]
+	public decimal? UnitPrice { get; set; }
+
+	[JsonPropertyName("totalPrice")]
+	public decimal? TotalPrice { get; set; }
+}
+
+internal sealed class VlmTaxLine
+{
+	[JsonPropertyName("label")]
+	public string? Label { get; set; }
+
+	[JsonPropertyName("amount")]
+	public decimal? Amount { get; set; }
+}

--- a/src/Presentation/API/appsettings.json
+++ b/src/Presentation/API/appsettings.json
@@ -1,6 +1,10 @@
 {
 	"Ocr": {
-		"Engine": "PaddleOCR"
+		"Engine": "PaddleOCR",
+		"Vlm": {
+			"Model": "glm-ocr:q8_0",
+			"TimeoutSeconds": 120
+		}
 	},
 	"Jwt": {
 		"Key": "dev-secret-key-at-least-32-characters-long-for-hs256",

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -1,0 +1,328 @@
+using System.Net;
+using System.Text.Json;
+using Application.Interfaces.Services;
+using Application.Models.Ocr;
+using FluentAssertions;
+using FluentAssertions.Specialized;
+using Infrastructure.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Polly;
+
+namespace Infrastructure.Tests.Services;
+
+public class OllamaReceiptExtractionServiceTests
+{
+	private static readonly byte[] FakeImage = [0x89, 0x50, 0x4E, 0x47];
+
+	private static OllamaReceiptExtractionService CreateService(
+		HttpMessageHandler handler,
+		VlmOcrOptions? options = null)
+	{
+		HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://test-ollama/") };
+		options ??= new VlmOcrOptions
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 30,
+		};
+		return new OllamaReceiptExtractionService(
+			httpClient,
+			options,
+			NullLogger<OllamaReceiptExtractionService>.Instance);
+	}
+
+	private static HttpMessageHandler CreateHandler(string responseBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+	{
+		Mock<HttpMessageHandler> handlerMock = new();
+		handlerMock.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.ReturnsAsync(new HttpResponseMessage
+			{
+				StatusCode = statusCode,
+				Content = new StringContent(responseBody, System.Text.Encoding.UTF8, "application/json"),
+			});
+		return handlerMock.Object;
+	}
+
+	private static string WrapInOllamaEnvelope(string innerJson)
+	{
+		return JsonSerializer.Serialize(new
+		{
+			model = "glm-ocr:q8_0",
+			response = innerJson,
+			done = true,
+		});
+	}
+
+	[Fact]
+	public async Task ExtractAsync_HappyPath_ReturnsAllFieldsWithHighConfidence()
+	{
+		// Arrange
+		string innerJson = """
+			{
+			  "store": "Walmart",
+			  "date": "2026-04-01",
+			  "items": [
+			    { "code": "UPC-001", "description": "Milk", "quantity": 1, "unitPrice": 3.99, "totalPrice": 3.99 },
+			    { "code": "UPC-002", "description": "Bread", "quantity": 2, "unitPrice": 2.50, "totalPrice": 5.00 }
+			  ],
+			  "subtotal": 8.99,
+			  "taxLines": [{ "label": "Sales Tax", "amount": 0.72 }],
+			  "total": 9.71,
+			  "paymentMethod": "MASTERCARD"
+			}
+			""";
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
+
+		// Act
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		receipt.StoreName.Value.Should().Be("Walmart");
+		receipt.StoreName.Confidence.Should().Be(ConfidenceLevel.High);
+		receipt.Date.Value.Should().Be(new DateOnly(2026, 4, 1));
+		receipt.Date.Confidence.Should().Be(ConfidenceLevel.High);
+
+		receipt.Items.Should().HaveCount(2);
+		receipt.Items[0].Code.Value.Should().Be("UPC-001");
+		receipt.Items[0].Description.Value.Should().Be("Milk");
+		receipt.Items[0].Quantity.Value.Should().Be(1m);
+		receipt.Items[0].UnitPrice.Value.Should().Be(3.99m);
+		receipt.Items[0].TotalPrice.Value.Should().Be(3.99m);
+		receipt.Items[1].Quantity.Value.Should().Be(2m);
+		receipt.Items[1].TotalPrice.Value.Should().Be(5.00m);
+
+		receipt.Subtotal.Value.Should().Be(8.99m);
+		receipt.TaxLines.Should().HaveCount(1);
+		receipt.TaxLines[0].Label.Value.Should().Be("Sales Tax");
+		receipt.TaxLines[0].Amount.Value.Should().Be(0.72m);
+		receipt.Total.Value.Should().Be(9.71m);
+		receipt.PaymentMethod.Value.Should().Be("MASTERCARD");
+		receipt.PaymentMethod.Confidence.Should().Be(ConfidenceLevel.High);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_MissingOptionalFields_ReturnsNoneConfidence()
+	{
+		// Arrange — no paymentMethod, no taxLines
+		string innerJson = """
+			{
+			  "store": "Walmart",
+			  "date": "2026-04-01",
+			  "items": [],
+			  "subtotal": 3.99,
+			  "total": 4.29
+			}
+			""";
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
+
+		// Act
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		receipt.PaymentMethod.Value.Should().BeNull();
+		receipt.PaymentMethod.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.TaxLines.Should().BeEmpty();
+		receipt.Items.Should().BeEmpty();
+		receipt.StoreName.Confidence.Should().Be(ConfidenceLevel.High);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_MalformedInnerJson_Throws()
+	{
+		// Arrange — the response field is not valid JSON
+		string envelope = WrapInOllamaEnvelope("{ this is not: valid JSON");
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(envelope));
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		ExceptionAssertions<InvalidOperationException> thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+		thrown.Which.InnerException.Should().BeOfType<JsonException>();
+	}
+
+	[Fact]
+	public async Task ExtractAsync_EmptyResponse_Throws()
+	{
+		// Arrange — envelope present but response field is empty string
+		string envelope = WrapInOllamaEnvelope(string.Empty);
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(envelope));
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*empty response*");
+	}
+
+	[Fact]
+	public async Task ExtractAsync_OperationCanceled_Propagates()
+	{
+		// Arrange — handler blocks until canceled
+		Mock<HttpMessageHandler> handlerMock = new();
+		handlerMock.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.Returns(async (HttpRequestMessage _, CancellationToken ct) =>
+			{
+				await Task.Delay(Timeout.Infinite, ct);
+				return new HttpResponseMessage(HttpStatusCode.OK);
+			});
+		OllamaReceiptExtractionService service = CreateService(handlerMock.Object);
+		using CancellationTokenSource cts = new();
+		cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", cts.Token);
+
+		// Assert — caller-initiated cancellation surfaces as OperationCanceledException
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	[Fact]
+	public async Task ExtractAsync_Timeout_ThrowsTimeoutException()
+	{
+		// Arrange — handler delays longer than TimeoutSeconds
+		Mock<HttpMessageHandler> handlerMock = new();
+		handlerMock.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.Returns(async (HttpRequestMessage _, CancellationToken ct) =>
+			{
+				await Task.Delay(TimeSpan.FromSeconds(5), ct);
+				return new HttpResponseMessage(HttpStatusCode.OK);
+			});
+		VlmOcrOptions options = new()
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 1,
+		};
+		OllamaReceiptExtractionService service = CreateService(handlerMock.Object, options);
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<TimeoutException>()
+			.WithMessage("*timed out after 1s*");
+	}
+
+	[Fact]
+	public async Task ExtractAsync_Request_IncludesModelAndBase64AndJsonFormat()
+	{
+		// Arrange
+		HttpRequestMessage? capturedRequest = null;
+		string? capturedBody = null;
+		Mock<HttpMessageHandler> handlerMock = new();
+		handlerMock.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.Returns(async (HttpRequestMessage req, CancellationToken _) =>
+			{
+				capturedRequest = req;
+				capturedBody = req.Content is not null ? await req.Content.ReadAsStringAsync() : null;
+				return new HttpResponseMessage
+				{
+					StatusCode = HttpStatusCode.OK,
+					Content = new StringContent(WrapInOllamaEnvelope("{}"), System.Text.Encoding.UTF8, "application/json"),
+				};
+			});
+		OllamaReceiptExtractionService service = CreateService(handlerMock.Object);
+
+		// Act
+		await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		capturedRequest.Should().NotBeNull();
+		capturedRequest!.Method.Should().Be(HttpMethod.Post);
+		capturedRequest.RequestUri!.AbsolutePath.Should().EndWith("/api/generate");
+		capturedBody.Should().NotBeNullOrEmpty();
+
+		using JsonDocument doc = JsonDocument.Parse(capturedBody!);
+		doc.RootElement.GetProperty("model").GetString().Should().Be("glm-ocr:q8_0");
+		doc.RootElement.GetProperty("format").GetString().Should().Be("json");
+		doc.RootElement.GetProperty("stream").GetBoolean().Should().BeFalse();
+		doc.RootElement.GetProperty("images")[0].GetString().Should().Be(Convert.ToBase64String(FakeImage));
+		doc.RootElement.GetProperty("prompt").GetString().Should().Contain("receipt");
+	}
+
+	[Fact]
+	public async Task ExtractAsync_RetryThenSuccess_ReturnsReceipt()
+	{
+		// Arrange — build a DI pipeline with retry. Fail twice with 503, then succeed.
+		int callCount = 0;
+		string successBody = WrapInOllamaEnvelope("""{ "store": "Walmart", "total": 10.00 }""");
+
+		Mock<HttpMessageHandler> handlerMock = new();
+		handlerMock.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.Returns(() =>
+			{
+				int call = Interlocked.Increment(ref callCount);
+				HttpResponseMessage message = call <= 2
+					? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+					{
+						Content = new StringContent("{}"),
+					}
+					: new HttpResponseMessage(HttpStatusCode.OK)
+					{
+						Content = new StringContent(successBody, System.Text.Encoding.UTF8, "application/json"),
+					};
+				return Task.FromResult(message);
+			});
+
+		ServiceCollection services = new();
+		services.AddLogging();
+		services.AddSingleton(new VlmOcrOptions
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 30,
+		});
+		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
+		{
+			client.BaseAddress = new Uri("http://test-ollama/");
+			client.Timeout = Timeout.InfiniteTimeSpan;
+		})
+		.ConfigurePrimaryHttpMessageHandler(() => handlerMock.Object)
+		.AddResilienceHandler("vlm-ocr-test", builder =>
+		{
+			builder.AddRetry(new HttpRetryStrategyOptions
+			{
+				MaxRetryAttempts = 3,
+				Delay = TimeSpan.FromMilliseconds(1),
+				BackoffType = DelayBackoffType.Constant,
+				ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+					.Handle<HttpRequestException>()
+					.HandleResult(r => r.StatusCode is HttpStatusCode.ServiceUnavailable
+						or HttpStatusCode.TooManyRequests
+						or HttpStatusCode.GatewayTimeout),
+			});
+		});
+
+		using ServiceProvider sp = services.BuildServiceProvider();
+		IReceiptExtractionService service = sp.GetRequiredService<IReceiptExtractionService>();
+
+		// Act
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		receipt.StoreName.Value.Should().Be("Walmart");
+		receipt.Total.Value.Should().Be(10.00m);
+		callCount.Should().Be(3); // 2 transient failures + 1 success
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `IReceiptExtractionService` (Application) and `OllamaReceiptExtractionService` (Infrastructure) — the backend half of the VLM pipeline introduced in the [RECEIPTS-616 epic](../../issues?q=RECEIPTS-616). POSTs base64-encoded receipt images to Ollama `/api/generate` (GLM-OCR) with `format: "json"`, parses the response into `ParsedReceipt`.
- Wires a YNAB-style resilience pipeline (3 retries + exponential backoff + jitter + circuit breaker) via `Microsoft.Extensions.Http.Resilience` — factored into `ConfigureVlmOcrResilience` for reuse.
- Adds `Ocr:Vlm:OllamaUrl | Model | TimeoutSeconds` config (defaults `glm-ocr:q8_0` / 120s). URL resolves `Ocr:Vlm:OllamaUrl` → `Ollama:BaseUrl` (Aspire-injected) → `http://localhost:11434`.
- Per-call CTS for timeout: caller-cancel surfaces as `OperationCanceledException`; internal timeout surfaces as `TimeoutException`. `HttpClient.Timeout` set to `Infinite` so the CTS is authoritative.
- `FieldConfidence` populated `High` when a VLM field is present, `None()` when absent (per epic's "VLM doesn't return per-field confidence" contract).

Resolves RECEIPTS-618.

## Test plan
- [x] 8 new unit tests in `OllamaReceiptExtractionServiceTests` — happy path, missing-optional-fields, malformed inner JSON, empty response, caller cancellation, internal timeout, request-shape assertion, and a retry-then-success test that builds a real `ServiceCollection` HTTP pipeline to exercise Polly.
- [x] Full unit suite (`dotnet test Receipts.slnx --filter "Category!=Integration"`) passes — 2423 tests.
- [x] `dotnet format --verify-no-changes` clean.
- [x] Pre-commit hook (11/11 steps) passes including frontend vitest suite.
- [ ] Live smoke against a running Aspire stack with GLM-OCR pulled — manual verification step for the epic's acceptance criteria (Walmart photo → subtotal/total/tax/payment/items), to run once all children land.

## Notes for reviewers
- Request/response DTOs (`OllamaGenerateRequest/Response`, `VlmReceiptPayload`) are `internal`; Infrastructure already has `InternalsVisibleTo(Infrastructure.Tests)`.
- Prompt stored as a `const` in `ReceiptExtractionPrompt` with `V1` / `Current` — satisfies the "versioned for A/B testing" note without an embedded-resource setup.
- Circuit breaker config mirrors YNAB verbatim (50% / 30s window / 5 min throughput / 60s break). Not unit-tested directly — stateful + time-dependent; covered as a side effect of the resilience handler being wired.