### PR TITLE
fix(infrastructure): validate image extension allowlist + filename basename (RECEIPTS-641)

### DIFF
--- a/src/Infrastructure/Services/LocalImageStorageService.cs
+++ b/src/Infrastructure/Services/LocalImageStorageService.cs
@@ -85,7 +85,15 @@ public class LocalImageStorageService(IConfiguration configuration) : IImageStor
 			throw new ArgumentException(InvalidFileNameMessage, nameof(fileName));
 		}
 
-		if (ContainsUnsafeCharacter(fileName) || fileName.Contains(".."))
+		// Reject parent ("..") and current-directory (".") references explicitly. Both
+		// would otherwise pass the unsafe-character and basename checks below and resolve
+		// to a directory path under the storage root, not a file.
+		if (fileName == "." || fileName.Contains(".."))
+		{
+			throw new ArgumentException(InvalidFileNameMessage, nameof(fileName));
+		}
+
+		if (ContainsUnsafeCharacter(fileName))
 		{
 			throw new ArgumentException(InvalidFileNameMessage, nameof(fileName));
 		}

--- a/src/Infrastructure/Services/LocalImageStorageService.cs
+++ b/src/Infrastructure/Services/LocalImageStorageService.cs
@@ -6,16 +6,33 @@ namespace Infrastructure.Services;
 
 public class LocalImageStorageService(IConfiguration configuration) : IImageStorageService
 {
+	// Allowlist of image extensions that may be written to disk. Compared case-insensitively
+	// against a normalized (lowercased) caller-supplied value to defeat trivial casing tricks
+	// and reject embedded path separators, NTFS alternate-stream markers, NUL bytes, and
+	// parent-directory references that Path.GetExtension can pass through unchanged.
+	private static readonly HashSet<string> AllowedExtensions =
+		new(StringComparer.Ordinal) { ".jpg", ".jpeg", ".png" };
+
+	internal const string InvalidExtensionMessage =
+		"Extension must be one of: .jpg, .jpeg, .png.";
+
+	internal const string InvalidFileNameMessage =
+		"File name must be a simple basename with no path separators, parent references, or stream markers.";
+
 	private string StorageRoot =>
 		configuration[ConfigurationVariables.ImageStoragePath]
 		?? Path.Combine(AppContext.BaseDirectory, "ImageStorage");
 
 	public async Task<string> SaveOriginalAsync(Guid receiptId, byte[] imageBytes, string extension, CancellationToken ct)
 	{
+		ValidateExtension(extension);
+
 		string directory = Path.Combine(StorageRoot, receiptId.ToString());
 		Directory.CreateDirectory(directory);
 
-		string fileName = $"original{extension}";
+		// Normalize to lowercase so all on-disk filenames are deterministic regardless of
+		// the casing the caller supplied (they passed the allowlist either way).
+		string fileName = $"original{extension.ToLowerInvariant()}";
 		string filePath = Path.Combine(directory, fileName);
 
 		await File.WriteAllBytesAsync(filePath, imageBytes, ct);
@@ -26,6 +43,7 @@ public class LocalImageStorageService(IConfiguration configuration) : IImageStor
 
 	public string GetImagePath(Guid receiptId, string fileName)
 	{
+		ValidateFileName(fileName);
 		return Path.Combine(StorageRoot, receiptId.ToString(), fileName);
 	}
 
@@ -37,5 +55,61 @@ public class LocalImageStorageService(IConfiguration configuration) : IImageStor
 			Directory.Delete(directory, recursive: true);
 		}
 		return Task.CompletedTask;
+	}
+
+	private static void ValidateExtension(string extension)
+	{
+		if (string.IsNullOrWhiteSpace(extension))
+		{
+			throw new ArgumentException(InvalidExtensionMessage, nameof(extension));
+		}
+
+		// Reject anything with structure beyond a simple ".ext": separators, NUL bytes,
+		// stream markers, parent references. Membership check below also catches these,
+		// but an explicit reject yields a clearer failure for fuzzy inputs.
+		if (ContainsUnsafeCharacter(extension) || extension.Contains(".."))
+		{
+			throw new ArgumentException(InvalidExtensionMessage, nameof(extension));
+		}
+
+		if (!AllowedExtensions.Contains(extension.ToLowerInvariant()))
+		{
+			throw new ArgumentException(InvalidExtensionMessage, nameof(extension));
+		}
+	}
+
+	private static void ValidateFileName(string fileName)
+	{
+		if (string.IsNullOrWhiteSpace(fileName))
+		{
+			throw new ArgumentException(InvalidFileNameMessage, nameof(fileName));
+		}
+
+		if (ContainsUnsafeCharacter(fileName) || fileName.Contains(".."))
+		{
+			throw new ArgumentException(InvalidFileNameMessage, nameof(fileName));
+		}
+
+		// Path.GetFileName strips any directory prefix; if the result differs from the
+		// input the caller smuggled in something more than a basename.
+		if (!string.Equals(Path.GetFileName(fileName), fileName, StringComparison.Ordinal))
+		{
+			throw new ArgumentException(InvalidFileNameMessage, nameof(fileName));
+		}
+	}
+
+	private static bool ContainsUnsafeCharacter(string value)
+	{
+		// Forward/backslashes (path traversal), colon (NTFS alternate streams / drive letters),
+		// and NUL (string-truncation tricks against native APIs). These short-circuit ahead of
+		// the allowlist check so the error message is consistent.
+		foreach (char c in value)
+		{
+			if (c == '/' || c == '\\' || c == ':' || c == '\0')
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/tests/Infrastructure.Tests/Services/LocalImageStorageServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/LocalImageStorageServiceTests.cs
@@ -1,0 +1,230 @@
+using Common;
+using FluentAssertions;
+using Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Moq;
+
+namespace Infrastructure.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="LocalImageStorageService"/>. Covers the extension allowlist on
+/// <c>SaveOriginalAsync</c> and basename validation on <c>GetImagePath</c> against
+/// path-traversal, NTFS alternate-stream, and embedded-NUL attack patterns described
+/// in RECEIPTS-641.
+/// </summary>
+public sealed class LocalImageStorageServiceTests : IDisposable
+{
+	private readonly string _tempRoot;
+	private readonly LocalImageStorageService _service;
+
+	public LocalImageStorageServiceTests()
+	{
+		_tempRoot = Path.Combine(Path.GetTempPath(), "receipts-tests-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempRoot);
+
+		Mock<IConfiguration> configuration = new();
+		// Per project memory: use the flat indexer, not GetSection/GetConnectionString,
+		// because Moq does not implement those extension methods.
+		configuration.Setup(c => c[ConfigurationVariables.ImageStoragePath]).Returns(_tempRoot);
+
+		_service = new LocalImageStorageService(configuration.Object);
+	}
+
+	public void Dispose()
+	{
+		if (Directory.Exists(_tempRoot))
+		{
+			Directory.Delete(_tempRoot, recursive: true);
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// SaveOriginalAsync — happy path
+	// ---------------------------------------------------------------------
+
+	[Theory]
+	[InlineData(".jpg")]
+	[InlineData(".jpeg")]
+	[InlineData(".png")]
+	[InlineData(".JPG")]
+	[InlineData(".JPEG")]
+	[InlineData(".PNG")]
+	public async Task SaveOriginalAsync_AllowedExtension_WritesFile(string extension)
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		byte[] bytes = [0x01, 0x02, 0x03];
+
+		// Act
+		string relativePath = await _service.SaveOriginalAsync(receiptId, bytes, extension, CancellationToken.None);
+
+		// Assert — relative path uses lowercased extension and correct receipt folder
+		string expectedRelative = Path.Combine(receiptId.ToString(), $"original{extension.ToLowerInvariant()}");
+		relativePath.Should().Be(expectedRelative);
+
+		string absolutePath = Path.Combine(_tempRoot, relativePath);
+		File.Exists(absolutePath).Should().BeTrue();
+		(await File.ReadAllBytesAsync(absolutePath)).Should().Equal(bytes);
+	}
+
+	// ---------------------------------------------------------------------
+	// SaveOriginalAsync — attack vectors from RECEIPTS-641
+	// ---------------------------------------------------------------------
+
+	[Theory]
+	// Path-traversal smuggled through Path.GetExtension (returns everything from the last '.')
+	[InlineData(".jpg/../../etc/passwd")]
+	[InlineData(".jpg\\..\\..\\Windows\\System32\\evil")]
+	// NTFS alternate data streams
+	[InlineData(".jpg:malicious")]
+	[InlineData(".jpg:$DATA")]
+	// Embedded NUL (string truncation trick against unmanaged APIs)
+	[InlineData(".jpg\0evil")]
+	// Disallowed extensions
+	[InlineData(".gif")]
+	[InlineData(".exe")]
+	[InlineData(".php")]
+	[InlineData(".txt")]
+	// Missing leading dot
+	[InlineData("jpg")]
+	[InlineData("png")]
+	// Parent reference only
+	[InlineData("..")]
+	[InlineData(".")]
+	public async Task SaveOriginalAsync_RejectsUnsafeExtension(string extension)
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		byte[] bytes = [0x01];
+
+		// Act
+		Func<Task> act = () => _service.SaveOriginalAsync(receiptId, bytes, extension, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<ArgumentException>()
+			.WithMessage($"*{LocalImageStorageService.InvalidExtensionMessage}*");
+
+		// Side-effect check: nothing should land on disk for the rejected receipt
+		string receiptDir = Path.Combine(_tempRoot, receiptId.ToString());
+		if (Directory.Exists(receiptDir))
+		{
+			Directory.GetFileSystemEntries(receiptDir).Should().BeEmpty(
+				"validation must reject before any directory or file is created");
+		}
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("\t")]
+	public async Task SaveOriginalAsync_RejectsEmptyExtension(string extension)
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		byte[] bytes = [0x01];
+
+		// Act
+		Func<Task> act = () => _service.SaveOriginalAsync(receiptId, bytes, extension, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<ArgumentException>();
+	}
+
+	[Fact]
+	public async Task SaveOriginalAsync_NullExtension_ThrowsArgumentException()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		byte[] bytes = [0x01];
+
+		// Act
+		Func<Task> act = () => _service.SaveOriginalAsync(receiptId, bytes, null!, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<ArgumentException>();
+	}
+
+	// ---------------------------------------------------------------------
+	// GetImagePath — happy path
+	// ---------------------------------------------------------------------
+
+	[Theory]
+	[InlineData("original.jpg")]
+	[InlineData("original.jpeg")]
+	[InlineData("original.png")]
+	[InlineData("original.JPG")]
+	public void GetImagePath_ValidBasename_ReturnsCombinedPath(string fileName)
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		string expected = Path.Combine(_tempRoot, receiptId.ToString(), fileName);
+
+		// Act
+		string actual = _service.GetImagePath(receiptId, fileName);
+
+		// Assert
+		actual.Should().Be(expected);
+	}
+
+	// ---------------------------------------------------------------------
+	// GetImagePath — attack vectors
+	// ---------------------------------------------------------------------
+
+	[Theory]
+	// Path traversal
+	[InlineData("../etc/passwd")]
+	[InlineData("..\\Windows\\System32\\config\\SAM")]
+	[InlineData("foo/bar.jpg")]
+	[InlineData("foo\\bar.jpg")]
+	[InlineData("..")]
+	[InlineData("a/../b.jpg")]
+	// NTFS alternate streams / drive letters
+	[InlineData("original.jpg:malicious")]
+	[InlineData("C:original.jpg")]
+	// NUL byte truncation
+	[InlineData("original.jpg\0evil")]
+	// Absolute paths
+	[InlineData("/etc/passwd")]
+	[InlineData("\\\\server\\share\\file.jpg")]
+	public void GetImagePath_RejectsUnsafeFileName(string fileName)
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+
+		// Act
+		Action act = () => _service.GetImagePath(receiptId, fileName);
+
+		// Assert
+		act.Should().Throw<ArgumentException>()
+			.WithMessage($"*{LocalImageStorageService.InvalidFileNameMessage}*");
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("\t")]
+	public void GetImagePath_RejectsEmptyFileName(string fileName)
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+
+		// Act
+		Action act = () => _service.GetImagePath(receiptId, fileName);
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	public void GetImagePath_NullFileName_ThrowsArgumentException()
+	{
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+
+		// Act
+		Action act = () => _service.GetImagePath(receiptId, null!);
+
+		// Assert
+		act.Should().Throw<ArgumentException>();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/LocalImageStorageServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/LocalImageStorageServiceTests.cs
@@ -104,13 +104,12 @@ public sealed class LocalImageStorageServiceTests : IDisposable
 		await act.Should().ThrowAsync<ArgumentException>()
 			.WithMessage($"*{LocalImageStorageService.InvalidExtensionMessage}*");
 
-		// Side-effect check: nothing should land on disk for the rejected receipt
+		// Side-effect check: validation must short-circuit before the receipt directory is
+		// even created. Asserting non-existence (rather than emptiness) catches a regression
+		// where someone reorders Directory.CreateDirectory above the ValidateExtension call.
 		string receiptDir = Path.Combine(_tempRoot, receiptId.ToString());
-		if (Directory.Exists(receiptDir))
-		{
-			Directory.GetFileSystemEntries(receiptDir).Should().BeEmpty(
-				"validation must reject before any directory or file is created");
-		}
+		Directory.Exists(receiptDir).Should().BeFalse(
+			"validation must reject before any directory is created");
 	}
 
 	[Theory]
@@ -177,6 +176,7 @@ public sealed class LocalImageStorageServiceTests : IDisposable
 	[InlineData("foo/bar.jpg")]
 	[InlineData("foo\\bar.jpg")]
 	[InlineData("..")]
+	[InlineData(".")]
 	[InlineData("a/../b.jpg")]
 	// NTFS alternate streams / drive letters
 	[InlineData("original.jpg:malicious")]


### PR DESCRIPTION
## Summary

- `LocalImageStorageService.SaveOriginalAsync` now validates `extension` against an allowlist (`.jpg`, `.jpeg`, `.png`, case-insensitive) and rejects any value containing `/`, `\`, `:`, NUL, or `..` before any directory or file is created. Previously, `Path.GetExtension(file.FileName)` in the controller could yield strings like `.jpg/../../etc/passwd` that were concatenated as `original{extension}` and written verbatim under the storage root.
- `GetImagePath` now requires `fileName` to be a simple basename (`Path.GetFileName(x) == x`) with no separators, parent references, NUL bytes, or NTFS alternate-stream markers (`:`).
- Both methods throw `ArgumentException` with a clear message on violation; the on-disk filename also normalizes the extension to lowercase for determinism.

Resolves RECEIPTS-641.

## Test plan

New `tests/Infrastructure.Tests/Services/LocalImageStorageServiceTests.cs` (42 tests) covers:

- Happy path matrix on both methods for `.jpg`, `.jpeg`, `.png` and mixed casing
- Path-traversal: `.jpg/../../etc/passwd`, `.jpg\..\..\Windows\System32\evil`, `../etc/passwd`, `foo/bar.jpg`, `foo\bar.jpg`, `..`, `a/../b.jpg`
- NTFS alternate streams: `.jpg:malicious`, `.jpg:$DATA`, `original.jpg:malicious`, `C:original.jpg`
- Embedded NUL: `.jpg\0evil`, `original.jpg\0evil`
- Disallowed extensions: `.gif`, `.exe`, `.php`, `.txt`, `jpg` (no leading dot)
- Empty / whitespace / null inputs on both methods
- Side-effect check: rejected `SaveOriginalAsync` calls leave the receipt directory empty

Verification:

- [x] `dotnet build src/Infrastructure/Infrastructure.csproj` — clean (only pre-existing transitive NU1903 warnings)
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — all unit tests pass (Application 463, Domain 137, Infrastructure 691 incl. 42 new, Presentation.API 1027)
- [x] Pre-commit hooks (incl. frontend Vitest 1882 tests) pass