### PR TITLE
fix(application): distinguish absent from low-confidence in FieldConfidence (RECEIPTS-631)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -6276,7 +6276,11 @@ components:
 
     ConfidenceLevel:
       type: string
-      enum: [low, medium, high]
+      description: |
+        Per-field confidence reported by the receipt extraction pipeline.
+        `none` means the field was absent from the source receipt; values `low`/`medium`/`high`
+        all carry a real extracted value at the corresponding confidence level.
+      enum: [none, low, medium, high]
 
     ProposedReceiptResponse:
       type: object

--- a/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
+++ b/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
@@ -55,13 +55,20 @@ public class ScanReceiptCommandHandler(
 		return (conversion.PageImages[0], PdfPageImageContentType);
 	}
 
+	/// <summary>
+	/// True when the extraction yielded no usable signal at all — every scalar field is
+	/// <see cref="FieldConfidence{T}.None"/> and there are no items or tax lines. Note this
+	/// must check for <see cref="ConfidenceLevel.None"/>, not <see cref="ConfidenceLevel.Low"/>:
+	/// a low-confidence extracted value is still a real reading the user can review and edit,
+	/// and rejecting it as "empty" would discard valid (if uncertain) data.
+	/// </summary>
 	private static bool IsEmpty(ParsedReceipt parsed)
 	{
-		return parsed.StoreName.Confidence == ConfidenceLevel.Low
-			&& parsed.Date.Confidence == ConfidenceLevel.Low
-			&& parsed.Subtotal.Confidence == ConfidenceLevel.Low
-			&& parsed.Total.Confidence == ConfidenceLevel.Low
-			&& parsed.PaymentMethod.Confidence == ConfidenceLevel.Low
+		return !parsed.StoreName.IsPresent
+			&& !parsed.Date.IsPresent
+			&& !parsed.Subtotal.IsPresent
+			&& !parsed.Total.IsPresent
+			&& !parsed.PaymentMethod.IsPresent
 			&& parsed.Items.Count == 0
 			&& parsed.TaxLines.Count == 0;
 	}

--- a/src/Application/Models/Ocr/ConfidenceLevel.cs
+++ b/src/Application/Models/Ocr/ConfidenceLevel.cs
@@ -1,3 +1,10 @@
 namespace Application.Models.Ocr;
 
-public enum ConfidenceLevel { Low, Medium, High }
+/// <summary>
+/// Per-field confidence reported by the receipt extraction pipeline. Ordered from
+/// "absent" through ascending information content. Placing <see cref="None"/> first
+/// makes <c>default(ConfidenceLevel)</c> resolve to <see cref="None"/>, which is the
+/// safest default — a freshly-constructed <c>FieldConfidence&lt;T&gt;</c> reads as
+/// "no value" rather than as a spurious low-confidence reading.
+/// </summary>
+public enum ConfidenceLevel { None, Low, Medium, High }

--- a/src/Application/Models/Ocr/FieldConfidence.cs
+++ b/src/Application/Models/Ocr/FieldConfidence.cs
@@ -5,5 +5,16 @@ public record FieldConfidence<T>(T? Value, ConfidenceLevel Confidence)
 	public static FieldConfidence<T> High(T value) => new(value, ConfidenceLevel.High);
 	public static FieldConfidence<T> Medium(T value) => new(value, ConfidenceLevel.Medium);
 	public static FieldConfidence<T> Low(T value) => new(value, ConfidenceLevel.Low);
-	public static FieldConfidence<T> None() => new(default, ConfidenceLevel.Low);
+
+	/// <summary>
+	/// Constructs a "field absent" sentinel: the source did not provide this field at all.
+	/// Distinct from <see cref="Low(T)"/>, which carries a real (but uncertain) extracted value.
+	/// </summary>
+	public static FieldConfidence<T> None() => new(default, ConfidenceLevel.None);
+
+	/// <summary>
+	/// True when the source provided a value for this field (at any confidence level).
+	/// False only for the <see cref="None()"/> sentinel.
+	/// </summary>
+	public bool IsPresent => Confidence != ConfidenceLevel.None;
 }

--- a/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
@@ -171,10 +171,11 @@ public class ReceiptScanController(
 	{
 		return level switch
 		{
+			OcrConfidenceLevel.None => DtoConfidenceLevel.None,
 			OcrConfidenceLevel.Low => DtoConfidenceLevel.Low,
 			OcrConfidenceLevel.Medium => DtoConfidenceLevel.Medium,
 			OcrConfidenceLevel.High => DtoConfidenceLevel.High,
-			_ => DtoConfidenceLevel.Low,
+			_ => DtoConfidenceLevel.None,
 		};
 	}
 }

--- a/src/Tools/VlmEval/FixtureEvaluator.cs
+++ b/src/Tools/VlmEval/FixtureEvaluator.cs
@@ -62,7 +62,7 @@ public sealed class FixtureEvaluator(
 			return new FieldDiff("store", DiffStatus.NotDeclared, null, actual.Value, null);
 		}
 
-		if (string.IsNullOrWhiteSpace(actual.Value))
+		if (!actual.IsPresent || string.IsNullOrWhiteSpace(actual.Value))
 		{
 			return new FieldDiff("store", DiffStatus.Fail, expected, null, "VLM did not extract store name");
 		}
@@ -83,7 +83,7 @@ public sealed class FixtureEvaluator(
 			return new FieldDiff("date", DiffStatus.NotDeclared, null, actual.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), null);
 		}
 
-		if (actual.Confidence == ConfidenceLevel.Low)
+		if (!actual.IsPresent)
 		{
 			return new FieldDiff("date", DiffStatus.Fail, expected.Value.ToString("yyyy-MM-dd"), null, "VLM did not extract date");
 		}
@@ -104,7 +104,7 @@ public sealed class FixtureEvaluator(
 			return new FieldDiff(field, DiffStatus.NotDeclared, null, Format(actual), null);
 		}
 
