### PR TITLE
fix(infrastructure): align OpenAPI scan description + encrypted PDF test (RECEIPTS-629)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -1918,11 +1918,13 @@ paths:
       tags: [Receipts]
       summary: Scan a receipt image or PDF and return a proposed receipt
       description: >
-        Accepts a JPEG image, PNG image, or PDF document. For images, runs
-        preprocessing, OCR, and parsing. For PDFs, extracts text from the text
-        layer or renders pages for OCR. Multi-page PDFs are supported (up to 50
-        pages). Returns a proposed receipt with per-field confidence scores.
-        The proposal is NOT persisted — it is a transient suggestion for review.
+        Accepts a JPEG image, PNG image, or PDF document. Images are sent
+        directly to the receipt extraction service (a local vision-language
+        model). For PDFs, the first page is rasterized to a PNG at 200 DPI and
+        sent to the VLM. PDFs are accepted up to 50 pages, but only the first
+        page is currently used for extraction. Returns a proposed receipt with
+        per-field confidence scores. The proposal is NOT persisted — it is a
+        transient suggestion for review.
       security:
         - BearerAuth: []
         - ApiKey: []

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -796,7 +796,7 @@ export interface paths {
         put?: never;
         /**
          * Scan a receipt image or PDF and return a proposed receipt
-         * @description Accepts a JPEG image, PNG image, or PDF document. For images, runs preprocessing, OCR, and parsing. For PDFs, extracts text from the text layer or renders pages for OCR. Multi-page PDFs are supported (up to 50 pages). Returns a proposed receipt with per-field confidence scores. The proposal is NOT persisted — it is a transient suggestion for review.
+         * @description Accepts a JPEG image, PNG image, or PDF document. Images are sent directly to the receipt extraction service (a local vision-language model). For PDFs, the first page is rasterized to a PNG at 200 DPI and sent to the VLM. PDFs are accepted up to 50 pages, but only the first page is currently used for extraction. Returns a proposed receipt with per-field confidence scores. The proposal is NOT persisted — it is a transient suggestion for review.
          */
         post: operations["ScanReceipt"];
         delete?: never;

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
@@ -507,32 +507,42 @@ public class PdfConversionServiceTests
 	/// <see cref="PdfDocumentEncryptedException"/> when no password is supplied — exactly
 	/// the path the service-level translation must catch via the typed predicate.
 	/// </para>
+	/// <para>
+	/// The xref byte offsets and <c>startxref</c> value below match the exact Latin-1
+	/// byte positions of each object in the produced file. Hand-counted offsets are
+	/// fragile, so future edits to the object literals must update these values too —
+	/// otherwise PdfPig falls back to scanning recovery and the test passes for the
+	/// wrong reason (or breaks on a PdfPig upgrade).
+	/// </para>
 	/// </summary>
 	private static byte[] CreateEncryptedPdf()
 	{
+		// Byte offsets are exact Latin-1 positions of each object marker in the
+		// concatenated string. Verified by counting the bytes — see RECEIPTS-629
+		// PR #496 review trail for the calculation.
 		const string Pdf =
-			"%PDF-1.4\n" +
-			"%\u00e2\u00e3\u00cf\u00d3\n" +
-			"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n" +
-			"2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n" +
-			"3 0 obj\n<</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R>>\nendobj\n" +
-			"4 0 obj\n<</Length 0>>\nstream\nendstream\nendobj\n" +
+			"%PDF-1.4\n" +                                                                            //   0..  8 (9 bytes)
+			"%\u00e2\u00e3\u00cf\u00d3\n" +                                                           //   9.. 14 (6 bytes)
+			"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n" +                                    //  15.. 61 (47 bytes)
+			"2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n" +                            //  62..116 (55 bytes)
+			"3 0 obj\n<</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R>>\nendobj\n" + // 117..201 (85 bytes)
+			"4 0 obj\n<</Length 0>>\nstream\nendstream\nendobj\n" +                                   // 202..247 (46 bytes)
 			"5 0 obj\n<</Filter /Standard /V 1 /R 2 /P -4 /Length 40 " +
 			"/O <0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF> " +
-			"/U <FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210>>>\nendobj\n" +
-			"xref\n" +
+			"/U <FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210>>>\nendobj\n" +     // 248..451 (204 bytes)
+			"xref\n" +                                                                                // 452 — startxref target
 			"0 6\n" +
 			"0000000000 65535 f \n" +
 			"0000000015 00000 n \n" +
-			"0000000059 00000 n \n" +
-			"0000000105 00000 n \n" +
-			"0000000169 00000 n \n" +
-			"0000000209 00000 n \n" +
+			"0000000062 00000 n \n" +
+			"0000000117 00000 n \n" +
+			"0000000202 00000 n \n" +
+			"0000000248 00000 n \n" +
 			"trailer\n" +
 			"<</Size 6 /Root 1 0 R /Encrypt 5 0 R " +
 			"/ID [<00000000000000000000000000000000> <00000000000000000000000000000000>]>>\n" +
 			"startxref\n" +
-			"388\n" +
+			"452\n" +
 			"%%EOF\n";
 		// ASCII-safe encoding — PDF's binary marker comment uses Latin-1 high bytes,
 		// but the rest is plain ASCII. Use Latin-1 to preserve the marker bytes faithfully.

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
@@ -274,6 +274,30 @@ public class PdfConversionServiceTests
 	}
 
 	[Fact]
+	public async Task ConvertAsync_EncryptedPdf_ThrowsPasswordProtectedInvalidOperationException()
+	{
+		// Arrange — RECEIPTS-629 acceptance: encrypted PDFs must be rejected with a
+		// clear "Password-protected" error before the rasterizer is invoked. PdfPig's
+		// PdfDocument.Open detects the trailer's /Encrypt entry and raises
+		// PdfDocumentEncryptedException; the service translates that to the user-facing
+		// InvalidOperationException via the typed predicate (no message-substring match).
+		// The fixture is a hand-crafted minimal PDF whose trailer references a Standard
+		// encryption dictionary (V=1, R=2). It opens enough to detect encryption but
+		// exposes no real password — exactly the typed-exception path we need to verify.
+		byte[] pdfBytes = CreateEncryptedPdf();
+
+		// Act
+		Func<Task> act = () => _service.ConvertAsync(pdfBytes, CancellationToken.None);
+
+		// Assert
+		FluentAssertions.Specialized.ExceptionAssertions<InvalidOperationException> thrown =
+			await act.Should().ThrowAsync<InvalidOperationException>()
+				.WithMessage("*Password-protected*");
+		thrown.Which.InnerException.Should().BeOfType<PdfDocumentEncryptedException>(
+			"the typed PdfPig encryption exception is the trigger that the service translates");
+	}
+
+	[Fact]
 	public void IsPasswordProtectedException_PdfDocumentEncryptedException_ReturnsTrue()
 	{
 		// Arrange — the typed exception PdfPig raises when PdfDocument.Open hits an
@@ -469,6 +493,50 @@ public class PdfConversionServiceTests
 	{
 		PdfDocumentBuilder builder = new();
 		return builder.Build();
+	}
+
+	/// <summary>
+	/// Builds a minimal encrypted PDF byte stream by hand. PdfPig's writer
+	/// (<see cref="PdfDocumentBuilder"/>) does not support emitting encrypted PDFs, so
+	/// the only way to exercise the encrypted-document path end-to-end without shipping
+	/// a binary fixture is to hand-craft the bytes.
+	/// <para>
+	/// The PDF below contains a Standard encryption dictionary (V=1, R=2, 40-bit RC4)
+	/// referenced from the trailer's <c>/Encrypt</c> key. PdfPig's <c>PdfDocument.Open</c>
+	/// detects the trailer entry and immediately raises
+	/// <see cref="PdfDocumentEncryptedException"/> when no password is supplied — exactly
+	/// the path the service-level translation must catch via the typed predicate.
+	/// </para>
+	/// </summary>
+	private static byte[] CreateEncryptedPdf()
+	{
+		const string Pdf =
+			"%PDF-1.4\n" +
+			"%\u00e2\u00e3\u00cf\u00d3\n" +
+			"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n" +
+			"2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n" +
+			"3 0 obj\n<</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R>>\nendobj\n" +
+			"4 0 obj\n<</Length 0>>\nstream\nendstream\nendobj\n" +
+			"5 0 obj\n<</Filter /Standard /V 1 /R 2 /P -4 /Length 40 " +
+			"/O <0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF> " +
+			"/U <FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210>>>\nendobj\n" +
+			"xref\n" +
+			"0 6\n" +
+			"0000000000 65535 f \n" +
+			"0000000015 00000 n \n" +
+			"0000000059 00000 n \n" +
+			"0000000105 00000 n \n" +
+			"0000000169 00000 n \n" +
+			"0000000209 00000 n \n" +
+			"trailer\n" +
+			"<</Size 6 /Root 1 0 R /Encrypt 5 0 R " +
+			"/ID [<00000000000000000000000000000000> <00000000000000000000000000000000>]>>\n" +
+			"startxref\n" +
+			"388\n" +
+			"%%EOF\n";
+		// ASCII-safe encoding — PDF's binary marker comment uses Latin-1 high bytes,
+		// but the rest is plain ASCII. Use Latin-1 to preserve the marker bytes faithfully.
+		return System.Text.Encoding.Latin1.GetBytes(Pdf);
 	}
 
 	private static void AssertContainsValidPng(IReadOnlyList<byte[]> images)


### PR DESCRIPTION
## Summary

The PDF rasterization implementation for `PdfConversionService` was actually delivered in [RECEIPTS-624 (commit 9d472211)](https://github.com/mggarofalo/receipts/commit/9d472211dd1d1e897616b95437fb65153fd27603) — the service switched to `PDFtoImage` (Sungaila) + `SkiaSharp.NativeAssets.Linux.NoDependencies`, renders the first PDF page at 200 DPI, and removed the embedded-image extraction path, the 400-px filter, and `TryCreatePngFromRawPixels`. RECEIPTS-645 then narrowed exception handlers and added typed-predicate tests.

Two acceptance items remained for RECEIPTS-629:

- **OpenAPI spec drift:** `openapi/spec.yaml` at `/api/receipts/scan` still claimed the endpoint "extracts text from the text layer or renders pages for OCR." It actually rasterizes the first page to a PNG at 200 DPI and sends it to the VLM. Aligned the spec with the controller's `[EndpointDescription]`. The multi-page warning piece is owned by [RECEIPTS-637](https://plane.wallingford.me/dev/browse/RECEIPTS-637/) — the wording here just says "PDFs are accepted up to 50 pages, but only the first page is currently used for extraction" and lets RECEIPTS-637 add the proper user-facing warning surface.
- **Encrypted-PDF integration test:** Coverage stopped at the predicate unit tests. Added an integration test that builds a hand-crafted minimal encrypted PDF (PdfPig's writer doesn't emit encrypted PDFs) and asserts `ConvertAsync` surfaces `InvalidOperationException("Password-protected PDFs are not supported.")` with `PdfDocumentEncryptedException` as `InnerException` — exercising the typed-predicate path end-to-end.

Resolves RECEIPTS-629

## Test plan

- [x] `dotnet build Receipts.slnx` — clean (only pre-existing NU1903 warnings)
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2422 passed, 0 failed
- [x] `npm run lint:spec` — passes
- [x] `npm run check:drift` — no drift between spec.yaml and runtime-generated API.json
- [x] New `ConvertAsync_EncryptedPdf_ThrowsPasswordProtectedInvalidOperationException` test passes alongside the 23 existing PdfConversionService tests

## Acceptance status

- A born-digital PDF receipt is rasterized and successfully extracted by the VLM — covered by `ConvertAsync_VectorOnlyPdf_ProducesRasterizedFirstPageImage` (existing)
- A multi-page Paperless OCR'd PDF rasterizes the first page faithfully — covered by `ConvertAsync_MultiPagePdf_RasterizesFirstPageOnly` (existing)
- Tests added with real fixture PDFs — born-digital ✓, encrypted ✓ (new); CMYK/JBIG2 require binary fixtures that PdfDocumentBuilder cannot synthesize and were left unaddressed — practical only with shipped binary fixtures from real-world examples
- OpenAPI spec endpoint description matches actual behavior — fixed in this PR
- No "embedded bitmap extraction" code remains — removed entirely in RECEIPTS-624

## Out of scope (explicit non-conflict)

- `PdfConversionResult.ExtractedText` / `PdfMetadata` cleanup — owned by [RECEIPTS-646](https://plane.wallingford.me/dev/browse/RECEIPTS-646/), intentionally left untouched.
- Multi-page handling spec drift / dropped-page warning surface — owned by [RECEIPTS-637](https://plane.wallingford.me/dev/browse/RECEIPTS-637/).