### PR TITLE
fix(infra): use invariant yyyy-MM-dd in vlm eval DiffDate NotDeclared (RECEIPTS-649)

### DIFF
--- a/src/Tools/VlmEval/FixtureEvaluator.cs
+++ b/src/Tools/VlmEval/FixtureEvaluator.cs
@@ -80,7 +80,7 @@ public sealed class FixtureEvaluator(
 	{
 		if (expected is null)
 		{
-			return new FieldDiff("date", DiffStatus.NotDeclared, null, actual.Value.ToString(), null);
+			return new FieldDiff("date", DiffStatus.NotDeclared, null, actual.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), null);
 		}
 
 		if (actual.Confidence == ConfidenceLevel.Low)

--- a/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
+++ b/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
@@ -124,21 +124,37 @@ public class FixtureEvaluatorTests
 	[Fact]
 	public void DiffDate_ExpectedNull_ReturnsNotDeclared()
 	{
-		// NOTE: When `expected` is null the production code formats `Actual` via the parameterless
-		// `DateOnly.ToString()` overload, which is culture-sensitive (en-US -> "1/14/2026",
-		// de-DE -> "14.01.2026", fr-FR -> "14/01/2026"). Every other branch of `DiffDate` uses
-		// the invariant "yyyy-MM-dd" format. This inconsistency is a separate production-code
-		// defect tracked under RECEIPTS-649; this test pins current behavior by computing the
-		// expected string the same way (so it stays green on any CI culture) until the prod fix
-		// flips the format string and this assertion can be tightened to "2026-01-14".
 		DateOnly actual = new(2026, 1, 14);
-		string cultureSensitiveExpectedActual = actual.ToString();
 
 		FieldDiff diff = FixtureEvaluator.DiffDate(null, FieldConfidence<DateOnly>.High(actual));
 
 		diff.Status.Should().Be(DiffStatus.NotDeclared);
 		diff.Expected.Should().BeNull();
-		diff.Actual.Should().Be(cultureSensitiveExpectedActual);
+		diff.Actual.Should().Be("2026-01-14");
+	}
+
+	[Theory]
+	[InlineData("de-DE")]
+	[InlineData("fr-FR")]
+	[InlineData("ja-JP")]
+	public void DiffDate_FormatsAsInvariantYyyyMmDd_AcrossCultures(string cultureName)
+	{
+		// Guards against regression of RECEIPTS-649: the NotDeclared branch must use
+		// invariant `yyyy-MM-dd` formatting like every other branch, regardless of host culture.
+		System.Globalization.CultureInfo originalCulture = System.Globalization.CultureInfo.CurrentCulture;
+		try
+		{
+			System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo(cultureName);
+			DateOnly actual = new(2026, 1, 14);
+
+			FieldDiff diff = FixtureEvaluator.DiffDate(null, FieldConfidence<DateOnly>.High(actual));
+
+			diff.Actual.Should().Be("2026-01-14");
+		}
+		finally
+		{
+			System.Globalization.CultureInfo.CurrentCulture = originalCulture;
+		}
 	}
 
 	#endregion


### PR DESCRIPTION
## Summary

- Switch `FixtureEvaluator.DiffDate` `NotDeclared` branch (line 83) from culture-sensitive `DateOnly.ToString()` to invariant `ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)`, matching every other branch in the file.
- Tighten `DiffDate_ExpectedNull_ReturnsNotDeclared` to assert the literal `"2026-01-14"` instead of recomputing the same culture-sensitive string the bug emitted (the workaround landed under RECEIPTS-633).
- Add a `[Theory]` exercising `de-DE`, `fr-FR`, `ja-JP` cultures to guard against regression.

Resolves RECEIPTS-649.

## Why

Found by `/find-bugs` on the RECEIPTS-633 PR. With the parameterless `DateOnly.ToString()`, the same date renders differently per host culture (`en-US` → `1/14/2026`, `de-DE` → `14.01.2026`, `fr-FR` → `14/01/2026`), making logs/scorecards/tests culture-dependent. RECEIPTS-633's test had a workaround that recomputed the culture-sensitive string in the assertion, hiding the production-code defect.

## Test plan

- [x] `dotnet test tests/VlmEval.Tests/VlmEval.Tests.csproj` passes (77 tests, including the 3 new culture theory cases)
- [x] Pre-commit hook full suite passes (1889 frontend tests + all backend tests, conventional-commit linter)
- [x] New theory test verifies the fix on `de-DE`, `fr-FR`, `ja-JP` cultures
- [ ] CI passes on PR

## Notes for downstream branches

- Touch is a single-line production change (line 83) plus a localized test edit. RECEIPTS-634 also targets `FixtureEvaluator.cs` (money-tolerance off-by-one) and should rebase cleanly.