### PR TITLE
test(infra): add unit tests for VlmEval FixtureEvaluator scoring core (RECEIPTS-633)

### DIFF
--- a/Receipts.slnx
+++ b/Receipts.slnx
@@ -24,5 +24,6 @@
     <Project Path="tests/Infrastructure.Tests/Infrastructure.Tests.csproj" />
     <Project Path="tests/Presentation.API.Tests/Presentation.API.Tests.csproj" />
     <Project Path="tests/SampleData/SampleData.csproj" />
+    <Project Path="tests/VlmEval.Tests/VlmEval.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Tools/VlmEval/FixtureEvaluator.cs
+++ b/src/Tools/VlmEval/FixtureEvaluator.cs
@@ -55,7 +55,7 @@ public sealed class FixtureEvaluator(
 		return new FixtureResult(fixture.Name, allDeclaredPassed, stopwatch.Elapsed, diffs, Error: null);
 	}
 
-	private static FieldDiff DiffStore(string? expected, FieldConfidence<string> actual)
+	internal static FieldDiff DiffStore(string? expected, FieldConfidence<string> actual)
 	{
 		if (expected is null)
 		{
@@ -76,7 +76,7 @@ public sealed class FixtureEvaluator(
 			match ? null : "store name does not contain expected substring");
 	}
 
-	private static FieldDiff DiffDate(DateOnly? expected, FieldConfidence<DateOnly> actual)
+	internal static FieldDiff DiffDate(DateOnly? expected, FieldConfidence<DateOnly> actual)
 	{
 		if (expected is null)
 		{
@@ -97,7 +97,7 @@ public sealed class FixtureEvaluator(
 			null);
 	}
 
-	private static FieldDiff DiffMoney(string field, decimal? expected, FieldConfidence<decimal> actual)
+	internal static FieldDiff DiffMoney(string field, decimal? expected, FieldConfidence<decimal> actual)
 	{
 		if (expected is null)
 		{
@@ -122,7 +122,7 @@ public sealed class FixtureEvaluator(
 			f.Confidence == ConfidenceLevel.Low ? null : f.Value.ToString("0.00", CultureInfo.InvariantCulture);
 	}
 
-	private static FieldDiff DiffTaxLines(List<ExpectedTaxLine>? expected, List<ParsedTaxLine> actual)
+	internal static FieldDiff DiffTaxLines(List<ExpectedTaxLine>? expected, List<ParsedTaxLine> actual)
 	{
 		if (expected is null || expected.Count == 0)
 		{
@@ -179,7 +179,7 @@ public sealed class FixtureEvaluator(
 		return bestIndex;
 	}
 
-	private static FieldDiff DiffPaymentMethod(string? expected, FieldConfidence<string?> actual)
+	internal static FieldDiff DiffPaymentMethod(string? expected, FieldConfidence<string?> actual)
 	{
 		if (expected is null)
 		{
@@ -200,7 +200,7 @@ public sealed class FixtureEvaluator(
 			match ? null : "payment method does not contain expected substring");
 	}
 
-	private static FieldDiff DiffMinItemCount(int? expected, List<ParsedReceiptItem> actual)
+	internal static FieldDiff DiffMinItemCount(int? expected, List<ParsedReceiptItem> actual)
 	{
 		if (expected is null)
 		{
@@ -216,7 +216,7 @@ public sealed class FixtureEvaluator(
 			match ? null : $"expected at least {expected.Value} items, got {actual.Count}");
 	}
 
-	private static List<FieldDiff> DiffItems(List<ExpectedItem>? expected, List<ParsedReceiptItem> actual)
+	internal static List<FieldDiff> DiffItems(List<ExpectedItem>? expected, List<ParsedReceiptItem> actual)
 	{
 		if (expected is null || expected.Count == 0)
 		{

--- a/src/Tools/VlmEval/VlmEval.csproj
+++ b/src/Tools/VlmEval/VlmEval.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="VlmEval.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
+++ b/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
@@ -124,13 +124,21 @@ public class FixtureEvaluatorTests
 	[Fact]
 	public void DiffDate_ExpectedNull_ReturnsNotDeclared()
 	{
+		// NOTE: When `expected` is null the production code formats `Actual` via the parameterless
+		// `DateOnly.ToString()` overload, which is culture-sensitive (en-US -> "1/14/2026",
+		// de-DE -> "14.01.2026", fr-FR -> "14/01/2026"). Every other branch of `DiffDate` uses
+		// the invariant "yyyy-MM-dd" format. This inconsistency is a separate production-code
+		// defect tracked under RECEIPTS-649; this test pins current behavior by computing the
+		// expected string the same way (so it stays green on any CI culture) until the prod fix
+		// flips the format string and this assertion can be tightened to "2026-01-14".
 		DateOnly actual = new(2026, 1, 14);
+		string cultureSensitiveExpectedActual = actual.ToString();
 
 		FieldDiff diff = FixtureEvaluator.DiffDate(null, FieldConfidence<DateOnly>.High(actual));
 
 		diff.Status.Should().Be(DiffStatus.NotDeclared);
 		diff.Expected.Should().BeNull();
-		diff.Actual.Should().Be("1/14/2026");
+		diff.Actual.Should().Be(cultureSensitiveExpectedActual);
 	}
 
 	#endregion
@@ -571,9 +579,11 @@ public class FixtureEvaluatorTests
 	}
 
 	[Fact]
-	public void DiffItems_PriceMismatch_FallsBackToDescription_ReturnsPass()
+	public void DiffItems_PriceMismatch_FallsBackToDescription_ThenFailsPriceValidation()
 	{
-		// Price doesn't match any item, but description does → falls back and matches.
+		// Price doesn't match any item, but description does. The description fallback locks
+		// in the matched line, but the subsequent price validation still flags the mismatch
+		// and the overall result is Fail (with a "totalPrice mismatch" detail).
 		List<ExpectedItem> expected = [new ExpectedItem { Description = "milk", TotalPrice = 99.99m }];
 		List<ParsedReceiptItem> actual =
 		[
@@ -582,7 +592,6 @@ public class FixtureEvaluatorTests
 
 		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
 
-		// Match is found via description fallback, but the price diff still fails the line.
 		diffs[0].Status.Should().Be(DiffStatus.Fail);
 		diffs[0].Detail.Should().Contain("totalPrice mismatch");
 	}

--- a/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
+++ b/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
@@ -1,0 +1,870 @@
+using Application.Interfaces.Services;
+using Application.Models.Ocr;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace VlmEval.Tests;
+
+/// <summary>
+/// Tests for <see cref="FixtureEvaluator"/> scoring helpers and the end-to-end
+/// <see cref="FixtureEvaluator.EvaluateAsync(Fixture, CancellationToken)"/> flow.
+///
+/// These tests document <em>current</em> behavior. Where current behavior is known to be
+/// buggy (e.g., money tolerance off-by-one — RECEIPTS-634), the test pins the existing
+/// behavior with a TODO comment so the fix in the follow-up issue will turn red and
+/// force the test to be flipped at the same time.
+/// </summary>
+public class FixtureEvaluatorTests
+{
+	#region DiffStore
+
+	[Fact]
+	public void DiffStore_SubstringMatch_ReturnsPass()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffStore("Walmart", FieldConfidence<string>.High("Walmart Supercenter #1234"));
+
+		diff.Field.Should().Be("store");
+		diff.Status.Should().Be(DiffStatus.Pass);
+		diff.Detail.Should().BeNull();
+	}
+
+	[Fact]
+	public void DiffStore_CaseInsensitiveMatch_ReturnsPass()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffStore("walmart", FieldConfidence<string>.High("WALMART SUPERCENTER"));
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffStore_NoSubstringMatch_ReturnsFail()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffStore("Walmart", FieldConfidence<string>.High("Target Store"));
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Expected.Should().Be("Walmart");
+		diff.Actual.Should().Be("Target Store");
+		diff.Detail.Should().Contain("does not contain expected substring");
+	}
+
+	[Fact]
+	public void DiffStore_MissingActualValue_ReturnsFail()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffStore("Walmart", FieldConfidence<string>.None());
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Expected.Should().Be("Walmart");
+		diff.Actual.Should().BeNull();
+		diff.Detail.Should().Be("VLM did not extract store name");
+	}
+
+	[Fact]
+	public void DiffStore_WhitespaceActualValue_ReturnsFail()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffStore("Walmart", FieldConfidence<string>.High("   "));
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Detail.Should().Be("VLM did not extract store name");
+	}
+
+	[Fact]
+	public void DiffStore_ExpectedNull_ReturnsNotDeclared()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffStore(null, FieldConfidence<string>.High("Walmart"));
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+		diff.Expected.Should().BeNull();
+		diff.Actual.Should().Be("Walmart");
+	}
+
+	#endregion
+
+	#region DiffDate
+
+	[Fact]
+	public void DiffDate_ExactMatch_ReturnsPass()
+	{
+		DateOnly expected = new(2026, 1, 14);
+
+		FieldDiff diff = FixtureEvaluator.DiffDate(expected, FieldConfidence<DateOnly>.High(expected));
+
+		diff.Field.Should().Be("date");
+		diff.Status.Should().Be(DiffStatus.Pass);
+		diff.Expected.Should().Be("2026-01-14");
+		diff.Actual.Should().Be("2026-01-14");
+	}
+
+	[Fact]
+	public void DiffDate_Mismatch_ReturnsFail()
+	{
+		DateOnly expected = new(2026, 1, 14);
+		DateOnly actual = new(2026, 1, 15);
+
+		FieldDiff diff = FixtureEvaluator.DiffDate(expected, FieldConfidence<DateOnly>.High(actual));
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Expected.Should().Be("2026-01-14");
+		diff.Actual.Should().Be("2026-01-15");
+	}
+
+	[Fact]
+	public void DiffDate_LowConfidenceActual_ReturnsFail()
+	{
+		DateOnly expected = new(2026, 1, 14);
+
+		FieldDiff diff = FixtureEvaluator.DiffDate(expected, FieldConfidence<DateOnly>.None());
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Expected.Should().Be("2026-01-14");
+		diff.Actual.Should().BeNull();
+		diff.Detail.Should().Be("VLM did not extract date");
+	}
+
+	[Fact]
+	public void DiffDate_ExpectedNull_ReturnsNotDeclared()
+	{
+		DateOnly actual = new(2026, 1, 14);
+
+		FieldDiff diff = FixtureEvaluator.DiffDate(null, FieldConfidence<DateOnly>.High(actual));
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+		diff.Expected.Should().BeNull();
+		diff.Actual.Should().Be("1/14/2026");
+	}
+
+	#endregion
+
+	#region DiffMoney
+
+	[Fact]
+	public void DiffMoney_ExactMatch_ReturnsPass()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 70.43m, FieldConfidence<decimal>.High(70.43m));
+
+		diff.Field.Should().Be("total");
+		diff.Status.Should().Be(DiffStatus.Pass);
+		diff.Expected.Should().Be("70.43");
+		diff.Actual.Should().Be("70.43");
+	}
+
+	[Fact]
+	public void DiffMoney_DeltaZero_ReturnsPass()
+	{
+		// delta = 0.00 < tolerance (0.01) → pass
+		FieldDiff diff = FixtureEvaluator.DiffMoney("subtotal", 1.00m, FieldConfidence<decimal>.High(1.00m));
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffMoney_DeltaUnderHalfCent_ReturnsPass()
+	{
+		// delta = 0.005 < tolerance (0.01) → pass
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 1.000m, FieldConfidence<decimal>.High(1.005m));
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffMoney_DeltaJustUnderTolerance_ReturnsPass()
+	{
+		// delta = 0.009 < tolerance (0.01) → pass
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 1.000m, FieldConfidence<decimal>.High(1.009m));
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffMoney_DeltaExactlyOneCent_ReturnsFail_BugDocumentedRECEIPTS634()
+	{
+		// TODO RECEIPTS-634: This test pins the off-by-one bug — line 113 of FixtureEvaluator
+		// uses `<` instead of `<=`, so a delta of EXACTLY $0.01 fails even though the README
+		// says "within $0.01 of expected". When RECEIPTS-634 fixes the comparison to `<=`,
+		// flip this assertion to `DiffStatus.Pass` and remove this comment.
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 1.00m, FieldConfidence<decimal>.High(1.01m));
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Detail.Should().Contain("delta=$0.01");
+	}
+
+	[Fact]
+	public void DiffMoney_DeltaOverTolerance_ReturnsFail()
+	{
+		// delta = 0.011 > tolerance (0.01) → fail (this fails today AND after the fix)
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 1.000m, FieldConfidence<decimal>.High(1.011m));
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Expected.Should().Be("1.00");
+		diff.Actual.Should().Be("1.01");
+	}
+
+	[Fact]
+	public void DiffMoney_NegativeDelta_UsesAbsoluteValue()
+	{
+		// actual is below expected — Math.Abs ensures it's still a small delta → pass
+		FieldDiff diff = FixtureEvaluator.DiffMoney("subtotal", 1.000m, FieldConfidence<decimal>.High(0.995m));
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffMoney_LowConfidenceActual_ReturnsFail()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 70.43m, FieldConfidence<decimal>.None());
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Expected.Should().Be("70.43");
+		diff.Actual.Should().BeNull();
+		diff.Detail.Should().Be("VLM did not extract total");
+	}
+
+	[Fact]
+	public void DiffMoney_ExpectedNull_ReturnsNotDeclared_WithFormattedActual()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", null, FieldConfidence<decimal>.High(70.43m));
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+		diff.Expected.Should().BeNull();
+		diff.Actual.Should().Be("70.43");
+	}
+
+	[Fact]
+	public void DiffMoney_ExpectedNull_LowConfidenceActual_FormatsActualAsNull()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", null, FieldConfidence<decimal>.None());
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+		diff.Actual.Should().BeNull();
+	}
+
+	#endregion
+
+	#region DiffTaxLines
+
+	[Fact]
+	public void DiffTaxLines_SingleMatch_ReturnsPass()
+	{
+		List<ExpectedTaxLine> expected = [new ExpectedTaxLine { Amount = 0.75m }];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax"), FieldConfidence<decimal>.High(0.75m))
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Field.Should().Be("taxLines");
+		diff.Status.Should().Be(DiffStatus.Pass);
+		diff.Detail.Should().BeNull();
+	}
+
+	[Fact]
+	public void DiffTaxLines_MultipleAmounts_AllMatched_ReturnsPass()
+	{
+		List<ExpectedTaxLine> expected =
+		[
+			new ExpectedTaxLine { Amount = 0.75m },
+			new ExpectedTaxLine { Amount = 1.20m },
+		];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("State"), FieldConfidence<decimal>.High(0.75m)),
+			new ParsedTaxLine(FieldConfidence<string>.High("County"), FieldConfidence<decimal>.High(1.20m)),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffTaxLines_MissingActualLine_ReturnsFail()
+	{
+		List<ExpectedTaxLine> expected = [new ExpectedTaxLine { Amount = 0.75m }];
+		List<ParsedTaxLine> actual = [];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Detail.Should().Contain("no tax line within $0.01 of $0.75");
+	}
+
+	[Fact]
+	public void DiffTaxLines_ActualHasMoreLines_StillPasses()
+	{
+		// README: "actual may contain more lines"
+		List<ExpectedTaxLine> expected = [new ExpectedTaxLine { Amount = 0.75m }];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax"), FieldConfidence<decimal>.High(0.75m)),
+			new ParsedTaxLine(FieldConfidence<string>.High("Other"), FieldConfidence<decimal>.High(2.50m)),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffTaxLines_DuplicateExpectedAmounts_ConsumesEachActualOnce()
+	{
+		// Expected has two 0.75 lines; actual has two 0.75 lines → both should match.
+		List<ExpectedTaxLine> expected =
+		[
+			new ExpectedTaxLine { Amount = 0.75m },
+			new ExpectedTaxLine { Amount = 0.75m },
+		];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax 1"), FieldConfidence<decimal>.High(0.75m)),
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax 2"), FieldConfidence<decimal>.High(0.75m)),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffTaxLines_DuplicateExpectedAmounts_OnlyOneActual_FailsForSecond()
+	{
+		// Two expected 0.75 lines but only one actual 0.75 line → second consumes index -1 → fail.
+		List<ExpectedTaxLine> expected =
+		[
+			new ExpectedTaxLine { Amount = 0.75m },
+			new ExpectedTaxLine { Amount = 0.75m },
+		];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax"), FieldConfidence<decimal>.High(0.75m)),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Detail.Should().Contain("no tax line within $0.01 of $0.75");
+	}
+
+	[Fact]
+	public void DiffTaxLines_LowConfidenceActualAmounts_AreIgnored()
+	{
+		// A low-confidence actual amount should not be available to match against.
+		List<ExpectedTaxLine> expected = [new ExpectedTaxLine { Amount = 0.75m }];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax"), FieldConfidence<decimal>.None()),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+	}
+
+	[Fact]
+	public void DiffTaxLines_ExpectedNull_ReturnsNotDeclared()
+	{
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax"), FieldConfidence<decimal>.High(0.75m)),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(null, actual);
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+		diff.Actual.Should().Be("actual=1");
+	}
+
+	[Fact]
+	public void DiffTaxLines_ExpectedEmpty_ReturnsNotDeclared()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines([], []);
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+	}
+
+	[Fact]
+	public void DiffTaxLines_ExpectedAmountIsNull_IsSkipped()
+	{
+		// Lines with a null amount don't constitute an assertion → pass.
+		List<ExpectedTaxLine> expected = [new ExpectedTaxLine { Label = "Sales", Amount = null }];
+		List<ParsedTaxLine> actual = [];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	#endregion
+
+	#region DiffPaymentMethod
+
+	[Fact]
+	public void DiffPaymentMethod_SubstringMatch_ReturnsPass()
+	{
+		// README: "MASTERCARD" matches "MasterCard ****1234"
+		FieldDiff diff = FixtureEvaluator.DiffPaymentMethod("MASTERCARD", FieldConfidence<string?>.High("MasterCard ****1234"));
+
+		diff.Field.Should().Be("paymentMethod");
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffPaymentMethod_NoMatch_ReturnsFail()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffPaymentMethod("VISA", FieldConfidence<string?>.High("Cash"));
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Detail.Should().Contain("does not contain expected substring");
+	}
+
+	[Fact]
+	public void DiffPaymentMethod_MissingActual_ReturnsFail()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffPaymentMethod("VISA", FieldConfidence<string?>.None());
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Detail.Should().Be("VLM did not extract paymentMethod");
+	}
+
+	[Fact]
+	public void DiffPaymentMethod_ExpectedNull_ReturnsNotDeclared()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffPaymentMethod(null, FieldConfidence<string?>.High("VISA"));
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+	}
+
+	#endregion
+
+	#region DiffMinItemCount
+
+	[Fact]
+	public void DiffMinItemCount_ActualMeetsThreshold_ReturnsPass()
+	{
+		List<ParsedReceiptItem> items =
+		[
+			MakeItem("Apple", 1.00m),
+			MakeItem("Bread", 2.00m),
+			MakeItem("Cheese", 3.00m),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffMinItemCount(3, items);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+		diff.Expected.Should().Be(">=3");
+		diff.Actual.Should().Be("3");
+	}
+
+	[Fact]
+	public void DiffMinItemCount_ActualExceedsThreshold_ReturnsPass()
+	{
+		List<ParsedReceiptItem> items =
+		[
+			MakeItem("Apple", 1.00m),
+			MakeItem("Bread", 2.00m),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffMinItemCount(1, items);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffMinItemCount_ActualBelowThreshold_ReturnsFail()
+	{
+		List<ParsedReceiptItem> items = [MakeItem("Apple", 1.00m)];
+
+		FieldDiff diff = FixtureEvaluator.DiffMinItemCount(3, items);
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Detail.Should().Contain("expected at least 3 items, got 1");
+	}
+
+	[Fact]
+	public void DiffMinItemCount_ExpectedNull_ReturnsNotDeclared()
+	{
+		List<ParsedReceiptItem> items = [MakeItem("Apple", 1.00m)];
+
+		FieldDiff diff = FixtureEvaluator.DiffMinItemCount(null, items);
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+		diff.Actual.Should().Be("1");
+	}
+
+	#endregion
+
+	#region DiffItems
+
+	[Fact]
+	public void DiffItems_ExpectedNull_ReturnsEmpty()
+	{
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(null, [MakeItem("Apple", 1.00m)]);
+
+		diffs.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void DiffItems_ExpectedEmpty_ReturnsEmpty()
+	{
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems([], [MakeItem("Apple", 1.00m)]);
+
+		diffs.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void DiffItems_PriceAndDescriptionBothNull_ReturnsNotDeclared()
+	{
+		List<ExpectedItem> expected = [new ExpectedItem()];
+		List<ParsedReceiptItem> actual = [MakeItem("Apple", 1.00m)];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs.Should().HaveCount(1);
+		diffs[0].Status.Should().Be(DiffStatus.NotDeclared);
+		diffs[0].Field.Should().Be("items[0]");
+	}
+
+	[Fact]
+	public void DiffItems_PriceMatch_ReturnsPass()
+	{
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "Apple", TotalPrice = 1.00m }];
+		List<ParsedReceiptItem> actual = [MakeItem("Apple", 1.00m)];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs.Should().HaveCount(1);
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffItems_PriceMatchPicksClosestPrice()
+	{
+		// Two candidate prices: 0.99 and 1.05. With expected=1.00, neither is within $0.01
+		// (1.05 delta = 0.05; 0.99 delta = 0.01 — the boundary value, currently rejected).
+		// Bring 0.99 within tolerance (delta=0.005) and confirm it wins over 1.05.
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "Apple", TotalPrice = 1.000m }];
+		List<ParsedReceiptItem> actual =
+		[
+			MakeItem("Bread", 1.05m),
+			MakeItem("Apple", 0.995m),
+		];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
+		diffs[0].Actual.Should().Contain("Apple");
+	}
+
+	[Fact]
+	public void DiffItems_DescriptionOnlyFallback_ReturnsPass()
+	{
+		// No price declared → falls back to description-only substring match.
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "milk" }];
+		List<ParsedReceiptItem> actual =
+		[
+			MakeItem("Whole Milk Gallon", 4.99m),
+		];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffItems_PriceMismatch_FallsBackToDescription_ReturnsPass()
+	{
+		// Price doesn't match any item, but description does → falls back and matches.
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "milk", TotalPrice = 99.99m }];
+		List<ParsedReceiptItem> actual =
+		[
+			MakeItem("Whole Milk Gallon", 4.99m),
+		];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		// Match is found via description fallback, but the price diff still fails the line.
+		diffs[0].Status.Should().Be(DiffStatus.Fail);
+		diffs[0].Detail.Should().Contain("totalPrice mismatch");
+	}
+
+	[Fact]
+	public void DiffItems_NoMatch_ReturnsFail()
+	{
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "Apple", TotalPrice = 1.00m }];
+		List<ParsedReceiptItem> actual = [MakeItem("Bread", 5.00m)];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs[0].Status.Should().Be(DiffStatus.Fail);
+		diffs[0].Detail.Should().Be("no matching line in VLM output");
+	}
+
+	[Fact]
+	public void DiffItems_DescriptionMismatch_ReturnsFail()
+	{
+		// Price matches but description doesn't → reports description mismatch.
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "Apple", TotalPrice = 1.000m }];
+		List<ParsedReceiptItem> actual = [MakeItem("Bread", 1.000m)];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs[0].Status.Should().Be(DiffStatus.Fail);
+		diffs[0].Detail.Should().Contain("description mismatch");
+	}
+
+	[Fact]
+	public void DiffItems_LowConfidenceTotalPrice_NotMatchedByPrice()
+	{
+		// Items with low-confidence prices are skipped by the price matcher.
+		// The fallback description matcher then finds them by description.
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "Apple", TotalPrice = 1.000m }];
+		List<ParsedReceiptItem> actual =
+		[
+			new ParsedReceiptItem(
+				Code: FieldConfidence<string?>.None(),
+				Description: FieldConfidence<string>.High("Apple"),
+				Quantity: FieldConfidence<decimal>.High(1m),
+				UnitPrice: FieldConfidence<decimal>.None(),
+				TotalPrice: FieldConfidence<decimal>.None()),
+		];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		// Price matcher skips the item, description fallback finds it, but then the
+		// "is the matched item's totalPrice low confidence?" check reports a missing price.
+		diffs[0].Status.Should().Be(DiffStatus.Fail);
+		diffs[0].Detail.Should().Contain("missing totalPrice");
+	}
+
+	[Fact]
+	public void DiffItems_PoolItemConsumedOnFirstMatch_ReturnsExpectedDiffs()
+	{
+		// Two expected lines both expecting Apple/1.00. Actual has two Apples at 1.00.
+		// First should consume actual[0]; second should consume actual[1].
+		List<ExpectedItem> expected =
+		[
+			new ExpectedItem { Description = "Apple", TotalPrice = 1.000m },
+			new ExpectedItem { Description = "Apple", TotalPrice = 1.000m },
+		];
+		List<ParsedReceiptItem> actual =
+		[
+			MakeItem("Apple A", 1.000m),
+			MakeItem("Apple B", 1.000m),
+		];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs.Should().HaveCount(2);
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
+		diffs[1].Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffItems_PoolExhausted_SecondExpectedFails()
+	{
+		// Two expected, only one actual.
+		List<ExpectedItem> expected =
+		[
+			new ExpectedItem { Description = "Apple", TotalPrice = 1.000m },
+			new ExpectedItem { Description = "Apple", TotalPrice = 1.000m },
+		];
+		List<ParsedReceiptItem> actual = [MakeItem("Apple", 1.000m)];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs.Should().HaveCount(2);
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
+		diffs[1].Status.Should().Be(DiffStatus.Fail);
+		diffs[1].Detail.Should().Be("no matching line in VLM output");
+	}
+
+	#endregion
+
+	#region EvaluateAsync end-to-end
+
+	[Fact]
+	public async Task EvaluateAsync_FileMissing_ReturnsFailWithReadError()
+	{
+		Mock<IReceiptExtractionService> service = new();
+		FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+
+		Fixture fixture = new(
+			Name: "missing.jpg",
+			FilePath: Path.Combine(Path.GetTempPath(), Guid.NewGuid() + "-does-not-exist.jpg"),
+			ContentType: "image/jpeg",
+			Expected: new ExpectedReceipt());
+
+		FixtureResult result = await evaluator.EvaluateAsync(fixture, CancellationToken.None);
+
+		result.Passed.Should().BeFalse();
+		result.Error.Should().StartWith("Failed to read fixture file");
+		service.VerifyNoOtherCalls();
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_ExtractionThrows_ReturnsFailWithVlmError()
+	{
+		string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".jpg");
+		await File.WriteAllBytesAsync(tempFile, [0x01, 0x02, 0x03]);
+		try
+		{
+			Mock<IReceiptExtractionService> service = new();
+			service
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.ThrowsAsync(new InvalidOperationException("VLM down"));
+
+			FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+
+			Fixture fixture = new("test.jpg", tempFile, "image/jpeg", new ExpectedReceipt());
+
+			FixtureResult result = await evaluator.EvaluateAsync(fixture, CancellationToken.None);
+
+			result.Passed.Should().BeFalse();
+			result.Error.Should().Contain("VLM call failed");
+			result.Error.Should().Contain("InvalidOperationException");
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_AllAssertionsPass_ReturnsPassed()
+	{
+		string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".jpg");
+		await File.WriteAllBytesAsync(tempFile, [0x01, 0x02, 0x03]);
+		try
+		{
+			ParsedReceipt parsed = new(
+				StoreName: FieldConfidence<string>.High("Walmart Supercenter"),
+				Date: FieldConfidence<DateOnly>.High(new DateOnly(2026, 1, 14)),
+				Items: [MakeItem("Apple", 1.00m)],
+				Subtotal: FieldConfidence<decimal>.High(1.00m),
+				TaxLines: [new ParsedTaxLine(FieldConfidence<string>.High("State"), FieldConfidence<decimal>.High(0.08m))],
+				Total: FieldConfidence<decimal>.High(1.08m),
+				PaymentMethod: FieldConfidence<string?>.High("VISA ****1111"));
+
+			Mock<IReceiptExtractionService> service = new();
+			service
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(parsed);
+
+			FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+
+			Fixture fixture = new(
+				Name: "test.jpg",
+				FilePath: tempFile,
+				ContentType: "image/jpeg",
+				Expected: new ExpectedReceipt
+				{
+					Store = "Walmart",
+					Date = new DateOnly(2026, 1, 14),
+					Subtotal = 1.00m,
+					Total = 1.08m,
+					TaxLines = [new ExpectedTaxLine { Amount = 0.08m }],
+					PaymentMethod = "VISA",
+					MinItemCount = 1,
+					Items = [new ExpectedItem { Description = "Apple", TotalPrice = 1.00m }],
+				});
+
+			FixtureResult result = await evaluator.EvaluateAsync(fixture, CancellationToken.None);
+
+			result.Passed.Should().BeTrue();
+			result.Error.Should().BeNull();
+			result.FieldDiffs.Should().NotBeEmpty();
+			result.FieldDiffs.Should().NotContain(d => d.Status == DiffStatus.Fail);
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_OnlyUndeclaredFields_ReturnsPassed_AllNotDeclared()
+	{
+		// An empty ExpectedReceipt (nothing declared) should pass — every diff is NotDeclared.
+		string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".jpg");
+		await File.WriteAllBytesAsync(tempFile, [0x01, 0x02, 0x03]);
+		try
+		{
+			ParsedReceipt parsed = new(
+				StoreName: FieldConfidence<string>.None(),
+				Date: FieldConfidence<DateOnly>.None(),
+				Items: [],
+				Subtotal: FieldConfidence<decimal>.None(),
+				TaxLines: [],
+				Total: FieldConfidence<decimal>.None(),
+				PaymentMethod: FieldConfidence<string?>.None());
+
+			Mock<IReceiptExtractionService> service = new();
+			service
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(parsed);
+
+			FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+
+			Fixture fixture = new("test.jpg", tempFile, "image/jpeg", new ExpectedReceipt());
+
+			FixtureResult result = await evaluator.EvaluateAsync(fixture, CancellationToken.None);
+
+			result.Passed.Should().BeTrue();
+			result.FieldDiffs.Should().OnlyContain(d => d.Status == DiffStatus.NotDeclared);
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_OneAssertionFails_OverallResultFails()
+	{
+		string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".jpg");
+		await File.WriteAllBytesAsync(tempFile, [0x01, 0x02, 0x03]);
+		try
+		{
+			ParsedReceipt parsed = new(
+				StoreName: FieldConfidence<string>.High("Target"), // expected Walmart → fail
+				Date: FieldConfidence<DateOnly>.None(),
+				Items: [],
+				Subtotal: FieldConfidence<decimal>.None(),
+				TaxLines: [],
+				Total: FieldConfidence<decimal>.None(),
+				PaymentMethod: FieldConfidence<string?>.None());
+
+			Mock<IReceiptExtractionService> service = new();
+			service
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(parsed);
+
+			FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+
+			Fixture fixture = new(
+				"test.jpg",
+				tempFile,
+				"image/jpeg",
+				new ExpectedReceipt { Store = "Walmart" });
+
+			FixtureResult result = await evaluator.EvaluateAsync(fixture, CancellationToken.None);
+
+			result.Passed.Should().BeFalse();
+			result.FieldDiffs.Should().Contain(d => d.Field == "store" && d.Status == DiffStatus.Fail);
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	#endregion
+
+	private static ParsedReceiptItem MakeItem(string description, decimal totalPrice) =>
+		new(
+			Code: FieldConfidence<string?>.None(),
+			Description: FieldConfidence<string>.High(description),
+			Quantity: FieldConfidence<decimal>.High(1m),
+			UnitPrice: FieldConfidence<decimal>.High(totalPrice),
+			TotalPrice: FieldConfidence<decimal>.High(totalPrice));
+}

--- a/tests/VlmEval.Tests/FixtureLoaderTests.cs
+++ b/tests/VlmEval.Tests/FixtureLoaderTests.cs
@@ -1,0 +1,301 @@
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace VlmEval.Tests;
+
+/// <summary>
+/// Tests for <see cref="FixtureLoader"/>. These exercise the on-disk pairing of fixture files with
+/// their <c>.expected.json</c> sidecars, including malformed/orphan/empty cases.
+///
+/// <para>
+/// Each test uses an isolated temporary directory and disposes it via the
+/// <see cref="IDisposable"/> implementation on the test class — xUnit creates one instance per
+/// test, so the directory is unique per test.
+/// </para>
+/// </summary>
+public class FixtureLoaderTests : IDisposable
+{
+	private readonly string _tempDir;
+	private readonly FixtureLoader _loader;
+
+	public FixtureLoaderTests()
+	{
+		_tempDir = Path.Combine(Path.GetTempPath(), "vlmeval-tests-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDir);
+		_loader = new FixtureLoader(NullLogger<FixtureLoader>.Instance);
+	}
+
+	public void Dispose()
+	{
+		try
+		{
+			if (Directory.Exists(_tempDir))
+			{
+				Directory.Delete(_tempDir, recursive: true);
+			}
+		}
+		catch
+		{
+			// Best-effort cleanup. Ignore if a file is locked on Windows.
+		}
+		GC.SuppressFinalize(this);
+	}
+
+	[Fact]
+	public void LoadFrom_NonexistentDirectory_ReturnsEmpty()
+	{
+		string missing = Path.Combine(_tempDir, "does-not-exist");
+
+		LoadedFixtures result = _loader.LoadFrom(missing);
+
+		result.Fixtures.Should().BeEmpty();
+		result.OrphanFiles.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void LoadFrom_EmptyDirectory_ReturnsEmpty()
+	{
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().BeEmpty();
+		result.OrphanFiles.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void LoadFrom_ImageWithoutSidecar_ReportsAsOrphan()
+	{
+		string imagePath = Path.Combine(_tempDir, "orphan.jpg");
+		File.WriteAllBytes(imagePath, [0xFF, 0xD8, 0xFF]); // JPEG magic
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().BeEmpty();
+		result.OrphanFiles.Should().ContainSingle().Which.Should().Be(imagePath);
+	}
+
+	[Fact]
+	public void LoadFrom_PdfWithoutSidecar_ReportsAsOrphan()
+	{
+		string pdfPath = Path.Combine(_tempDir, "orphan.pdf");
+		File.WriteAllBytes(pdfPath, [0x25, 0x50, 0x44, 0x46]); // %PDF magic
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().BeEmpty();
+		result.OrphanFiles.Should().ContainSingle().Which.Should().Be(pdfPath);
+	}
+
+	[Fact]
+	public void LoadFrom_MalformedSidecarJson_SkipsFixture()
+	{
+		string imagePath = Path.Combine(_tempDir, "bad.jpg");
+		string sidecarPath = imagePath + ".expected.json";
+		File.WriteAllBytes(imagePath, [0xFF, 0xD8, 0xFF]);
+		File.WriteAllText(sidecarPath, "{ this is not valid json", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		// Malformed sidecars are skipped (logged as error). They are NOT reported as orphans.
+		result.Fixtures.Should().BeEmpty();
+		result.OrphanFiles.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void LoadFrom_NullDeserializedSidecar_SkipsFixture()
+	{
+		// JSON literal `null` deserializes to a null ExpectedReceipt → fixture skipped.
+		string imagePath = Path.Combine(_tempDir, "nullside.jpg");
+		string sidecarPath = imagePath + ".expected.json";
+		File.WriteAllBytes(imagePath, [0xFF, 0xD8, 0xFF]);
+		File.WriteAllText(sidecarPath, "null", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void LoadFrom_ValidPair_LoadsFixture()
+	{
+		string imagePath = Path.Combine(_tempDir, "valid.jpg");
+		string sidecarPath = imagePath + ".expected.json";
+		File.WriteAllBytes(imagePath, [0xFF, 0xD8, 0xFF]);
+		File.WriteAllText(sidecarPath, """
+			{
+				"store": "Walmart",
+				"total": 70.43
+			}
+			""", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().ContainSingle();
+		Fixture fixture = result.Fixtures[0];
+		fixture.Name.Should().Be("valid.jpg");
+		fixture.FilePath.Should().Be(imagePath);
+		fixture.ContentType.Should().Be("image/jpeg");
+		fixture.Expected.Store.Should().Be("Walmart");
+		fixture.Expected.Total.Should().Be(70.43m);
+	}
+
+	[Theory]
+	[InlineData(".jpg", "image/jpeg")]
+	[InlineData(".jpeg", "image/jpeg")]
+	[InlineData(".png", "image/png")]
+	[InlineData(".pdf", "application/pdf")]
+	public void LoadFrom_KnownExtensions_AreMappedToContentType(string ext, string expectedContentType)
+	{
+		string imagePath = Path.Combine(_tempDir, "fix" + ext);
+		string sidecarPath = imagePath + ".expected.json";
+		File.WriteAllBytes(imagePath, [0x00]);
+		File.WriteAllText(sidecarPath, "{}", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().ContainSingle();
+		result.Fixtures[0].ContentType.Should().Be(expectedContentType);
+	}
+
+	[Fact]
+	public void LoadFrom_UpperCaseExtension_IsMappedToContentType()
+	{
+		// Extension lookup is OrdinalIgnoreCase.
+		string imagePath = Path.Combine(_tempDir, "upper.JPG");
+		string sidecarPath = imagePath + ".expected.json";
+		File.WriteAllBytes(imagePath, [0xFF, 0xD8, 0xFF]);
+		File.WriteAllText(sidecarPath, "{}", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		// On case-insensitive filesystems (Windows) the path may differ in case after enumeration.
+		result.Fixtures.Should().ContainSingle();
+		result.Fixtures[0].ContentType.Should().Be("image/jpeg");
+	}
+
+	[Fact]
+	public void LoadFrom_UnknownExtension_IsIgnored()
+	{
+		// .txt is not in the extension map → silently skipped (not an orphan).
+		string textPath = Path.Combine(_tempDir, "notes.txt");
+		File.WriteAllText(textPath, "hello", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().BeEmpty();
+		result.OrphanFiles.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void LoadFrom_SidecarWithoutFixture_IsIgnored()
+	{
+		// A bare *.expected.json with no matching image/pdf is silently ignored.
+		string sidecarPath = Path.Combine(_tempDir, "ghost.jpg.expected.json");
+		File.WriteAllText(sidecarPath, "{}", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().BeEmpty();
+		result.OrphanFiles.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void LoadFrom_SidecarWithJsonComments_LoadsSuccessfully()
+	{
+		// JsonCommentHandling.Skip → // and /* ... */ comments are tolerated.
+		string imagePath = Path.Combine(_tempDir, "withcomments.jpg");
+		string sidecarPath = imagePath + ".expected.json";
+		File.WriteAllBytes(imagePath, [0xFF, 0xD8, 0xFF]);
+		File.WriteAllText(sidecarPath, """
+			{
+				// line comment
+				"store": "Target",
+				/* block comment */
+				"total": 1.23
+			}
+			""", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().ContainSingle();
+		result.Fixtures[0].Expected.Store.Should().Be("Target");
+		result.Fixtures[0].Expected.Total.Should().Be(1.23m);
+	}
+
+	[Fact]
+	public void LoadFrom_SidecarWithTrailingComma_LoadsSuccessfully()
+	{
+		// AllowTrailingCommas = true → trailing commas in objects/arrays are tolerated.
+		string imagePath = Path.Combine(_tempDir, "trailing.jpg");
+		string sidecarPath = imagePath + ".expected.json";
+		File.WriteAllBytes(imagePath, [0xFF, 0xD8, 0xFF]);
+		File.WriteAllText(sidecarPath, """
+			{
+				"store": "Costco",
+				"total": 42.10,
+			}
+			""", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().ContainSingle();
+		result.Fixtures[0].Expected.Store.Should().Be("Costco");
+	}
+
+	[Fact]
+	public void LoadFrom_SidecarWithUtf8Bom_LoadsSuccessfully()
+	{
+		// System.Text.Json's parser handles UTF-8 BOMs natively when reading via byte array,
+		// and File.ReadAllText decodes the BOM-prefixed bytes into a BOM-less string.
+		// This test pins the current behavior: UTF-8 BOM is accepted.
+		string imagePath = Path.Combine(_tempDir, "bom.jpg");
+		string sidecarPath = imagePath + ".expected.json";
+		File.WriteAllBytes(imagePath, [0xFF, 0xD8, 0xFF]);
+
+		string json = """{"store":"BOM Store"}""";
+		byte[] bom = [0xEF, 0xBB, 0xBF];
+		byte[] body = Encoding.UTF8.GetBytes(json);
+		byte[] withBom = [.. bom, .. body];
+		File.WriteAllBytes(sidecarPath, withBom);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().ContainSingle();
+		result.Fixtures[0].Expected.Store.Should().Be("BOM Store");
+	}
+
+	[Fact]
+	public void LoadFrom_OrdersFixturesAlphabetically()
+	{
+		string a = Path.Combine(_tempDir, "a.jpg");
+		string b = Path.Combine(_tempDir, "b.jpg");
+		string c = Path.Combine(_tempDir, "c.jpg");
+		foreach (string p in new[] { c, a, b }) // intentionally out of order
+		{
+			File.WriteAllBytes(p, [0xFF, 0xD8, 0xFF]);
+			File.WriteAllText(p + ".expected.json", "{}", Encoding.UTF8);
+		}
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().HaveCount(3);
+		result.Fixtures[0].Name.Should().Be("a.jpg");
+		result.Fixtures[1].Name.Should().Be("b.jpg");
+		result.Fixtures[2].Name.Should().Be("c.jpg");
+	}
+
+	[Fact]
+	public void LoadFrom_MixedOrphansAndValid_ReportsBoth()
+	{
+		string orphan = Path.Combine(_tempDir, "orphan.jpg");
+		string valid = Path.Combine(_tempDir, "valid.jpg");
+		File.WriteAllBytes(orphan, [0xFF, 0xD8, 0xFF]);
+		File.WriteAllBytes(valid, [0xFF, 0xD8, 0xFF]);
+		File.WriteAllText(valid + ".expected.json", "{}", Encoding.UTF8);
+
+		LoadedFixtures result = _loader.LoadFrom(_tempDir);
+
+		result.Fixtures.Should().ContainSingle().Which.Name.Should().Be("valid.jpg");
+		result.OrphanFiles.Should().ContainSingle().Which.Should().Be(orphan);
+	}
+}

--- a/tests/VlmEval.Tests/GlobalUsings.cs
+++ b/tests/VlmEval.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/VlmEval.Tests/VlmEval.Tests.csproj
+++ b/tests/VlmEval.Tests/VlmEval.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Tools\VlmEval\VlmEval.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Adds `tests/VlmEval.Tests` project with **74 unit tests** covering the `FixtureEvaluator` scoring helpers (`DiffStore` / `DiffDate` / `DiffMoney` / `DiffTaxLines` / `DiffPaymentMethod` / `DiffMinItemCount` / `DiffItems`) and the `FixtureLoader` sidecar pairing logic.
- Marks the diff helpers `internal static` (was `private static`) and adds `[InternalsVisibleTo("VlmEval.Tests")]` to `VlmEval.csproj` so tests can exercise them directly. End-to-end `EvaluateAsync` tests use a `Moq`'d `IReceiptExtractionService` to verify wiring + error paths.
- Tests **document current behavior**, including the known $0.01 off-by-one boundary bug (delta of exactly `$0.01` currently fails because the comparison is `<` not `<=`). Flagged with `// TODO RECEIPTS-634` so the upcoming fix flips the assertion at the same time the production code changes.

Resolves RECEIPTS-633.

## Coverage

| File | Line coverage |
|------|---------------|
| `src/Tools/VlmEval/FixtureEvaluator.cs` | **99.5%** |
| `src/Tools/VlmEval/FixtureLoader.cs` | **100%** |

Acceptance criteria satisfied:
- [x] `tests/VlmEval.Tests/` project exists and is part of `Receipts.slnx`.
- [x] FixtureEvaluator and FixtureLoader have ≥80% line coverage.
- [x] Documented: greedy-by-input-order matching for duplicate prices (covered by `DiffTaxLines_DuplicateExpectedAmounts_*` and `DiffItems_PoolItemConsumedOnFirstMatch_*` tests).
- [ ] Money tolerance boundary (`<=` instead of `<`) — **explicitly deferred to RECEIPTS-634** per the task brief; this PR locks in current behavior so the fix flips the test alongside the production change.

## Test plan

- `dotnet build Receipts.slnx` — passes (no errors, only pre-existing transitive vuln warnings).
- `dotnet test Receipts.slnx --filter "Category!=Integration"` — **2,368 tests pass**, including the 74 new ones.
- `dotnet test tests/VlmEval.Tests/VlmEval.Tests.csproj --collect:"XPlat Code Coverage"` — emits cobertura with the line rates above.

## Notes

This is a **tests-only** change. No production behavior is altered — the only runtime-visible source change is widening the visibility of seven diff helpers from `private` to `internal`, which keeps them inaccessible outside the assembly + the test project.