### PR TITLE
chore(infrastructure)!: drop Receipts.ProcessedImagePath column (RECEIPTS-622)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -6269,11 +6269,9 @@ components:
 
     UploadReceiptImageResponse:
       type: object
-      required: [originalImagePath, processedImagePath]
+      required: [originalImagePath]
       properties:
         originalImagePath:
-          type: string
-        processedImagePath:
           type: string
 
     ConfidenceLevel:

--- a/src/Application/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandler.cs
+++ b/src/Application/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandler.cs
@@ -24,14 +24,10 @@ public class UploadReceiptImageCommandHandler(
 
 		try
 		{
-			// The VLM-based receipt extraction pipeline ingests the original bytes directly,
-			// so there is no separate "processed" image to persist. Mirror the original path
-			// onto ProcessedImagePath to keep the DB schema populated; dropping the column is
-			// tracked separately.
-			await receiptService.UpdateImagePathsAsync(
-				request.ReceiptId, originalPath, originalPath, cancellationToken);
+			await receiptService.UpdateOriginalImagePathAsync(
+				request.ReceiptId, originalPath, cancellationToken);
 
-			return new UploadReceiptImageResult(originalPath, originalPath);
+			return new UploadReceiptImageResult(originalPath);
 		}
 		catch
 		{

--- a/src/Application/Commands/Receipt/UploadImage/UploadReceiptImageResult.cs
+++ b/src/Application/Commands/Receipt/UploadImage/UploadReceiptImageResult.cs
@@ -1,3 +1,3 @@
 namespace Application.Commands.Receipt.UploadImage;
 
-public record UploadReceiptImageResult(string OriginalImagePath, string ProcessedImagePath);
+public record UploadReceiptImageResult(string OriginalImagePath);

--- a/src/Application/Interfaces/Services/IImageStorageService.cs
+++ b/src/Application/Interfaces/Services/IImageStorageService.cs
@@ -3,7 +3,6 @@ namespace Application.Interfaces.Services;
 public interface IImageStorageService
 {
 	Task<string> SaveOriginalAsync(Guid receiptId, byte[] imageBytes, string extension, CancellationToken ct);
-	Task<string> SaveProcessedAsync(Guid receiptId, byte[] processedBytes, CancellationToken ct);
 	string GetImagePath(Guid receiptId, string fileName);
 	Task DeleteReceiptImagesAsync(Guid receiptId, CancellationToken ct);
 }

--- a/src/Application/Interfaces/Services/IReceiptService.cs
+++ b/src/Application/Interfaces/Services/IReceiptService.cs
@@ -8,6 +8,6 @@ public interface IReceiptService : ISoftDeletableService<Receipt>
 	Task<PagedResult<Receipt>> GetAllAsync(int offset, int limit, SortParams sort, Guid? accountId, Guid? cardId, string? q, CancellationToken cancellationToken);
 	Task<List<Receipt>> CreateAsync(List<Receipt> models, CancellationToken cancellationToken);
 	Task UpdateAsync(List<Receipt> models, CancellationToken cancellationToken);
-	Task UpdateImagePathsAsync(Guid receiptId, string originalImagePath, string processedImagePath, CancellationToken cancellationToken);
+	Task UpdateOriginalImagePathAsync(Guid receiptId, string originalImagePath, CancellationToken cancellationToken);
 	Task<List<string>> GetDistinctLocationsAsync(string? query, int limit, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Configurations/ReceiptEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/ReceiptEntityConfiguration.cs
@@ -17,9 +17,6 @@ public class ReceiptEntityConfiguration : IEntityTypeConfiguration<ReceiptEntity
 		builder.Property(e => e.OriginalImagePath)
 			.HasMaxLength(1024);
 
-		builder.Property(e => e.ProcessedImagePath)
-			.HasMaxLength(1024);
-
 		builder.HasQueryFilter(e => e.DeletedAt == null);
 	}
 }

--- a/src/Infrastructure/Entities/Core/ReceiptEntity.cs
+++ b/src/Infrastructure/Entities/Core/ReceiptEntity.cs
@@ -11,7 +11,6 @@ public class ReceiptEntity : ISoftDeletable
 	public decimal TaxAmount { get; set; }
 	public Currency TaxAmountCurrency { get; set; }
 	public string? OriginalImagePath { get; set; }
-	public string? ProcessedImagePath { get; set; }
 	public DateTimeOffset? DeletedAt { get; set; }
 	public string? DeletedByUserId { get; set; }
 	public Guid? DeletedByApiKeyId { get; set; }

--- a/src/Infrastructure/Interfaces/Repositories/IReceiptRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/IReceiptRepository.cs
@@ -12,7 +12,7 @@ public interface IReceiptRepository
 	Task<int> GetDeletedCountAsync(CancellationToken cancellationToken);
 	Task<List<ReceiptEntity>> CreateAsync(List<ReceiptEntity> entities, CancellationToken cancellationToken);
 	Task UpdateAsync(List<ReceiptEntity> entities, CancellationToken cancellationToken);
-	Task UpdateImagePathsAsync(Guid id, string originalImagePath, string processedImagePath, CancellationToken cancellationToken);
+	Task UpdateOriginalImagePathAsync(Guid id, string originalImagePath, CancellationToken cancellationToken);
 	Task DeleteAsync(List<Guid> ids, CancellationToken cancellationToken);
 	Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken);
 	Task<int> GetCountAsync(CancellationToken cancellationToken);

