### PR TITLE
feat(infrastructure): rasterize first pdf page for vlm extraction

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,6 +51,8 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="PdfPig" Version="0.1.14" />
+    <PackageVersion Include="PDFtoImage" Version="5.2.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
   </ItemGroup>
 </Project>

--- a/src/Application/Interfaces/Services/IPdfConversionService.cs
+++ b/src/Application/Interfaces/Services/IPdfConversionService.cs
@@ -9,10 +9,11 @@ public record PdfMetadata(string? Title, DateOnly? CreationDate);
 /// Result of converting a PDF document for OCR processing.
 /// </summary>
 /// <param name="PageImages">
-/// Embedded page images extracted from the PDF, independent of whether a text layer
-/// exists. Small decorative images (logos, icons) are filtered out so that only
-/// receipt-sized scans are returned. Empty when the PDF has no embedded bitmaps large
-/// enough to be a receipt scan.
+/// The rasterized first page of the PDF as a PNG byte array. Always contains exactly one
+/// entry when <see cref="IPdfConversionService.ConvertAsync"/> returns successfully —
+/// the first page is rendered regardless of whether the PDF contains embedded raster
+/// images, vector graphics, or only a text layer. The scan command handler consumes
+/// only this first image.
 /// </param>
 /// <param name="ExtractedText">
 /// Text extracted directly from the PDF text layer, if available.
@@ -37,9 +38,9 @@ public interface IPdfConversionService
 	const int MaxPages = 50;
 
 	/// <summary>
-	/// Converts a PDF to images and/or extracts text.
-	/// If the PDF has a text layer, returns extracted text directly.
-	/// If the PDF contains only images, extracts them for OCR processing.
+	/// Rasterizes the first page of the PDF to a PNG and optionally extracts the text
+	/// layer. The PNG is always produced (even for vector-only or text-only PDFs) so
+	/// that downstream VLM/OCR processing always has a usable image.
 	/// </summary>
 	Task<PdfConversionResult> ConvertAsync(byte[] pdfBytes, CancellationToken ct);
 }

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -37,6 +37,8 @@
     <PackageReference Include="Riok.Mapperly" />
     <PackageReference Include="SixLabors.ImageSharp" />
     <PackageReference Include="PdfPig" />
+    <PackageReference Include="PDFtoImage" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Infrastructure/Services/PdfConversionService.cs
+++ b/src/Infrastructure/Services/PdfConversionService.cs
@@ -1,12 +1,8 @@
 using Application.Interfaces.Services;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.PixelFormats;
+using PDFtoImage;
 using UglyToad.PdfPig;
 using UglyToad.PdfPig.Content;
-using UglyToad.PdfPig.Graphics.Colors;
 
 namespace Infrastructure.Services;
 
@@ -19,23 +15,18 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 	internal const int MinTextLengthPerPage = 10;
 
 	/// <summary>
-	/// Maximum pixel dimension (width or height) for images created from raw pixel data.
-	/// Matches the cap in <see cref="ImageValidationService"/>.
+	/// DPI used when rasterizing the first PDF page for VLM/OCR consumption. 200 DPI is the
+	/// baseline recommended by the rasterization issue (RECEIPTS-624) — high enough for
+	/// legible receipt text, low enough to keep memory/bandwidth reasonable. Tune via
+	/// fixture set if extraction quality regresses.
 	/// </summary>
-	private const int MaxImageDimension = 10_000;
+	internal const int RasterizationDpi = 200;
 
 	/// <summary>
-	/// Minimum pixel dimension (width and height) for an embedded image to be considered
-	/// a candidate receipt scan. Decorative images on text-layer pages (logos, icons,
-	/// background marks) are typically well under this threshold; Paperless-style scans
-	/// and phone-camera photos are always far above it.
+	/// Zero-based index of the PDF page to rasterize for receipt extraction. The scan
+	/// command handler only consumes the first page image, so only page 0 is rendered.
 	/// </summary>
