### PR TITLE
feat(client): render new receipt fields in scan-review wizard

### DIFF
--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -53,6 +53,21 @@ vi.mock("@/hooks/useReceiptItemSuggestions", () => ({
   ),
 }));
 
+function makeItem(overrides: Partial<ReceiptLineItem> = {}): ReceiptLineItem {
+  return {
+    id: "test-id",
+    receiptItemCode: "",
+    description: "Test",
+    pricingMode: "quantity",
+    quantity: 1,
+    unitPrice: 0,
+    category: "Food",
+    subcategory: "",
+    taxCode: "",
+    ...overrides,
+  };
+}
+
 describe("LineItemsSection", () => {
   const defaultProps = {
     items: [] as ReceiptLineItem[],
@@ -97,6 +112,7 @@ describe("LineItemsSection", () => {
         unitPrice: 3.5,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -119,6 +135,7 @@ describe("LineItemsSection", () => {
         unitPrice: 3.5,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
       {
         id: "2",
@@ -129,6 +146,7 @@ describe("LineItemsSection", () => {
         unitPrice: 4.0,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -152,6 +170,7 @@ describe("LineItemsSection", () => {
         unitPrice: 0.09,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -173,6 +192,7 @@ describe("LineItemsSection", () => {
         unitPrice: 3.5,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -194,6 +214,7 @@ describe("LineItemsSection", () => {
         unitPrice: 5,
         category: "Household",
         subcategory: "Cleaning",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -215,6 +236,7 @@ describe("LineItemsSection", () => {
         unitPrice: 3.5,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -235,6 +257,7 @@ describe("LineItemsSection", () => {
         unitPrice: 3.5,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -263,6 +286,7 @@ describe("LineItemsSection", () => {
         unitPrice: 3.5,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -295,6 +319,7 @@ describe("LineItemsSection", () => {
         unitPrice: 3.5,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -327,6 +352,7 @@ describe("LineItemsSection", () => {
         unitPrice: 3.5,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -357,6 +383,7 @@ describe("LineItemsSection", () => {
         unitPrice: 25,
         category: "Food",
         subcategory: "",
+        taxCode: "",
       },
     ];
     renderWithProviders(
@@ -366,5 +393,120 @@ describe("LineItemsSection", () => {
     await user.click(screen.getByRole("button", { name: /edit/i }));
 
     expect(screen.getByLabelText("Edit quantity")).toBeDisabled();
+  });
+
+  // --- Tax code column tests ---
+
+  it("renders the Tax column header in the items table", () => {
+    const items: ReceiptLineItem[] = [makeItem({ id: "1", description: "Milk" })];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+    expect(
+      screen.getByRole("columnheader", { name: /tax/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("displays the tax code badge for items that have one", () => {
+    const items: ReceiptLineItem[] = [
+      makeItem({ id: "1", description: "Milk", taxCode: "F" }),
+    ];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+    expect(screen.getByText("F")).toBeInTheDocument();
+  });
+
+  it("renders an em-dash placeholder when an item has no tax code", () => {
+    const items: ReceiptLineItem[] = [
+      makeItem({ id: "1", description: "Milk", taxCode: "" }),
+    ];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+    expect(screen.getByLabelText("No tax code")).toBeInTheDocument();
+  });
+
+  it("renders the tax-code input in the form row", () => {
+    renderWithProviders(<LineItemsSection {...defaultProps} />);
+    expect(screen.getByLabelText("Tax code")).toBeInTheDocument();
+  });
+
+  it("uppercases tax-code input as the user types", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<LineItemsSection {...defaultProps} />);
+    const taxInput = screen.getByLabelText("Tax code") as HTMLInputElement;
+    await user.type(taxInput, "f");
+    expect(taxInput.value).toBe("F");
+  });
+
+  it("shows confidence indicator when itemConfidence flags low taxCode", () => {
+    const items: ReceiptLineItem[] = [
+      makeItem({ id: "1", description: "Milk", taxCode: "F" }),
+    ];
+    renderWithProviders(
+      <LineItemsSection
+        {...defaultProps}
+        items={items}
+        itemConfidence={[{ taxCode: "low" }]}
+      />,
+    );
+    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+  });
+
+  it("preserves the existing tax code when an item is edited and saved without changing it", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const items: ReceiptLineItem[] = [
+      makeItem({
+        id: "1",
+        description: "Milk",
+        quantity: 1,
+        unitPrice: 1,
+        taxCode: "F",
+      }),
+    ];
+
+    renderWithProviders(
+      <LineItemsSection items={items} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ taxCode: "F" }),
+    ]);
+  });
+
+  it("uppercases the tax code when edited inline", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const items: ReceiptLineItem[] = [
+      makeItem({
+        id: "1",
+        description: "Milk",
+        quantity: 1,
+        unitPrice: 1,
+        taxCode: "",
+      }),
+    ];
+
+    renderWithProviders(
+      <LineItemsSection items={items} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const taxCodeInput = screen.getByLabelText("Edit tax code") as HTMLInputElement;
+    await user.type(taxCodeInput, "n");
+
+    expect(taxCodeInput.value).toBe("N");
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ taxCode: "N" }),
+    ]);
   });
 });

--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -440,18 +440,61 @@ describe("LineItemsSection", () => {
     expect(taxInput.value).toBe("F");
   });
 
-  it("shows confidence indicator when itemConfidence flags low taxCode", () => {
+  it("shows confidence indicator when itemConfidenceById flags low taxCode", () => {
     const items: ReceiptLineItem[] = [
-      makeItem({ id: "1", description: "Milk", taxCode: "F" }),
+      makeItem({ id: "item-1", description: "Milk", taxCode: "F" }),
     ];
+    const itemConfidenceById = new Map([
+      ["item-1", { taxCode: "low" as const }],
+    ]);
     renderWithProviders(
       <LineItemsSection
         {...defaultProps}
         items={items}
-        itemConfidence={[{ taxCode: "low" }]}
+        itemConfidenceById={itemConfidenceById}
       />,
     );
     expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+  });
+
+  it("keeps the confidence indicator paired with the surviving item after a removal", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const items: ReceiptLineItem[] = [
+      makeItem({ id: "item-1", description: "Milk", taxCode: "F" }),
+      makeItem({ id: "item-2", description: "Bread", taxCode: "N" }),
+    ];
+    // Only item-2 has low confidence on taxCode.
+    const itemConfidenceById = new Map([
+      ["item-2", { taxCode: "low" as const }],
+    ]);
+
+    const { rerender } = renderWithProviders(
+      <LineItemsSection
+        items={items}
+        onChange={onChange}
+        itemConfidenceById={itemConfidenceById}
+      />,
+    );
+
+    // Remove item-1 (Milk). The remaining item is Bread, which is the one
+    // that had low confidence — the badge should still appear.
+    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
+    await user.click(removeButtons[0]);
+    expect(onChange).toHaveBeenCalledWith([items[1]]);
+
+    // Simulate the parent removing item-1 from state.
+    rerender(
+      <LineItemsSection
+        items={[items[1]]}
+        onChange={onChange}
+        itemConfidenceById={itemConfidenceById}
+      />,
+    );
+
+    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+    // Bread (item-2) is the only row left; the indicator still belongs to it.
+    expect(screen.getByText("Bread")).toBeInTheDocument();
   });
 
   it("preserves the existing tax code when an item is edited and saved without changing it", async () => {

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -88,17 +88,19 @@ interface LineItemsSectionProps {
   onChange: (items: ReceiptLineItem[]) => void;
   location?: string | null;
   /**
-   * Per-item confidence levels (matched by index). Used to surface
-   * low-confidence indicators next to fields populated from a scan proposal.
+   * Per-item confidence levels keyed by stable item id (not index). Keying
+   * by id preserves correctness after rows are added or removed — an
+   * index-based lookup would misalign confidence with the wrong row after
+   * a deletion.
    */
-  itemConfidence?: Array<{ taxCode?: ConfidenceLevel }>;
+  itemConfidenceById?: Map<string, { taxCode?: ConfidenceLevel }>;
 }
 
 export function LineItemsSection({
   items,
   onChange,
   location,
-  itemConfidence,
+  itemConfidenceById,
 }: LineItemsSectionProps) {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const suggestionsListId = "new-receipt-suggestions-list";
@@ -744,8 +746,8 @@ export function LineItemsSection({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {items.map((item, index) => {
-                const taxCodeConfidence = itemConfidence?.[index]?.taxCode;
+              {items.map((item) => {
+                const taxCodeConfidence = itemConfidenceById?.get(item.id)?.taxCode;
                 return editingItemId === item.id ? (
                   <TableRow key={item.id}>
                     <TableCell>

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -48,6 +48,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Plus, Trash2, Loader2, Sparkles, Pencil, Check, X } from "lucide-react";
+import { ConfidenceIndicator } from "@/pages/scan-receipt/ConfidenceIndicator";
+import type { ConfidenceLevel } from "@/pages/scan-receipt/types";
+
+const TAX_CODE_PATTERN = /^[A-Za-z]?$/;
 
 const itemSchema = z.object({
   receiptItemCode: z.string().optional().default(""),
@@ -56,6 +60,13 @@ const itemSchema = z.object({
   unitPrice: z.number().min(0, "Unit price must be non-negative"),
   category: z.string().min(1, "Category is required"),
   subcategory: z.string().optional().default(""),
+  taxCode: z
+    .string()
+    .optional()
+    .default("")
+    .refine((v) => !v || TAX_CODE_PATTERN.test(v), {
+      message: "Tax code must be a single letter",
+    }),
 });
 
 type ItemFormValues = z.output<typeof itemSchema>;
@@ -69,15 +80,26 @@ export interface ReceiptLineItem {
   unitPrice: number;
   category: string;
   subcategory: string;
+  taxCode: string;
 }
 
 interface LineItemsSectionProps {
   items: ReceiptLineItem[];
   onChange: (items: ReceiptLineItem[]) => void;
   location?: string | null;
+  /**
+   * Per-item confidence levels (matched by index). Used to surface
+   * low-confidence indicators next to fields populated from a scan proposal.
+   */
+  itemConfidence?: Array<{ taxCode?: ConfidenceLevel }>;
 }
 
-export function LineItemsSection({ items, onChange, location }: LineItemsSectionProps) {
+export function LineItemsSection({
+  items,
+  onChange,
+  location,
+  itemConfidence,
+}: LineItemsSectionProps) {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const suggestionsListId = "new-receipt-suggestions-list";
   const { data: categories } = useCategories(0, 50, undefined, undefined, true);
@@ -100,6 +122,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
       unitPrice: 0,
       category: "",
       subcategory: "",
+      taxCode: "",
     },
   });
 
@@ -266,6 +289,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
         unitPrice: values.unitPrice,
         category: values.category,
         subcategory: values.subcategory ?? "",
+        taxCode: (values.taxCode ?? "").toUpperCase(),
       };
       onChange([...items, newItem]);
       form.reset({
@@ -275,6 +299,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
         unitPrice: 0,
         category: values.category,
         subcategory: "",
+        taxCode: "",
       });
       setShowSuggestions(false);
     },
@@ -293,7 +318,8 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     description: string;
     quantity: number;
     unitPrice: number;
-  }>({ description: "", quantity: 1, unitPrice: 0 });
+    taxCode: string;
+  }>({ description: "", quantity: 1, unitPrice: 0, taxCode: "" });
 
   const startEditing = useCallback((item: ReceiptLineItem) => {
     setEditingItemId(item.id);
@@ -301,6 +327,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
       description: item.description,
       quantity: item.quantity,
       unitPrice: item.unitPrice,
+      taxCode: item.taxCode ?? "",
     });
   }, []);
 
@@ -313,6 +340,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     if (!editDraft.description.trim()) return;
     if (!Number.isFinite(editDraft.quantity) || editDraft.quantity <= 0) return;
     if (!Number.isFinite(editDraft.unitPrice) || editDraft.unitPrice < 0) return;
+    if (editDraft.taxCode && !TAX_CODE_PATTERN.test(editDraft.taxCode)) return;
 
     onChange(
       items.map((item) =>
@@ -322,6 +350,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
               description: editDraft.description.trim(),
               quantity: editDraft.quantity,
               unitPrice: editDraft.unitPrice,
+              taxCode: editDraft.taxCode.toUpperCase(),
             }
           : item,
       ),
@@ -572,8 +601,8 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
 
             </div>
 
-            {/* Row 2: Subcategory, Quantity, Unit Price, Add Item */}
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end">
+            {/* Row 2: Subcategory, Tax Code, Quantity, Unit Price, Add Item */}
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-[1fr_auto_auto_auto_auto] sm:items-end">
               <FormField
                 control={form.control}
                 name="subcategory"
@@ -618,6 +647,35 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                         emptyMessage="No subcategories found."
                         allowCustom
                         disabled={!selectedCategory}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="taxCode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Tax</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="text"
+                        maxLength={1}
+                        className="w-12 text-center font-mono uppercase"
+                        placeholder="—"
+                        aria-label="Tax code"
+                        autoComplete="off"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) => {
+                          const next = e.target.value.toUpperCase();
+                          if (TAX_CODE_PATTERN.test(next)) {
+                            field.onChange(next);
+                          }
+                        }}
                       />
                     </FormControl>
                     <FormMessage />
@@ -679,14 +737,16 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                 <TableHead>Unit Price</TableHead>
                 <TableHead>Line Total</TableHead>
                 <TableHead>Category</TableHead>
+                <TableHead>Tax</TableHead>
                 <TableHead className="w-12">
                   <span className="sr-only">Actions</span>
                 </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {items.map((item) =>
-                editingItemId === item.id ? (
+              {items.map((item, index) => {
+                const taxCodeConfidence = itemConfidence?.[index]?.taxCode;
+                return editingItemId === item.id ? (
                   <TableRow key={item.id}>
                     <TableCell>
                       <Input
@@ -736,6 +796,24 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                       {item.subcategory ? ` / ${item.subcategory}` : ""}
                     </TableCell>
                     <TableCell>
+                      <Input
+                        type="text"
+                        maxLength={1}
+                        value={editDraft.taxCode}
+                        onChange={(e) => {
+                          const next = e.target.value.toUpperCase();
+                          if (TAX_CODE_PATTERN.test(next)) {
+                            setEditDraft((d) => ({
+                              ...d,
+                              taxCode: next,
+                            }));
+                          }
+                        }}
+                        aria-label="Edit tax code"
+                        className="h-8 w-10 text-center font-mono uppercase"
+                      />
+                    </TableCell>
+                    <TableCell>
                       <div className="flex gap-1">
                         <Button
                           variant="ghost"
@@ -769,6 +847,23 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                       {item.subcategory ? ` / ${item.subcategory}` : ""}
                     </TableCell>
                     <TableCell>
+                      <div className="flex items-center gap-1">
+                        {item.taxCode ? (
+                          <Badge variant="outline" className="font-mono">
+                            {item.taxCode}
+                          </Badge>
+                        ) : (
+                          <span
+                            className="text-xs text-muted-foreground"
+                            aria-label="No tax code"
+                          >
+                            —
+                          </span>
+                        )}
+                        <ConfidenceIndicator confidence={taxCodeConfidence} />
+                      </div>
+                    </TableCell>
+                    <TableCell>
                       <div className="flex gap-1">
                         <Button
                           variant="ghost"
@@ -789,8 +884,8 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                       </div>
                     </TableCell>
                   </TableRow>
-                ),
-              )}
+                );
+              })}
             </TableBody>
           </Table>
         )}

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -65,11 +65,18 @@ vi.mock("./TransactionsSection", () => ({
 vi.mock("./LineItemsSection", () => ({
   LineItemsSection: ({
     onChange,
+    itemConfidence,
   }: {
     items: unknown[];
     onChange: (data: unknown[]) => void;
+    itemConfidence?: Array<{ taxCode?: string }>;
   }) => (
     <div data-testid="line-items-section">
+      {itemConfidence && (
+        <span data-testid="line-items-confidence">
+          {JSON.stringify(itemConfidence)}
+        </span>
+      )}
       <button
         onClick={() =>
           onChange([
@@ -82,12 +89,33 @@ vi.mock("./LineItemsSection", () => ({
               unitPrice: 50,
               category: "Food",
               subcategory: "",
+              taxCode: "",
             },
           ])
         }
       >
         Add Item
       </button>
+    </div>
+  ),
+}));
+
+vi.mock("./PaymentsSection", () => ({
+  PaymentsSection: ({
+    payments,
+    onChange,
+  }: {
+    payments: Array<{ id: string; method: string; amount: number; lastFour: string }>;
+    onChange: (data: unknown[]) => void;
+  }) => (
+    <div data-testid="payments-section">
+      <span data-testid="payments-count">{payments.length}</span>
+      {payments.map((p) => (
+        <span key={p.id} data-testid={`payment-${p.method}`}>
+          {p.method}:{p.amount}:{p.lastFour}
+        </span>
+      ))}
+      <button onClick={() => onChange([])}>Clear Payments</button>
     </div>
   ),
 }));
@@ -339,5 +367,158 @@ describe("NewReceiptPage", () => {
     await vi.waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("Failed to create receipt.");
     });
+  });
+
+  // --- Rich-fields tests (RECEIPTS-628) ---
+
+  it("renders Store Address and Store Phone inputs", () => {
+    renderWithProviders(<NewReceiptPage />);
+    expect(screen.getByLabelText(/store address/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/store phone/i)).toBeInTheDocument();
+  });
+
+  it("pre-populates store address and phone from initial values", () => {
+    renderWithProviders(
+      <NewReceiptPage
+        initialValues={{
+          header: {
+            location: "Walmart",
+            date: "2024-06-15",
+            taxAmount: 0,
+            storeAddress: "123 Main St",
+            storePhone: "(555) 123-4567",
+          },
+          metadata: { receiptId: "", storeNumber: "", terminalId: "" },
+          payments: [],
+          items: [],
+        }}
+      />,
+    );
+    expect(
+      (screen.getByLabelText(/store address/i) as HTMLInputElement).value,
+    ).toBe("123 Main St");
+    expect(
+      (screen.getByLabelText(/store phone/i) as HTMLInputElement).value,
+    ).toBe("(555) 123-4567");
+  });
+
+  it("does not render the receipt details panel when metadata is empty", () => {
+    renderWithProviders(<NewReceiptPage />);
+    expect(
+      screen.queryByText(/receipt details/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the receipt details panel when metadata is populated", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <NewReceiptPage
+        initialValues={{
+          header: {
+            location: "Walmart",
+            date: "2024-06-15",
+            taxAmount: 0,
+            storeAddress: "",
+            storePhone: "",
+          },
+          metadata: {
+            receiptId: "TX-987654",
+            storeNumber: "0042",
+            terminalId: "T01",
+          },
+          payments: [],
+          items: [],
+        }}
+      />,
+    );
+
+    // The panel is collapsed by default, so the heading is rendered but values
+    // are inside the collapsible content.
+    expect(screen.getByText(/receipt details/i)).toBeInTheDocument();
+
+    // Expand the panel to reveal values
+    await user.click(
+      screen.getByRole("button", { name: /expand receipt details/i }),
+    );
+
+    expect(screen.getByText("TX-987654")).toBeInTheDocument();
+    expect(screen.getByText("0042")).toBeInTheDocument();
+    expect(screen.getByText("T01")).toBeInTheDocument();
+  });
+
+  it("does not render the payments section when no payments are present", () => {
+    renderWithProviders(<NewReceiptPage />);
+    expect(screen.queryByTestId("payments-section")).not.toBeInTheDocument();
+  });
+
+  it("renders the payments section when initial payments are populated", () => {
+    renderWithProviders(
+      <NewReceiptPage
+        initialValues={{
+          header: {
+            location: "Walmart",
+            date: "2024-06-15",
+            taxAmount: 0,
+            storeAddress: "",
+            storePhone: "",
+          },
+          metadata: { receiptId: "", storeNumber: "", terminalId: "" },
+          payments: [
+            { method: "MASTERCARD", amount: 54.32, lastFour: "4538" },
+          ],
+          items: [],
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("payments-section")).toBeInTheDocument();
+    expect(screen.getByTestId("payments-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("payment-MASTERCARD")).toHaveTextContent(
+      "MASTERCARD:54.32:4538",
+    );
+  });
+
+  it("forwards item confidence to the line items section", () => {
+    renderWithProviders(
+      <NewReceiptPage
+        confidenceMap={{ items: [{ taxCode: "low" }] }}
+      />,
+    );
+
+    expect(screen.getByTestId("line-items-confidence")).toHaveTextContent(
+      JSON.stringify([{ taxCode: "low" }]),
+    );
+  });
+
+  it("validates the store phone format on submit", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Enter an invalid phone — alpha characters not allowed
+    const phoneInput = screen.getByLabelText(/store phone/i);
+    await user.type(phoneInput, "not-a-phone");
+
+    // Fill rest of header so we get past required fields
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const walmart = await screen.findByText("Walmart");
+    await user.click(walmart);
+
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(dateInput);
+    await user.type(dateInput, "01/15/2024");
+
+    // Add transaction + item so that we don't bail on those checks first
+    await user.click(screen.getAllByText("Add Transaction")[0]);
+    await user.click(screen.getAllByText("Add Item")[0]);
+
+    // Submit triggers form validation
+    const submitButtons = screen.getAllByText("Submit Receipt");
+    await user.click(submitButtons[0]);
+
+    expect(
+      await screen.findByText(/store phone is not in a recognised format/i),
+    ).toBeInTheDocument();
+    expect(mockCreateCompleteReceiptAsync).not.toHaveBeenCalled();
   });
 });

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -65,16 +65,16 @@ vi.mock("./TransactionsSection", () => ({
 vi.mock("./LineItemsSection", () => ({
   LineItemsSection: ({
     onChange,
-    itemConfidence,
+    itemConfidenceById,
   }: {
     items: unknown[];
     onChange: (data: unknown[]) => void;
-    itemConfidence?: Array<{ taxCode?: string }>;
+    itemConfidenceById?: Map<string, { taxCode?: string }>;
   }) => (
     <div data-testid="line-items-section">
-      {itemConfidence && (
-        <span data-testid="line-items-confidence">
-          {JSON.stringify(itemConfidence)}
+      {itemConfidenceById && (
+        <span data-testid="line-items-confidence-size">
+          {itemConfidenceById.size}
         </span>
       )}
       <button
@@ -478,15 +478,75 @@ describe("NewReceiptPage", () => {
     );
   });
 
-  it("forwards item confidence to the line items section", () => {
+  it("builds an item-confidence Map keyed by item id when scan items are present", () => {
     renderWithProviders(
       <NewReceiptPage
+        initialValues={{
+          header: {
+            location: "Walmart",
+            date: "2024-06-15",
+            taxAmount: 0,
+            storeAddress: "",
+            storePhone: "",
+          },
+          metadata: { receiptId: "", storeNumber: "", terminalId: "" },
+          payments: [],
+          items: [
+            {
+              receiptItemCode: "MILK",
+              description: "Milk",
+              pricingMode: "quantity",
+              quantity: 1,
+              unitPrice: 3.5,
+              category: "",
+              subcategory: "",
+              taxCode: "F",
+            },
+          ],
+        }}
         confidenceMap={{ items: [{ taxCode: "low" }] }}
       />,
     );
 
-    expect(screen.getByTestId("line-items-confidence")).toHaveTextContent(
-      JSON.stringify([{ taxCode: "low" }]),
+    // The Map should contain exactly one entry (one scan item with low taxCode confidence).
+    expect(screen.getByTestId("line-items-confidence-size")).toHaveTextContent(
+      "1",
+    );
+  });
+
+  it("does not include confidence entries for items lacking a confidence record", () => {
+    renderWithProviders(
+      <NewReceiptPage
+        initialValues={{
+          header: {
+            location: "Walmart",
+            date: "2024-06-15",
+            taxAmount: 0,
+            storeAddress: "",
+            storePhone: "",
+          },
+          metadata: { receiptId: "", storeNumber: "", terminalId: "" },
+          payments: [],
+          items: [
+            {
+              receiptItemCode: "MILK",
+              description: "Milk",
+              pricingMode: "quantity",
+              quantity: 1,
+              unitPrice: 3.5,
+              category: "",
+              subcategory: "",
+              taxCode: "",
+            },
+          ],
+        }}
+        // No items entry in confidence map → empty Map.
+        confidenceMap={{}}
+      />,
+    );
+
+    expect(screen.getByTestId("line-items-confidence-size")).toHaveTextContent(
+      "0",
     );
   });
 

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -94,20 +94,28 @@ export default function NewReceiptPage({
   const { options: locationOptions, add: addLocation } = useLocationHistory();
 
   const [transactions, setTransactions] = useState<ReceiptTransaction[]>([]);
-  const [items, setItems] = useState<ReceiptLineItem[]>(() =>
-    initialValues?.items.map((item) => ({
-      id: generateId(),
-      ...item,
-    })) ?? [],
+
+  // Items, payments, and their confidence-by-id maps are initialised together
+  // from the scan proposal so confidence stays correctly paired with rows after
+  // additions or deletions. The maps are write-once: a stale entry for a
+  // deleted row is harmless because no row will ever look it up again.
+  const [
+    { items: initialItems, itemConfidenceById: initialItemConfidence },
+  ] = useState(() =>
+    initialItemsAndConfidence(initialValues, confidenceMap),
   );
-  const [payments, setPayments] = useState<ReceiptPayment[]>(() =>
-    initialValues?.payments.map((p) => ({
-      id: generateId(),
-      method: p.method,
-      amount: p.amount,
-      lastFour: p.lastFour,
-    })) ?? [],
+  const [items, setItems] = useState<ReceiptLineItem[]>(initialItems);
+  const [itemConfidenceById] = useState(initialItemConfidence);
+
+  const [
+    { payments: initialPayments, paymentConfidenceById: initialPaymentConfidence },
+  ] = useState(() =>
+    initialPaymentsAndConfidence(initialValues, confidenceMap),
   );
+  const [payments, setPayments] =
+    useState<ReceiptPayment[]>(initialPayments);
+  const [paymentConfidenceById] = useState(initialPaymentConfidence);
+
   const [showDiscard, setShowDiscard] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -397,7 +405,7 @@ export default function NewReceiptPage({
             <PaymentsSection
               payments={payments}
               onChange={setPayments}
-              confidence={confidenceMap?.payments}
+              confidenceById={paymentConfidenceById}
             />
           )}
 
@@ -413,7 +421,7 @@ export default function NewReceiptPage({
             items={items}
             onChange={setItems}
             location={location}
-            itemConfidence={confidenceMap?.items}
+            itemConfidenceById={itemConfidenceById}
           />
         </div>
 
@@ -555,4 +563,57 @@ function ReceiptDetailsPanel({
       </Collapsible>
     </Card>
   );
+}
+
+type ItemConfidenceEntry = NonNullable<ReceiptConfidenceMap["items"]>[number];
+type PaymentConfidenceEntry = NonNullable<ReceiptConfidenceMap["payments"]>[number];
+
+function initialItemsAndConfidence(
+  initialValues: ScanInitialValues | undefined,
+  confidenceMap: ReceiptConfidenceMap | undefined,
+): {
+  items: ReceiptLineItem[];
+  itemConfidenceById: Map<string, ItemConfidenceEntry>;
+} {
+  const sourceItems = initialValues?.items ?? [];
+  const sourceConfidence = confidenceMap?.items ?? [];
+
+  const items: ReceiptLineItem[] = sourceItems.map((item) => ({
+    id: generateId(),
+    ...item,
+  }));
+  const itemConfidenceById = new Map<string, ItemConfidenceEntry>();
+  for (let i = 0; i < items.length; i++) {
+    const entry = sourceConfidence[i];
+    if (entry) {
+      itemConfidenceById.set(items[i].id, entry);
+    }
+  }
+  return { items, itemConfidenceById };
+}
+
+function initialPaymentsAndConfidence(
+  initialValues: ScanInitialValues | undefined,
+  confidenceMap: ReceiptConfidenceMap | undefined,
+): {
+  payments: ReceiptPayment[];
+  paymentConfidenceById: Map<string, PaymentConfidenceEntry>;
+} {
+  const sourcePayments = initialValues?.payments ?? [];
+  const sourceConfidence = confidenceMap?.payments ?? [];
+
+  const payments: ReceiptPayment[] = sourcePayments.map((p) => ({
+    id: generateId(),
+    method: p.method,
+    amount: p.amount,
+    lastFour: p.lastFour,
+  }));
+  const paymentConfidenceById = new Map<string, PaymentConfidenceEntry>();
+  for (let i = 0; i < payments.length; i++) {
+    const entry = sourceConfidence[i];
+    if (entry) {
+      paymentConfidenceById.set(payments[i].id, entry);
+    }
+  }
+  return { payments, paymentConfidenceById };
 }

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -12,6 +12,7 @@ import {
   type ReceiptTransaction,
 } from "./TransactionsSection";
 import { LineItemsSection, type ReceiptLineItem } from "./LineItemsSection";
+import { PaymentsSection, type ReceiptPayment } from "./PaymentsSection";
 import { BalanceSidebar } from "./BalanceSidebar";
 import { ConfidenceIndicator } from "@/pages/scan-receipt/ConfidenceIndicator";
 import type {
@@ -21,6 +22,15 @@ import type {
 import { Combobox } from "@/components/ui/combobox";
 import { DateInput } from "@/components/ui/date-input";
 import { CurrencyInput } from "@/components/ui/currency-input";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Button } from "@/components/ui/button";
+import { ChevronDown } from "lucide-react";
 import {
   Form,
   FormControl,
@@ -41,6 +51,9 @@ import {
 } from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
 
+// US phone format: 7 to 15 digits (lenient — covers international too).
+const PHONE_PATTERN = /^[\d\s+()\-.]{7,20}$/;
+
 const headerSchema = z.object({
   location: z
     .string()
@@ -48,6 +61,18 @@ const headerSchema = z.object({
     .max(200, "Location must be 200 characters or fewer"),
   date: z.string().min(1, "Date is required"),
   taxAmount: z.number().min(0, "Tax amount must be non-negative"),
+  storeAddress: z
+    .string()
+    .max(500, "Store address must be 500 characters or fewer")
+    .optional()
+    .default(""),
+  storePhone: z
+    .string()
+    .optional()
+    .default("")
+    .refine((v) => !v || PHONE_PATTERN.test(v), {
+      message: "Store phone is not in a recognised format",
+    }),
 });
 
 type HeaderFormValues = z.output<typeof headerSchema>;
@@ -75,6 +100,14 @@ export default function NewReceiptPage({
       ...item,
     })) ?? [],
   );
+  const [payments, setPayments] = useState<ReceiptPayment[]>(() =>
+    initialValues?.payments.map((p) => ({
+      id: generateId(),
+      method: p.method,
+      amount: p.amount,
+      lastFour: p.lastFour,
+    })) ?? [],
+  );
   const [showDiscard, setShowDiscard] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -88,12 +121,16 @@ export default function NewReceiptPage({
       location: initialValues?.header.location ?? "",
       date: initialValues?.header.date ?? "",
       taxAmount: initialValues?.header.taxAmount ?? 0,
+      storeAddress: initialValues?.header.storeAddress ?? "",
+      storePhone: initialValues?.header.storePhone ?? "",
     },
   });
 
   const location = form.watch("location");
   const taxAmount = form.watch("taxAmount");
   const receiptDate = form.watch("date");
+  const storeAddress = form.watch("storeAddress");
+  const storePhone = form.watch("storePhone");
 
   // Auto-focus location on mount
   useEffect(() => {
@@ -115,12 +152,24 @@ export default function NewReceiptPage({
     [transactions],
   );
 
+  // Derived: should we show the optional sections?
+  const metadata = initialValues?.metadata;
+  const hasMetadata =
+    !!metadata &&
+    (metadata.receiptId !== "" ||
+      metadata.storeNumber !== "" ||
+      metadata.terminalId !== "");
+  const showPaymentsSection = payments.length > 0;
+
   const hasData =
     location !== "" ||
     receiptDate !== "" ||
     taxAmount !== 0 ||
     transactions.length > 0 ||
-    items.length > 0;
+    items.length > 0 ||
+    payments.length > 0 ||
+    (storeAddress ?? "") !== "" ||
+    (storePhone ?? "") !== "";
 
   const handleCancel = useCallback(() => {
     if (hasData) {
@@ -156,6 +205,10 @@ export default function NewReceiptPage({
     try {
       addLocation(headerValues.location);
 
+      // NOTE: storeAddress/storePhone/payments/metadata/taxCode are accepted
+      // and reviewable in the UI but not yet persisted by the
+      // CreateCompleteReceipt API. They will round-trip once the backend is
+      // extended (tracked by separate issues under the VLM epic).
       const result = await createCompleteReceiptAsync({
         receipt: {
           location: headerValues.location,
@@ -206,73 +259,147 @@ export default function NewReceiptPage({
         <div className="space-y-6">
           {/* Receipt Header */}
           <Form {...form}>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-              <FormField
-                control={form.control}
-                name="location"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel required className="flex items-center gap-2">
-                      Location
-                      <ConfidenceIndicator confidence={confidenceMap?.location} />
-                    </FormLabel>
-                    <FormControl>
-                      <Combobox
-                        ref={locationRef}
-                        options={locationOptions}
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        placeholder="e.g. Walmart, Target, Costco"
-                        searchPlaceholder="Search locations..."
-                        emptyMessage="No saved locations."
-                        allowCustom
-                        aria-required="true"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <FormField
+                  control={form.control}
+                  name="location"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel required className="flex items-center gap-2">
+                        Location
+                        <ConfidenceIndicator confidence={confidenceMap?.location} />
+                      </FormLabel>
+                      <FormControl>
+                        <Combobox
+                          ref={locationRef}
+                          options={locationOptions}
+                          value={field.value}
+                          onValueChange={field.onChange}
+                          placeholder="e.g. Walmart, Target, Costco"
+                          searchPlaceholder="Search locations..."
+                          emptyMessage="No saved locations."
+                          allowCustom
+                          aria-required="true"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              <FormField
-                control={form.control}
-                name="date"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel required className="flex items-center gap-2">
-                      Date
-                      <ConfidenceIndicator confidence={confidenceMap?.date} />
-                    </FormLabel>
-                    <FormControl>
-                      <DateInput
-                        aria-required="true"
-                        max={new Date().toISOString().split("T")[0]}
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                <FormField
+                  control={form.control}
+                  name="date"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel required className="flex items-center gap-2">
+                        Date
+                        <ConfidenceIndicator confidence={confidenceMap?.date} />
+                      </FormLabel>
+                      <FormControl>
+                        <DateInput
+                          aria-required="true"
+                          max={new Date().toISOString().split("T")[0]}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              <FormField
-                control={form.control}
-                name="taxAmount"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="flex items-center gap-2">
-                      Tax Amount
-                      <ConfidenceIndicator confidence={confidenceMap?.taxAmount} />
-                    </FormLabel>
-                    <FormControl>
-                      <CurrencyInput {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                <FormField
+                  control={form.control}
+                  name="taxAmount"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="flex items-center gap-2">
+                        Tax Amount
+                        <ConfidenceIndicator
+                          confidence={confidenceMap?.taxAmount}
+                        />
+                      </FormLabel>
+                      <FormControl>
+                        <CurrencyInput {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              {/* Optional store contact details */}
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="storeAddress"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="flex items-center gap-2">
+                        Store Address
+                        <ConfidenceIndicator
+                          confidence={confidenceMap?.storeAddress}
+                        />
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="123 Main St, Springfield, IL 62701"
+                          autoComplete="street-address"
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="storePhone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="flex items-center gap-2">
+                        Store Phone
+                        <ConfidenceIndicator
+                          confidence={confidenceMap?.storePhone}
+                        />
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          type="tel"
+                          inputMode="tel"
+                          placeholder="(555) 123-4567"
+                          autoComplete="tel"
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
             </div>
           </Form>
+
+          {/* Receipt Details — read-only metadata, only shown when populated */}
+          {hasMetadata && (
+            <ReceiptDetailsPanel
+              metadata={metadata!}
+              confidenceMap={confidenceMap}
+            />
+          )}
+
+          {/* Detected payments — only shown when populated from a scan */}
+          {showPaymentsSection && (
+            <PaymentsSection
+              payments={payments}
+              onChange={setPayments}
+              confidence={confidenceMap?.payments}
+            />
+          )}
 
           {/* Transactions */}
           <TransactionsSection
@@ -282,7 +409,12 @@ export default function NewReceiptPage({
           />
 
           {/* Line Items */}
-          <LineItemsSection items={items} onChange={setItems} location={location} />
+          <LineItemsSection
+            items={items}
+            onChange={setItems}
+            location={location}
+            itemConfidence={confidenceMap?.items}
+          />
         </div>
 
         {/* Right column — sticky balance sidebar */}
@@ -328,5 +460,99 @@ export default function NewReceiptPage({
         </AlertDialogContent>
       </AlertDialog>
     </div>
+  );
+}
+
+interface ReceiptDetailsPanelProps {
+  metadata: { receiptId: string; storeNumber: string; terminalId: string };
+  confidenceMap?: ReceiptConfidenceMap;
+}
+
+function ReceiptDetailsPanel({
+  metadata,
+  confidenceMap,
+}: ReceiptDetailsPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const rows: Array<{
+    label: string;
+    value: string;
+    confidence?: ReceiptConfidenceMap[keyof ReceiptConfidenceMap];
+  }> = [];
+
+  if (metadata.receiptId) {
+    rows.push({
+      label: "Receipt ID",
+      value: metadata.receiptId,
+      confidence: confidenceMap?.receiptId,
+    });
+  }
+  if (metadata.storeNumber) {
+    rows.push({
+      label: "Store Number",
+      value: metadata.storeNumber,
+      confidence: confidenceMap?.storeNumber,
+    });
+  }
+  if (metadata.terminalId) {
+    rows.push({
+      label: "Terminal ID",
+      value: metadata.terminalId,
+      confidence: confidenceMap?.terminalId,
+    });
+  }
+
+  return (
+    <Card>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg">Receipt Details</CardTitle>
+            <CollapsibleTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-expanded={isOpen}
+                aria-controls="receipt-details-content"
+                aria-label={
+                  isOpen ? "Collapse receipt details" : "Expand receipt details"
+                }
+              >
+                <ChevronDown
+                  className={`h-4 w-4 transition-transform ${
+                    isOpen ? "rotate-180" : ""
+                  }`}
+                  aria-hidden="true"
+                />
+              </Button>
+            </CollapsibleTrigger>
+          </div>
+        </CardHeader>
+        <CollapsibleContent id="receipt-details-content">
+          <CardContent>
+            <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
+              {rows.map((row) => (
+                <div key={row.label} className="contents">
+                  <dt className="text-muted-foreground">{row.label}</dt>
+                  <dd className="flex items-center gap-2 font-mono">
+                    <span>{row.value}</span>
+                    <ConfidenceIndicator
+                      confidence={
+                        row.confidence as
+                          | ReceiptConfidenceMap[
+                              | "receiptId"
+                              | "storeNumber"
+                              | "terminalId"]
+                          | undefined
+                      }
+                    />
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
   );
 }

--- a/src/client/src/pages/new-receipt/PaymentsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/PaymentsSection.test.tsx
@@ -1,0 +1,150 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { PaymentsSection, type ReceiptPayment } from "./PaymentsSection";
+
+describe("PaymentsSection", () => {
+  it("renders an empty state when there are no payments", () => {
+    renderWithProviders(
+      <PaymentsSection payments={[]} onChange={vi.fn()} />,
+    );
+    expect(
+      screen.getByText("No payments detected on the receipt."),
+    ).toBeInTheDocument();
+  });
+
+  it("displays a row per payment with method, amount, and last four", () => {
+    const payments: ReceiptPayment[] = [
+      { id: "1", method: "MASTERCARD", amount: 54.32, lastFour: "4538" },
+      { id: "2", method: "Cash", amount: 5, lastFour: "" },
+    ];
+
+    renderWithProviders(
+      <PaymentsSection payments={payments} onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByDisplayValue("MASTERCARD")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("4538")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Cash")).toBeInTheDocument();
+  });
+
+  it("calls onChange when adding a payment", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PaymentsSection payments={[]} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add payment/i }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        method: "",
+        amount: 0,
+        lastFour: "",
+      }),
+    ]);
+  });
+
+  it("calls onChange when removing a payment", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const payments: ReceiptPayment[] = [
+      { id: "1", method: "MASTERCARD", amount: 54.32, lastFour: "4538" },
+    ];
+
+    renderWithProviders(
+      <PaymentsSection payments={payments} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /remove payment/i }));
+
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("updates a payment method when typed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const payments: ReceiptPayment[] = [
+      { id: "1", method: "VIS", amount: 0, lastFour: "" },
+    ];
+
+    renderWithProviders(
+      <PaymentsSection payments={payments} onChange={onChange} />,
+    );
+
+    const methodInput = screen.getByDisplayValue("VIS");
+    await user.type(methodInput, "A");
+
+    // Latest call should include the appended character
+    const lastCall = onChange.mock.calls.at(-1)![0];
+    expect(lastCall[0]).toMatchObject({ method: "VISA" });
+  });
+
+  it("rejects more than four digits in the last-four field", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const payments: ReceiptPayment[] = [
+      { id: "1", method: "VISA", amount: 0, lastFour: "1234" },
+    ];
+
+    renderWithProviders(
+      <PaymentsSection payments={payments} onChange={onChange} />,
+    );
+
+    const lastFourInput = screen.getByDisplayValue("1234");
+    await user.type(lastFourInput, "5");
+
+    // The handler should refuse the change because the result would be 5 digits.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-numeric characters in the last-four field", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const payments: ReceiptPayment[] = [
+      { id: "1", method: "VISA", amount: 0, lastFour: "" },
+    ];
+
+    renderWithProviders(
+      <PaymentsSection payments={payments} onChange={onChange} />,
+    );
+
+    const lastFourInputs = screen.getAllByLabelText("Last four digits");
+    await user.type(lastFourInputs[0], "abc");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("renders a low-confidence indicator on the matching field", () => {
+    const payments: ReceiptPayment[] = [
+      { id: "1", method: "MASTERCARD", amount: 54.32, lastFour: "4538" },
+    ];
+
+    renderWithProviders(
+      <PaymentsSection
+        payments={payments}
+        onChange={vi.fn()}
+        confidence={[
+          { method: "low" },
+        ]}
+      />,
+    );
+
+    // ConfidenceIndicator renders "Low confidence" badge text for low.
+    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+  });
+
+  it("displays the running total of payment amounts", () => {
+    const payments: ReceiptPayment[] = [
+      { id: "1", method: "VISA", amount: 10, lastFour: "" },
+      { id: "2", method: "Cash", amount: 5.5, lastFour: "" },
+    ];
+
+    renderWithProviders(
+      <PaymentsSection payments={payments} onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/Total: \$15\.50/)).toBeInTheDocument();
+  });
+});

--- a/src/client/src/pages/new-receipt/PaymentsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/PaymentsSection.test.tsx
@@ -118,21 +118,58 @@ describe("PaymentsSection", () => {
 
   it("renders a low-confidence indicator on the matching field", () => {
     const payments: ReceiptPayment[] = [
-      { id: "1", method: "MASTERCARD", amount: 54.32, lastFour: "4538" },
+      { id: "p-1", method: "MASTERCARD", amount: 54.32, lastFour: "4538" },
     ];
+    const confidenceById = new Map([["p-1", { method: "low" as const }]]);
 
     renderWithProviders(
       <PaymentsSection
         payments={payments}
         onChange={vi.fn()}
-        confidence={[
-          { method: "low" },
-        ]}
+        confidenceById={confidenceById}
       />,
     );
 
     // ConfidenceIndicator renders "Low confidence" badge text for low.
     expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+  });
+
+  it("keeps the confidence indicator paired with the surviving payment after a removal", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const payments: ReceiptPayment[] = [
+      { id: "p-1", method: "MASTERCARD", amount: 10, lastFour: "1234" },
+      { id: "p-2", method: "VISA", amount: 5, lastFour: "5678" },
+    ];
+    // Only p-2 has low confidence.
+    const confidenceById = new Map([["p-2", { method: "low" as const }]]);
+
+    const { rerender } = renderWithProviders(
+      <PaymentsSection
+        payments={payments}
+        onChange={onChange}
+        confidenceById={confidenceById}
+      />,
+    );
+
+    // Remove p-1.
+    const removeButtons = screen.getAllByRole("button", {
+      name: /remove payment/i,
+    });
+    await user.click(removeButtons[0]);
+    expect(onChange).toHaveBeenCalledWith([payments[1]]);
+
+    // Simulate parent updating the array.
+    rerender(
+      <PaymentsSection
+        payments={[payments[1]]}
+        onChange={onChange}
+        confidenceById={confidenceById}
+      />,
+    );
+
+    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue("VISA")).toBeInTheDocument();
   });
 
   it("displays the running total of payment amounts", () => {

--- a/src/client/src/pages/new-receipt/PaymentsSection.tsx
+++ b/src/client/src/pages/new-receipt/PaymentsSection.tsx
@@ -29,10 +29,15 @@ interface PaymentsSectionProps {
   payments: ReceiptPayment[];
   onChange: (payments: ReceiptPayment[]) => void;
   /**
-   * Per-payment confidence levels keyed by index. Used to surface
-   * low-confidence highlights when the receipt was populated from a scan.
+   * Per-payment confidence levels keyed by stable payment id (not index).
+   * Keying by id preserves correctness after rows are added or removed —
+   * an index-based lookup would misalign confidence with the wrong row
+   * after a deletion.
    */
-  confidence?: ReceiptConfidenceMap["payments"];
+  confidenceById?: Map<
+    string,
+    NonNullable<ReceiptConfidenceMap["payments"]>[number]
+  >;
 }
 
 const LAST_FOUR_PATTERN = /^\d{0,4}$/;
@@ -40,7 +45,7 @@ const LAST_FOUR_PATTERN = /^\d{0,4}$/;
 export function PaymentsSection({
   payments,
   onChange,
-  confidence,
+  confidenceById,
 }: PaymentsSectionProps) {
   const handleAdd = useCallback(() => {
     onChange([
@@ -99,8 +104,8 @@ export function PaymentsSection({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {payments.map((payment, index) => {
-                const fieldConfidence = confidence?.[index];
+              {payments.map((payment) => {
+                const fieldConfidence = confidenceById?.get(payment.id);
                 const methodId = `payment-${payment.id}-method`;
                 const amountId = `payment-${payment.id}-amount`;
                 const lastFourId = `payment-${payment.id}-lastFour`;

--- a/src/client/src/pages/new-receipt/PaymentsSection.tsx
+++ b/src/client/src/pages/new-receipt/PaymentsSection.tsx
@@ -1,0 +1,203 @@
+import { useCallback } from "react";
+import { generateId } from "@/lib/id";
+import { formatCurrency } from "@/lib/format";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import { ConfidenceIndicator } from "@/pages/scan-receipt/ConfidenceIndicator";
+import type { ReceiptConfidenceMap } from "@/pages/scan-receipt/types";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Plus, Trash2 } from "lucide-react";
+
+export interface ReceiptPayment {
+  id: string;
+  method: string;
+  amount: number;
+  lastFour: string;
+}
+
+interface PaymentsSectionProps {
+  payments: ReceiptPayment[];
+  onChange: (payments: ReceiptPayment[]) => void;
+  /**
+   * Per-payment confidence levels keyed by index. Used to surface
+   * low-confidence highlights when the receipt was populated from a scan.
+   */
+  confidence?: ReceiptConfidenceMap["payments"];
+}
+
+const LAST_FOUR_PATTERN = /^\d{0,4}$/;
+
+export function PaymentsSection({
+  payments,
+  onChange,
+  confidence,
+}: PaymentsSectionProps) {
+  const handleAdd = useCallback(() => {
+    onChange([
+      ...payments,
+      { id: generateId(), method: "", amount: 0, lastFour: "" },
+    ]);
+  }, [payments, onChange]);
+
+  const handleRemove = useCallback(
+    (id: string) => {
+      onChange(payments.filter((p) => p.id !== id));
+    },
+    [payments, onChange],
+  );
+
+  const handleField = useCallback(
+    <K extends keyof Omit<ReceiptPayment, "id">>(
+      id: string,
+      field: K,
+      value: ReceiptPayment[K],
+    ) => {
+      onChange(
+        payments.map((p) => (p.id === id ? { ...p, [field]: value } : p)),
+      );
+    },
+    [payments, onChange],
+  );
+
+  const total = payments.reduce((sum, p) => sum + (p.amount || 0), 0);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">Detected Payments</CardTitle>
+          <span className="text-sm text-muted-foreground">
+            Total: {formatCurrency(total)}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {payments.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No payments detected on the receipt.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Method</TableHead>
+                <TableHead>Amount</TableHead>
+                <TableHead>Last 4</TableHead>
+                <TableHead className="w-12">
+                  <span className="sr-only">Actions</span>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {payments.map((payment, index) => {
+                const fieldConfidence = confidence?.[index];
+                const methodId = `payment-${payment.id}-method`;
+                const amountId = `payment-${payment.id}-amount`;
+                const lastFourId = `payment-${payment.id}-lastFour`;
+                return (
+                  <TableRow key={payment.id}>
+                    <TableCell>
+                      <Label htmlFor={methodId} className="sr-only">
+                        Payment method
+                      </Label>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          id={methodId}
+                          value={payment.method}
+                          onChange={(e) =>
+                            handleField(payment.id, "method", e.target.value)
+                          }
+                          placeholder="e.g. Visa, Cash"
+                          className="h-8"
+                        />
+                        <ConfidenceIndicator
+                          confidence={fieldConfidence?.method}
+                        />
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Label htmlFor={amountId} className="sr-only">
+                        Payment amount
+                      </Label>
+                      <div className="flex items-center gap-2">
+                        <CurrencyInput
+                          id={amountId}
+                          value={payment.amount}
+                          onChange={(v) =>
+                            handleField(payment.id, "amount", v)
+                          }
+                          className="h-8"
+                        />
+                        <ConfidenceIndicator
+                          confidence={fieldConfidence?.amount}
+                        />
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Label htmlFor={lastFourId} className="sr-only">
+                        Last four digits
+                      </Label>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          id={lastFourId}
+                          value={payment.lastFour}
+                          inputMode="numeric"
+                          pattern="\d{0,4}"
+                          maxLength={4}
+                          onChange={(e) => {
+                            const next = e.target.value;
+                            if (LAST_FOUR_PATTERN.test(next)) {
+                              handleField(payment.id, "lastFour", next);
+                            }
+                          }}
+                          placeholder="1234"
+                          className="h-8 w-20 font-mono"
+                          aria-invalid={
+                            payment.lastFour.length > 0 &&
+                            payment.lastFour.length !== 4
+                          }
+                        />
+                        <ConfidenceIndicator
+                          confidence={fieldConfidence?.lastFour}
+                        />
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleRemove(payment.id)}
+                        aria-label="Remove payment"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={handleAdd}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Add Payment
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/client/src/pages/scan-receipt/ScanReceiptPage.test.tsx
+++ b/src/client/src/pages/scan-receipt/ScanReceiptPage.test.tsx
@@ -3,6 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockMutationResult } from "@/test/mock-hooks";
 import ScanReceiptPage from "./ScanReceiptPage";
+import type { components } from "@/generated/api";
+
+type ProposedReceiptResponse = components["schemas"]["ProposedReceiptResponse"];
 
 vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
@@ -11,9 +14,7 @@ vi.mock("@/hooks/usePageTitle", () => ({
 const mockMutate = vi.fn();
 
 vi.mock("@/hooks/useReceiptScan", () => ({
-  useReceiptScan: vi.fn(() =>
-    mockMutationResult({ mutate: mockMutate }),
-  ),
+  useReceiptScan: vi.fn(() => mockMutationResult({ mutate: mockMutate })),
 }));
 
 // Mock NewReceiptPage to isolate ScanReceiptPage logic
@@ -22,13 +23,37 @@ vi.mock("@/pages/new-receipt/NewReceiptPage", () => ({
     initialValues,
     confidenceMap,
   }: {
-    initialValues?: { header: { location: string } };
-    confidenceMap?: Record<string, string>;
+    initialValues?: {
+      header: { location: string; storeAddress: string; storePhone: string };
+      metadata: { receiptId: string; storeNumber: string; terminalId: string };
+      payments: Array<{ method: string; amount: number; lastFour: string }>;
+    };
+    confidenceMap?: Record<string, unknown>;
   }) => (
     <div data-testid="new-receipt-page">
       {initialValues?.header.location && (
         <span data-testid="prepopulated-location">
           {initialValues.header.location}
+        </span>
+      )}
+      {initialValues?.header.storeAddress && (
+        <span data-testid="prepopulated-address">
+          {initialValues.header.storeAddress}
+        </span>
+      )}
+      {initialValues?.header.storePhone && (
+        <span data-testid="prepopulated-phone">
+          {initialValues.header.storePhone}
+        </span>
+      )}
+      {initialValues?.metadata?.receiptId && (
+        <span data-testid="prepopulated-receipt-id">
+          {initialValues.metadata.receiptId}
+        </span>
+      )}
+      {initialValues?.payments && initialValues.payments.length > 0 && (
+        <span data-testid="prepopulated-payments">
+          {JSON.stringify(initialValues.payments)}
         </span>
       )}
       {confidenceMap && (
@@ -37,6 +62,44 @@ vi.mock("@/pages/new-receipt/NewReceiptPage", () => ({
     </div>
   ),
 }));
+
+function makeProposal(
+  overrides: Partial<ProposedReceiptResponse> = {},
+): ProposedReceiptResponse {
+  return {
+    storeName: "Test Store",
+    storeNameConfidence: "high",
+    storeAddress: null,
+    storeAddressConfidence: "high",
+    storePhone: null,
+    storePhoneConfidence: "high",
+    date: "2024-06-15",
+    dateConfidence: "high",
+    items: [],
+    subtotal: 0,
+    subtotalConfidence: "high",
+    taxLines: [
+      {
+        label: "Tax",
+        labelConfidence: "high",
+        amount: 0,
+        amountConfidence: "high",
+      },
+    ],
+    total: 0,
+    totalConfidence: "high",
+    paymentMethod: null,
+    paymentMethodConfidence: "high",
+    payments: [],
+    receiptId: null,
+    receiptIdConfidence: "high",
+    storeNumber: null,
+    storeNumberConfidence: "high",
+    terminalId: null,
+    terminalIdConfidence: "high",
+    ...overrides,
+  };
+}
 
 function createTestFile(
   name = "receipt.jpg",
@@ -98,27 +161,7 @@ describe("ScanReceiptPage", () => {
         _file: File,
         options: { onSuccess: (data: unknown) => void },
       ) => {
-        options.onSuccess({
-          storeName: "Test Store",
-          storeNameConfidence: "high",
-          date: "2024-06-15",
-          dateConfidence: "high",
-          items: [],
-          subtotal: 0,
-          subtotalConfidence: "high",
-          taxLines: [
-            {
-              label: "Tax",
-              labelConfidence: "high",
-              amount: 0,
-              amountConfidence: "high",
-            },
-          ],
-          total: 0,
-          totalConfidence: "high",
-          paymentMethod: null,
-          paymentMethodConfidence: "high",
-        });
+        options.onSuccess(makeProposal({ storeName: "Test Store" }));
       },
     );
 
@@ -176,27 +219,12 @@ describe("ScanReceiptPage", () => {
         _file: File,
         options: { onSuccess: (data: unknown) => void },
       ) => {
-        options.onSuccess({
-          storeName: "Low Confidence Store",
-          storeNameConfidence: "low",
-          date: "2024-06-15",
-          dateConfidence: "high",
-          items: [],
-          subtotal: 10,
-          subtotalConfidence: "high",
-          taxLines: [
-            {
-              label: "Tax",
-              labelConfidence: "high",
-              amount: 1,
-              amountConfidence: "high",
-            },
-          ],
-          total: 11,
-          totalConfidence: "high",
-          paymentMethod: null,
-          paymentMethodConfidence: "high",
-        });
+        options.onSuccess(
+          makeProposal({
+            storeName: "Low Confidence Store",
+            storeNameConfidence: "low",
+          }),
+        );
       },
     );
 
@@ -216,5 +244,62 @@ describe("ScanReceiptPage", () => {
       screen.getByTestId("confidence-map").textContent!,
     );
     expect(confidenceMap).toEqual({ location: "low" });
+  });
+
+  it("forwards new fields (address, phone, metadata, payments) to the wizard", async () => {
+    mockMutate.mockImplementation(
+      (
+        _file: File,
+        options: { onSuccess: (data: unknown) => void },
+      ) => {
+        options.onSuccess(
+          makeProposal({
+            storeAddress: "123 Main St",
+            storePhone: "(555) 123-4567",
+            receiptId: "TX-987654",
+            storeNumber: "0042",
+            terminalId: "T01",
+            payments: [
+              {
+                method: "MASTERCARD",
+                methodConfidence: "high",
+                amount: 54.32,
+                amountConfidence: "high",
+                lastFour: "4538",
+                lastFourConfidence: "high",
+              },
+            ],
+          }),
+        );
+      },
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ScanReceiptPage />);
+
+    const fileInput = screen.getByTestId("file-input");
+    const file = createTestFile();
+    await user.upload(fileInput, file);
+    await user.click(screen.getByRole("button", { name: /scan receipt/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("new-receipt-page")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("prepopulated-address")).toHaveTextContent(
+      "123 Main St",
+    );
+    expect(screen.getByTestId("prepopulated-phone")).toHaveTextContent(
+      "(555) 123-4567",
+    );
+    expect(screen.getByTestId("prepopulated-receipt-id")).toHaveTextContent(
+      "TX-987654",
+    );
+    const payments = JSON.parse(
+      screen.getByTestId("prepopulated-payments").textContent!,
+    );
+    expect(payments).toEqual([
+      { method: "MASTERCARD", amount: 54.32, lastFour: "4538" },
+    ]);
   });
 });

--- a/src/client/src/pages/scan-receipt/ScanReceiptPage.tsx
+++ b/src/client/src/pages/scan-receipt/ScanReceiptPage.tsx
@@ -5,66 +5,14 @@ import { isTimeoutError } from "@/lib/api-client";
 import { ReceiptImageUpload } from "./ReceiptImageUpload";
 import NewReceiptPage from "@/pages/new-receipt/NewReceiptPage";
 import type { components } from "@/generated/api";
-import type { ScanInitialValues, ReceiptConfidenceMap } from "./types";
+import {
+  mapProposalToInitialValues,
+  mapProposalToConfidenceMap,
+} from "./proposalMappers";
 
 type ProposedReceiptResponse = components["schemas"]["ProposedReceiptResponse"];
-type ConfidenceLevel = components["schemas"]["ConfidenceLevel"];
 
 type Status = "idle" | "uploading" | "success" | "error";
-
-function mapProposalToInitialValues(
-  proposal: ProposedReceiptResponse,
-): ScanInitialValues {
-  const taxAmount = Number(proposal.taxLines[0]?.amount ?? 0);
-
-  let date = "";
-  if (proposal.date) {
-    // The API returns a DateOnly (YYYY-MM-DD). If it comes as ISO datetime, extract the date part.
-    date = proposal.date.split("T")[0];
-  }
-
-  return {
-    header: {
-      location: proposal.storeName ?? "",
-      date,
-      taxAmount,
-    },
-    items: proposal.items.map((item) => ({
-      receiptItemCode: item.code ?? "",
-      description: item.description ?? "",
-      pricingMode: "quantity" as const,
-      quantity: Number(item.quantity ?? 1),
-      unitPrice: Number(item.unitPrice ?? 0),
-      category: "",
-      subcategory: "",
-    })),
-  };
-}
-
-function mapProposalToConfidenceMap(
-  proposal: ProposedReceiptResponse,
-): ReceiptConfidenceMap {
-  const map: ReceiptConfidenceMap = {};
-
-  const addIfNotHigh = (
-    key: keyof ReceiptConfidenceMap,
-    confidence: ConfidenceLevel,
-  ) => {
-    if (confidence !== "high") {
-      map[key] = confidence;
-    }
-  };
-
-  addIfNotHigh("location", proposal.storeNameConfidence);
-  addIfNotHigh("date", proposal.dateConfidence);
-
-  // Use the first tax line's confidence, or the subtotal confidence as fallback
-  const taxConfidence =
-    proposal.taxLines[0]?.amountConfidence ?? proposal.subtotalConfidence;
-  addIfNotHigh("taxAmount", taxConfidence);
-
-  return map;
-}
 
 function getErrorMessage(error: unknown): string {
   if (isTimeoutError(error)) {

--- a/src/client/src/pages/scan-receipt/index.ts
+++ b/src/client/src/pages/scan-receipt/index.ts
@@ -1,11 +1,17 @@
 export { default as ScanReceiptPage } from "./ScanReceiptPage";
 export { ReceiptImageUpload } from "./ReceiptImageUpload";
 export { ConfidenceIndicator } from "./ConfidenceIndicator";
+export {
+  mapProposalToInitialValues,
+  mapProposalToConfidenceMap,
+} from "./proposalMappers";
 export type {
   ConfidenceLevel,
   ReceiptConfidenceMap,
   ScanInitialValues,
+  ScanPayment,
   ProposedReceiptResponse,
   ProposedReceiptItemResponse,
   ProposedTaxLineResponse,
+  ProposedPaymentResponse,
 } from "./types";

--- a/src/client/src/pages/scan-receipt/proposalMappers.test.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapProposalToInitialValues,
+  mapProposalToConfidenceMap,
+} from "./proposalMappers";
+import type { components } from "@/generated/api";
+
+type ProposedReceiptResponse = components["schemas"]["ProposedReceiptResponse"];
+
+function makeProposal(
+  overrides: Partial<ProposedReceiptResponse> = {},
+): ProposedReceiptResponse {
+  return {
+    storeName: "Test Store",
+    storeNameConfidence: "high",
+    storeAddress: null,
+    storeAddressConfidence: "high",
+    storePhone: null,
+    storePhoneConfidence: "high",
+    date: "2024-06-15",
+    dateConfidence: "high",
+    items: [],
+    subtotal: 0,
+    subtotalConfidence: "high",
+    taxLines: [],
+    total: 0,
+    totalConfidence: "high",
+    paymentMethod: null,
+    paymentMethodConfidence: "high",
+    payments: [],
+    receiptId: null,
+    receiptIdConfidence: "high",
+    storeNumber: null,
+    storeNumberConfidence: "high",
+    terminalId: null,
+    terminalIdConfidence: "high",
+    ...overrides,
+  };
+}
+
+describe("mapProposalToInitialValues", () => {
+  it("populates header from proposal including new address/phone fields", () => {
+    const proposal = makeProposal({
+      storeName: "Walmart",
+      storeAddress: "123 Main St, Springfield",
+      storePhone: "(555) 123-4567",
+      date: "2024-06-15",
+      taxLines: [
+        {
+          label: "Tax",
+          labelConfidence: "high",
+          amount: 1.25,
+          amountConfidence: "high",
+        },
+      ],
+    });
+
+    const result = mapProposalToInitialValues(proposal);
+
+    expect(result.header).toEqual({
+      location: "Walmart",
+      date: "2024-06-15",
+      taxAmount: 1.25,
+      storeAddress: "123 Main St, Springfield",
+      storePhone: "(555) 123-4567",
+    });
+  });
+
+  it("populates metadata with receiptId, storeNumber, and terminalId", () => {
+    const proposal = makeProposal({
+      receiptId: "TX-987654",
+      storeNumber: "0042",
+      terminalId: "T01",
+    });
+
+    const result = mapProposalToInitialValues(proposal);
+
+    expect(result.metadata).toEqual({
+      receiptId: "TX-987654",
+      storeNumber: "0042",
+      terminalId: "T01",
+    });
+  });
+
+  it("populates payments array preserving order", () => {
+    const proposal = makeProposal({
+      payments: [
+        {
+          method: "MASTERCARD",
+          methodConfidence: "high",
+          amount: 54.32,
+          amountConfidence: "high",
+          lastFour: "4538",
+          lastFourConfidence: "high",
+        },
+        {
+          method: "Cash",
+          methodConfidence: "high",
+          amount: 5.0,
+          amountConfidence: "high",
+          lastFour: null,
+          lastFourConfidence: "high",
+        },
+      ],
+    });
+
+    const result = mapProposalToInitialValues(proposal);
+
+    expect(result.payments).toEqual([
+      { method: "MASTERCARD", amount: 54.32, lastFour: "4538" },
+      { method: "Cash", amount: 5.0, lastFour: "" },
+    ]);
+  });
+
+  it("populates per-item taxCode", () => {
+    const proposal = makeProposal({
+      items: [
+        {
+          code: "MILK-GAL",
+          codeConfidence: "high",
+          description: "Whole milk",
+          descriptionConfidence: "high",
+          quantity: 1,
+          quantityConfidence: "high",
+          unitPrice: 3.99,
+          unitPriceConfidence: "high",
+          totalPrice: 3.99,
+          totalPriceConfidence: "high",
+          taxCode: "F",
+          taxCodeConfidence: "high",
+        },
+      ],
+    });
+
+    const result = mapProposalToInitialValues(proposal);
+
+    expect(result.items[0].taxCode).toBe("F");
+  });
+
+  it("defaults nullable fields to empty strings or zero", () => {
+    const proposal = makeProposal({
+      storeName: null,
+      storeAddress: null,
+      storePhone: null,
+      date: null,
+      receiptId: null,
+      storeNumber: null,
+      terminalId: null,
+    });
+
+    const result = mapProposalToInitialValues(proposal);
+
+    expect(result.header.location).toBe("");
+    expect(result.header.date).toBe("");
+    expect(result.header.storeAddress).toBe("");
+    expect(result.header.storePhone).toBe("");
+    expect(result.metadata).toEqual({
+      receiptId: "",
+      storeNumber: "",
+      terminalId: "",
+    });
+    expect(result.payments).toEqual([]);
+    expect(result.items).toEqual([]);
+  });
+
+  it("strips ISO time component from a datetime date", () => {
+    const proposal = makeProposal({ date: "2024-06-15T12:34:56Z" });
+
+    const result = mapProposalToInitialValues(proposal);
+
+    expect(result.header.date).toBe("2024-06-15");
+  });
+});
+
+describe("mapProposalToConfidenceMap", () => {
+  it("omits high-confidence fields", () => {
+    const proposal = makeProposal();
+
+    const result = mapProposalToConfidenceMap(proposal);
+
+    expect(result).toEqual({});
+  });
+
+  it("flags low/medium confidence on the new fields", () => {
+    const proposal = makeProposal({
+      storeAddress: "123 Main St",
+      storeAddressConfidence: "low",
+      storePhone: "(555) 123-4567",
+      storePhoneConfidence: "medium",
+      receiptId: "TX-1",
+      receiptIdConfidence: "low",
+      storeNumber: "0042",
+      storeNumberConfidence: "medium",
+      terminalId: "T01",
+      terminalIdConfidence: "low",
+    });
+
+    const result = mapProposalToConfidenceMap(proposal);
+
+    expect(result).toMatchObject({
+      storeAddress: "low",
+      storePhone: "medium",
+      receiptId: "low",
+      storeNumber: "medium",
+      terminalId: "low",
+    });
+  });
+
+  it("emits a payments array entry for each payment, dropping high-confidence fields", () => {
+    const proposal = makeProposal({
+      payments: [
+        {
+          method: "MASTERCARD",
+          methodConfidence: "high",
+          amount: 54.32,
+          amountConfidence: "low",
+          lastFour: "4538",
+          lastFourConfidence: "medium",
+        },
+        {
+          method: "Cash",
+          methodConfidence: "high",
+          amount: 5,
+          amountConfidence: "high",
+          lastFour: null,
+          lastFourConfidence: "high",
+        },
+      ],
+    });
+
+    const result = mapProposalToConfidenceMap(proposal);
+
+    expect(result.payments).toEqual([
+      { amount: "low", lastFour: "medium" },
+      {},
+    ]);
+  });
+
+  it("does not include payments key when no payments exist", () => {
+    const proposal = makeProposal({ payments: [] });
+
+    const result = mapProposalToConfidenceMap(proposal);
+
+    expect(result.payments).toBeUndefined();
+  });
+
+  it("includes items entries only when at least one taxCode confidence is non-high", () => {
+    const lowItem = {
+      code: "X",
+      codeConfidence: "high" as const,
+      description: "x",
+      descriptionConfidence: "high" as const,
+      quantity: 1,
+      quantityConfidence: "high" as const,
+      unitPrice: 1,
+      unitPriceConfidence: "high" as const,
+      totalPrice: 1,
+      totalPriceConfidence: "high" as const,
+      taxCode: "F",
+      taxCodeConfidence: "low" as const,
+    };
+    const highItem = { ...lowItem, taxCodeConfidence: "high" as const };
+
+    const allHigh = mapProposalToConfidenceMap(
+      makeProposal({ items: [highItem] }),
+    );
+    expect(allHigh.items).toBeUndefined();
+
+    const someLow = mapProposalToConfidenceMap(
+      makeProposal({ items: [highItem, lowItem] }),
+    );
+    expect(someLow.items).toEqual([{}, { taxCode: "low" }]);
+  });
+});

--- a/src/client/src/pages/scan-receipt/proposalMappers.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.ts
@@ -1,0 +1,122 @@
+import type { components } from "@/generated/api";
+import type { ScanInitialValues, ReceiptConfidenceMap } from "./types";
+
+type ProposedReceiptResponse = components["schemas"]["ProposedReceiptResponse"];
+
+/**
+ * Map a {@link ProposedReceiptResponse} (returned by the VLM scan endpoint)
+ * to the {@link ScanInitialValues} shape consumed by the new-receipt wizard.
+ */
+export function mapProposalToInitialValues(
+  proposal: ProposedReceiptResponse,
+): ScanInitialValues {
+  const taxAmount = Number(proposal.taxLines[0]?.amount ?? 0);
+
+  let date = "";
+  if (proposal.date) {
+    // The API returns a DateOnly (YYYY-MM-DD). If it comes as ISO datetime, extract the date part.
+    date = proposal.date.split("T")[0];
+  }
+
+  return {
+    header: {
+      location: proposal.storeName ?? "",
+      date,
+      taxAmount,
+      storeAddress: proposal.storeAddress ?? "",
+      storePhone: proposal.storePhone ?? "",
+    },
+    metadata: {
+      receiptId: proposal.receiptId ?? "",
+      storeNumber: proposal.storeNumber ?? "",
+      terminalId: proposal.terminalId ?? "",
+    },
+    payments: proposal.payments.map((p) => ({
+      method: p.method ?? "",
+      amount: Number(p.amount ?? 0),
+      lastFour: p.lastFour ?? "",
+    })),
+    items: proposal.items.map((item) => ({
+      receiptItemCode: item.code ?? "",
+      description: item.description ?? "",
+      pricingMode: "quantity" as const,
+      quantity: Number(item.quantity ?? 1),
+      unitPrice: Number(item.unitPrice ?? 0),
+      category: "",
+      subcategory: "",
+      taxCode: item.taxCode ?? "",
+    })),
+  };
+}
+
+/**
+ * Build a confidence map from the proposal that highlights low/medium fields
+ * (so the new-receipt wizard can render review badges).
+ *
+ * Fields whose confidence is "high" are intentionally omitted — the absence
+ * of a key signals "no badge needed".
+ */
+export function mapProposalToConfidenceMap(
+  proposal: ProposedReceiptResponse,
+): ReceiptConfidenceMap {
+  const map: ReceiptConfidenceMap = {};
+
+  if (proposal.storeNameConfidence !== "high") {
+    map.location = proposal.storeNameConfidence;
+  }
+  if (proposal.dateConfidence !== "high") {
+    map.date = proposal.dateConfidence;
+  }
+
+  // Use the first tax line's confidence, or the subtotal confidence as fallback.
+  const taxConfidence =
+    proposal.taxLines[0]?.amountConfidence ?? proposal.subtotalConfidence;
+  if (taxConfidence !== "high") {
+    map.taxAmount = taxConfidence;
+  }
+
+  if (proposal.storeAddressConfidence !== "high") {
+    map.storeAddress = proposal.storeAddressConfidence;
+  }
+  if (proposal.storePhoneConfidence !== "high") {
+    map.storePhone = proposal.storePhoneConfidence;
+  }
+  if (proposal.receiptIdConfidence !== "high") {
+    map.receiptId = proposal.receiptIdConfidence;
+  }
+  if (proposal.storeNumberConfidence !== "high") {
+    map.storeNumber = proposal.storeNumberConfidence;
+  }
+  if (proposal.terminalIdConfidence !== "high") {
+    map.terminalId = proposal.terminalIdConfidence;
+  }
+
+  // Per-payment confidences. Always emit an entry per payment so indices align,
+  // omitting fields whose confidence is "high".
+  if (proposal.payments.length > 0) {
+    map.payments = proposal.payments.map((p) => {
+      const entry: NonNullable<ReceiptConfidenceMap["payments"]>[number] = {};
+      if (p.methodConfidence !== "high") entry.method = p.methodConfidence;
+      if (p.amountConfidence !== "high") entry.amount = p.amountConfidence;
+      if (p.lastFourConfidence !== "high") entry.lastFour = p.lastFourConfidence;
+      return entry;
+    });
+  }
+
+  // Per-item taxCode confidences.
+  if (proposal.items.length > 0) {
+    const itemEntries = proposal.items.map((item) => {
+      const entry: NonNullable<ReceiptConfidenceMap["items"]>[number] = {};
+      if (item.taxCodeConfidence !== "high") {
+        entry.taxCode = item.taxCodeConfidence;
+      }
+      return entry;
+    });
+    // Only include if any entry has at least one non-high confidence
+    if (itemEntries.some((e) => Object.keys(e).length > 0)) {
+      map.items = itemEntries;
+    }
+  }
+
+  return map;
+}

--- a/src/client/src/pages/scan-receipt/types.ts
+++ b/src/client/src/pages/scan-receipt/types.ts
@@ -7,12 +7,34 @@ export type ProposedReceiptItemResponse =
   components["schemas"]["ProposedReceiptItemResponse"];
 export type ProposedTaxLineResponse =
   components["schemas"]["ProposedTaxLineResponse"];
+export type ProposedPaymentResponse =
+  components["schemas"]["ProposedPaymentResponse"];
 
-// Internal UI types with no API counterpart
+export interface ScanPayment {
+  method: string;
+  amount: number;
+  lastFour: string;
+}
+
+// Confidence map for new-receipt fields populated from a scan proposal.
+// Items are keyed by index since they are identified by position, not id.
 export interface ReceiptConfidenceMap {
   location?: ConfidenceLevel;
   date?: ConfidenceLevel;
   taxAmount?: ConfidenceLevel;
+  storeAddress?: ConfidenceLevel;
+  storePhone?: ConfidenceLevel;
+  receiptId?: ConfidenceLevel;
+  storeNumber?: ConfidenceLevel;
+  terminalId?: ConfidenceLevel;
+  payments?: Array<{
+    method?: ConfidenceLevel;
+    amount?: ConfidenceLevel;
+    lastFour?: ConfidenceLevel;
+  }>;
+  items?: Array<{
+    taxCode?: ConfidenceLevel;
+  }>;
 }
 
 export interface ScanInitialValues {
@@ -20,7 +42,15 @@ export interface ScanInitialValues {
     location: string;
     date: string;
     taxAmount: number;
+    storeAddress: string;
+    storePhone: string;
   };
+  metadata: {
+    receiptId: string;
+    storeNumber: string;
+    terminalId: string;
+  };
+  payments: ScanPayment[];
   items: Array<{
     receiptItemCode: string;
     description: string;
@@ -29,5 +59,6 @@ export interface ScanInitialValues {
     unitPrice: number;
     category: string;
     subcategory: string;
+    taxCode: string;
   }>;
 }


### PR DESCRIPTION
## Summary

Surfaces the rich VLM-extracted fields added by RECEIPTS-626 in the scan-review wizard:

- `storeAddress`, `storePhone` — editable inputs in the receipt header (with confidence indicators)
- `payments[]` (multi-tender) — new collapsible **Detected Payments** section that pre-populates from the scan and lets the user edit `method`, `amount`, and `lastFour`
- `receiptId`, `storeNumber`, `terminalId` — shown in a collapsible read-only **Receipt Details** panel (only rendered when at least one is populated)
- Per-item `taxCode` (single letter F/N/X/T/etc.) — new column on the line-items table; editable via the form row and inline edit; uppercased on input

Resolves RECEIPTS-628.

## UX decisions

- **Editable**: `storeAddress`, `storePhone`, every `payments[].*`, per-item `taxCode`. The user can correct VLM extraction errors before submitting.
- **Read-only**: `receiptId`, `storeNumber`, `terminalId` are metadata only — they don't influence accounting and shouldn't be hand-edited. Collapsed by default to keep the wizard focused.
- **Confidence visualisation**: every new field reuses the existing `ConfidenceIndicator` (low → amber "Low confidence" badge; medium → "Review" badge). The `mapProposalToConfidenceMap` helper omits `"high"` so unflagged fields stay clean.
- **Detected Payments are separate from Transactions**: VLM payments are the literal payment lines printed on the receipt (e.g. "MASTERCARD 4538 \$54.32"), whereas the existing **Transactions** section links the user's saved cards/accounts to the receipt for accounting. The two are intentionally not merged.
- **Backwards-compatible defaults**: `NewReceiptPage` continues to render correctly when invoked directly (`/receipts/new`) without a scan — the new sections are gated on whether their respective initial values are populated. `storeAddress`/`storePhone` always render so a user composing a receipt manually can still capture them; they fall back to empty strings.

## Notes / assumptions

- **Submit payload unchanged**: the `CreateCompleteReceipt` API does not yet accept the new fields, so they are reviewable in the UI but not persisted. A follow-up issue should extend the request DTOs once the backend is ready (see VLM epic). This is documented inline in `NewReceiptPage.tsx`.
- **Tax-code validation**: a single ASCII letter (uppercased on input). Empty allowed.
- **Phone validation**: lenient regex `^[\d\s+()\-.]{7,20}$` to accept US and international formats. Only validates on submit, so partial input doesn't show errors.
- **Tests**: added `proposalMappers.test.ts` (11 tests covering the new mapper output), `PaymentsSection.test.tsx` (9 tests), extended `LineItemsSection.test.tsx` with 8 tax-code-focused tests, and extended `NewReceiptPage.test.tsx` and `ScanReceiptPage.test.tsx` with new-fields coverage. All 1879 client tests pass.
- **No backend or generated-DTO changes** — UI-only, per scope.

## Test plan

- [x] `cd src/client && npx vitest run` — all 169 test files / 1879 tests pass
- [x] `cd src/client && npm run lint` — no new errors (2 pre-existing warnings unrelated to this PR)
- [x] `cd src/client && npx tsc --noEmit` — clean
- [x] Pre-commit hooks (full backend + frontend test suite) succeed
- [ ] Manual: run Aspire, navigate to `/receipts/scan`, scan a real receipt, confirm the new sections render and are editable. Confidence badges should appear on low/medium fields.