--- a/src/Infrastructure/Mapping/ReceiptMapper.cs
+++ b/src/Infrastructure/Mapping/ReceiptMapper.cs
@@ -16,7 +16,6 @@ public partial class ReceiptMapper
 	[MapperIgnoreTarget(nameof(ReceiptEntity.DeletedByApiKeyId))]
 	[MapperIgnoreTarget(nameof(ReceiptEntity.CascadeDeletedByParentId))]
 	[MapperIgnoreTarget(nameof(ReceiptEntity.OriginalImagePath))]
-	[MapperIgnoreTarget(nameof(ReceiptEntity.ProcessedImagePath))]
 	public partial ReceiptEntity ToEntity(Receipt source);
 
 	private Money MapTaxAmount(decimal amount, Currency currency) => new(amount, currency);
@@ -27,6 +26,5 @@ public partial class ReceiptMapper
 	[MapperIgnoreSource(nameof(ReceiptEntity.DeletedByApiKeyId))]
 	[MapperIgnoreSource(nameof(ReceiptEntity.CascadeDeletedByParentId))]
 	[MapperIgnoreSource(nameof(ReceiptEntity.OriginalImagePath))]
-	[MapperIgnoreSource(nameof(ReceiptEntity.ProcessedImagePath))]
 	public partial Receipt ToDomain(ReceiptEntity source);
 }

--- a/src/Infrastructure/Migrations/20260424010928_DropProcessedImagePathFromReceipts.Designer.cs
+++ b/src/Infrastructure/Migrations/20260424010928_DropProcessedImagePathFromReceipts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424010928_DropProcessedImagePathFromReceipts")]
+    partial class DropProcessedImagePathFromReceipts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260424010928_DropProcessedImagePathFromReceipts.cs
+++ b/src/Infrastructure/Migrations/20260424010928_DropProcessedImagePathFromReceipts.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class DropProcessedImagePathFromReceipts : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropColumn(
+			name: "ProcessedImagePath",
+			table: "Receipts");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AddColumn<string>(
+			name: "ProcessedImagePath",
+			table: "Receipts",
+			type: "character varying(1024)",
+			maxLength: 1024,
+			nullable: true);
+	}
+}

--- a/src/Infrastructure/Repositories/ReceiptRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptRepository.cs
@@ -132,14 +132,13 @@ public class ReceiptRepository(IDbContextFactory<ApplicationDbContext> contextFa
 		await context.SaveChangesAsync(cancellationToken);
 	}
 
