### PR TITLE
fix(infra): vlm container readiness probes + model gating (RECEIPTS-636)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,11 @@ services:
 
   # VLM OCR: Ollama container serving qwen2.5vl:3b for receipt extraction (RECEIPTS-616 epic).
   # Named volume persists the model cache so the first-run ~3 GB pull only happens once.
+  #
+  # The `ollama list` healthcheck validates the Ollama daemon is responsive (it queries the
+  # Ollama HTTP API under the hood and fails if the server is not yet listening). It does NOT
+  # validate that the configured model is pulled — model presence is enforced on the `app`
+  # service via depends_on vlm-ocr-pull: service_completed_successfully (RECEIPTS-636).
   vlm-ocr:
     image: ollama/ollama:latest
     container_name: receipts-vlm-ocr
@@ -163,8 +168,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      vlm-ocr:
-        condition: service_healthy
+      # Gate API startup on the pull sidecar exiting successfully — that proves both
+      # (1) Ollama is healthy (the sidecar's own depends_on requires service_healthy on vlm-ocr)
+      # and (2) qwen2.5vl:3b is pulled into the shared volume. This prevents the API smoke
+      # test from racing the model pull on first cold start (RECEIPTS-636). Mirrors the
+      # AppHost.cs pattern that uses .WaitForCompletion(vlmOcrPull) on the API resource.
+      vlm-ocr-pull:
+        condition: service_completed_successfully
       otel-collector:
         condition: service_started
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,11 @@ services:
 
   # One-shot sidecar: pulls qwen2.5vl:3b if it is not already cached, then exits.
   # Idempotent — subsequent runs find the model present and skip the download.
+  #
+  # `app` now gates startup on this sidecar exiting successfully (RECEIPTS-636), so a
+  # non-zero exit here permanently blocks the API. To avoid that on transient network
+  # errors during the ~3 GB cold-start pull, the command retries up to 5 times with
+  # backoff before giving up.
   vlm-ocr-pull:
     image: ollama/ollama:latest
     container_name: receipts-vlm-ocr-pull
@@ -129,7 +134,23 @@ services:
       vlm-ocr:
         condition: service_healthy
     entrypoint: ["/bin/sh"]
-    command: ["-c", "ollama list | grep -q 'qwen2.5vl:3b' || ollama pull qwen2.5vl:3b"]
+    command:
+      - -c
+      - |
+        for i in 1 2 3 4 5; do
+          if ollama list | grep -q 'qwen2.5vl:3b'; then
+            echo "qwen2.5vl:3b already present; skipping pull"
+            exit 0
+          fi
+          echo "Pulling qwen2.5vl:3b (attempt $$i/5)..."
+          if ollama pull qwen2.5vl:3b; then
+            exit 0
+          fi
+          echo "Pull failed; sleeping before retry"
+          sleep 10
+        done
+        echo "All pull attempts failed" >&2
+        exit 1
     environment:
       - OLLAMA_HOST=http://vlm-ocr:11434
     networks:

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -29,24 +29,34 @@ IResourceBuilder<ProjectResource> seeder = builder.AddProject<Projects.DbSeeder>
 // Host port is left unset so Aspire picks a free one — Ollama's default 11434 is frequently
 // already bound on developer machines running the native Ollama daemon, which would wedge Aspire
 // startup since the API below does .WaitFor(vlmOcr).
+//
+// .WithHttpHealthCheck("/api/tags") gates WaitFor() on Ollama actually responding rather than
+// just the container being up — without this, dependents (the pull sidecar, the API smoke test)
+// would race the Ollama startup. /api/tags is the lightest Ollama endpoint that returns 200
+// once the server is ready (RECEIPTS-636).
 IResourceBuilder<ContainerResource> vlmOcr = builder.AddContainer("vlm-ocr", "ollama/ollama", "latest")
 	.WithVolume("vlm-ocr-models", "/root/.ollama")
-	.WithHttpEndpoint(targetPort: 11434, name: "http");
+	.WithHttpEndpoint(targetPort: 11434, name: "http")
+	.WithHttpHealthCheck("/api/tags");
 
 // One-shot sidecar that pulls qwen2.5vl:3b if it is not already cached in the shared volume,
 // then exits. Idempotent — subsequent runs find the model present and skip the download.
-builder.AddContainer("vlm-ocr-pull", "ollama/ollama", "latest")
+IResourceBuilder<ContainerResource> vlmOcrPull = builder.AddContainer("vlm-ocr-pull", "ollama/ollama", "latest")
 	.WithEntrypoint("/bin/sh")
 	.WithArgs("-c", "ollama list | grep -q 'qwen2.5vl:3b' || ollama pull qwen2.5vl:3b")
 	.WithEnvironment("OLLAMA_HOST", "http://vlm-ocr:11434")
 	.WaitFor(vlmOcr);
 