-		if (actual.Confidence == ConfidenceLevel.Low)
+		if (!actual.IsPresent)
 		{
 			return new FieldDiff(field, DiffStatus.Fail, expected.Value.ToString("0.00", CultureInfo.InvariantCulture), null, $"VLM did not extract {field}");
 		}
@@ -119,7 +119,7 @@ public sealed class FixtureEvaluator(
 			match ? null : $"delta=${delta.ToString("0.00", CultureInfo.InvariantCulture)}");
 
 		static string? Format(FieldConfidence<decimal> f) =>
-			f.Confidence == ConfidenceLevel.Low ? null : f.Value.ToString("0.00", CultureInfo.InvariantCulture);
+			f.IsPresent ? f.Value.ToString("0.00", CultureInfo.InvariantCulture) : null;
 	}
 
 	internal static FieldDiff DiffTaxLines(List<ExpectedTaxLine>? expected, List<ParsedTaxLine> actual)
@@ -130,7 +130,7 @@ public sealed class FixtureEvaluator(
 		}
 
 		List<decimal> actualAmounts = [.. actual
-			.Where(t => t.Amount.Confidence != ConfidenceLevel.Low)
+			.Where(t => t.Amount.IsPresent)
 			.Select(t => t.Amount.Value)];
 
 		List<string> failures = [];
@@ -159,7 +159,7 @@ public sealed class FixtureEvaluator(
 			"taxLines",
 			pass ? DiffStatus.Pass : DiffStatus.Fail,
 			string.Join(", ", expected.Where(t => t.Amount is not null).Select(t => t.Amount!.Value.ToString("0.00", CultureInfo.InvariantCulture))),
-			string.Join(", ", actual.Where(t => t.Amount.Confidence != ConfidenceLevel.Low).Select(t => t.Amount.Value.ToString("0.00", CultureInfo.InvariantCulture))),
+			string.Join(", ", actual.Where(t => t.Amount.IsPresent).Select(t => t.Amount.Value.ToString("0.00", CultureInfo.InvariantCulture))),
 			pass ? null : string.Join("; ", failures));
 	}
 
@@ -186,7 +186,7 @@ public sealed class FixtureEvaluator(
 			return new FieldDiff("paymentMethod", DiffStatus.NotDeclared, null, actual.Value, null);
 		}
 
-		if (string.IsNullOrWhiteSpace(actual.Value))
+		if (!actual.IsPresent || string.IsNullOrWhiteSpace(actual.Value))
 		{
 			return new FieldDiff("paymentMethod", DiffStatus.Fail, expected, null, "VLM did not extract paymentMethod");
 		}