-	public async Task UpdateImagePathsAsync(Guid id, string originalImagePath, string processedImagePath, CancellationToken cancellationToken)
+	public async Task UpdateOriginalImagePathAsync(Guid id, string originalImagePath, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
 		ReceiptEntity entity = await context.Receipts.FindAsync([id], cancellationToken)
 			?? throw new KeyNotFoundException($"Receipt {id} not found.");
 
 		entity.OriginalImagePath = originalImagePath;
-		entity.ProcessedImagePath = processedImagePath;
 
 		await context.SaveChangesAsync(cancellationToken);
 	}

--- a/src/Infrastructure/Services/LocalImageStorageService.cs
+++ b/src/Infrastructure/Services/LocalImageStorageService.cs
@@ -24,19 +24,6 @@ public class LocalImageStorageService(IConfiguration configuration) : IImageStor
 		return Path.Combine(receiptId.ToString(), fileName);
 	}
 
-	public async Task<string> SaveProcessedAsync(Guid receiptId, byte[] processedBytes, CancellationToken ct)
-	{
-		string directory = Path.Combine(StorageRoot, receiptId.ToString());
-		Directory.CreateDirectory(directory);
-
-		string filePath = Path.Combine(directory, "processed.png");
-
-		await File.WriteAllBytesAsync(filePath, processedBytes, ct);
-
-		// Return relative path (receiptId/filename) instead of absolute filesystem path
-		return Path.Combine(receiptId.ToString(), "processed.png");
-	}
-
 	public string GetImagePath(Guid receiptId, string fileName)
 	{
 		return Path.Combine(StorageRoot, receiptId.ToString(), fileName);

--- a/src/Infrastructure/Services/ReceiptService.cs
+++ b/src/Infrastructure/Services/ReceiptService.cs
@@ -64,9 +64,9 @@ public class ReceiptService(IReceiptRepository repository, ReceiptMapper mapper)
 		await repository.UpdateAsync(receiptEntities, cancellationToken);
 	}
 
-	public async Task UpdateImagePathsAsync(Guid receiptId, string originalImagePath, string processedImagePath, CancellationToken cancellationToken)
+	public async Task UpdateOriginalImagePathAsync(Guid receiptId, string originalImagePath, CancellationToken cancellationToken)
 	{
-		await repository.UpdateImagePathsAsync(receiptId, originalImagePath, processedImagePath, cancellationToken);
+		await repository.UpdateOriginalImagePathAsync(receiptId, originalImagePath, cancellationToken);
 	}
 
 	public async Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken)

--- a/src/Presentation/API/Controllers/Core/ReceiptImageController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptImageController.cs
@@ -27,7 +27,7 @@ public class ReceiptImageController(
 	[HttpPost("{receiptId}/image")]
 	[RequestSizeLimit(20 * 1024 * 1024)]
 	[EndpointSummary("Upload an image for a receipt")]
-	[EndpointDescription("Accepts a JPEG or PNG image, saves the original, runs preprocessing (grayscale, adaptive threshold, deskew), and returns both image paths.")]
+	[EndpointDescription("Accepts a JPEG or PNG image, saves the original, and returns the stored image path.")]
 	public async Task<Results<Ok<UploadReceiptImageResponse>, NotFound, BadRequest<string>, StatusCodeHttpResult>> UploadImage(
 		[FromRoute] Guid receiptId,
 		IFormFile? file,
@@ -90,7 +90,6 @@ public class ReceiptImageController(
 		return TypedResults.Ok(new UploadReceiptImageResponse
 		{
 			OriginalImagePath = result.OriginalImagePath,
-			ProcessedImagePath = result.ProcessedImagePath,
 		});
 	}
 }

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -3109,7 +3109,6 @@ export interface components {
         };
         UploadReceiptImageResponse: {
             originalImagePath: string;
-            processedImagePath: string;
         };
         /** @enum {string} */
         ConfidenceLevel: "low" | "medium" | "high";

--- a/tests/Application.Tests/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandlerTests.cs
@@ -94,7 +94,7 @@ public class UploadReceiptImageCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task Handle_ValidCommand_ReturnsOriginalPathAsBothPaths()
+	public async Task Handle_ValidCommand_ReturnsOriginalPath()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -115,13 +115,10 @@ public class UploadReceiptImageCommandHandlerTests
 		UploadReceiptImageResult result = await _handler.Handle(command, CancellationToken.None);
 
 		// Assert
-		// With the VLM-based scan pipeline, there is no separate "processed" image —
-		// both paths point to the original bytes.
 		result.OriginalImagePath.Should().Be(expectedPath);
-		result.ProcessedImagePath.Should().Be(expectedPath);
 
 		_mockReceiptService.Verify(
-			s => s.UpdateImagePathsAsync(receiptId, expectedPath, expectedPath, It.IsAny<CancellationToken>()),
+			s => s.UpdateOriginalImagePathAsync(receiptId, expectedPath, It.IsAny<CancellationToken>()),
 			Times.Once);
 	}
 
