### PR TITLE
feat(application): extend ParsedReceipt for rich VLM fields (RECEIPTS-626)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -6282,18 +6282,36 @@ components:
       type: object
       required:
         - storeNameConfidence
+        - storeAddressConfidence
+        - storePhoneConfidence
         - dateConfidence
         - items
         - subtotalConfidence
         - taxLines
         - totalConfidence
         - paymentMethodConfidence
+        - payments
+        - receiptIdConfidence
+        - storeNumberConfidence
+        - terminalIdConfidence
       properties:
         storeName:
           type:
             - string
             - "null"
         storeNameConfidence:
+          $ref: "#/components/schemas/ConfidenceLevel"
+        storeAddress:
+          type:
+            - string
+            - "null"
+        storeAddressConfidence:
+          $ref: "#/components/schemas/ConfidenceLevel"
+        storePhone:
+          type:
+            - string
+            - "null"
+        storePhoneConfidence:
           $ref: "#/components/schemas/ConfidenceLevel"
         date:
           type:
@@ -6330,6 +6348,28 @@ components:
             - "null"
         paymentMethodConfidence:
           $ref: "#/components/schemas/ConfidenceLevel"
+        payments:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProposedPaymentResponse"
+        receiptId:
+          type:
+            - string
+            - "null"
+        receiptIdConfidence:
+          $ref: "#/components/schemas/ConfidenceLevel"
+        storeNumber:
+          type:
+            - string
+            - "null"
+        storeNumberConfidence:
+          $ref: "#/components/schemas/ConfidenceLevel"
+        terminalId:
+          type:
+            - string
+            - "null"
+        terminalIdConfidence:
+          $ref: "#/components/schemas/ConfidenceLevel"
 
     ProposedReceiptItemResponse:
       type: object
@@ -6339,6 +6379,7 @@ components:
         - quantityConfidence
         - unitPriceConfidence
         - totalPriceConfidence
+        - taxCodeConfidence
       properties:
         code:
           type:
@@ -6373,6 +6414,12 @@ components:
           format: double
         totalPriceConfidence:
           $ref: "#/components/schemas/ConfidenceLevel"
+        taxCode:
+          type:
+            - string
+            - "null"
+        taxCodeConfidence:
+          $ref: "#/components/schemas/ConfidenceLevel"
 
     ProposedTaxLineResponse:
       type: object
@@ -6392,6 +6439,33 @@ components:
             - "null"
           format: double
         amountConfidence:
+          $ref: "#/components/schemas/ConfidenceLevel"
+
+    ProposedPaymentResponse:
+      type: object
+      required:
+        - methodConfidence
+        - amountConfidence
+        - lastFourConfidence
+      properties:
+        method:
+          type:
+            - string
+            - "null"
+        methodConfidence:
+          $ref: "#/components/schemas/ConfidenceLevel"
+        amount:
+          type:
+            - number
+            - "null"
+          format: double
+        amountConfidence:
+          $ref: "#/components/schemas/ConfidenceLevel"
+        lastFour:
+          type:
+            - string
+            - "null"
+        lastFourConfidence:
           $ref: "#/components/schemas/ConfidenceLevel"
 
     CreateCompleteReceiptRequest:

--- a/src/Application/Models/Ocr/ParsedPayment.cs
+++ b/src/Application/Models/Ocr/ParsedPayment.cs
@@ -1,0 +1,12 @@
+namespace Application.Models.Ocr;
+
+/// <summary>
+/// A single payment tender extracted from a receipt. A receipt may include multiple payments
+/// (split tender, gift card + card, etc.) — prefer <see cref="ParsedReceipt.Payments"/> over
+/// the legacy <see cref="ParsedReceipt.PaymentMethod"/> when you need per-payment detail.
+/// </summary>
+public record ParsedPayment(
+	FieldConfidence<string?> Method,
+	FieldConfidence<decimal?> Amount,
+	FieldConfidence<string?> LastFour
+);