-	internal const int MinReceiptImageDimension = 400;
-
-	/// <summary>
-	/// Maximum total accumulated image bytes (100 MB) before we stop extracting images.
-	/// </summary>
-	private const long MaxTotalImageBytes = 100 * 1024 * 1024;
+	private const int RasterizePageIndex = 0;
 
 	/// <summary>
 	/// PDF magic bytes: <c>%PDF</c> (0x25 0x50 0x44 0x46).
@@ -70,11 +61,14 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 				"The uploaded file is not a valid PDF or is corrupted.", ex);
 		}
 
+		int pageCount;
+		PdfMetadata? metadata;
+		string? extractedText;
 		using (document)
 		{
 			try
 			{
-				return ProcessDocument(document, ct);
+				(pageCount, metadata, extractedText) = ProcessDocumentMetadataAndText(document, ct);
 			}
 			catch (InvalidOperationException)
 			{
@@ -90,9 +84,32 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 					"An error occurred while processing the PDF document.", ex);
 			}
 		}
+
+		ct.ThrowIfCancellationRequested();
+
+		// Always rasterize the first page so the VLM always gets a usable image, even for
+		// vector-only or text-only PDFs (emailed POS receipts, scanner-app exports,
+		// invoicing-tool PDFs) that have no embedded raster images. This replaces the old
+		// embedded-image extraction path, which failed for vector PDFs with
+		// "no extractable images" and produced a 422 at the scan endpoint.
+		byte[] firstPagePng = RasterizeFirstPage(pdfBytes);
+
+		logger.LogInformation(
+			"Rasterized first PDF page at {Dpi} DPI ({PngSize} bytes) for VLM extraction (document has {PageCount} page(s))",
+			RasterizationDpi, firstPagePng.Length, pageCount);
+
+		if (extractedText is not null)
+		{
+			logger.LogDebug(
+				"Extracted text layer from PDF ({TextLength} chars); retained as informational only",
+				extractedText.Length);
+		}
+
+		return Task.FromResult(new PdfConversionResult([firstPagePng], extractedText, metadata));
 	}
 
