### PR TITLE
fix(client): add type annotation and missing fields to MSW scan fixture

### DIFF
--- a/src/client/src/pages/scan-receipt/proposalMappers.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.ts
@@ -10,7 +10,15 @@ type ProposedReceiptResponse = components["schemas"]["ProposedReceiptResponse"];
 export function mapProposalToInitialValues(
   proposal: ProposedReceiptResponse,
 ): ScanInitialValues {
-  const taxAmount = Number(proposal.taxLines[0]?.amount ?? 0);
+  // Defensive guards: the OpenAPI contract declares these arrays as required
+  // (non-optional), but a stale fixture or partially-stubbed test handler can
+  // omit them. Coalescing to [] prevents a hard `TypeError: Cannot read
+  // properties of undefined` and keeps the wizard usable. See RECEIPTS-632.
+  const taxLines = proposal.taxLines ?? [];
+  const payments = proposal.payments ?? [];
+  const items = proposal.items ?? [];
+
+  const taxAmount = Number(taxLines[0]?.amount ?? 0);
 
   let date = "";
   if (proposal.date) {
@@ -31,12 +39,12 @@ export function mapProposalToInitialValues(
       storeNumber: proposal.storeNumber ?? "",
       terminalId: proposal.terminalId ?? "",
     },
-    payments: proposal.payments.map((p) => ({
+    payments: payments.map((p) => ({
       method: p.method ?? "",
       amount: Number(p.amount ?? 0),
       lastFour: p.lastFour ?? "",
     })),
-    items: proposal.items.map((item) => ({
+    items: items.map((item) => ({
       receiptItemCode: item.code ?? "",
       description: item.description ?? "",
       pricingMode: "quantity" as const,
@@ -59,6 +67,11 @@ export function mapProposalToInitialValues(
 export function mapProposalToConfidenceMap(
   proposal: ProposedReceiptResponse,
 ): ReceiptConfidenceMap {
+  // See note in mapProposalToInitialValues — same defensive guards.
+  const taxLines = proposal.taxLines ?? [];
+  const payments = proposal.payments ?? [];
+  const items = proposal.items ?? [];
+
   const map: ReceiptConfidenceMap = {};
 
   if (proposal.storeNameConfidence !== "high") {
@@ -70,7 +83,7 @@ export function mapProposalToConfidenceMap(
 
   // Use the first tax line's confidence, or the subtotal confidence as fallback.
   const taxConfidence =
-    proposal.taxLines[0]?.amountConfidence ?? proposal.subtotalConfidence;
+    taxLines[0]?.amountConfidence ?? proposal.subtotalConfidence;
   if (taxConfidence !== "high") {
     map.taxAmount = taxConfidence;
   }
@@ -93,19 +106,20 @@ export function mapProposalToConfidenceMap(
 
   // Per-payment confidences. Always emit an entry per payment so indices align,
   // omitting fields whose confidence is "high".
-  if (proposal.payments.length > 0) {
-    map.payments = proposal.payments.map((p) => {
+  if (payments.length > 0) {
+    map.payments = payments.map((p) => {
       const entry: NonNullable<ReceiptConfidenceMap["payments"]>[number] = {};
       if (p.methodConfidence !== "high") entry.method = p.methodConfidence;
       if (p.amountConfidence !== "high") entry.amount = p.amountConfidence;
-      if (p.lastFourConfidence !== "high") entry.lastFour = p.lastFourConfidence;
+      if (p.lastFourConfidence !== "high")
+        entry.lastFour = p.lastFourConfidence;
       return entry;
     });
   }
 
   // Per-item taxCode confidences.
-  if (proposal.items.length > 0) {
-    const itemEntries = proposal.items.map((item) => {
+  if (items.length > 0) {
+    const itemEntries = items.map((item) => {
       const entry: NonNullable<ReceiptConfidenceMap["items"]>[number] = {};
       if (item.taxCodeConfidence !== "high") {
         entry.taxCode = item.taxCodeConfidence;

--- a/src/client/src/test/msw/fixtures/scan.test.ts
+++ b/src/client/src/test/msw/fixtures/scan.test.ts
@@ -65,9 +65,11 @@ describe("scanProposal fixture", () => {
     expect(scanProposal).toHaveProperty("terminalIdConfidence");
   });
 
-  it("exercises a representative mix of confidence levels", () => {
-    // The fixture exists to drive UI badge rendering; keeping a mix of
-    // high/medium/low ensures the wizard's confidence visuals stay covered.
+  it("exercises every confidence level (high, medium, low) across its fields", () => {
+    // The fixture exists to drive UI badge rendering; require all three
+    // confidence levels to appear so the wizard's high/medium/low badge
+    // paths stay covered. A weaker `size > 1` check would silently let
+    // a future fixture edit drop one level entirely.
     const allConfidences = new Set<string>();
     allConfidences.add(scanProposal.storeNameConfidence);
     allConfidences.add(scanProposal.storeAddressConfidence);
@@ -75,6 +77,8 @@ describe("scanProposal fixture", () => {
     allConfidences.add(scanProposal.dateConfidence);
     allConfidences.add(scanProposal.terminalIdConfidence);
     allConfidences.add(scanProposal.storeNumberConfidence);
-    expect(allConfidences.size).toBeGreaterThan(1);
+    expect(allConfidences).toContain("high");
+    expect(allConfidences).toContain("medium");
+    expect(allConfidences).toContain("low");
   });
 });

--- a/src/client/src/test/msw/fixtures/scan.test.ts
+++ b/src/client/src/test/msw/fixtures/scan.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { scanProposal } from "./scan";
+import {
+  mapProposalToInitialValues,
+  mapProposalToConfidenceMap,
+} from "@/pages/scan-receipt/proposalMappers";
+
+/**
+ * Regression coverage for RECEIPTS-632.
+ *
+ * The MSW scan fixture used to drift from the OpenAPI contract because it
+ * was a bare object literal with no type annotation — TypeScript silently
+ * accepted missing required fields, and integration tests crashed at runtime
+ * with `TypeError: Cannot read properties of undefined`.
+ *
+ * These tests lock down the fixture's shape against the same proposal
+ * mappers that production code uses, so any future drift surfaces here
+ * (and in the type-check) instead of in a downstream test.
+ */
+describe("scanProposal fixture", () => {
+  it("can be mapped to initial values without throwing", () => {
+    expect(() => mapProposalToInitialValues(scanProposal)).not.toThrow();
+  });
+
+  it("can be mapped to a confidence map without throwing", () => {
+    expect(() => mapProposalToConfidenceMap(scanProposal)).not.toThrow();
+  });
+
+  it("provides a non-empty payments array", () => {
+    // The wizard renders payment chips; an empty array silently hides them
+    // and would mask a real regression in upstream payment extraction.
+    expect(scanProposal.payments.length).toBeGreaterThan(0);
+    for (const payment of scanProposal.payments) {
+      expect(payment).toHaveProperty("method");
+      expect(payment).toHaveProperty("amount");
+      expect(payment).toHaveProperty("lastFour");
+      expect(payment).toHaveProperty("methodConfidence");
+      expect(payment).toHaveProperty("amountConfidence");
+      expect(payment).toHaveProperty("lastFourConfidence");
+    }
+  });
+
+  it("provides taxCode and taxCodeConfidence for every item", () => {
+    // Per-item taxCode is required by the OpenAPI contract; missing it
+    // crashes mapProposalToInitialValues at runtime.
+    expect(scanProposal.items.length).toBeGreaterThan(0);
+    for (const item of scanProposal.items) {
+      expect(item).toHaveProperty("taxCode");
+      expect(item).toHaveProperty("taxCodeConfidence");
+    }
+  });
+
+  it("populates every required top-level metadata field", () => {
+    // These fields were added during VLM rollout and are required by the
+    // OpenAPI contract; the fixture must keep them populated.
+    expect(scanProposal).toHaveProperty("storeAddress");
+    expect(scanProposal).toHaveProperty("storeAddressConfidence");
+    expect(scanProposal).toHaveProperty("storePhone");
+    expect(scanProposal).toHaveProperty("storePhoneConfidence");
+    expect(scanProposal).toHaveProperty("receiptId");
+    expect(scanProposal).toHaveProperty("receiptIdConfidence");
+    expect(scanProposal).toHaveProperty("storeNumber");
+    expect(scanProposal).toHaveProperty("storeNumberConfidence");
+    expect(scanProposal).toHaveProperty("terminalId");
+    expect(scanProposal).toHaveProperty("terminalIdConfidence");
+  });
+
+  it("exercises a representative mix of confidence levels", () => {
+    // The fixture exists to drive UI badge rendering; keeping a mix of
+    // high/medium/low ensures the wizard's confidence visuals stay covered.
+    const allConfidences = new Set<string>();
+    allConfidences.add(scanProposal.storeNameConfidence);
+    allConfidences.add(scanProposal.storeAddressConfidence);
+    allConfidences.add(scanProposal.storePhoneConfidence);
+    allConfidences.add(scanProposal.dateConfidence);
+    allConfidences.add(scanProposal.terminalIdConfidence);
+    allConfidences.add(scanProposal.storeNumberConfidence);
+    expect(allConfidences.size).toBeGreaterThan(1);
+  });
+});

--- a/src/client/src/test/msw/fixtures/scan.ts
+++ b/src/client/src/test/msw/fixtures/scan.ts
@@ -1,6 +1,25 @@
-export const scanProposal = {
+import type { components } from "@/generated/api";
+
+type ProposedReceiptResponse = components["schemas"]["ProposedReceiptResponse"];
+
+/**
+ * Fixture for the VLM scan endpoint (`POST /api/receipts/scan`).
+ *
+ * Typed as {@link ProposedReceiptResponse} so TypeScript enforces field
+ * completeness against the OpenAPI contract — adding a new required field
+ * upstream causes this file to fail to type-check, preventing the silent
+ * runtime crash described in RECEIPTS-632.
+ *
+ * Confidence values are intentionally a mix of high/medium/low so the
+ * new-receipt wizard's badge rendering is exercised under realistic data.
+ */
+export const scanProposal: ProposedReceiptResponse = {
   storeName: "Walmart Supercenter",
   storeNameConfidence: "high",
+  storeAddress: "123 Main St, Springfield, IL 62701",
+  storeAddressConfidence: "medium",
+  storePhone: "(555) 123-4567",
+  storePhoneConfidence: "low",
   date: "2024-06-15",
   dateConfidence: "high",
   items: [
@@ -15,6 +34,8 @@ export const scanProposal = {
       unitPriceConfidence: "medium",
       totalPrice: 7.98,
       totalPriceConfidence: "high",
+      taxCode: "F",
+      taxCodeConfidence: "high",
     },
     {
       code: null,
@@ -27,6 +48,8 @@ export const scanProposal = {
       unitPriceConfidence: "low",
       totalPrice: 1.29,
       totalPriceConfidence: "medium",
+      taxCode: null,
+      taxCodeConfidence: "low",
     },
   ],
   subtotal: 9.27,
@@ -43,4 +66,20 @@ export const scanProposal = {
   totalConfidence: "high",
   paymentMethod: "VISA",
   paymentMethodConfidence: "medium",
+  payments: [
+    {
+      method: "VISA",
+      methodConfidence: "high",
+      amount: 10.01,
+      amountConfidence: "high",
+      lastFour: "4242",
+      lastFourConfidence: "medium",
+    },
+  ],
+  receiptId: "TX-987654321",
+  receiptIdConfidence: "high",
+  storeNumber: "0042",
+  storeNumberConfidence: "medium",
+  terminalId: "T01",
+  terminalIdConfidence: "low",
 };


### PR DESCRIPTION
## Summary

The MSW scan fixture (`src/client/src/test/msw/fixtures/scan.ts`) drifted from the OpenAPI contract during the VLM rollout. Without a `: ProposedReceiptResponse` annotation, TypeScript silently accepted the gap, and integration tests crashed at runtime with `TypeError: Cannot read properties of undefined` when `mapProposalToInitialValues` read `proposal.payments` or `proposal.items[i].taxCode`.

- **Fixture is now typed.** `scanProposal` carries `: ProposedReceiptResponse` so future contract drift fails the type check instead of leaking to runtime.
- **All required fields are populated** with a representative high/medium/low confidence mix to exercise wizard badge rendering: `payments`, `storeAddress(Confidence)`, `storePhone(Confidence)`, `receiptId(Confidence)`, `storeNumber(Confidence)`, `terminalId(Confidence)`, and per-item `taxCode(Confidence)`.
- **Defensive guards in `proposalMappers.ts`** — `?? []` on `taxLines`, `payments`, `items` so any future contract drift produces a degraded UI rather than a hard crash. The arrays are required by the OpenAPI types, but a partially-stubbed test handler or unrelated future schema change can still skip them.
- **New regression test** `src/client/src/test/msw/fixtures/scan.test.ts` drives the fixture through both proposal mappers and asserts each newly-required field is present, so this exact bug can't reappear silently.

Resolves RECEIPTS-632

Parent epic: RECEIPTS-616 (VLM receipt extraction). PR targets `feat/receipts-616-vlm-receipt-extraction` per the parent-branch workflow.

## Test plan

- [x] `npm test` passes — 170 files, 1888 tests (run via pre-commit hook).
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint <changed files>` clean.
- [x] `npx prettier --check <changed files>` clean.
- [x] New `scan.test.ts` covers: maps without throwing, payments non-empty, every item has taxCode + taxCodeConfidence, all top-level VLM-rollout fields present, mixed confidence levels.
- [x] Existing `proposalMappers.test.ts` still passes with the new defensive guards.