@@ -178,13 +175,8 @@ public class UploadReceiptImageCommandHandlerTests
 		_mockValidationService.Verify(s => s.ValidateAsync(imageBytes, It.IsAny<CancellationToken>()), Times.Once);
 		_mockStorageService.Verify(s => s.SaveOriginalAsync(receiptId, imageBytes, ".png", It.IsAny<CancellationToken>()), Times.Once);
 		_mockReceiptService.Verify(
-			s => s.UpdateImagePathsAsync(receiptId, expectedPath, expectedPath, It.IsAny<CancellationToken>()),
+			s => s.UpdateOriginalImagePathAsync(receiptId, expectedPath, It.IsAny<CancellationToken>()),
 			Times.Once);
-
-		// SaveProcessedAsync is never called — preprocessing was removed with the legacy OCR pipeline.
-		_mockStorageService.Verify(
-			s => s.SaveProcessedAsync(It.IsAny<Guid>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
-			Times.Never);
 	}
 
 	[Fact]
@@ -238,7 +230,7 @@ public class UploadReceiptImageCommandHandlerTests
 			.ReturnsAsync(savedPath);
 
 		_mockReceiptService
-			.Setup(s => s.UpdateImagePathsAsync(receiptId, savedPath, savedPath, It.IsAny<CancellationToken>()))
+			.Setup(s => s.UpdateOriginalImagePathAsync(receiptId, savedPath, It.IsAny<CancellationToken>()))
 			.ThrowsAsync(new InvalidOperationException("DB offline"));
 
 		// Act

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptImageControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptImageControllerTests.cs
@@ -146,7 +146,7 @@ public class ReceiptImageControllerTests
 	}
 
 	[Fact]