--- a/src/Application/Models/Ocr/ParsedReceipt.cs
+++ b/src/Application/Models/Ocr/ParsedReceipt.cs
@@ -7,5 +7,37 @@ public record ParsedReceipt(
 	FieldConfidence<decimal> Subtotal,
 	List<ParsedTaxLine> TaxLines,
 	FieldConfidence<decimal> Total,
-	FieldConfidence<string?> PaymentMethod
-);
+	FieldConfidence<string?> PaymentMethod)
+{
+	/// <summary>
+	/// Store street address, as printed on the receipt. Extracted alongside the store name.
+	/// </summary>
+	public FieldConfidence<string?> StoreAddress { get; init; } = FieldConfidence<string?>.None();
+
+	/// <summary>
+	/// Store phone number, as printed on the receipt.
+	/// </summary>
+	public FieldConfidence<string?> StorePhone { get; init; } = FieldConfidence<string?>.None();
+
+	/// <summary>
+	/// All payment tenders applied to the receipt, in the order they appear. For split-tender
+	/// receipts this preserves every payment — <see cref="PaymentMethod"/> only carries the
+	/// first non-empty method string for backward compatibility with the V1 shape.
+	/// </summary>
+	public List<ParsedPayment> Payments { get; init; } = [];
+
+	/// <summary>
+	/// Receipt identifier / transaction number printed on the receipt (e.g. "7QKKG1XDWPD").
+	/// </summary>
+	public FieldConfidence<string?> ReceiptId { get; init; } = FieldConfidence<string?>.None();
+
+	/// <summary>
+	/// Store / branch number printed on the receipt (e.g. "ST# 05487").
+	/// </summary>
+	public FieldConfidence<string?> StoreNumber { get; init; } = FieldConfidence<string?>.None();
+
+	/// <summary>
+	/// Terminal / register / POS identifier printed on the receipt (e.g. "TE# 54 TR# 1105").
+	/// </summary>
+	public FieldConfidence<string?> TerminalId { get; init; } = FieldConfidence<string?>.None();
+}

--- a/src/Application/Models/Ocr/ParsedReceiptItem.cs
+++ b/src/Application/Models/Ocr/ParsedReceiptItem.cs
@@ -5,5 +5,11 @@ public record ParsedReceiptItem(
 	FieldConfidence<string> Description,
 	FieldConfidence<decimal> Quantity,
 	FieldConfidence<decimal> UnitPrice,
-	FieldConfidence<decimal> TotalPrice
-);
+	FieldConfidence<decimal> TotalPrice)
+{
+	/// <summary>
+	/// Per-item tax code as printed on the receipt (e.g. "N" = non-taxable, "T" = taxable,
+	/// "F" = food). Store-specific; we preserve the raw string without interpretation.
+	/// </summary>
+	public FieldConfidence<string?> TaxCode { get; init; } = FieldConfidence<string?>.None();
+}

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -94,6 +94,14 @@ public sealed class OllamaReceiptExtractionService : IReceiptExtractionService
 			? FieldConfidence<string>.High(payload.Store.Name)
 			: FieldConfidence<string>.None();
 
+		FieldConfidence<string?> storeAddress = !string.IsNullOrWhiteSpace(payload.Store?.Address)
+			? FieldConfidence<string?>.High(payload.Store.Address)
+			: FieldConfidence<string?>.None();
+
+		FieldConfidence<string?> storePhone = !string.IsNullOrWhiteSpace(payload.Store?.Phone)
+			? FieldConfidence<string?>.High(payload.Store.Phone)
+			: FieldConfidence<string?>.None();
+
 		FieldConfidence<DateOnly> date = TryParseDate(payload.Datetime) is { } d
 			? FieldConfidence<DateOnly>.High(d)
 			: FieldConfidence<DateOnly>.None();
@@ -110,15 +118,38 @@ public sealed class OllamaReceiptExtractionService : IReceiptExtractionService
 			? FieldConfidence<decimal>.High(t)
 			: FieldConfidence<decimal>.None();
 
-		// Collapse first payment's method into the single-string PaymentMethod on ParsedReceipt.
-		// Multi-tender receipts lose detail here; see RECEIPTS-626 for the domain-model extension.
+		// Preserve every payment tender from the VLM payload. The legacy PaymentMethod field
+		// is kept populated with the first non-empty method string for backward compatibility;
+		// new consumers should read the Payments list instead.
+		List<ParsedPayment> payments = (payload.Payments ?? []).Select(MapPayment).ToList();
+
 		string? primaryMethod = payload.Payments?
 			.FirstOrDefault(p => !string.IsNullOrWhiteSpace(p.Method))?.Method;
 		FieldConfidence<string?> paymentMethod = !string.IsNullOrWhiteSpace(primaryMethod)
 			? FieldConfidence<string?>.High(primaryMethod)
 			: FieldConfidence<string?>.None();
 