@@ -244,7 +244,7 @@ public sealed class FixtureEvaluator(
 				decimal best = decimal.MaxValue;
 				for (int p = 0; p < pool.Count; p++)
 				{
-					if (pool[p].TotalPrice.Confidence == ConfidenceLevel.Low)
+					if (!pool[p].TotalPrice.IsPresent)
 					{
 						continue;
 					}
@@ -294,7 +294,7 @@ public sealed class FixtureEvaluator(
 
 			if (item.TotalPrice is not null)
 			{
-				if (matched.TotalPrice.Confidence == ConfidenceLevel.Low)
+				if (!matched.TotalPrice.IsPresent)
 				{
 					issues.Add("missing totalPrice");
 				}
@@ -325,9 +325,9 @@ public sealed class FixtureEvaluator(
 	private static string FormatActualItem(ParsedReceiptItem item)
 	{
 		string desc = item.Description.Value ?? "?";
-		string price = item.TotalPrice.Confidence == ConfidenceLevel.Low
-			? "?"
-			: item.TotalPrice.Value.ToString("0.00", CultureInfo.InvariantCulture);
+		string price = item.TotalPrice.IsPresent
+			? item.TotalPrice.Value.ToString("0.00", CultureInfo.InvariantCulture)
+			: "?";
 		return $"{desc} @ {price}";
 	}
 }

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -3110,8 +3110,13 @@ export interface components {
         UploadReceiptImageResponse: {
             originalImagePath: string;
         };
-        /** @enum {string} */
-        ConfidenceLevel: "low" | "medium" | "high";
+        /**
+         * @description Per-field confidence reported by the receipt extraction pipeline.
+         *     `none` means the field was absent from the source receipt; values `low`/`medium`/`high`
+         *     all carry a real extracted value at the corresponding confidence level.
+         * @enum {string}
+         */
+        ConfidenceLevel: "none" | "low" | "medium" | "high";
         ProposedReceiptResponse: {
             storeName?: string | null;
             storeNameConfidence: components["schemas"]["ConfidenceLevel"];

--- a/src/client/src/pages/scan-receipt/ConfidenceIndicator.tsx
+++ b/src/client/src/pages/scan-receipt/ConfidenceIndicator.tsx
@@ -10,7 +10,9 @@ export function ConfidenceIndicator({
   confidence,
   className,
 }: ConfidenceIndicatorProps) {
-  if (!confidence || confidence === "high") {
+  // "none" means the source receipt did not contain this field at all — there is no
+  // value to indicate confidence in. Treat the same as "high" / undefined: render nothing.
+  if (!confidence || confidence === "high" || confidence === "none") {
     return null;
   }
 

--- a/src/client/src/pages/scan-receipt/proposalMappers.test.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.test.ts
@@ -205,6 +205,47 @@ describe("mapProposalToConfidenceMap", () => {
     expect(result).toEqual({});
   });
 
+  it("falls back to subtotalConfidence when first tax line's amount is 'none'", () => {
+    // Regression for the bug-finder review of RECEIPTS-631: the `??` operator
+    // does NOT fall through for the non-nullish string "none". Without an
+    // explicit check, a tax line whose amount is absent would silently drop
+    // the subtotal-based review badge — the user would never be prompted to
+    // verify a low-confidence subtotal.
+    const proposal = makeProposal({
+      taxLines: [
+        {
+          label: "Tax",
+          labelConfidence: "high",
+          amount: null,
+          amountConfidence: "none",
+        },
+      ],
+      subtotalConfidence: "low",
+    });
+
+    const result = mapProposalToConfidenceMap(proposal);
+
+    expect(result.taxAmount).toBe("low");
+  });
+
+  it("uses first tax line's amountConfidence when present and not 'none'", () => {
+    const proposal = makeProposal({
+      taxLines: [
+        {
+          label: "Tax",
+          labelConfidence: "high",
+          amount: 1.25,
+          amountConfidence: "low",
+        },
+      ],
+      subtotalConfidence: "high",
+    });
+
+    const result = mapProposalToConfidenceMap(proposal);
+
+    expect(result.taxAmount).toBe("low");
+  });
+
   it("flags low/medium confidence but never 'none' on per-payment fields", () => {
     const proposal = makeProposal({
       payments: [

--- a/src/client/src/pages/scan-receipt/proposalMappers.test.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.test.ts
@@ -184,6 +184,47 @@ describe("mapProposalToConfidenceMap", () => {
     expect(result).toEqual({});
   });
 
+  it("omits 'none' confidence fields (RECEIPTS-631: absent fields need no badge)", () => {
+    // 'none' means the source receipt did not contain that field at all — the user
+    // has nothing to review, so no badge should appear in the confidence map.
+    const proposal = makeProposal({
+      storeAddress: null,
+      storeAddressConfidence: "none",
+      storePhone: null,
+      storePhoneConfidence: "none",
+      receiptId: null,
+      receiptIdConfidence: "none",
+      storeNumber: null,
+      storeNumberConfidence: "none",
+      terminalId: null,
+      terminalIdConfidence: "none",
+    });
+
+    const result = mapProposalToConfidenceMap(proposal);
+
+    expect(result).toEqual({});
+  });
+
+  it("flags low/medium confidence but never 'none' on per-payment fields", () => {
+    const proposal = makeProposal({
+      payments: [
+        {
+          method: "VISA",
+          methodConfidence: "low",
+          amount: 5,
+          amountConfidence: "high",
+          lastFour: null,
+          lastFourConfidence: "none",
+        },
+      ],
+    });
+
+    const result = mapProposalToConfidenceMap(proposal);
+
+    // method: "low" surfaces; amount/lastFour are dropped (high + none).
+    expect(result.payments).toEqual([{ method: "low" }]);
+  });
+
   it("flags low/medium confidence on the new fields", () => {
     const proposal = makeProposal({
       storeAddress: "123 Main St",

--- a/src/client/src/pages/scan-receipt/proposalMappers.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.ts
@@ -2,7 +2,11 @@ import type { components } from "@/generated/api";
 import { generateId } from "@/lib/id";
 import type { ReceiptLineItem } from "@/pages/new-receipt/LineItemsSection";
 import type { ReceiptPayment } from "@/pages/new-receipt/PaymentsSection";
-import type { ScanInitialValues, ReceiptConfidenceMap } from "./types";
+import type {
+  ConfidenceLevel,
+  ScanInitialValues,
+  ReceiptConfidenceMap,
+} from "./types";
 
 type ProposedReceiptResponse = components["schemas"]["ProposedReceiptResponse"];
 
@@ -10,6 +14,16 @@ type ItemConfidenceEntry = NonNullable<ReceiptConfidenceMap["items"]>[number];
 type PaymentConfidenceEntry = NonNullable<
   ReceiptConfidenceMap["payments"]
 >[number];
+
+/**
+ * True when a confidence value indicates the user needs to review the field.
+ * "high" — extracted with high confidence; no review needed.
+ * "none" — the source receipt did not contain this field; there is nothing to review.
+ * "low" / "medium" — extracted with reduced confidence; surface to the user.
+ */
+function needsReview(confidence: ConfidenceLevel): boolean {
+  return confidence !== "high" && confidence !== "none";
+}
 
 /**
  * Map a {@link ProposedReceiptResponse} (returned by the VLM scan endpoint)
@@ -69,8 +83,10 @@ export function mapProposalToInitialValues(
  * Build a confidence map from the proposal that highlights low/medium fields
  * (so the new-receipt wizard can render review badges).
  *
- * Fields whose confidence is "high" are intentionally omitted — the absence
- * of a key signals "no badge needed".
+ * Fields whose confidence is "high" or "none" are intentionally omitted — the
+ * absence of a key signals "no badge needed". "high" means we are confident in
+ * the extracted value; "none" means the source receipt did not contain that
+ * field at all (so there is nothing for the user to review).
  */
 export function mapProposalToConfidenceMap(
   proposal: ProposedReceiptResponse,
@@ -82,44 +98,44 @@ export function mapProposalToConfidenceMap(
 
   const map: ReceiptConfidenceMap = {};
 
-  if (proposal.storeNameConfidence !== "high") {
+  if (needsReview(proposal.storeNameConfidence)) {
     map.location = proposal.storeNameConfidence;
   }
-  if (proposal.dateConfidence !== "high") {
+  if (needsReview(proposal.dateConfidence)) {
     map.date = proposal.dateConfidence;
   }
 
   // Use the first tax line's confidence, or the subtotal confidence as fallback.
   const taxConfidence =
     taxLines[0]?.amountConfidence ?? proposal.subtotalConfidence;
-  if (taxConfidence !== "high") {
+  if (needsReview(taxConfidence)) {
     map.taxAmount = taxConfidence;
   }
 
-  if (proposal.storeAddressConfidence !== "high") {
+  if (needsReview(proposal.storeAddressConfidence)) {
     map.storeAddress = proposal.storeAddressConfidence;
   }
-  if (proposal.storePhoneConfidence !== "high") {
+  if (needsReview(proposal.storePhoneConfidence)) {
     map.storePhone = proposal.storePhoneConfidence;
   }
-  if (proposal.receiptIdConfidence !== "high") {
+  if (needsReview(proposal.receiptIdConfidence)) {
     map.receiptId = proposal.receiptIdConfidence;
   }
-  if (proposal.storeNumberConfidence !== "high") {
+  if (needsReview(proposal.storeNumberConfidence)) {
     map.storeNumber = proposal.storeNumberConfidence;
   }
-  if (proposal.terminalIdConfidence !== "high") {
+  if (needsReview(proposal.terminalIdConfidence)) {
     map.terminalId = proposal.terminalIdConfidence;
   }
 
   // Per-payment confidences. Always emit an entry per payment so indices align,
-  // omitting fields whose confidence is "high".
+  // omitting fields whose confidence is "high" or "none".
   if (payments.length > 0) {
     map.payments = payments.map((p) => {
-      const entry: NonNullable<ReceiptConfidenceMap["payments"]>[number] = {};
-      if (p.methodConfidence !== "high") entry.method = p.methodConfidence;
-      if (p.amountConfidence !== "high") entry.amount = p.amountConfidence;
-      if (p.lastFourConfidence !== "high")
+      const entry: PaymentConfidenceEntry = {};
+      if (needsReview(p.methodConfidence)) entry.method = p.methodConfidence;
+      if (needsReview(p.amountConfidence)) entry.amount = p.amountConfidence;
+      if (needsReview(p.lastFourConfidence))
         entry.lastFour = p.lastFourConfidence;
       return entry;
     });
@@ -128,13 +144,13 @@ export function mapProposalToConfidenceMap(
   // Per-item taxCode confidences.
   if (items.length > 0) {
     const itemEntries = items.map((item) => {
-      const entry: NonNullable<ReceiptConfidenceMap["items"]>[number] = {};
-      if (item.taxCodeConfidence !== "high") {
+      const entry: ItemConfidenceEntry = {};
+      if (needsReview(item.taxCodeConfidence)) {
         entry.taxCode = item.taxCodeConfidence;
       }
       return entry;
     });
-    // Only include if any entry has at least one non-high confidence
+    // Only include if any entry has at least one non-high/non-none confidence
     if (itemEntries.some((e) => Object.keys(e).length > 0)) {
       map.items = itemEntries;
     }

--- a/src/client/src/pages/scan-receipt/proposalMappers.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.ts
@@ -106,8 +106,15 @@ export function mapProposalToConfidenceMap(
   }
 
   // Use the first tax line's confidence, or the subtotal confidence as fallback.
+  // `??` is not enough: under RECEIPTS-631, an absent tax-line amount comes back as
+  // "none" — a non-nullish string — which would block the fallback and leave the
+  // taxAmount badge silently unset even when the subtotal came in at low confidence.
+  // Treat "none" the same way as `undefined` for the purpose of falling back.
+  const firstTaxAmountConfidence = taxLines[0]?.amountConfidence;
   const taxConfidence =
-    taxLines[0]?.amountConfidence ?? proposal.subtotalConfidence;
+    firstTaxAmountConfidence && firstTaxAmountConfidence !== "none"
+      ? firstTaxAmountConfidence
+      : proposal.subtotalConfidence;
   if (needsReview(taxConfidence)) {
     map.taxAmount = taxConfidence;
   }

--- a/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
@@ -298,6 +298,109 @@ public class ScanReceiptCommandHandlerTests
 	}
 
 	[Fact]
+	public async Task Handle_ExtractionReturnsLowConfidenceStoreNameOnly_ReturnsResult()
+	{
+		// Arrange — RECEIPTS-631: a receipt where every field except StoreName is None must
+		// NOT be treated as empty. A low-confidence extracted value (even one as minimal as
+		// the store name) is still a real reading the user can review and edit. The previous
+		// IsEmpty check rejected this case as "empty" because Low and None were conflated.
+		byte[] imageBytes = [0xFF, 0xD8];
+		ScanReceiptCommand command = new(imageBytes, "image/jpeg");
+
+		ParsedReceipt parsed = new(
+			FieldConfidence<string>.Low("Walmart"),
+			FieldConfidence<DateOnly>.None(),
+			[],
+			FieldConfidence<decimal>.None(),
+			[],
+			FieldConfidence<decimal>.None(),
+			FieldConfidence<string?>.None()
+		);
+
+		_mockExtractionService
+			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(parsed);
+
+		// Act
+		ScanReceiptResult actual = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.ParsedReceipt.Should().BeSameAs(parsed);
+		actual.ParsedReceipt.StoreName.Value.Should().Be("Walmart");
+		actual.ParsedReceipt.StoreName.Confidence.Should().Be(ConfidenceLevel.Low);
+	}
+
+	[Fact]
+	public async Task Handle_ExtractionReturnsLowConfidenceZeroTotalOnly_ReturnsResult()
+	{
+		// Arrange — RECEIPTS-631 specifically: distinguishes Low(0m) from None() for value
+		// types. A receipt where the VLM extracted "$0.00" with low confidence (e.g. an
+		// illegible total) is still a present field and must not trigger the empty-receipt
+		// short-circuit.
+		byte[] imageBytes = [0xFF, 0xD8];
+		ScanReceiptCommand command = new(imageBytes, "image/jpeg");
+
+		ParsedReceipt parsed = new(
+			FieldConfidence<string>.None(),
+			FieldConfidence<DateOnly>.None(),
+			[],
+			FieldConfidence<decimal>.None(),
+			[],
+			FieldConfidence<decimal>.Low(0m),
+			FieldConfidence<string?>.None()
+		);
+
+		_mockExtractionService
+			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(parsed);
+
+		// Act
+		ScanReceiptResult actual = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.ParsedReceipt.Should().BeSameAs(parsed);
+		actual.ParsedReceipt.Total.Value.Should().Be(0m);
+		actual.ParsedReceipt.Total.Confidence.Should().Be(ConfidenceLevel.Low);
+	}
+
+	[Fact]
+	public async Task Handle_ExtractionReturnsItemsButNoScalarFields_ReturnsResult()
+	{
+		// Arrange — a receipt that yielded zero header/total fields but at least one line
+		// item is still useful data. The handler must not reject it as empty.
+		byte[] imageBytes = [0xFF, 0xD8];
+		ScanReceiptCommand command = new(imageBytes, "image/jpeg");
+
+		ParsedReceipt parsed = new(
+			FieldConfidence<string>.None(),
+			FieldConfidence<DateOnly>.None(),
+			[
+				new ParsedReceiptItem(
+					FieldConfidence<string?>.None(),
+					FieldConfidence<string>.High("MILK"),
+					FieldConfidence<decimal>.None(),
+					FieldConfidence<decimal>.None(),
+					FieldConfidence<decimal>.High(3.49m))
+			],
+			FieldConfidence<decimal>.None(),
+			[],
+			FieldConfidence<decimal>.None(),
+			FieldConfidence<string?>.None()
+		);
+
+		_mockExtractionService
+			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(parsed);
+
+		// Act
+		ScanReceiptResult actual = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.ParsedReceipt.Should().BeSameAs(parsed);
+		actual.ParsedReceipt.Items.Should().HaveCount(1);
+	}
+
+	[Fact]
 	public async Task Handle_ExtractionServiceThrows_PropagatesException()
 	{
 		// Arrange

--- a/tests/Application.Tests/Models/Ocr/FieldConfidenceTests.cs
+++ b/tests/Application.Tests/Models/Ocr/FieldConfidenceTests.cs
@@ -1,0 +1,85 @@
+using Application.Models.Ocr;
+using FluentAssertions;
+
+namespace Application.Tests.Models.Ocr;
+
+/// <summary>
+/// Verifies the "absent vs. present" semantics of <see cref="FieldConfidence{T}"/>.
+/// RECEIPTS-631 split the previous overloaded <c>None() == Low</c> sentinel into
+/// distinct <see cref="ConfidenceLevel.None"/> and <see cref="ConfidenceLevel.Low"/>
+/// states; these tests pin the new contract so a future regression cannot silently
+/// merge the two again.
+/// </summary>
+public class FieldConfidenceTests
+{
+	[Fact]
+	public void None_ProducesDefaultValue_WithNoneConfidence()
+	{
+		FieldConfidence<string> f = FieldConfidence<string>.None();
+
+		f.Value.Should().BeNull();
+		f.Confidence.Should().Be(ConfidenceLevel.None);
+	}
+
+	[Fact]
+	public void None_OnValueType_ProducesDefaultWithNoneConfidence()
+	{
+		FieldConfidence<decimal> f = FieldConfidence<decimal>.None();
+
+		// Value is the CLR default (0m) but Confidence is None — distinct from Low(0m).
+		f.Value.Should().Be(0m);
+		f.Confidence.Should().Be(ConfidenceLevel.None);
+	}
+
+	[Fact]
+	public void Low_WithRealValue_IsDistinctFromNone()
+	{
+		FieldConfidence<string> low = FieldConfidence<string>.Low("Walmart");
+		FieldConfidence<string> none = FieldConfidence<string>.None();
+
+		low.Should().NotBe(none);
+		low.Confidence.Should().Be(ConfidenceLevel.Low);
+		low.Value.Should().Be("Walmart");
+		none.Confidence.Should().Be(ConfidenceLevel.None);
+	}
+
+	[Fact]
+	public void Low_WithDefaultValue_IsStillDistinctFromNone()
+	{
+		// A deliberate Low(0m) — meaning the VLM extracted "$0.00" with low confidence —
+		// must remain distinguishable from None() (the field was not extracted at all).
+		FieldConfidence<decimal> lowZero = FieldConfidence<decimal>.Low(0m);
+		FieldConfidence<decimal> none = FieldConfidence<decimal>.None();
+
+		lowZero.Should().NotBe(none);
+		lowZero.Confidence.Should().Be(ConfidenceLevel.Low);
+		none.Confidence.Should().Be(ConfidenceLevel.None);
+	}
+
+	[Fact]
+	public void IsPresent_True_ForLowMediumHigh()
+	{
+		FieldConfidence<string>.Low("v").IsPresent.Should().BeTrue();
+		FieldConfidence<string>.Medium("v").IsPresent.Should().BeTrue();
+		FieldConfidence<string>.High("v").IsPresent.Should().BeTrue();
+	}
+
+	[Fact]
+	public void IsPresent_False_ForNone()
+	{
+		FieldConfidence<string>.None().IsPresent.Should().BeFalse();
+		FieldConfidence<decimal>.None().IsPresent.Should().BeFalse();
+		FieldConfidence<DateOnly>.None().IsPresent.Should().BeFalse();
+	}
+
+	[Fact]
+	public void DefaultEnumValue_IsNone()
+	{
+		// Defensive: a freshly default-initialized ConfidenceLevel must read as None,
+		// not Low. This guards against silent misclassification of zero-initialized
+		// values reaching production code as "low confidence" extractions.
+		ConfidenceLevel defaultLevel = default;
+
+		defaultLevel.Should().Be(ConfidenceLevel.None);
+	}
+}

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -122,8 +122,8 @@ public class OllamaReceiptExtractionServiceTests
 		receipt.Items.Should().HaveCount(2);
 		receipt.Items[0].Code.Value.Should().Be("078742228030");
 		receipt.Items[0].Description.Value.Should().Be("GRANULATED");
-		receipt.Items[0].Quantity.Confidence.Should().Be(ConfidenceLevel.Low);
-		receipt.Items[0].UnitPrice.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.Items[0].Quantity.Confidence.Should().Be(ConfidenceLevel.None);
+		receipt.Items[0].UnitPrice.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.Items[0].TotalPrice.Value.Should().Be(3.07m);
 		receipt.Items[0].TaxCode.Value.Should().Be("F");
 		receipt.Items[0].TaxCode.Confidence.Should().Be(ConfidenceLevel.High);
@@ -203,7 +203,7 @@ public class OllamaReceiptExtractionServiceTests
 
 		// Assert
 		receipt.Date.Value.Should().Be(default(DateOnly));
-		receipt.Date.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.Date.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.StoreName.Value.Should().Be("Walmart");
 		receipt.Total.Value.Should().Be(10.00m);
 	}
@@ -264,7 +264,7 @@ public class OllamaReceiptExtractionServiceTests
 		// Assert — both rows kept; BREAD is untouched
 		receipt.Items.Should().HaveCount(2);
 		receipt.Items[0].Description.Value.Should().Be("BREAD");
-		receipt.Items[0].Quantity.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.Items[0].Quantity.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.Items[1].Description.Value.Should().Be("2.460 lb. @ 1 lb. /0.50");
 		receipt.Items[1].Quantity.Value.Should().Be(2.460m);
 	}
@@ -380,7 +380,7 @@ public class OllamaReceiptExtractionServiceTests
 
 		// Assert
 		receipt.PaymentMethod.Value.Should().BeNull();
-		receipt.PaymentMethod.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.PaymentMethod.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.TaxLines.Should().BeEmpty();
 		receipt.Items.Should().BeEmpty();
 		receipt.StoreName.Confidence.Should().Be(ConfidenceLevel.High);
@@ -417,7 +417,7 @@ public class OllamaReceiptExtractionServiceTests
 		receipt.Payments[0].Amount.Value.Should().Be(10.00m);
 		receipt.Payments[0].Amount.Confidence.Should().Be(ConfidenceLevel.High);
 		receipt.Payments[0].LastFour.Value.Should().BeNull();
-		receipt.Payments[0].LastFour.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.Payments[0].LastFour.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.Payments[1].Method.Value.Should().Be("VISA");
 		receipt.Payments[1].Amount.Value.Should().Be(30.00m);
 		receipt.Payments[1].LastFour.Value.Should().Be("1234");
@@ -440,10 +440,10 @@ public class OllamaReceiptExtractionServiceTests
 		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
 
 		// Assert
-		receipt.StoreName.Confidence.Should().Be(ConfidenceLevel.Low);
-		receipt.StoreAddress.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.StoreName.Confidence.Should().Be(ConfidenceLevel.None);
+		receipt.StoreAddress.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.StoreAddress.Value.Should().BeNull();
-		receipt.StorePhone.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.StorePhone.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.StorePhone.Value.Should().BeNull();
 		receipt.Date.Value.Should().Be(new DateOnly(2026, 4, 1));
 		receipt.Total.Value.Should().Be(10.00m);
@@ -469,11 +469,11 @@ public class OllamaReceiptExtractionServiceTests
 
 		// Assert
 		receipt.ReceiptId.Value.Should().BeNull();
-		receipt.ReceiptId.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.ReceiptId.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.StoreNumber.Value.Should().BeNull();
-		receipt.StoreNumber.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.StoreNumber.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.TerminalId.Value.Should().BeNull();
-		receipt.TerminalId.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.TerminalId.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.Payments.Should().BeEmpty();
 	}
 
@@ -522,18 +522,17 @@ public class OllamaReceiptExtractionServiceTests
 	// Whitespace and separators
 	[InlineData("3 409")]
 	[InlineData("3-409")]
-	// Empty string variants
-	[InlineData("")]
-	[InlineData("   ")]
 	// Non-ASCII Unicode digit sequences. .NET's default \d regex expands to the full
 	// Unicode Decimal_Number category, so the pattern must use [0-9] explicitly to enforce
 	// the documented "ASCII digits" contract. Without that, Arabic-Indic (٣٤٠٩) and
 	// Devanagari (३४०९) digits would slip through with High confidence.
 	[InlineData("\u0663\u0664\u0660\u0669")]
 	[InlineData("\u096B\u096C\u0966\u0966")]
-	public void ValidateLastFour_InvalidPatterns_YieldNullWithLowConfidence(string raw)
+	public void ValidateLastFour_InvalidNonEmptyPatterns_YieldNullWithLowConfidence(string raw)
 	{
-		// Act
+		// Act — non-empty/non-whitespace input that fails the regex represents a hallucinated
+		// or malformed value the VLM emitted. We retain Low confidence to signal "the model
+		// said something but we rejected it" — distinct from None ("the model said nothing").
 		FieldConfidence<string?> result = OllamaReceiptExtractionService.ValidateLastFour(raw);
 
 		// Assert
@@ -541,15 +540,30 @@ public class OllamaReceiptExtractionServiceTests
 		result.Confidence.Should().Be(ConfidenceLevel.Low);
 	}
 
-	[Fact]
-	public void ValidateLastFour_NullInput_YieldsNullWithLowConfidence()
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("\t")]
+	public void ValidateLastFour_EmptyOrWhitespace_YieldsNullWithNoneConfidence(string raw)
 	{
-		// Act
+		// Act — an empty/whitespace lastFour is functionally equivalent to "the field was
+		// absent", which we represent with ConfidenceLevel.None.
+		FieldConfidence<string?> result = OllamaReceiptExtractionService.ValidateLastFour(raw);
+
+		// Assert
+		result.Value.Should().BeNull();
+		result.Confidence.Should().Be(ConfidenceLevel.None);
+	}
+
+	[Fact]
+	public void ValidateLastFour_NullInput_YieldsNullWithNoneConfidence()
+	{
+		// Act — null is treated identically to an empty/absent value.
 		FieldConfidence<string?> result = OllamaReceiptExtractionService.ValidateLastFour(null);
 
 		// Assert
 		result.Value.Should().BeNull();
-		result.Confidence.Should().Be(ConfidenceLevel.Low);
+		result.Confidence.Should().Be(ConfidenceLevel.None);
 	}
 
 	[Theory]
@@ -623,13 +637,13 @@ public class OllamaReceiptExtractionServiceTests
 		// Assert — the payment is preserved with correct confidence
 		receipt.Payments.Should().HaveCount(1);
 		receipt.Payments[0].Method.Value.Should().BeNull();
-		receipt.Payments[0].Method.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.Payments[0].Method.Confidence.Should().Be(ConfidenceLevel.None);
 		receipt.Payments[0].Amount.Value.Should().Be(15.00m);
 		receipt.Payments[0].Amount.Confidence.Should().Be(ConfidenceLevel.High);
 
 		// Assert — legacy PaymentMethod falls back to None since no method string was found
 		receipt.PaymentMethod.Value.Should().BeNull();
-		receipt.PaymentMethod.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.PaymentMethod.Confidence.Should().Be(ConfidenceLevel.None);
 	}
 
 	[Fact]

--- a/tests/Presentation.API.Tests/Configuration/JsonSerializerEnumCasingTests.cs
+++ b/tests/Presentation.API.Tests/Configuration/JsonSerializerEnumCasingTests.cs
@@ -35,10 +35,12 @@ public class JsonSerializerEnumCasingTests
 		string highJson = JsonSerializer.Serialize(ConfidenceLevel.High, options);
 		string mediumJson = JsonSerializer.Serialize(ConfidenceLevel.Medium, options);
 		string lowJson = JsonSerializer.Serialize(ConfidenceLevel.Low, options);
+		string noneJson = JsonSerializer.Serialize(ConfidenceLevel.None, options);
 
 		highJson.Should().Be("\"high\"");
 		mediumJson.Should().Be("\"medium\"");
 		lowJson.Should().Be("\"low\"");
+		noneJson.Should().Be("\"none\"");
 	}
 
 	[Fact]
@@ -49,9 +51,11 @@ public class JsonSerializerEnumCasingTests
 		ConfidenceLevel high = JsonSerializer.Deserialize<ConfidenceLevel>("\"high\"", options);
 		ConfidenceLevel medium = JsonSerializer.Deserialize<ConfidenceLevel>("\"medium\"", options);
 		ConfidenceLevel low = JsonSerializer.Deserialize<ConfidenceLevel>("\"low\"", options);
+		ConfidenceLevel none = JsonSerializer.Deserialize<ConfidenceLevel>("\"none\"", options);
 
 		high.Should().Be(ConfidenceLevel.High);
 		medium.Should().Be(ConfidenceLevel.Medium);
 		low.Should().Be(ConfidenceLevel.Low);
+		none.Should().Be(ConfidenceLevel.None);
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
@@ -319,7 +319,7 @@ public class ReceiptScanControllerTests
 		response.Payments.ElementAt(0).Method.Should().Be("GIFT CARD");
 		response.Payments.ElementAt(0).Amount.Should().Be(10d);
 		response.Payments.ElementAt(0).LastFour.Should().BeNull();
-		response.Payments.ElementAt(0).LastFourConfidence.Should().Be(DtoConfidenceLevel.Low);
+		response.Payments.ElementAt(0).LastFourConfidence.Should().Be(DtoConfidenceLevel.None);
 		response.Payments.ElementAt(1).Method.Should().Be("VISA");
 		response.Payments.ElementAt(1).Amount.Should().Be(30d);
 		response.Payments.ElementAt(1).LastFour.Should().Be("1234");

--- a/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
+++ b/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
@@ -109,7 +109,7 @@ public class FixtureEvaluatorTests
 	}
 
 	[Fact]
-	public void DiffDate_LowConfidenceActual_ReturnsFail()
+	public void DiffDate_NoneConfidenceActual_ReturnsFail()
 	{
 		DateOnly expected = new(2026, 1, 14);
 
@@ -119,6 +119,19 @@ public class FixtureEvaluatorTests
 		diff.Expected.Should().Be("2026-01-14");
 		diff.Actual.Should().BeNull();
 		diff.Detail.Should().Be("VLM did not extract date");
+	}
+
+	[Fact]
+	public void DiffDate_LowConfidenceMatch_ReturnsPass()
+	{
+		// RECEIPTS-631: Low(date) is a real (uncertain) extracted date and should be
+		// compared against expected. Only None() should short-circuit as "did not extract".
+		DateOnly expected = new(2026, 1, 14);
+
+		FieldDiff diff = FixtureEvaluator.DiffDate(expected, FieldConfidence<DateOnly>.Low(expected));
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+		diff.Actual.Should().Be("2026-01-14");
 	}
 
 	[Fact]
@@ -233,7 +246,7 @@ public class FixtureEvaluatorTests
 	}
 
 	[Fact]
-	public void DiffMoney_LowConfidenceActual_ReturnsFail()
+	public void DiffMoney_NoneConfidenceActual_ReturnsFail()
 	{
 		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 70.43m, FieldConfidence<decimal>.None());
 
@@ -241,6 +254,18 @@ public class FixtureEvaluatorTests
 		diff.Expected.Should().Be("70.43");
 		diff.Actual.Should().BeNull();
 		diff.Detail.Should().Be("VLM did not extract total");
+	}
+
+	[Fact]
+	public void DiffMoney_LowConfidenceActualMatchingExpected_ReturnsPass()
+	{
+		// RECEIPTS-631: a low-confidence extracted value (e.g. illegible total the VLM
+		// transcribed uncertainly) must still be compared against the expected value.
+		// Only None() should short-circuit to "did not extract".
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 70.43m, FieldConfidence<decimal>.Low(70.43m));
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+		diff.Actual.Should().Be("70.43");
 	}
 
 	[Fact]
@@ -254,7 +279,7 @@ public class FixtureEvaluatorTests
 	}
 
 	[Fact]
-	public void DiffMoney_ExpectedNull_LowConfidenceActual_FormatsActualAsNull()
+	public void DiffMoney_ExpectedNull_NoneConfidenceActual_FormatsActualAsNull()
 	{
 		FieldDiff diff = FixtureEvaluator.DiffMoney("total", null, FieldConfidence<decimal>.None());
 
@@ -370,9 +395,9 @@ public class FixtureEvaluatorTests
 	}
 
 	[Fact]
-	public void DiffTaxLines_LowConfidenceActualAmounts_AreIgnored()
+	public void DiffTaxLines_NoneConfidenceActualAmounts_AreIgnored()
 	{
-		// A low-confidence actual amount should not be available to match against.
+		// A None-confidence (absent) actual amount should not be available to match against.
 		List<ExpectedTaxLine> expected = [new ExpectedTaxLine { Amount = 0.75m }];
 		List<ParsedTaxLine> actual =
 		[
@@ -382,6 +407,23 @@ public class FixtureEvaluatorTests
 		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
 
 		diff.Status.Should().Be(DiffStatus.Fail);
+	}
+
+	[Fact]
+	public void DiffTaxLines_LowConfidenceActualAmount_IsStillMatched()
+	{
+		// RECEIPTS-631: Low(value) carries a real (if uncertain) amount and must be
+		// considered when matching against expected tax lines. Only None() amounts
+		// should be excluded from the matching pool.
+		List<ExpectedTaxLine> expected = [new ExpectedTaxLine { Amount = 0.75m }];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax"), FieldConfidence<decimal>.Low(0.75m)),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
 	}
 
 	[Fact]
@@ -638,9 +680,9 @@ public class FixtureEvaluatorTests
 	}
 
 	[Fact]
-	public void DiffItems_LowConfidenceTotalPrice_NotMatchedByPrice()
+	public void DiffItems_NoneConfidenceTotalPrice_NotMatchedByPrice()
 	{
-		// Items with low-confidence prices are skipped by the price matcher.
+		// Items with absent (None) prices are skipped by the price matcher.
 		// The fallback description matcher then finds them by description.
 		List<ExpectedItem> expected = [new ExpectedItem { Description = "Apple", TotalPrice = 1.000m }];
 		List<ParsedReceiptItem> actual =
@@ -656,9 +698,30 @@ public class FixtureEvaluatorTests
 		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
 
 		// Price matcher skips the item, description fallback finds it, but then the
-		// "is the matched item's totalPrice low confidence?" check reports a missing price.
+		// "is the matched item's totalPrice present?" check reports a missing price.
 		diffs[0].Status.Should().Be(DiffStatus.Fail);
 		diffs[0].Detail.Should().Contain("missing totalPrice");
+	}
+
+	[Fact]
+	public void DiffItems_LowConfidenceTotalPriceMatchingExpected_ReturnsPass()
+	{
+		// RECEIPTS-631: a low-confidence extracted item price is real data and must be
+		// matched. The previous behavior incorrectly skipped such items.
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "Apple", TotalPrice = 1.000m }];
+		List<ParsedReceiptItem> actual =
+		[
+			new ParsedReceiptItem(
+				Code: FieldConfidence<string?>.None(),
+				Description: FieldConfidence<string>.High("Apple"),
+				Quantity: FieldConfidence<decimal>.High(1m),
+				UnitPrice: FieldConfidence<decimal>.High(1m),
+				TotalPrice: FieldConfidence<decimal>.Low(1.000m)),
+		];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

- Add `ConfidenceLevel.None` so `FieldConfidence<T>.None()` is distinguishable from `Low(default(T))` at compile time and runtime. The previous overload conflated "field absent on the source receipt" with "low-confidence extracted value", which:
  - caused `ScanReceiptCommandHandler.IsEmpty` to reject valid low-confidence extractions as empty
  - made `FixtureEvaluator`'s `DiffStore`/`DiffDate`/`DiffMoney`/`DiffPaymentMethod` checks drift against three different "is present" predicates
  - leaked `0m` / `1/1/0001` sentinel values to API responses for missing fields
- Centralise the predicate as `FieldConfidence<T>.IsPresent` (backend) and `needsReview()` (frontend). All existing call sites now share one definition.
- React `ConfidenceIndicator` and `mapProposalToConfidenceMap` treat `none` like `high` (no badge needed) — absent fields have nothing for the user to review.

Resolves RECEIPTS-631

## Files touched

- `src/Application/Models/Ocr/ConfidenceLevel.cs` — `{ None, Low, Medium, High }` (None first so `default(enum) == None`)
- `src/Application/Models/Ocr/FieldConfidence.cs` — `None()` returns `(default, None)`; new `IsPresent` helper
- `src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs` — `IsEmpty` uses `IsPresent`
- `src/Tools/VlmEval/FixtureEvaluator.cs` — all four diff methods + item matching consistently use `IsPresent`
- `src/Presentation/API/Controllers/Core/ReceiptScanController.cs` — `MapConfidence` covers `None`
- `openapi/spec.yaml` + regenerated React types — `ConfidenceLevel` adds `none`
- `src/client/src/pages/scan-receipt/ConfidenceIndicator.tsx` + `proposalMappers.ts` — treat `none` as no-badge
- New `tests/Application.Tests/Models/Ocr/FieldConfidenceTests.cs` — pins `Low(0m) != None()` etc.
- New tests in `ScanReceiptCommandHandlerTests`, `FixtureEvaluatorTests`, `JsonSerializerEnumCasingTests`, `proposalMappers.test.ts`

## Test plan

- [x] `dotnet build Receipts.slnx` clean (0 errors)
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2418 unit tests pass (was 2407 before adding new ones)
- [x] `npm test` (React) — 1891 tests pass
- [x] `dotnet format Receipts.slnx --verify-no-changes` clean
- [x] Pre-commit hook (build with warnings-as-errors, drift check, full unit test runs, ESLint, TypeScript build) — all green
- [ ] CI verifies the same on the PR

## Conflict notes

This change is foundational and touches files other in-flight VLM PRs also touch (RECEIPTS-630/635/638 modify `OllamaReceiptExtractionService.cs`; RECEIPTS-637/640 touch `ScanReceiptCommandHandler.cs`). The changes here are surgical — only the `IsEmpty` predicate body changed in the handler, and `OllamaReceiptExtractionService.cs` itself is untouched (the `.None()` callsites' behaviour changed transparently, no edits needed).