-	public async Task UploadImage_ValidJpeg_ReturnsOkWithPaths()
+	public async Task UploadImage_ValidJpeg_ReturnsOkWithPath()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -154,7 +154,7 @@ public class ReceiptImageControllerTests
 
 		_mediatorMock
 			.Setup(m => m.Send(It.IsAny<UploadReceiptImageCommand>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.jpg", $"{receiptId}/processed.png"));
+			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.jpg"));
 
 		// Act
 		var result = await _controller.UploadImage(receiptId, file);
@@ -162,11 +162,10 @@ public class ReceiptImageControllerTests
 		// Assert
 		Ok<UploadReceiptImageResponse> okResult = result.Result.Should().BeOfType<Ok<UploadReceiptImageResponse>>().Subject;
 		okResult.Value!.OriginalImagePath.Should().Be($"{receiptId}/original.jpg");
-		okResult.Value.ProcessedImagePath.Should().Be($"{receiptId}/processed.png");
 	}
 
 	[Fact]
-	public async Task UploadImage_ValidPng_ReturnsOkWithPaths()
+	public async Task UploadImage_ValidPng_ReturnsOkWithPath()
 	{
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
@@ -174,7 +173,7 @@ public class ReceiptImageControllerTests
 
 		_mediatorMock
 			.Setup(m => m.Send(It.IsAny<UploadReceiptImageCommand>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.png", $"{receiptId}/processed.png"));
+			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.png"));
 
 		// Act
 		var result = await _controller.UploadImage(receiptId, file);
@@ -182,7 +181,6 @@ public class ReceiptImageControllerTests
 		// Assert
 		Ok<UploadReceiptImageResponse> okResult = result.Result.Should().BeOfType<Ok<UploadReceiptImageResponse>>().Subject;
 		okResult.Value!.OriginalImagePath.Should().Be($"{receiptId}/original.png");
-		okResult.Value.ProcessedImagePath.Should().Be($"{receiptId}/processed.png");
 	}
 
 	[Fact]
@@ -203,7 +201,7 @@ public class ReceiptImageControllerTests
 			.Setup(m => m.Send(
 				It.Is<UploadReceiptImageCommand>(c => c.FileExtension == ".png"),
 				It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.png", $"{receiptId}/processed.png"));
+			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.png"));
 
 		// Act
 		var result = await _controller.UploadImage(receiptId, fileMock.Object);
@@ -235,7 +233,7 @@ public class ReceiptImageControllerTests
 			.Setup(m => m.Send(
 				It.Is<UploadReceiptImageCommand>(c => c.FileExtension == ".jpg"),
 				It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.jpg", $"{receiptId}/processed.png"));
+			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.jpg"));
 
 		// Act
 		var result = await _controller.UploadImage(receiptId, fileMock.Object);
@@ -256,7 +254,7 @@ public class ReceiptImageControllerTests
 
 		_mediatorMock
 			.Setup(m => m.Send(It.IsAny<UploadReceiptImageCommand>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.jpg", $"{receiptId}/processed.png"));
+			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.jpg"));
 
 		// Act
 		var result = await _controller.UploadImage(receiptId, file);
@@ -274,7 +272,7 @@ public class ReceiptImageControllerTests
 
 		_mediatorMock
 			.Setup(m => m.Send(It.IsAny<UploadReceiptImageCommand>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.jpg", $"{receiptId}/processed.png"));
+			.ReturnsAsync(new UploadReceiptImageResult($"{receiptId}/original.jpg"));
 
 		// Act
 		await _controller.UploadImage(receiptId, file);


### PR DESCRIPTION
## Summary
- Drop the redundant `ProcessedImagePath` column from `Receipts` and clean up every reference in the codebase. The VLM-based extraction pipeline landed in RECEIPTS-616 ingests the original image bytes directly — there is no longer a distinct "processed" image, and RECEIPTS-620 left the upload handler mirroring `OriginalImagePath` onto `ProcessedImagePath` only as a stopgap.
- Narrow the storage/service/repository/handler surface to a single `OriginalImagePath`, and strip `processedImagePath` from `UploadReceiptImageResponse` in the OpenAPI spec + regenerated types.
- Audit result for scope item "`ReceiptResponse` remove `ProcessedImagePath`": no-op — that field is not present on `ReceiptResponse` in the current spec. Confirmed by grep.

Resolves RECEIPTS-622.

**Breaking API change** — `UploadReceiptImageResponse` no longer includes `processedImagePath`. Marked with `!` in the commit header, matching RECEIPTS-620's convention.

## PR target
Targets `feat/receipts-616-vlm-receipt-extraction` because the mirroring code this PR removes lives on that epic branch, not on `develop`. The epic will bundle this into its eventual PR to `develop`.

## Test plan
- [x] `dotnet build Receipts.slnx` — clean.
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — all 2254 unit tests pass.
- [x] `cd src/client && npx tsc -b && npx vite build` — client builds cleanly.
- [x] Repo-wide grep for `ProcessedImagePath` / `processedImagePath` / `processed_image_path` — only migration-history matches remain (historical snapshots + the new `DropProcessedImagePathFromReceipts` migration). No production code references.
- [ ] Manual: fresh upload + scan + view cycle against Aspire dev run (required by issue acceptance — reviewer or author to perform before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)