-		return new ParsedReceipt(storeName, date, items, subtotal, taxLines, total, paymentMethod);
+		FieldConfidence<string?> receiptId = !string.IsNullOrWhiteSpace(payload.ReceiptId)
+			? FieldConfidence<string?>.High(payload.ReceiptId)
+			: FieldConfidence<string?>.None();
+
+		FieldConfidence<string?> storeNumber = !string.IsNullOrWhiteSpace(payload.StoreNumber)
+			? FieldConfidence<string?>.High(payload.StoreNumber)
+			: FieldConfidence<string?>.None();
+
+		FieldConfidence<string?> terminalId = !string.IsNullOrWhiteSpace(payload.TerminalId)
+			? FieldConfidence<string?>.High(payload.TerminalId)
+			: FieldConfidence<string?>.None();
+
+		return new ParsedReceipt(storeName, date, items, subtotal, taxLines, total, paymentMethod)
+		{
+			StoreAddress = storeAddress,
+			StorePhone = storePhone,
+			Payments = payments,
+			ReceiptId = receiptId,
+			StoreNumber = storeNumber,
+			TerminalId = terminalId,
+		};
 	}
 
 	/// <summary>
@@ -181,7 +212,31 @@ public sealed class OllamaReceiptExtractionService : IReceiptExtractionService
 			? FieldConfidence<decimal>.High(t)
 			: FieldConfidence<decimal>.None();
 
-		return new ParsedReceiptItem(code, description, quantity, unitPrice, totalPrice);
+		FieldConfidence<string?> taxCode = !string.IsNullOrWhiteSpace(item.TaxCode)
+			? FieldConfidence<string?>.High(item.TaxCode)
+			: FieldConfidence<string?>.None();
+
+		return new ParsedReceiptItem(code, description, quantity, unitPrice, totalPrice)
+		{
+			TaxCode = taxCode,
+		};
+	}
+
+	private static ParsedPayment MapPayment(VlmPayment payment)
+	{
+		FieldConfidence<string?> method = !string.IsNullOrWhiteSpace(payment.Method)
+			? FieldConfidence<string?>.High(payment.Method)
+			: FieldConfidence<string?>.None();
+
+		FieldConfidence<decimal?> amount = payment.Amount is { } a
+			? FieldConfidence<decimal?>.High(a)
+			: FieldConfidence<decimal?>.None();
+
+		FieldConfidence<string?> lastFour = !string.IsNullOrWhiteSpace(payment.LastFour)
+			? FieldConfidence<string?>.High(payment.LastFour)
+			: FieldConfidence<string?>.None();
+
+		return new ParsedPayment(method, amount, lastFour);
 	}
 
 	private static readonly string[] DateFormats =

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -173,6 +173,14 @@ public sealed class OllamaReceiptExtractionService : IReceiptExtractionService
 				{
 					parent.Quantity = item.Quantity;
 					parent.UnitPrice = item.UnitPrice;
+					// If the V3 prompt echoes taxCode on the sub-line but not on the parent,
+					// absorb it so the merged item doesn't drop the code entirely. The parent's
+					// taxCode wins when both are present (the printed marker sits next to the
+					// parent line on the physical receipt).
+					if (string.IsNullOrWhiteSpace(parent.TaxCode) && !string.IsNullOrWhiteSpace(item.TaxCode))
+					{
+						parent.TaxCode = item.TaxCode;
+					}
 					continue;
 				}
 			}

--- a/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
@@ -97,6 +97,10 @@ public class ReceiptScanController(
 		{
 			StoreName = parsed.StoreName.Value,
 			StoreNameConfidence = MapConfidence(parsed.StoreName.Confidence),
+			StoreAddress = parsed.StoreAddress.Value,
+			StoreAddressConfidence = MapConfidence(parsed.StoreAddress.Confidence),
+			StorePhone = parsed.StorePhone.Value,
+			StorePhoneConfidence = MapConfidence(parsed.StorePhone.Confidence),
 			Date = parsed.Date.Value,
 			DateConfidence = MapConfidence(parsed.Date.Confidence),
 			Items = parsed.Items.Select(MapItem).ToList(),
@@ -107,6 +111,13 @@ public class ReceiptScanController(
 			TotalConfidence = MapConfidence(parsed.Total.Confidence),
 			PaymentMethod = parsed.PaymentMethod.Value,
 			PaymentMethodConfidence = MapConfidence(parsed.PaymentMethod.Confidence),
+			Payments = parsed.Payments.Select(MapPayment).ToList(),
+			ReceiptId = parsed.ReceiptId.Value,
+			ReceiptIdConfidence = MapConfidence(parsed.ReceiptId.Confidence),
+			StoreNumber = parsed.StoreNumber.Value,
+			StoreNumberConfidence = MapConfidence(parsed.StoreNumber.Confidence),
+			TerminalId = parsed.TerminalId.Value,
+			TerminalIdConfidence = MapConfidence(parsed.TerminalId.Confidence),
 		};
 	}
 
@@ -124,6 +135,8 @@ public class ReceiptScanController(
 			UnitPriceConfidence = MapConfidence(item.UnitPrice.Confidence),
 			TotalPrice = ToNullableDouble(item.TotalPrice.Value),
 			TotalPriceConfidence = MapConfidence(item.TotalPrice.Confidence),
+			TaxCode = item.TaxCode.Value,
+			TaxCodeConfidence = MapConfidence(item.TaxCode.Confidence),
 		};
 	}
 