-	private Task<PdfConversionResult> ProcessDocument(PdfDocument document, CancellationToken ct)
+	private (int PageCount, PdfMetadata? Metadata, string? ExtractedText) ProcessDocumentMetadataAndText(
+		PdfDocument document, CancellationToken ct)
 	{
 		if (document.NumberOfPages == 0)
 		{
@@ -107,14 +124,10 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 
 		PdfMetadata? metadata = ExtractMetadata(document);
 
-		// Always collect both text and images from every page. Consumers (the scan command
-		// handler) use the images for VLM-based extraction; the text layer is kept as an
-		// optional informational field that is no longer consumed on the scan path.
+		// Collect text from every page for informational purposes. The scan command path
+		// no longer consumes this — rasterized pixels are the source of truth — but the
+		// text layer is retained for logging and potential future use.
 		List<string> pageTexts = [];
-		List<byte[]> pageImages = [];
-		long totalImageBytes = 0;
-		bool imageBytesCapReached = false;
-
 		foreach (Page page in document.GetPages())
 		{
 			ct.ThrowIfCancellationRequested();
@@ -124,72 +137,46 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 			{
 				pageTexts.Add(pageText);
 			}
-
-			if (imageBytesCapReached)
-			{
-				continue;
-			}
-
-			foreach (IPdfImage image in page.GetImages())
-			{
-				ct.ThrowIfCancellationRequested();
-
-				if (imageBytesCapReached)
-				{
-					break;
-				}
-
-				// Skip decorative images (logos, icons) on text-layer pages. A real
-				// receipt scan is always at least ~400px on a side; logos rarely exceed
-				// a couple hundred pixels.
-				if (image.WidthInSamples < MinReceiptImageDimension
-					|| image.HeightInSamples < MinReceiptImageDimension)
-				{
-					continue;
-				}
-
-				byte[]? imageBytes = TryExtractImageBytes(image);
-				if (imageBytes is null)
-				{
-					continue;
-				}
-
-				totalImageBytes += imageBytes.Length;
-				if (totalImageBytes > MaxTotalImageBytes)
-				{
-					logger.LogWarning(
-						"Accumulated image bytes ({TotalBytes}) exceeded cap of {MaxBytes}; stopping image extraction",
-						totalImageBytes, MaxTotalImageBytes);
-					imageBytesCapReached = true;
-					break;
-				}
-
-				pageImages.Add(imageBytes);
-			}
-		}
-
-		if (pageImages.Count == 0 && pageTexts.Count == 0)
-		{
-			throw new InvalidOperationException(
-				"The PDF document contains no readable text and no extractable images.");
 		}
 
 		string? combinedText = pageTexts.Count > 0 ? string.Join("\n\n", pageTexts) : null;
+		return (document.NumberOfPages, metadata, combinedText);
+	}
 
-		if (pageImages.Count > 0)
+	// PDFtoImage targets Android/iOS/Linux/macCatalyst/macOS/Windows — all platforms we
+	// deploy to (Docker/Linux, macOS/Windows dev) or target on mobile. The CA1416
+	// analyzer can't prove at the call site that we'll only run on these platforms, so
+	// suppress the warning for this helper.
+	[System.Diagnostics.CodeAnalysis.SuppressMessage(
+		"Interoperability",
+		"CA1416:Validate platform compatibility",
+		Justification = "PDFtoImage supports all platforms this application runs on (Linux, macOS, Windows).")]
+	private byte[] RasterizeFirstPage(byte[] pdfBytes)
+	{
+		try
 		{
-			logger.LogInformation(
-				"Extracted {ImageCount} images from PDF for OCR processing",
-				pageImages.Count);
+			using MemoryStream ms = new();
+			Conversion.SavePng(
+				ms,
+				pdfBytes,
+				page: RasterizePageIndex,
+				password: null,
+				options: new RenderOptions(Dpi: RasterizationDpi));
+			return ms.ToArray();
 		}
-		if (combinedText is not null)
+		catch (Exception ex) when (IsPasswordProtectedException(ex))
 		{
-			logger.LogInformation(
-				"Extracted text from {PageCount} PDF pages ({TextLength} chars)",
-				pageTexts.Count, combinedText.Length);
+			// PdfPig usually catches password-protected PDFs earlier, but PDFium may detect
+			// it here for files that opened cleanly in PdfPig but encrypt their content
+			// streams. Surface the same error either way.
+			throw new InvalidOperationException(
+				"Password-protected PDFs are not supported.", ex);
 		}
-
-		return Task.FromResult(new PdfConversionResult(pageImages, combinedText, metadata));
+		catch (Exception ex)
+		{
+			throw new InvalidOperationException(
+				"Failed to rasterize the first page of the PDF document.", ex);
+		}
 	}
 
 	private PdfMetadata? ExtractMetadata(PdfDocument document)
@@ -216,94 +203,6 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 		catch (Exception ex)
 		{
 			logger.LogDebug(ex, "Failed to extract PDF metadata");
-			return null;
-		}
-	}
-
-	private byte[]? TryExtractImageBytes(IPdfImage image)
-	{
-		try
-		{
-			// Try to get the raw image bytes
-			if (!image.TryGetPng(out byte[]? pngBytes) || pngBytes is null)
-			{
-				// Fall back to raw bytes and try to interpret them
-				byte[] rawBytes = image.RawBytes.ToArray();
-				if (rawBytes.Length == 0)
-				{
-					return null;
-				}
-
-				// Try to load as an image to validate
-				try
-				{
-					IImageFormat? format = Image.DetectFormat(rawBytes);
-					if (format is not null)
-					{
-						return rawBytes;
-					}
-				}
-				catch
-				{
-					// Not a valid image format
-				}
-
-				// For non-standard color spaces, try to create an image from raw pixel data
-				if (image.WidthInSamples > 0 && image.HeightInSamples > 0 &&
-					image.ColorSpaceDetails?.BaseType == ColorSpace.DeviceRGB)
-				{
-					return TryCreatePngFromRawPixels(
-						rawBytes, (int)image.WidthInSamples, (int)image.HeightInSamples);
-				}
-
-				return null;
-			}
-
-			return pngBytes;
-		}
-		catch (Exception ex)
-		{
-			logger.LogDebug(ex, "Failed to extract image from PDF page");
-			return null;
-		}
-	}
-
-	private static byte[]? TryCreatePngFromRawPixels(byte[] rawBytes, int width, int height)
-	{
-		// Reject dimensions that would cause excessive memory allocation
-		if (width > MaxImageDimension || height > MaxImageDimension)
-		{
-			return null;
-		}
-
-		int expectedLength = width * height * 3; // RGB
-		if (rawBytes.Length < expectedLength)
-		{
-			return null;
-		}
-
-		try
-		{
-			using Image<Rgb24> image = new(width, height);
-			image.ProcessPixelRows(accessor =>
-			{
-				for (int y = 0; y < height; y++)
-				{
-					Span<Rgb24> row = accessor.GetRowSpan(y);
-					for (int x = 0; x < width; x++)
-					{
-						int offset = (y * width + x) * 3;
-						row[x] = new Rgb24(rawBytes[offset], rawBytes[offset + 1], rawBytes[offset + 2]);
-					}
-				}
-			});
-
-			using MemoryStream ms = new();
-			image.Save(ms, new PngEncoder());
-			return ms.ToArray();
-		}
-		catch
-		{
 			return null;
 		}
 	}