-// API: starts after seeder completes; Ollama URL injected for the smoke test and future extraction service
+// API: starts after seeder completes; Ollama URL injected for the smoke test and future extraction service.
+// .WaitForCompletion(vlmOcrPull) ensures the model is fully pulled (cold first-run can be ~3 GB)
+// before the API boots so the smoke test in InfrastructureService never catches Ollama mid-pull
+// (RECEIPTS-636).
 IResourceBuilder<ProjectResource> api = builder.AddProject<Projects.API>("api")
 	.WithReference(db)
 	.WithEnvironment("Ollama__BaseUrl", vlmOcr.GetEndpoint("http"))
 	.WaitForCompletion(seeder)
-	.WaitFor(vlmOcr);
+	.WaitFor(vlmOcr)
+	.WaitForCompletion(vlmOcrPull);
 
 // VlmEval: dev-only sidecar that runs the local VLM receipt-extraction pipeline against a
 // gitignored directory of real receipt fixtures and logs a scorecard. Parked on startup —

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -41,9 +41,30 @@ IResourceBuilder<ContainerResource> vlmOcr = builder.AddContainer("vlm-ocr", "ol
 
 // One-shot sidecar that pulls qwen2.5vl:3b if it is not already cached in the shared volume,
 // then exits. Idempotent — subsequent runs find the model present and skip the download.
+//
+// The API and VlmEval gate on this sidecar via .WaitForCompletion (RECEIPTS-636), so a
+// non-zero exit here permanently blocks dependents. Retry up to 5 times with backoff
+// to tolerate transient network failures during the ~3 GB cold-start pull. Mirrors the
+// docker-compose vlm-ocr-pull retry pattern.
+const string vlmOcrPullCommand = """
+	for i in 1 2 3 4 5; do
+	  if ollama list | grep -q 'qwen2.5vl:3b'; then
+	    echo "qwen2.5vl:3b already present; skipping pull"
+	    exit 0
+	  fi
+	  echo "Pulling qwen2.5vl:3b (attempt $i/5)..."
+	  if ollama pull qwen2.5vl:3b; then
+	    exit 0
+	  fi
+	  echo "Pull failed; sleeping before retry"
+	  sleep 10
+	done
+	echo "All pull attempts failed" >&2
+	exit 1
+	""";
 IResourceBuilder<ContainerResource> vlmOcrPull = builder.AddContainer("vlm-ocr-pull", "ollama/ollama", "latest")
 	.WithEntrypoint("/bin/sh")
-	.WithArgs("-c", "ollama list | grep -q 'qwen2.5vl:3b' || ollama pull qwen2.5vl:3b")
+	.WithArgs("-c", vlmOcrPullCommand)
 	.WithEnvironment("OLLAMA_HOST", "http://vlm-ocr:11434")
 	.WaitFor(vlmOcr);
 
@@ -68,6 +89,7 @@ builder.AddProject<Projects.VlmEval>("vlm-eval")
 	.WithEnvironment("Ollama__BaseUrl", vlmOcr.GetEndpoint("http"))
 	.WithEnvironment("VlmEval__FixturesPath", vlmEvalFixturesPath)
 	.WaitFor(vlmOcr)
+	.WaitForCompletion(vlmOcrPull)
 	.WithExplicitStart();
 
 builder.AddViteApp("frontend", "../client")


### PR DESCRIPTION
## Summary

- **Aspire**: Add `.WithHttpHealthCheck("/api/tags")` to the `vlm-ocr` container so `WaitFor` actually gates on Ollama responding (not just container start). Add `.WaitForCompletion(vlmOcrPull)` on the API resource so the API does not boot until qwen2.5vl:3b is fully pulled into the shared volume.
- **docker-compose**: Change the `app` service's dependency on `vlm-ocr: service_healthy` to `vlm-ocr-pull: service_completed_successfully` — the pull sidecar's own `depends_on` already requires a healthy Ollama, and waiting for its successful exit guarantees model presence (which `ollama list` could not validate). Mirrors the Aspire pattern so first-run cold starts do not race the model pull.

Resolves RECEIPTS-636.

## Test plan

- [ ] **Aspire**: Start the AppHost; observe in the dashboard that the API resource stays in `Waiting` until the `vlm-ocr` health check passes AND the `vlm-ocr-pull` sidecar exits successfully. Smoke test logs should show "model available" cleanly with no mid-pull racing.
- [ ] **docker-compose**: `docker compose up`; verify `receipts-app` is held in the dependency-wait state until `receipts-vlm-ocr-pull` completes (status code 0). On a fresh machine with an empty `vlm-ocr-models` volume, this should take as long as the model pull (~3 GB).
- [ ] **Idempotency**: Restart the stack with the model already cached — `vlm-ocr-pull` should exit immediately, and the API should start within seconds.

## Notes

No new unit tests; these are integration / orchestration concerns. AppHost build verified locally (`dotnet build src/Receipts.AppHost`). Full unit suite (1882 tests) passed via pre-commit hook.