@@ -135,6 +148,19 @@ public class ReceiptScanController(
 			LabelConfidence = MapConfidence(taxLine.Label.Confidence),
 			Amount = ToNullableDouble(taxLine.Amount.Value),
 			AmountConfidence = MapConfidence(taxLine.Amount.Confidence),
+		};
+	}
+
+	private static ProposedPaymentResponse MapPayment(ParsedPayment payment)
+	{
+		return new ProposedPaymentResponse
+		{
+			Method = payment.Method.Value,
+			MethodConfidence = MapConfidence(payment.Method.Confidence),
+			Amount = ToNullableDouble(payment.Amount.Value),
+			AmountConfidence = MapConfidence(payment.Amount.Confidence),
+			LastFour = payment.LastFour.Value,
+			LastFourConfidence = MapConfidence(payment.LastFour.Confidence),
 		};
 	}
 

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -3115,6 +3115,10 @@ export interface components {
         ProposedReceiptResponse: {
             storeName?: string | null;
             storeNameConfidence: components["schemas"]["ConfidenceLevel"];
+            storeAddress?: string | null;
+            storeAddressConfidence: components["schemas"]["ConfidenceLevel"];
+            storePhone?: string | null;
+            storePhoneConfidence: components["schemas"]["ConfidenceLevel"];
             /** Format: date */
             date?: string | null;
             dateConfidence: components["schemas"]["ConfidenceLevel"];
@@ -3128,6 +3132,13 @@ export interface components {
             totalConfidence: components["schemas"]["ConfidenceLevel"];
             paymentMethod?: string | null;
             paymentMethodConfidence: components["schemas"]["ConfidenceLevel"];
+            payments: components["schemas"]["ProposedPaymentResponse"][];
+            receiptId?: string | null;
+            receiptIdConfidence: components["schemas"]["ConfidenceLevel"];
+            storeNumber?: string | null;
+            storeNumberConfidence: components["schemas"]["ConfidenceLevel"];
+            terminalId?: string | null;
+            terminalIdConfidence: components["schemas"]["ConfidenceLevel"];
         };
         ProposedReceiptItemResponse: {
             code?: string | null;
@@ -3143,6 +3154,8 @@ export interface components {
             /** Format: double */
             totalPrice?: number | null;
             totalPriceConfidence: components["schemas"]["ConfidenceLevel"];
+            taxCode?: string | null;
+            taxCodeConfidence: components["schemas"]["ConfidenceLevel"];
         };
         ProposedTaxLineResponse: {
             label?: string | null;
@@ -3150,6 +3163,15 @@ export interface components {
             /** Format: double */
             amount?: number | null;
             amountConfidence: components["schemas"]["ConfidenceLevel"];
+        };
+        ProposedPaymentResponse: {
+            method?: string | null;
+            methodConfidence: components["schemas"]["ConfidenceLevel"];
+            /** Format: double */
+            amount?: number | null;
+            amountConfidence: components["schemas"]["ConfidenceLevel"];
+            lastFour?: string | null;
+            lastFourConfidence: components["schemas"]["ConfidenceLevel"];
         };
         CreateCompleteReceiptRequest: {
             receipt: components["schemas"]["CreateReceiptRequest"];

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -314,9 +314,50 @@ public class OllamaReceiptExtractionServiceTests
 		merged[0].Description.Should().Be("BANANAS");
 		merged[0].Quantity.Should().Be(2.460m);
 		merged[0].UnitPrice.Should().Be(0.50m);
+		merged[0].TaxCode.Should().Be("N");
 		merged[1].Description.Should().Be("BANANAS");
 		merged[1].Quantity.Should().Be(2.720m);
 		merged[1].UnitPrice.Should().Be(0.50m);
+		merged[1].TaxCode.Should().Be("N");
+	}
+
+	[Fact]
+	public void MergeWeightSublines_ParentMissingTaxCode_AbsorbsFromSubline()
+	{
+		// Arrange — defensive: if the VLM echoes taxCode on the sub-line but not on the
+		// parent, the merge must preserve it. Without this, the merged item drops the code
+		// entirely now that MapItem reads ParsedReceiptItem.TaxCode.
+		List<VlmReceiptItem> items =
+		[
+			new() { Description = "BANANAS", Code = "000000004011", LineTotal = 1.23m, Quantity = null, UnitPrice = null, TaxCode = null },
+			new() { Description = "2.460 lb. @ 1 lb. /0.50", Code = null, LineTotal = 1.23m, Quantity = 2.460m, UnitPrice = 0.50m, TaxCode = "N" },
+		];
+
+		// Act
+		List<VlmReceiptItem> merged = OllamaReceiptExtractionService.MergeWeightSublines(items);
+
+		// Assert — sub-line is absorbed; parent inherits the tax code
+		merged.Should().HaveCount(1);
+		merged[0].TaxCode.Should().Be("N");
+	}
+
+	[Fact]
+	public void MergeWeightSublines_ParentHasTaxCode_WinsOverSubline()
+	{
+		// Arrange — parent populated, sub-line disagrees. Parent wins because the tax-code
+		// marker sits next to the parent line on the physical receipt.
+		List<VlmReceiptItem> items =
+		[
+			new() { Description = "BANANAS", Code = "000000004011", LineTotal = 1.23m, Quantity = null, UnitPrice = null, TaxCode = "N" },
+			new() { Description = "2.460 lb. @ 1 lb. /0.50", Code = null, LineTotal = 1.23m, Quantity = 2.460m, UnitPrice = 0.50m, TaxCode = "T" },
+		];
+
+		// Act
+		List<VlmReceiptItem> merged = OllamaReceiptExtractionService.MergeWeightSublines(items);
+
+		// Assert — parent's taxCode is preserved
+		merged.Should().HaveCount(1);
+		merged[0].TaxCode.Should().Be("N");
 	}
 
 	[Fact]

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -114,16 +114,24 @@ public class OllamaReceiptExtractionServiceTests
 		receipt.Date.Value.Should().Be(new DateOnly(2026, 1, 14));
 		receipt.Date.Confidence.Should().Be(ConfidenceLevel.High);
 
+		receipt.StoreAddress.Value.Should().Be("9 BENTON RD, TRAVELERS REST SC 29690");
+		receipt.StoreAddress.Confidence.Should().Be(ConfidenceLevel.High);
+		receipt.StorePhone.Value.Should().Be("864-834-7179");
+		receipt.StorePhone.Confidence.Should().Be(ConfidenceLevel.High);
+
 		receipt.Items.Should().HaveCount(2);
 		receipt.Items[0].Code.Value.Should().Be("078742228030");
 		receipt.Items[0].Description.Value.Should().Be("GRANULATED");
 		receipt.Items[0].Quantity.Confidence.Should().Be(ConfidenceLevel.Low);
 		receipt.Items[0].UnitPrice.Confidence.Should().Be(ConfidenceLevel.Low);
 		receipt.Items[0].TotalPrice.Value.Should().Be(3.07m);
+		receipt.Items[0].TaxCode.Value.Should().Be("F");
+		receipt.Items[0].TaxCode.Confidence.Should().Be(ConfidenceLevel.High);
 
 		receipt.Items[1].Quantity.Value.Should().Be(2.46m);
 		receipt.Items[1].UnitPrice.Value.Should().Be(0.50m);
 		receipt.Items[1].TotalPrice.Value.Should().Be(1.23m);
+		receipt.Items[1].TaxCode.Value.Should().Be("N");
 
 		receipt.Subtotal.Value.Should().Be(69.68m);
 		receipt.TaxLines.Should().HaveCount(1);
@@ -132,6 +140,19 @@ public class OllamaReceiptExtractionServiceTests
 		receipt.Total.Value.Should().Be(70.43m);
 		receipt.PaymentMethod.Value.Should().Be("MASTERCARD");
 		receipt.PaymentMethod.Confidence.Should().Be(ConfidenceLevel.High);
+
+		receipt.Payments.Should().HaveCount(1);
+		receipt.Payments[0].Method.Value.Should().Be("MASTERCARD");
+		receipt.Payments[0].Amount.Value.Should().Be(70.43m);
+		receipt.Payments[0].LastFour.Value.Should().Be("3409");
+		receipt.Payments[0].LastFour.Confidence.Should().Be(ConfidenceLevel.High);
+
+		receipt.ReceiptId.Value.Should().Be("7QKKG1XDWPD");
+		receipt.ReceiptId.Confidence.Should().Be(ConfidenceLevel.High);
+		receipt.StoreNumber.Value.Should().Be("05487");
+		receipt.StoreNumber.Confidence.Should().Be(ConfidenceLevel.High);
+		receipt.TerminalId.Value.Should().Be("54731105");
+		receipt.TerminalId.Confidence.Should().Be(ConfidenceLevel.High);
 	}
 
 	[Theory]
@@ -325,10 +346,11 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	[Fact]
-	public async Task ExtractAsync_MultiPayment_TakesFirstMethod()
+	public async Task ExtractAsync_MultiPayment_PreservesAllPayments()
 	{
-		// Arrange — split tender (gift card + card). V1 ParsedReceipt can only carry one method;
-		// we pick the first that has a non-empty method string.
+		// Arrange — split tender (gift card + card). The legacy PaymentMethod field picks
+		// the first non-empty method for backward compatibility, but the Payments list must
+		// carry every tender with its amount and last-four for downstream reconciliation.
 		string innerJson = """
 			{
 			  "store": { "name": "Walmart" },
@@ -344,9 +366,21 @@ public class OllamaReceiptExtractionServiceTests
 		// Act
 		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
 
-		// Assert
+		// Assert — legacy field keeps the first method
 		receipt.PaymentMethod.Value.Should().Be("GIFT CARD");
 		receipt.PaymentMethod.Confidence.Should().Be(ConfidenceLevel.High);
+
+		// Assert — full Payments list is preserved in order
+		receipt.Payments.Should().HaveCount(2);
+		receipt.Payments[0].Method.Value.Should().Be("GIFT CARD");
+		receipt.Payments[0].Amount.Value.Should().Be(10.00m);
+		receipt.Payments[0].Amount.Confidence.Should().Be(ConfidenceLevel.High);
+		receipt.Payments[0].LastFour.Value.Should().BeNull();
+		receipt.Payments[0].LastFour.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.Payments[1].Method.Value.Should().Be("VISA");
+		receipt.Payments[1].Amount.Value.Should().Be(30.00m);
+		receipt.Payments[1].LastFour.Value.Should().Be("1234");
+		receipt.Payments[1].LastFour.Confidence.Should().Be(ConfidenceLevel.High);
 	}
 
 	[Fact]
@@ -366,8 +400,72 @@ public class OllamaReceiptExtractionServiceTests
 
 		// Assert
 		receipt.StoreName.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.StoreAddress.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.StoreAddress.Value.Should().BeNull();
+		receipt.StorePhone.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.StorePhone.Value.Should().BeNull();
 		receipt.Date.Value.Should().Be(new DateOnly(2026, 4, 1));
 		receipt.Total.Value.Should().Be(10.00m);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_MissingIdentifiersAndPayments_YieldNoneConfidenceAndEmptyList()
+	{
+		// Arrange — receiptId/storeNumber/terminalId are all commonly missing on smaller
+		// independent-store receipts, and a receipt with no payments block should yield an
+		// empty Payments list rather than throwing.
+		string innerJson = """
+			{
+			  "store": { "name": "Corner Market" },
+			  "datetime": "2026-04-01",
+			  "total": 3.99
+			}
+			""";
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
+
+		// Act
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		receipt.ReceiptId.Value.Should().BeNull();
+		receipt.ReceiptId.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.StoreNumber.Value.Should().BeNull();
+		receipt.StoreNumber.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.TerminalId.Value.Should().BeNull();
+		receipt.TerminalId.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.Payments.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ExtractAsync_PaymentWithMissingMethod_YieldsNoneConfidenceOnThatPaymentMethod()
+	{
+		// Arrange — defensive: if a payment record omits the method but has an amount, we
+		// still include the payment in the list but mark the method as None-confidence so
+		// downstream code can distinguish "truly unknown tender" from legacy-mapper behavior.
+		string innerJson = """
+			{
+			  "store": { "name": "Walmart" },
+			  "total": 15.00,
+			  "payments": [
+			    { "method": null, "amount": 15.00, "lastFour": null }
+			  ]
+			}
+			""";
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
+
+		// Act
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert — the payment is preserved with correct confidence
+		receipt.Payments.Should().HaveCount(1);
+		receipt.Payments[0].Method.Value.Should().BeNull();
+		receipt.Payments[0].Method.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.Payments[0].Amount.Value.Should().Be(15.00m);
+		receipt.Payments[0].Amount.Confidence.Should().Be(ConfidenceLevel.High);
+
+		// Assert — legacy PaymentMethod falls back to None since no method string was found
+		receipt.PaymentMethod.Value.Should().BeNull();
+		receipt.PaymentMethod.Confidence.Should().Be(ConfidenceLevel.Low);
 	}
 
 	[Fact]

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
@@ -202,6 +202,9 @@ public class ReceiptScanControllerTests
 					FieldConfidence<decimal>.High(1m),
 					FieldConfidence<decimal>.High(3.49m),
 					FieldConfidence<decimal>.High(3.49m))
+				{
+					TaxCode = FieldConfidence<string?>.High("N"),
+				}
 			],
 			FieldConfidence<decimal>.Medium(3.49m),
 			[
@@ -211,7 +214,21 @@ public class ReceiptScanControllerTests
 			],
 			FieldConfidence<decimal>.High(3.74m),
 			FieldConfidence<string?>.Low("VISA")
-		);
+		)
+		{
+			StoreAddress = FieldConfidence<string?>.High("9 BENTON RD, TRAVELERS REST SC 29690"),
+			StorePhone = FieldConfidence<string?>.High("864-834-7179"),
+			Payments =
+			[
+				new ParsedPayment(
+					FieldConfidence<string?>.High("VISA"),
+					FieldConfidence<decimal?>.High(3.74m),
+					FieldConfidence<string?>.High("1234")),
+			],
+			ReceiptId = FieldConfidence<string?>.High("7QKKG1XDWPD"),
+			StoreNumber = FieldConfidence<string?>.High("05487"),
+			TerminalId = FieldConfidence<string?>.High("54731105"),
+		};
 
 		ScanReceiptResult scanResult = new(parsedReceipt);
 
@@ -228,11 +245,17 @@ public class ReceiptScanControllerTests
 
 		response.StoreName.Should().Be("WALMART");
 		response.StoreNameConfidence.Should().Be(DtoConfidenceLevel.High);
+		response.StoreAddress.Should().Be("9 BENTON RD, TRAVELERS REST SC 29690");
+		response.StoreAddressConfidence.Should().Be(DtoConfidenceLevel.High);
+		response.StorePhone.Should().Be("864-834-7179");
+		response.StorePhoneConfidence.Should().Be(DtoConfidenceLevel.High);
 		response.Date.Should().Be(new DateOnly(2026, 3, 15));
 		response.DateConfidence.Should().Be(DtoConfidenceLevel.Medium);
 		response.Items.Should().HaveCount(1);
 		response.Items.First().Description.Should().Be("MILK 2%");
 		response.Items.First().TotalPrice.Should().Be(3.49d);
+		response.Items.First().TaxCode.Should().Be("N");
+		response.Items.First().TaxCodeConfidence.Should().Be(DtoConfidenceLevel.High);
 		response.Subtotal.Should().Be(3.49d);
 		response.TaxLines.Should().HaveCount(1);
 		response.TaxLines.First().Label.Should().Be("TAX");
@@ -240,6 +263,66 @@ public class ReceiptScanControllerTests
 		response.Total.Should().Be(3.74d);
 		response.TotalConfidence.Should().Be(DtoConfidenceLevel.High);
 		response.PaymentMethod.Should().Be("VISA");
+		response.Payments.Should().HaveCount(1);
+		response.Payments.First().Method.Should().Be("VISA");
+		response.Payments.First().Amount.Should().Be(3.74d);
+		response.Payments.First().LastFour.Should().Be("1234");
+		response.Payments.First().LastFourConfidence.Should().Be(DtoConfidenceLevel.High);
+		response.ReceiptId.Should().Be("7QKKG1XDWPD");
+		response.ReceiptIdConfidence.Should().Be(DtoConfidenceLevel.High);
+		response.StoreNumber.Should().Be("05487");
+		response.StoreNumberConfidence.Should().Be(DtoConfidenceLevel.High);
+		response.TerminalId.Should().Be("54731105");
+		response.TerminalIdConfidence.Should().Be(DtoConfidenceLevel.High);
+	}
+
+	[Fact]
+	public async Task ScanReceipt_MultiPayment_ReturnsAllPaymentsInResponse()
+	{
+		// Arrange — split-tender receipt (gift card + card). The response must carry both
+		// payments so downstream code can reconcile per-tender amounts.
+		IFormFile file = CreateMockFormFile("receipt.jpg", "image/jpeg", 2048);
+
+		ParsedReceipt parsedReceipt = new(
+			FieldConfidence<string>.High("WALMART"),
+			FieldConfidence<DateOnly>.High(new DateOnly(2026, 3, 15)),
+			[],
+			FieldConfidence<decimal>.High(40m),
+			[],
+			FieldConfidence<decimal>.High(40m),
+			FieldConfidence<string?>.High("GIFT CARD")
+		)
+		{
+			Payments =
+			[
+				new ParsedPayment(
+					FieldConfidence<string?>.High("GIFT CARD"),
+					FieldConfidence<decimal?>.High(10m),
+					FieldConfidence<string?>.None()),
+				new ParsedPayment(
+					FieldConfidence<string?>.High("VISA"),
+					FieldConfidence<decimal?>.High(30m),
+					FieldConfidence<string?>.High("1234")),
+			],
+		};
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<ScanReceiptCommand>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ScanReceiptResult(parsedReceipt));
+
+		// Act
+		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
+
+		// Assert
+		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
+		response.Payments.Should().HaveCount(2);
+		response.Payments.ElementAt(0).Method.Should().Be("GIFT CARD");
+		response.Payments.ElementAt(0).Amount.Should().Be(10d);
+		response.Payments.ElementAt(0).LastFour.Should().BeNull();
+		response.Payments.ElementAt(0).LastFourConfidence.Should().Be(DtoConfidenceLevel.Low);
+		response.Payments.ElementAt(1).Method.Should().Be("VISA");
+		response.Payments.ElementAt(1).Amount.Should().Be(30d);
+		response.Payments.ElementAt(1).LastFour.Should().Be("1234");
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

- Extends `ParsedReceipt` / `ParsedReceiptItem` with the fields the VLM already returns but the Application-layer mapper was dropping: `storeAddress`, `storePhone`, full `payments` list (with method/amount/lastFour), `receiptId`, `storeNumber`, `terminalId`, and per-item `taxCode`.
- Adds the matching OpenAPI schema + DTO changes so `ProposedReceiptResponse` carries the new fields end-to-end. `ProposedPaymentResponse` is a new schema; TS types regenerated.
- `OllamaReceiptExtractionService` and `ReceiptScanController` updated to populate / propagate the new fields. Multi-payment receipts now surface every tender instead of only `payments[0].method`.
- Tests extended: happy-path asserts every new field, multi-payment test verifies the full `Payments` list, added missing-identifier + payment-with-null-method coverage; controller test covers the full response shape including a split-tender scenario.

Resolves RECEIPTS-626.

## Stacking

**This PR is stacked on #483 (RECEIPTS-625).** It targets `feat/receipts-625-vlm-schema-v3`, not `main`. Merge #483 first — the rich VLM payload types (`VlmStore.Address`, `VlmReceiptPayload.ReceiptId`, `VlmPayment`, etc.) this PR consumes land in #483.

## Design notes

- `ParsedReceipt` / `ParsedReceiptItem` remain positional records. The new fields are **init-only properties with None-confidence defaults**, so existing callers of `new ParsedReceipt(...)` (tests, the VLM-eval fixture harness, the command handler) stay source-compatible without touching every call site.
- The legacy `PaymentMethod` (single-string) is kept populated with the first non-empty method for backward compatibility; new consumers should prefer the `Payments` list.
- No frontend UX changes — the scan-review wizard does not yet surface these fields. Filed **RECEIPTS-628** as a follow-up to add the UI plumbing. Backend plumbing ships first so the UX work can make focused decisions (per-payment editing UX, tax-code dropdown vs raw string, read-only vs editable identifier metadata).

## Assumptions

- Kept the `storeName` / `storeAddress` / `storePhone` split at the top level rather than introducing a nested `ParsedStore` sub-record. Consistent with the existing flat shape where `StoreName` sits at the top.
- `ParsedPayment.Amount` is `FieldConfidence<decimal?>` (nullable `decimal`) to preserve the distinction between "amount not printed" and "amount was zero."
- No changes to the fixture-eval tool (`src/Tools/VlmEval/`) — it still diffs on store-name / date / total / tax-lines / payment-method / items, which all still exist. Expanding it to cover the new fields is out of scope and can be a follow-up if we want regression coverage on address/phone/taxCode accuracy.

## Test plan

- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2,278 tests pass
- [x] Spec lint: `npm run lint:spec` — clean
- [x] Drift check: `npm run check:drift` — no drift
- [x] Breaking check vs base: `node scripts/check-breaking.mjs origin/feat/receipts-625-vlm-schema-v3` — additive only, no breaking changes
- [x] TS types regenerated, `tsc -b` clean, client vitest suite 1,842 tests pass