--- a/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
@@ -32,7 +32,7 @@ public class ReceiptScanController(
 	[HttpPost("scan")]
 	[RequestSizeLimit(20 * 1024 * 1024)]
 	[EndpointSummary("Scan a receipt image or PDF and return a proposed receipt")]
-	[EndpointDescription("Accepts a JPEG or PNG image, or a PDF document. Images are sent directly to the receipt extraction service (a local vision-language model). PDFs are rasterized page-by-page and the first page image is extracted. Returns a proposed receipt with per-field confidence scores. The proposal is NOT persisted.")]
+	[EndpointDescription("Accepts a JPEG or PNG image, or a PDF document. Images are sent directly to the receipt extraction service (a local vision-language model). PDFs have their first page rasterized to a PNG at 200 DPI; the rendered image is then sent to the VLM. Additional pages are ignored. Returns a proposed receipt with per-field confidence scores. The proposal is NOT persisted.")]
 	[ProducesResponseType(StatusCodes.Status415UnsupportedMediaType)]
 	public async Task<Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>>> ScanReceipt(
 		IFormFile? file,

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
@@ -24,10 +24,13 @@ public class PdfConversionServiceTests
 	}
 
 	[Fact]
-	public async Task ConvertAsync_PdfWithTextLayer_ReturnsExtractedText()
+	public async Task ConvertAsync_PdfWithTextLayer_RasterizesFirstPageAndExtractsText()
 	{
 		// Arrange — PdfDocumentBuilder doesn't support newlines in AddText,
-		// so we use a single line of sufficient length
+		// so we use a single line of sufficient length. This is the vector-only case:
+		// no embedded raster images, only text glyphs as vector outlines. Before
+		// RECEIPTS-624 this produced an empty PageImages list and /api/receipts/scan
+		// returned 422. Now the first page is always rasterized to a PNG.
 		byte[] pdfBytes = CreateTextPdf("WALMART MILK 2% $3.49 TOTAL $3.74");
 
 		// Act
@@ -36,7 +39,26 @@ public class PdfConversionServiceTests
 		// Assert
 		result.ExtractedText.Should().NotBeNullOrWhiteSpace();
 		result.ExtractedText.Should().Contain("WALMART");
-		result.PageImages.Should().BeEmpty();
+		AssertContainsValidPng(result.PageImages);
+	}
+
+	[Fact]
+	public async Task ConvertAsync_VectorOnlyPdf_ProducesRasterizedFirstPageImage()
+	{
+		// Arrange — acceptance criterion for RECEIPTS-624: vector-only PDFs (emailed POS
+		// receipts, scanner-app exports) must succeed. We build a text-only PDF because
+		// PdfDocumentBuilder cannot emit arbitrary vector paths, but the rasterization
+		// code path is the same: PDFium renders glyph outlines to pixels regardless of
+		// whether the page contains raster images.
+		byte[] pdfBytes = CreateTextPdf("Vector PDF receipt content with more than ten characters of text");
+
+		// Act
+		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+
+		// Assert
+		result.PageImages.Should().ContainSingle(
+			"rasterization always produces exactly one first-page image");
+		AssertPngHasDimensions(result.PageImages[0], minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -54,9 +76,12 @@ public class PdfConversionServiceTests
 	}
 
 	[Fact]
-	public async Task ConvertAsync_MultiPagePdf_ConcatenatesText()
+	public async Task ConvertAsync_MultiPagePdf_RasterizesFirstPageOnly()
 	{
-		// Arrange — each page must have text >= MinTextLengthPerPage
+		// Arrange — each page must have text >= MinTextLengthPerPage. The scan command
+		// handler only consumes the first page image, so the converter only rasterizes
+		// page 0 even when the PDF has multiple pages. Text from all pages is still
+		// concatenated and returned as an informational text layer.
 		byte[] pdfBytes = CreateMultiPageTextPdf(
 		[
 			"Page one content from WALMART store",
@@ -67,8 +92,11 @@ public class PdfConversionServiceTests
 		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
+		result.PageImages.Should().ContainSingle(
+			"only the first page is rasterized regardless of total page count");
 		result.ExtractedText.Should().Contain("WALMART");
 		result.ExtractedText.Should().Contain("MILK");
+		AssertPngHasDimensions(result.PageImages[0], minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -131,7 +159,7 @@ public class PdfConversionServiceTests
 	public async Task ConvertAsync_CancellationRequested_ThrowsOperationCanceledException()
 	{
 		// Arrange
-		byte[] pdfBytes = CreateTextPdf("Some text");
+		byte[] pdfBytes = CreateTextPdf("Some text that is sufficiently long to be indexed");
 		CancellationTokenSource cts = new();
 		await cts.CancelAsync();
 
@@ -143,42 +171,27 @@ public class PdfConversionServiceTests
 	}
 
 	[Fact]
-	public async Task ConvertAsync_PdfWithNoTextAndNoImages_ThrowsInvalidOperationException()
+	public async Task ConvertAsync_PdfWithBelowThresholdText_StillRasterizes()
 	{
-		// Arrange — create a PDF with a page that has very little text (below threshold)
+		// Arrange — a PDF whose text layer is below MinTextLengthPerPage. Before
+		// rasterization, this threw "no readable text" because the text was too short
+		// and no embedded raster images existed. Now the rasterized first page is the
+		// usable output regardless of the text layer length — the VLM will read pixels
+		// directly.
 		byte[] pdfBytes = CreateTextPdf("Hi");
-
-		// Act
-		Func<Task> act = () => _service.ConvertAsync(pdfBytes, CancellationToken.None);
-
-		// Assert — "Hi" is only 2 chars, below MinTextLengthPerPage threshold
-		await act.Should().ThrowAsync<InvalidOperationException>()
-			.WithMessage("*no readable text*");
-	}
-
-	[Fact]
-	public async Task ConvertAsync_MixedContentPdf_ReturnsTextFromTextPages()
-	{
-		// Arrange — page 1 has sufficient text, page 2 has very little (below threshold)
-		// This tests the fix for BUG-001: text from text-layer pages should not be
-		// discarded just because other pages lack a text layer.
-		byte[] pdfBytes = CreateMultiPageTextPdf(
-		[
-			"Page one has a valid receipt text WALMART MILK $3.49 TOTAL $3.74",
-			"x" // Below MinTextLengthPerPage threshold
-		]);
 
 		// Act
 		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
-		// Assert — should return the text from page 1, not throw or return images
-		result.ExtractedText.Should().NotBeNullOrWhiteSpace();
-		result.ExtractedText.Should().Contain("WALMART");
-		result.PageImages.Should().BeEmpty();
+		// Assert
+		result.PageImages.Should().ContainSingle();
+		result.ExtractedText.Should().BeNull(
+			"\"Hi\" is below the MinTextLengthPerPage threshold so the text layer is discarded");
+		AssertPngHasDimensions(result.PageImages[0], minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
-	public async Task ConvertAsync_PdfWithSufficientText_ReturnsTextDirectly()
+	public async Task ConvertAsync_PdfWithSufficientText_RasterizesAndReturnsText()
 	{
 		// Arrange — text must be >= MinTextLengthPerPage chars
 		string text = new('A', PdfConversionService.MinTextLengthPerPage + 10);
@@ -189,13 +202,18 @@ public class PdfConversionServiceTests
 
 		// Assert
 		result.ExtractedText.Should().NotBeNullOrWhiteSpace();
-		result.PageImages.Should().BeEmpty();
+		result.PageImages.Should().ContainSingle();
 	}
 
 	[Fact]
-	public async Task ConvertAsync_PdfWithTextLayerAndLargeImage_ExtractsImage()
+	public async Task ConvertAsync_PdfWithTextLayerAndLargeImage_RasterizesFirstPage()
 	{
 		// Arrange — a Paperless-style PDF: text layer (OCR) + large embedded scan image.
+		// Previously the embedded image was extracted directly; now the full rasterized
+		// first page (which includes the embedded image as rendered on the page) is used.
+		// The scan handler gets a PNG with at least the raster image's content plus any
+		// surrounding text. This keeps Paperless-style flows working while unifying the
+		// code path.
 		byte[] pdfBytes = CreateTextPdfWithPng(
 			text: "WALMART SUPERCENTER TOTAL $3.74",
 			imageWidth: 600,
@@ -204,19 +222,22 @@ public class PdfConversionServiceTests
 		// Act
 		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
-		// Assert — text layer is still extracted (informational), but the embedded image
-		// is what the scan handler will use.
-		result.PageImages.Should().NotBeEmpty();
+		// Assert — text layer is still extracted (informational), and the rasterized
+		// first page is what the scan handler will use.
+		result.PageImages.Should().ContainSingle();
 		result.ExtractedText.Should().NotBeNullOrWhiteSpace();
 		result.ExtractedText.Should().Contain("WALMART");
+		AssertPngHasDimensions(result.PageImages[0], minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
-	public async Task ConvertAsync_PdfWithTextLayerAndSmallLogo_FiltersOutDecorativeImage()
+	public async Task ConvertAsync_PdfWithSmallLogoAndText_StillRasterizes()
 	{
-		// Arrange — a digital receipt PDF: text layer + tiny decorative logo. The logo
-		// must NOT be returned because the scan handler would feed it to the VLM and get
-		// nothing back, surfacing as an "extraction failed" error to the user.
+		// Arrange — previously a text+small-logo PDF produced empty PageImages because
+		// the logo was below the 400x400 embedded-image size filter. That caused the scan
+		// handler to throw OcrNoTextException for emailed POS receipts with a tiny store
+		// logo. Now the rasterized first page carries the whole document including the
+		// logo and surrounding text, so the VLM can extract the receipt.
 		byte[] pdfBytes = CreateTextPdfWithPng(
 			text: "WALMART SUPERCENTER TOTAL $3.74",
 			imageWidth: 64,
@@ -226,8 +247,45 @@ public class PdfConversionServiceTests
 		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.PageImages.Should().BeEmpty();
+		result.PageImages.Should().ContainSingle();
 		result.ExtractedText.Should().Contain("WALMART");
+	}
+
+	[Fact]
+	public async Task ConvertAsync_OversizedPdf_ThrowsBeforeRasterization()
+	{
+		// Arrange — build a PDF with one more page than IPdfConversionService.MaxPages
+		// allows. The converter must reject these cleanly before invoking PDFtoImage,
+		// otherwise a hostile or accidental upload could spend rasterization budget on
+		// work we reject anyway.
+		string[] pages = Enumerable
+			.Range(1, IPdfConversionService.MaxPages + 1)
+			.Select(i => $"Page {i} content with enough text to satisfy the threshold")
+			.ToArray();
+		byte[] pdfBytes = CreateMultiPageTextPdf(pages);
+
+		// Act
+		Func<Task> act = () => _service.ConvertAsync(pdfBytes, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*exceeds the maximum*");
+	}
+
+	[Fact]
+	public async Task ConvertAsync_PasswordProtectedPdf_ThrowsInvalidOperationException()
+	{
+		// Arrange — PdfPig can write password-protected PDFs via EncryptionInformation.
+		// PdfDocument.Open will detect the encryption and throw; the service should
+		// translate that into a clean "password-protected PDFs are not supported" error.
+		byte[] pdfBytes = CreatePasswordProtectedPdf("Some encrypted receipt content here");
+
+		// Act
+		Func<Task> act = () => _service.ConvertAsync(pdfBytes, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*Password-protected*");
 	}
 
 	private static byte[] CreateTextPdf(string text)
@@ -235,7 +293,7 @@ public class PdfConversionServiceTests
 		PdfDocumentBuilder builder = new();
 		PdfPageBuilder page = builder.AddPage(PageSize.Letter);
 		PdfDocumentBuilder.AddedFont font = builder.AddStandard14Font(Standard14Font.Helvetica);
-		page.AddText(text, 12, new UglyToad.PdfPig.Core.PdfPoint(72, 720), font);
+		page.AddText(text, 12, new PdfPoint(72, 720), font);
 		return builder.Build();
 	}
 
@@ -244,7 +302,7 @@ public class PdfConversionServiceTests
 		PdfDocumentBuilder builder = new();
 		PdfPageBuilder page = builder.AddPage(PageSize.Letter);
 		PdfDocumentBuilder.AddedFont font = builder.AddStandard14Font(Standard14Font.Helvetica);
-		page.AddText(text, 12, new UglyToad.PdfPig.Core.PdfPoint(72, 720), font);
+		page.AddText(text, 12, new PdfPoint(72, 720), font);
 
 		byte[] pngBytes = CreateSolidPng(imageWidth, imageHeight);
 		page.AddPng(pngBytes, new PdfRectangle(72, 200, 72 + imageWidth, 200 + imageHeight));
@@ -266,7 +324,7 @@ public class PdfConversionServiceTests
 		builder.DocumentInformation.Title = title;
 		PdfPageBuilder page = builder.AddPage(PageSize.Letter);
 		PdfDocumentBuilder.AddedFont font = builder.AddStandard14Font(Standard14Font.Helvetica);
-		page.AddText(text, 12, new UglyToad.PdfPig.Core.PdfPoint(72, 720), font);
+		page.AddText(text, 12, new PdfPoint(72, 720), font);
 		return builder.Build();
 	}
 
@@ -277,7 +335,7 @@ public class PdfConversionServiceTests
 		foreach (string text in pageTexts)
 		{
 			PdfPageBuilder page = builder.AddPage(PageSize.Letter);
-			page.AddText(text, 12, new UglyToad.PdfPig.Core.PdfPoint(72, 720), font);
+			page.AddText(text, 12, new PdfPoint(72, 720), font);
 		}
 		return builder.Build();
 	}
@@ -286,5 +344,58 @@ public class PdfConversionServiceTests
 	{
 		PdfDocumentBuilder builder = new();
 		return builder.Build();
+	}
+
+	private static byte[] CreatePasswordProtectedPdf(string text)
+	{
+		// PdfPig 0.1.x does not expose a write-side encryption API, so we build an
+		// unencrypted PDF and splice an /Encrypt reference into the trailer dictionary.
+		// PdfDocument.Open then reports the document as encrypted — an exception whose
+		// message contains "encryption", which PdfConversionService routes through
+		// IsPasswordProtectedException into the user-facing "Password-protected PDFs are
+		// not supported" error. This exercises the branch without shipping a real
+		// encrypted PDF fixture in the repo.
+		PdfDocumentBuilder builder = new();
+		PdfPageBuilder page = builder.AddPage(PageSize.Letter);
+		PdfDocumentBuilder.AddedFont font = builder.AddStandard14Font(Standard14Font.Helvetica);
+		page.AddText(text, 12, new PdfPoint(72, 720), font);
+		byte[] built = builder.Build();
+
+		string pdf = System.Text.Encoding.Latin1.GetString(built);
+		const string trailerMarker = "trailer\n<<";
+		int trailerIdx = pdf.IndexOf(trailerMarker, StringComparison.Ordinal);
+		if (trailerIdx < 0)
+		{
+			throw new InvalidOperationException(
+				"PdfPig 0.1.x emits 'trailer\\n<<' — if this fixture generator breaks " +
+				"because the trailer format changed, update the splice below.");
+		}
+
+		string patched = pdf.Insert(
+			trailerIdx + trailerMarker.Length,
+			" /Encrypt 99 0 R");
+		return System.Text.Encoding.Latin1.GetBytes(patched);
+	}
+
+	private static void AssertContainsValidPng(IReadOnlyList<byte[]> images)
+	{
+		images.Should().NotBeEmpty();
+		foreach (byte[] png in images)
+		{
+			png.Should().NotBeEmpty();
+			png.Length.Should().BeGreaterThan(8);
+			// PNG magic: 89 50 4E 47 0D 0A 1A 0A
+			png[0].Should().Be(0x89);
+			png[1].Should().Be(0x50);
+			png[2].Should().Be(0x4E);
+			png[3].Should().Be(0x47);
+		}
+	}
+
+	private static void AssertPngHasDimensions(byte[] png, int minWidth, int minHeight)
+	{
+		using Image<Rgba32> img = Image.Load<Rgba32>(png);
+		img.Width.Should().BeGreaterThanOrEqualTo(minWidth);
+		img.Height.Should().BeGreaterThanOrEqualTo(minHeight);
 	}
 }


### PR DESCRIPTION
## Summary

- Vector-only / text-only PDFs (emailed POS receipts, scanner-app exports, invoicing-tool PDFs) previously failed `/api/receipts/scan` with 422 because `PdfConversionService` only extracted embedded raster images >= 400x400 via PdfPig's `page.GetImages()`.
- Switch to [`PDFtoImage`](https://github.com/sungaila/PDFtoImage) (managed, cross-platform, PDFium under the hood) + `SkiaSharp.NativeAssets.Linux.NoDependencies` and always rasterize the first PDF page to a 200 DPI PNG. The scan handler already consumes only the first page image, so only page 0 is rendered — fast and low-memory.
- Text layer is still extracted and returned as informational metadata, but no longer drives the scan path. `PageImages` now always contains exactly one entry: the rasterized first page.
- Endpoint description in `ReceiptScanController` updated to reflect the new behavior (PNG at 200 DPI, additional pages ignored).

Resolves RECEIPTS-624

## Test plan

- [x] Unit tests in `PdfConversionServiceTests.cs` cover:
  - vector/text-only PDF produces a valid rasterized first-page PNG (RECEIPTS-624 acceptance criterion)
  - multi-page PDF rasterizes only page 0 while still concatenating text from all pages
  - PDFs with both text + large embedded image still work (Paperless-style flow)
  - PDFs with text + small logo (previously filtered out) now rasterize the whole page
  - PDF with text below `MinTextLengthPerPage` threshold still produces a usable image
  - oversized PDF (> `MaxPages`) rejects before rasterization
  - password-protected PDF errors cleanly via `IsPasswordProtectedException`
  - invalid magic bytes, empty byte array, cancellation — all existing error paths preserved
- [x] All 2,256 backend unit tests pass
- [x] All 1,842 frontend tests pass
- [x] `dotnet build` with `TreatWarningsAsErrors=true` succeeds (CA1416 suppressed with documented justification — PDFtoImage supports all deployment platforms)
- [x] `dotnet format --verify-no-changes` passes
- [x] OpenAPI drift check passes

## Assumptions / notes

- **DPI baseline: 200** per issue recommendation. This is a tunable constant (`RasterizationDpi`) that can be raised if extraction quality regresses on specific fixtures.
- **Only page 0 is rendered.** The scan handler has always discarded additional pages with a warning log, so this is a no-op behavior change for existing PDFs.
- **`SkiaSharp.NativeAssets.Linux.NoDependencies`** avoids the `libfontconfig1` runtime requirement. PDFium itself is bundled by PDFtoImage as a native asset for each RID.
- **Password-protected test** splices an `/Encrypt` reference into a PdfPig-written trailer because PdfPig 0.1.x does not expose a write-encryption API. If PdfPig's trailer format changes, the helper throws loudly rather than silently passing.
- **Docker runtime** currently ships `libgomp1` + `libgdiplus`. PDFium + SkiaSharp NoDependencies native assets are self-contained and do not require additional apt packages; if production runs surface a missing `.so` we can revisit by adding a targeted library.