### PR TITLE
fix(client): replace LineItemsSection editingItemId useEffect with derived boolean (RECEIPTS-642)

### DIFF
--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -371,6 +371,38 @@ describe("LineItemsSection", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it("hides the edit form when the item being edited is removed externally", async () => {
+    // Regression test for RECEIPTS-642: replaced a useEffect-based
+    // editingItemId cleanup with a derived `isEditing` value computed during
+    // render. When the parent removes the item, no row matches editingItemId,
+    // so the edit UI no longer renders — without a double render.
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const items: ReceiptLineItem[] = [
+      makeItem({ id: "item-1", description: "Milk" }),
+      makeItem({ id: "item-2", description: "Bread" }),
+    ];
+
+    const { rerender } = renderWithProviders(
+      <LineItemsSection items={items} onChange={onChange} />,
+    );
+
+    // Enter edit mode on Milk (item-1).
+    const editButtons = screen.getAllByRole("button", { name: /edit/i });
+    await user.click(editButtons[0]);
+    expect(screen.getByLabelText("Edit description")).toBeInTheDocument();
+
+    // Parent removes item-1 from state externally.
+    rerender(
+      <LineItemsSection items={[items[1]]} onChange={onChange} />,
+    );
+
+    // Edit form should no longer be visible because no row matches the stale
+    // editingItemId. Bread (item-2) renders in display mode, not edit mode.
+    expect(screen.queryByLabelText("Edit description")).not.toBeInTheDocument();
+    expect(screen.getByText("Bread")).toBeInTheDocument();
+  });
+
   it("disables quantity input in edit mode for flat pricing items", async () => {
     const user = userEvent.setup();
     const items: ReceiptLineItem[] = [

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useRef, useEffect } from "react";
+import { useState, useMemo, useCallback, useRef } from "react";
 import { generateId } from "@/lib/id";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
@@ -360,12 +360,12 @@ export function LineItemsSection({
     setEditingItemId(null);
   }, [editingItemId, editDraft, items, onChange]);
 
-  // Clear stale editing state when the edited item is removed externally
-  useEffect(() => {
-    if (editingItemId && !items.some((i) => i.id === editingItemId)) {
-      setEditingItemId(null);
-    }
-  }, [items, editingItemId]);
+  // Derived during render: stale `editingItemId` (e.g. parent removed the
+  // edited item) becomes harmless because no row matches and no edit UI shows.
+  // See docs/react/effects.md rule 4 — replaces a "form field cascade via
+  // Effects" anti-pattern that caused a double render on external removal.
+  const isEditing =
+    editingItemId !== null && items.some((i) => i.id === editingItemId);
 
   return (
     <Card>
@@ -748,7 +748,7 @@ export function LineItemsSection({
             <TableBody>
               {items.map((item) => {
                 const taxCodeConfidence = itemConfidenceById?.get(item.id)?.taxCode;
-                return editingItemId === item.id ? (
+                return isEditing && editingItemId === item.id ? (
                   <TableRow key={item.id}>
                     <TableCell>
                       <Input


### PR DESCRIPTION
## Summary

- Removes the `useEffect` in `LineItemsSection.tsx` that cleared stale `editingItemId` when the edited item was removed externally — a "form field cascade via Effects" anti-pattern (`docs/react/effects.md` rule 4) that caused a double render on every external removal.
- Replaces it with `isEditing` derived during render (`editingItemId !== null && items.some(i => i.id === editingItemId)`); the per-row edit form is gated on `isEditing` so a stale `editingItemId` becomes harmless because no row matches.
- Adds a regression test asserting the edit form disappears when the parent removes the item being edited.

Resolves RECEIPTS-642

## Test plan

- [x] `npx tsc -b --noEmit` passes
- [x] `npx vitest run src/pages/new-receipt/LineItemsSection.test.tsx` — all 25 tests pass (24 existing + 1 new regression test)
- [x] `npx vitest run src/pages/new-receipt/` — all 75 tests pass
- [x] `npx eslint` clean on both modified files
- [x] Pre-commit hook runs full client test suite — 1883 tests pass