### PR TITLE
chore(application): drop dead PdfConversionResult.ExtractedText/Metadata fields (RECEIPTS-646)

### DIFF
--- a/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
+++ b/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
@@ -2,14 +2,12 @@ using Application.Exceptions;
 using Application.Interfaces.Services;
 using Application.Models.Ocr;
 using MediatR;
-using Microsoft.Extensions.Logging;
 
 namespace Application.Commands.Receipt.Scan;
 
 public class ScanReceiptCommandHandler(
 	IReceiptExtractionService extractionService,
-	IPdfConversionService pdfConversionService,
-	ILogger<ScanReceiptCommandHandler> logger) : IRequestHandler<ScanReceiptCommand, ScanReceiptResult>
+	IPdfConversionService pdfConversionService) : IRequestHandler<ScanReceiptCommand, ScanReceiptResult>
 {
 	internal const string PdfContentType = "application/pdf";
 	internal const string PdfPageImageContentType = "image/png";
@@ -36,23 +34,10 @@ public class ScanReceiptCommandHandler(
 			return (request.ImageBytes, request.ContentType);
 		}
 
-		IReadOnlyList<byte[]> pageImages = await pdfConversionService.ConvertAsync(
+		byte[] firstPageImage = await pdfConversionService.ConvertAsync(
 			request.ImageBytes, cancellationToken);
 
-		if (pageImages.Count == 0)
-		{
-			throw new OcrNoTextException(
-				"The PDF document contains no extractable images for receipt scanning.");
-		}
-
-		if (pageImages.Count > 1)
-		{
-			logger.LogInformation(
-				"PDF contains {PageCount} page images; extracting receipt from the first page only",
-				pageImages.Count);
-		}
-
-		return (pageImages[0], PdfPageImageContentType);
+		return (firstPageImage, PdfPageImageContentType);
 	}
 
 	/// <summary>

--- a/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
+++ b/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
@@ -36,23 +36,23 @@ public class ScanReceiptCommandHandler(
 			return (request.ImageBytes, request.ContentType);
 		}
 
-		PdfConversionResult conversion = await pdfConversionService.ConvertAsync(
+		IReadOnlyList<byte[]> pageImages = await pdfConversionService.ConvertAsync(
 			request.ImageBytes, cancellationToken);
 
-		if (conversion.PageImages.Count == 0)
+		if (pageImages.Count == 0)
 		{
 			throw new OcrNoTextException(
 				"The PDF document contains no extractable images for receipt scanning.");
 		}
 
-		if (conversion.PageImages.Count > 1)
+		if (pageImages.Count > 1)
 		{
 			logger.LogInformation(
 				"PDF contains {PageCount} page images; extracting receipt from the first page only",
-				conversion.PageImages.Count);
+				pageImages.Count);
 		}
 
-		return (conversion.PageImages[0], PdfPageImageContentType);
+		return (pageImages[0], PdfPageImageContentType);
 	}
 
 	/// <summary>

--- a/src/Application/Interfaces/Services/IPdfConversionService.cs
+++ b/src/Application/Interfaces/Services/IPdfConversionService.cs
@@ -13,13 +13,10 @@ public interface IPdfConversionService
 	/// <summary>
 	/// Rasterizes the first page of the PDF to a PNG. The PNG is always produced
 	/// (even for vector-only or text-only PDFs) so that downstream VLM/OCR processing
-	/// always has a usable image.
+	/// always has a usable image. Multi-page PDFs are validated against
+	/// <see cref="MaxPages"/> but only the first page is rendered. Failures (invalid
+	/// bytes, password-protected, oversized, rasterization error) surface as
+	/// <see cref="InvalidOperationException"/>.
 	/// </summary>
-	/// <returns>
-	/// A list containing exactly one entry — the rasterized first page as a PNG byte
-	/// array — when the conversion succeeds. The scan command handler consumes only
-	/// the first image; multi-page PDFs are still validated against
-	/// <see cref="MaxPages"/> but only the first page is rendered.
-	/// </returns>
-	Task<IReadOnlyList<byte[]>> ConvertAsync(byte[] pdfBytes, CancellationToken ct);
+	Task<byte[]> ConvertAsync(byte[] pdfBytes, CancellationToken ct);
 }

--- a/src/Application/Interfaces/Services/IPdfConversionService.cs
+++ b/src/Application/Interfaces/Services/IPdfConversionService.cs
@@ -1,33 +1,6 @@
 namespace Application.Interfaces.Services;
 
 /// <summary>
-/// Metadata extracted from a PDF document.
-/// </summary>
-public record PdfMetadata(string? Title, DateOnly? CreationDate);
-
-/// <summary>
-/// Result of converting a PDF document for OCR processing.
-/// </summary>
-/// <param name="PageImages">
-/// The rasterized first page of the PDF as a PNG byte array. Always contains exactly one
-/// entry when <see cref="IPdfConversionService.ConvertAsync"/> returns successfully —
-/// the first page is rendered regardless of whether the PDF contains embedded raster
-/// images, vector graphics, or only a text layer. The scan command handler consumes
-/// only this first image.
-/// </param>
-/// <param name="ExtractedText">
-/// Text extracted directly from the PDF text layer, if available.
-/// Null when the PDF contains no text layer (pure scanned document).
-/// No longer consumed by the scan command path — retained for informational purposes
-/// and may be removed in a future cleanup.
-/// </param>
-/// <param name="Metadata">Optional PDF document metadata.</param>
-public record PdfConversionResult(
-	IReadOnlyList<byte[]> PageImages,
-	string? ExtractedText,
-	PdfMetadata? Metadata);
-
-/// <summary>
 /// Converts PDF documents to a format suitable for OCR processing.
 /// </summary>
 public interface IPdfConversionService
@@ -38,9 +11,15 @@ public interface IPdfConversionService
 	const int MaxPages = 50;
 
 	/// <summary>
-	/// Rasterizes the first page of the PDF to a PNG and optionally extracts the text
-	/// layer. The PNG is always produced (even for vector-only or text-only PDFs) so
-	/// that downstream VLM/OCR processing always has a usable image.
+	/// Rasterizes the first page of the PDF to a PNG. The PNG is always produced
+	/// (even for vector-only or text-only PDFs) so that downstream VLM/OCR processing
+	/// always has a usable image.
 	/// </summary>
-	Task<PdfConversionResult> ConvertAsync(byte[] pdfBytes, CancellationToken ct);
+	/// <returns>
+	/// A list containing exactly one entry — the rasterized first page as a PNG byte
+	/// array — when the conversion succeeds. The scan command handler consumes only
+	/// the first image; multi-page PDFs are still validated against
+	/// <see cref="MaxPages"/> but only the first page is rendered.
+	/// </returns>
+	Task<IReadOnlyList<byte[]>> ConvertAsync(byte[] pdfBytes, CancellationToken ct);
 }

--- a/src/Infrastructure/Services/PdfConversionService.cs
+++ b/src/Infrastructure/Services/PdfConversionService.cs
@@ -27,7 +27,7 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 	/// </summary>
 	private static readonly byte[] PdfMagicBytes = [0x25, 0x50, 0x44, 0x46];
 
-	public Task<IReadOnlyList<byte[]>> ConvertAsync(byte[] pdfBytes, CancellationToken ct)
+	public Task<byte[]> ConvertAsync(byte[] pdfBytes, CancellationToken ct)
 	{
 		ct.ThrowIfCancellationRequested();
 
@@ -90,7 +90,7 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 			"Rasterized first PDF page at {Dpi} DPI ({PngSize} bytes) for VLM extraction (document has {PageCount} page(s))",
 			RasterizationDpi, firstPagePng.Length, pageCount);
 
-		return Task.FromResult<IReadOnlyList<byte[]>>([firstPagePng]);
+		return Task.FromResult(firstPagePng);
 	}
 
 	private static int ValidateDocument(PdfDocument document)

--- a/src/Infrastructure/Services/PdfConversionService.cs
+++ b/src/Infrastructure/Services/PdfConversionService.cs
@@ -2,19 +2,12 @@ using Application.Interfaces.Services;
 using Microsoft.Extensions.Logging;
 using PDFtoImage;
 using UglyToad.PdfPig;
-using UglyToad.PdfPig.Content;
 using UglyToad.PdfPig.Exceptions;
 
 namespace Infrastructure.Services;
 
 public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfConversionService
 {
-	/// <summary>
-	/// Minimum text length per page to consider the page as having a usable text layer.
-	/// Pages with fewer characters are treated as image-only.
-	/// </summary>
-	internal const int MinTextLengthPerPage = 10;
-
 	/// <summary>
 	/// DPI used when rasterizing the first PDF page for VLM/OCR consumption. 200 DPI is the
 	/// baseline recommended by the rasterization issue (RECEIPTS-624) — high enough for
@@ -34,7 +27,7 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 	/// </summary>
 	private static readonly byte[] PdfMagicBytes = [0x25, 0x50, 0x44, 0x46];
 
-	public Task<PdfConversionResult> ConvertAsync(byte[] pdfBytes, CancellationToken ct)
+	public Task<IReadOnlyList<byte[]>> ConvertAsync(byte[] pdfBytes, CancellationToken ct)
 	{
 		ct.ThrowIfCancellationRequested();
 
@@ -63,13 +56,11 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 		}
 
 		int pageCount;
-		PdfMetadata? metadata;
-		string? extractedText;
 		using (document)
 		{
 			try
 			{
-				(pageCount, metadata, extractedText) = ProcessDocumentMetadataAndText(document, ct);
+				pageCount = ValidateDocument(document);
 			}
 			catch (InvalidOperationException)
 			{
@@ -99,18 +90,10 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 			"Rasterized first PDF page at {Dpi} DPI ({PngSize} bytes) for VLM extraction (document has {PageCount} page(s))",
 			RasterizationDpi, firstPagePng.Length, pageCount);
 
-		if (extractedText is not null)
-		{
-			logger.LogDebug(
-				"Extracted text layer from PDF ({TextLength} chars); retained as informational only",
-				extractedText.Length);
-		}
-
-		return Task.FromResult(new PdfConversionResult([firstPagePng], extractedText, metadata));
+		return Task.FromResult<IReadOnlyList<byte[]>>([firstPagePng]);
 	}
 
-	private (int PageCount, PdfMetadata? Metadata, string? ExtractedText) ProcessDocumentMetadataAndText(
-		PdfDocument document, CancellationToken ct)
+	private static int ValidateDocument(PdfDocument document)
 	{
 		if (document.NumberOfPages == 0)
 		{
@@ -123,25 +106,7 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 				$"The PDF document has {document.NumberOfPages} pages, which exceeds the maximum of {IPdfConversionService.MaxPages}.");
 		}
 
-		PdfMetadata? metadata = ExtractMetadata(document);
-
-		// Collect text from every page for informational purposes. The scan command path
-		// no longer consumes this — rasterized pixels are the source of truth — but the
-		// text layer is retained for logging and potential future use.
-		List<string> pageTexts = [];
-		foreach (Page page in document.GetPages())
-		{
-			ct.ThrowIfCancellationRequested();
-
-			string pageText = page.Text ?? string.Empty;
-			if (pageText.Trim().Length >= MinTextLengthPerPage)
-			{
-				pageTexts.Add(pageText);
-			}
-		}
-
-		string? combinedText = pageTexts.Count > 0 ? string.Join("\n\n", pageTexts) : null;
-		return (document.NumberOfPages, metadata, combinedText);
+		return document.NumberOfPages;
 	}
 
 	// PDFtoImage targets Android/iOS/Linux/macCatalyst/macOS/Windows — all platforms we
@@ -181,34 +146,6 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 		{
 			throw new InvalidOperationException(
 				"Failed to rasterize the first page of the PDF document.", ex);
-		}
-	}
-
-	private PdfMetadata? ExtractMetadata(PdfDocument document)
-	{
-		try
-		{
-			DocumentInformation info = document.Information;
-			string? title = string.IsNullOrWhiteSpace(info.Title) ? null : info.Title;
-
-			DateOnly? creationDate = null;
-			DateTimeOffset? createdDateTimeOffset = info.GetCreatedDateTimeOffset();
-			if (createdDateTimeOffset.HasValue)
-			{
-				creationDate = DateOnly.FromDateTime(createdDateTimeOffset.Value.DateTime);
-			}
-
-			if (title is null && creationDate is null)
-			{
-				return null;
-			}
-
-			return new PdfMetadata(title, creationDate);
-		}
-		catch (Exception ex)
-		{
-			logger.LogDebug(ex, "Failed to extract PDF metadata");
-			return null;
 		}
 	}
 

--- a/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
@@ -162,7 +162,7 @@ public class ScanReceiptCommandHandlerTests
 		ScanReceiptCommand command = new(pdfBytes, "application/pdf");
 
 		byte[] firstPageImage = [0x89, 0x50, 0x4E, 0x47];
-		PdfConversionResult conversion = new([firstPageImage], null, null);
+		IReadOnlyList<byte[]> conversion = [firstPageImage];
 
 		_mockPdfConversionService
 			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))
@@ -184,38 +184,6 @@ public class ScanReceiptCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task Handle_Pdf_IgnoresExtractedTextField()
-	{
-		// Arrange — even when the PDF has a text layer, the handler must still call
-		// the VLM on the page image. The embedded-text shortcut was removed per
-		// RECEIPTS-619 (Paperless OCR is mediocre, prefer re-OCR).
-		byte[] pdfBytes = [0x25, 0x50, 0x44, 0x46];
-		ScanReceiptCommand command = new(pdfBytes, "application/pdf");
-
-		byte[] firstPageImage = [0x89, 0x50, 0x4E, 0x47];
-		PdfConversionResult conversion = new(
-			[firstPageImage],
-			"WALMART\nMILK 2%  $3.49\nTOTAL  $3.74",
-			new PdfMetadata("Receipt", null));
-
-		_mockPdfConversionService
-			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))
-			.ReturnsAsync(conversion);
-
-		_mockExtractionService
-			.Setup(s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()))
-			.ReturnsAsync(BuildPopulatedReceipt());
-
-		// Act
-		await _handler.Handle(command, CancellationToken.None);
-
-		// Assert
-		_mockExtractionService.Verify(
-			s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()),
-			Times.Once);
-	}
-
-	[Fact]
 	public async Task Handle_PdfWithMultiplePages_UsesFirstPageOnly()
 	{
 		// Arrange
@@ -225,7 +193,7 @@ public class ScanReceiptCommandHandlerTests
 		byte[] page1 = [0x89, 0x50, 0x4E, 0x47];
 		byte[] page2 = [0x89, 0x50, 0x4E, 0x48];
 		byte[] page3 = [0x89, 0x50, 0x4E, 0x49];
-		PdfConversionResult conversion = new([page1, page2, page3], null, null);
+		IReadOnlyList<byte[]> conversion = [page1, page2, page3];
 
 		_mockPdfConversionService
 			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))
@@ -257,10 +225,7 @@ public class ScanReceiptCommandHandlerTests
 		byte[] pdfBytes = [0x25, 0x50, 0x44, 0x46];
 		ScanReceiptCommand command = new(pdfBytes, "application/pdf");
 
-		PdfConversionResult conversion = new(
-			Array.Empty<byte[]>(),
-			"some text layer content",
-			null);
+		IReadOnlyList<byte[]> conversion = Array.Empty<byte[]>();
 
 		_mockPdfConversionService
 			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))

--- a/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
@@ -3,7 +3,6 @@ using Application.Exceptions;
 using Application.Interfaces.Services;
 using Application.Models.Ocr;
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Application.Tests.Commands.Receipt.Scan;
@@ -65,18 +64,15 @@ public class ScanReceiptCommandHandlerTests
 {
 	private readonly Mock<IReceiptExtractionService> _mockExtractionService;
 	private readonly Mock<IPdfConversionService> _mockPdfConversionService;
-	private readonly Mock<ILogger<ScanReceiptCommandHandler>> _mockLogger;
 	private readonly ScanReceiptCommandHandler _handler;
 
 	public ScanReceiptCommandHandlerTests()
 	{
 		_mockExtractionService = new Mock<IReceiptExtractionService>();
 		_mockPdfConversionService = new Mock<IPdfConversionService>();
-		_mockLogger = new Mock<ILogger<ScanReceiptCommandHandler>>();
 		_handler = new ScanReceiptCommandHandler(
 			_mockExtractionService.Object,
-			_mockPdfConversionService.Object,
-			_mockLogger.Object);
+			_mockPdfConversionService.Object);
 	}
 
 	private static ParsedReceipt BuildPopulatedReceipt(string storeName = "WALMART", decimal total = 3.74m)
@@ -162,11 +158,10 @@ public class ScanReceiptCommandHandlerTests
 		ScanReceiptCommand command = new(pdfBytes, "application/pdf");
 
 		byte[] firstPageImage = [0x89, 0x50, 0x4E, 0x47];
-		IReadOnlyList<byte[]> conversion = [firstPageImage];
 
 		_mockPdfConversionService
 			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))
-			.ReturnsAsync(conversion);
+			.ReturnsAsync(firstPageImage);
 
 		ParsedReceipt parsed = BuildPopulatedReceipt();
 		_mockExtractionService
@@ -181,66 +176,6 @@ public class ScanReceiptCommandHandlerTests
 		_mockExtractionService.Verify(
 			s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()),
 			Times.Once);
-	}
-
-	[Fact]
-	public async Task Handle_PdfWithMultiplePages_UsesFirstPageOnly()
-	{
-		// Arrange
-		byte[] pdfBytes = [0x25, 0x50, 0x44, 0x46];
-		ScanReceiptCommand command = new(pdfBytes, "application/pdf");
-
-		byte[] page1 = [0x89, 0x50, 0x4E, 0x47];
-		byte[] page2 = [0x89, 0x50, 0x4E, 0x48];
-		byte[] page3 = [0x89, 0x50, 0x4E, 0x49];
-		IReadOnlyList<byte[]> conversion = [page1, page2, page3];
-
-		_mockPdfConversionService
-			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))
-			.ReturnsAsync(conversion);
-
-		_mockExtractionService
-			.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(BuildPopulatedReceipt());
-
-		// Act
-		await _handler.Handle(command, CancellationToken.None);
-
-		// Assert
-		_mockExtractionService.Verify(
-			s => s.ExtractAsync(page1, "image/png", It.IsAny<CancellationToken>()),
-			Times.Once);
-		_mockExtractionService.Verify(
-			s => s.ExtractAsync(page2, It.IsAny<string>(), It.IsAny<CancellationToken>()),
-			Times.Never);
-		_mockExtractionService.Verify(
-			s => s.ExtractAsync(page3, It.IsAny<string>(), It.IsAny<CancellationToken>()),
-			Times.Never);
-	}
-
-	[Fact]
-	public async Task Handle_PdfWithNoImages_ThrowsOcrNoTextException()
-	{
-		// Arrange
-		byte[] pdfBytes = [0x25, 0x50, 0x44, 0x46];
-		ScanReceiptCommand command = new(pdfBytes, "application/pdf");
-
-		IReadOnlyList<byte[]> conversion = Array.Empty<byte[]>();
-
-		_mockPdfConversionService
-			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))
-			.ReturnsAsync(conversion);
-
-		// Act
-		Func<Task> act = () => _handler.Handle(command, CancellationToken.None);
-
-		// Assert
-		await act.Should().ThrowAsync<OcrNoTextException>()
-			.WithMessage("*no extractable images*");
-
-		_mockExtractionService.Verify(
-			s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
-			Times.Never);
 	}
 
 	[Fact]

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
@@ -30,15 +30,15 @@ public class PdfConversionServiceTests
 		// Arrange — PdfDocumentBuilder doesn't support newlines in AddText,
 		// so we use a single line of sufficient length. This is the vector-only case:
 		// no embedded raster images, only text glyphs as vector outlines. Before
-		// RECEIPTS-624 this produced an empty page-images list and /api/receipts/scan
+		// RECEIPTS-624 this produced no rasterized image and /api/receipts/scan
 		// returned 422. Now the first page is always rasterized to a PNG.
 		byte[] pdfBytes = CreateTextPdf("WALMART MILK 2% $3.49 TOTAL $3.74");
 
 		// Act
-		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		AssertContainsValidPng(result);
+		AssertValidPng(result);
 	}
 
 	[Fact]
@@ -52,12 +52,10 @@ public class PdfConversionServiceTests
 		byte[] pdfBytes = CreateTextPdf("Vector PDF receipt content with more than ten characters of text");
 
 		// Act
-		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.Should().ContainSingle(
-			"rasterization always produces exactly one first-page image");
-		AssertPngHasDimensions(result[0], minWidth: 100, minHeight: 100);
+		AssertPngHasDimensions(result, minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -73,12 +71,10 @@ public class PdfConversionServiceTests
 		]);
 
 		// Act
-		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.Should().ContainSingle(
-			"only the first page is rasterized regardless of total page count");
-		AssertPngHasDimensions(result[0], minWidth: 100, minHeight: 100);
+		AssertPngHasDimensions(result, minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -162,11 +158,10 @@ public class PdfConversionServiceTests
 		byte[] pdfBytes = CreateTextPdf("Hi");
 
 		// Act
-		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.Should().ContainSingle();
-		AssertPngHasDimensions(result[0], minWidth: 100, minHeight: 100);
+		AssertPngHasDimensions(result, minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -184,31 +179,30 @@ public class PdfConversionServiceTests
 			imageHeight: 800);
 
 		// Act
-		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert — the rasterized first page is what the scan handler will use.
-		result.Should().ContainSingle();
-		AssertPngHasDimensions(result[0], minWidth: 100, minHeight: 100);
+		AssertPngHasDimensions(result, minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
 	public async Task ConvertAsync_PdfWithSmallLogoAndText_StillRasterizes()
 	{
-		// Arrange — previously a text+small-logo PDF produced empty page images because
-		// the logo was below the 400x400 embedded-image size filter. That caused the scan
-		// handler to throw OcrNoTextException for emailed POS receipts with a tiny store
-		// logo. Now the rasterized first page carries the whole document including the
-		// logo and surrounding text, so the VLM can extract the receipt.
+		// Arrange — previously a text+small-logo PDF produced no extractable image
+		// because the logo was below the 400x400 embedded-image size filter. That caused
+		// the scan handler to throw OcrNoTextException for emailed POS receipts with a
+		// tiny store logo. Now the rasterized first page carries the whole document
+		// including the logo and surrounding text, so the VLM can extract the receipt.
 		byte[] pdfBytes = CreateTextPdfWithPng(
 			text: "WALMART SUPERCENTER TOTAL $3.74",
 			imageWidth: 64,
 			imageHeight: 64);
 
 		// Act
-		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.Should().ContainSingle();
+		AssertValidPng(result);
 	}
 
 	[Fact]
@@ -498,19 +492,15 @@ public class PdfConversionServiceTests
 		return System.Text.Encoding.Latin1.GetBytes(Pdf);
 	}
 
-	private static void AssertContainsValidPng(IReadOnlyList<byte[]> images)
+	private static void AssertValidPng(byte[] png)
 	{
-		images.Should().NotBeEmpty();
-		foreach (byte[] png in images)
-		{
-			png.Should().NotBeEmpty();
-			png.Length.Should().BeGreaterThan(8);
-			// PNG magic: 89 50 4E 47 0D 0A 1A 0A
-			png[0].Should().Be(0x89);
-			png[1].Should().Be(0x50);
-			png[2].Should().Be(0x4E);
-			png[3].Should().Be(0x47);
-		}
+		png.Should().NotBeEmpty();
+		png.Length.Should().BeGreaterThan(8);
+		// PNG magic: 89 50 4E 47 0D 0A 1A 0A
+		png[0].Should().Be(0x89);
+		png[1].Should().Be(0x50);
+		png[2].Should().Be(0x4E);
+		png[3].Should().Be(0x47);
 	}
 
 	private static void AssertPngHasDimensions(byte[] png, int minWidth, int minHeight)

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
@@ -25,22 +25,20 @@ public class PdfConversionServiceTests
 	}
 
 	[Fact]
-	public async Task ConvertAsync_PdfWithTextLayer_RasterizesFirstPageAndExtractsText()
+	public async Task ConvertAsync_PdfWithTextLayer_RasterizesFirstPage()
 	{
 		// Arrange — PdfDocumentBuilder doesn't support newlines in AddText,
 		// so we use a single line of sufficient length. This is the vector-only case:
 		// no embedded raster images, only text glyphs as vector outlines. Before
-		// RECEIPTS-624 this produced an empty PageImages list and /api/receipts/scan
+		// RECEIPTS-624 this produced an empty page-images list and /api/receipts/scan
 		// returned 422. Now the first page is always rasterized to a PNG.
 		byte[] pdfBytes = CreateTextPdf("WALMART MILK 2% $3.49 TOTAL $3.74");
 
 		// Act
-		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.ExtractedText.Should().NotBeNullOrWhiteSpace();
-		result.ExtractedText.Should().Contain("WALMART");
-		AssertContainsValidPng(result.PageImages);
+		AssertContainsValidPng(result);
 	}
 
 	[Fact]
@@ -54,35 +52,20 @@ public class PdfConversionServiceTests
 		byte[] pdfBytes = CreateTextPdf("Vector PDF receipt content with more than ten characters of text");
 
 		// Act
-		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.PageImages.Should().ContainSingle(
+		result.Should().ContainSingle(
 			"rasterization always produces exactly one first-page image");
-		AssertPngHasDimensions(result.PageImages[0], minWidth: 100, minHeight: 100);
-	}
-
-	[Fact]
-	public async Task ConvertAsync_PdfWithTextLayer_ReturnsMetadata()
-	{
-		// Arrange
-		byte[] pdfBytes = CreateTextPdfWithMetadata("Test Receipt", "Some text content here");
-
-		// Act
-		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
-
-		// Assert
-		result.Metadata.Should().NotBeNull();
-		result.Metadata!.Title.Should().Be("Test Receipt");
+		AssertPngHasDimensions(result[0], minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
 	public async Task ConvertAsync_MultiPagePdf_RasterizesFirstPageOnly()
 	{
-		// Arrange — each page must have text >= MinTextLengthPerPage. The scan command
+		// Arrange — each page contributes to the page count check. The scan command
 		// handler only consumes the first page image, so the converter only rasterizes
-		// page 0 even when the PDF has multiple pages. Text from all pages is still
-		// concatenated and returned as an informational text layer.
+		// page 0 even when the PDF has multiple pages.
 		byte[] pdfBytes = CreateMultiPageTextPdf(
 		[
 			"Page one content from WALMART store",
@@ -90,14 +73,12 @@ public class PdfConversionServiceTests
 		]);
 
 		// Act
-		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.PageImages.Should().ContainSingle(
+		result.Should().ContainSingle(
 			"only the first page is rasterized regardless of total page count");
-		result.ExtractedText.Should().Contain("WALMART");
-		result.ExtractedText.Should().Contain("MILK");
-		AssertPngHasDimensions(result.PageImages[0], minWidth: 100, minHeight: 100);
+		AssertPngHasDimensions(result[0], minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -172,38 +153,20 @@ public class PdfConversionServiceTests
 	}
 
 	[Fact]
-	public async Task ConvertAsync_PdfWithBelowThresholdText_StillRasterizes()
+	public async Task ConvertAsync_PdfWithShortText_StillRasterizes()
 	{
-		// Arrange — a PDF whose text layer is below MinTextLengthPerPage. Before
-		// rasterization, this threw "no readable text" because the text was too short
-		// and no embedded raster images existed. Now the rasterized first page is the
-		// usable output regardless of the text layer length — the VLM will read pixels
-		// directly.
+		// Arrange — a PDF whose text layer is very short. Before rasterization, this
+		// threw "no readable text" because no embedded raster images existed. Now the
+		// rasterized first page is the usable output regardless of the text layer
+		// length — the VLM reads pixels directly.
 		byte[] pdfBytes = CreateTextPdf("Hi");
 
 		// Act
-		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.PageImages.Should().ContainSingle();
-		result.ExtractedText.Should().BeNull(
-			"\"Hi\" is below the MinTextLengthPerPage threshold so the text layer is discarded");
-		AssertPngHasDimensions(result.PageImages[0], minWidth: 100, minHeight: 100);
-	}
-
-	[Fact]
-	public async Task ConvertAsync_PdfWithSufficientText_RasterizesAndReturnsText()
-	{
-		// Arrange — text must be >= MinTextLengthPerPage chars
-		string text = new('A', PdfConversionService.MinTextLengthPerPage + 10);
-		byte[] pdfBytes = CreateTextPdf(text);
-
-		// Act
-		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
-
-		// Assert
-		result.ExtractedText.Should().NotBeNullOrWhiteSpace();
-		result.PageImages.Should().ContainSingle();
+		result.Should().ContainSingle();
+		AssertPngHasDimensions(result[0], minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -221,20 +184,17 @@ public class PdfConversionServiceTests
 			imageHeight: 800);
 
 		// Act
-		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
-		// Assert — text layer is still extracted (informational), and the rasterized
-		// first page is what the scan handler will use.
-		result.PageImages.Should().ContainSingle();
-		result.ExtractedText.Should().NotBeNullOrWhiteSpace();
-		result.ExtractedText.Should().Contain("WALMART");
-		AssertPngHasDimensions(result.PageImages[0], minWidth: 100, minHeight: 100);
+		// Assert — the rasterized first page is what the scan handler will use.
+		result.Should().ContainSingle();
+		AssertPngHasDimensions(result[0], minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
 	public async Task ConvertAsync_PdfWithSmallLogoAndText_StillRasterizes()
 	{
-		// Arrange — previously a text+small-logo PDF produced empty PageImages because
+		// Arrange — previously a text+small-logo PDF produced empty page images because
 		// the logo was below the 400x400 embedded-image size filter. That caused the scan
 		// handler to throw OcrNoTextException for emailed POS receipts with a tiny store
 		// logo. Now the rasterized first page carries the whole document including the
@@ -245,11 +205,10 @@ public class PdfConversionServiceTests
 			imageHeight: 64);
 
 		// Act
-		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		IReadOnlyList<byte[]> result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		result.PageImages.Should().ContainSingle();
-		result.ExtractedText.Should().Contain("WALMART");
+		result.Should().ContainSingle();
 	}
 
 	[Fact]
@@ -465,16 +424,6 @@ public class PdfConversionServiceTests
 		using MemoryStream ms = new();
 		image.Save(ms, new PngEncoder());
 		return ms.ToArray();
-	}
-
-	private static byte[] CreateTextPdfWithMetadata(string title, string text)
-	{
-		PdfDocumentBuilder builder = new();
-		builder.DocumentInformation.Title = title;
-		PdfPageBuilder page = builder.AddPage(PageSize.Letter);
-		PdfDocumentBuilder.AddedFont font = builder.AddStandard14Font(Standard14Font.Helvetica);
-		page.AddText(text, 12, new PdfPoint(72, 720), font);
-		return builder.Build();
 	}
 
 	private static byte[] CreateMultiPageTextPdf(string[] pageTexts)


### PR DESCRIPTION
## Summary

- Drop the unused `ExtractedText` and `Metadata` fields from the PDF conversion result. The XML doc on `ExtractedText` already admitted "may be removed in a future cleanup" — no production consumer reads them; only the Infrastructure tests that produced them and a handler test that explicitly asserted the handler ignored `ExtractedText`.
- Collapse `PdfConversionResult` to `Task<IReadOnlyList<byte[]>> ConvertAsync(...)` directly since only the page-images list is used. Drop `PdfMetadata` entirely.
- Remove the now-dead text-collection logic in `PdfConversionService` (`MinTextLengthPerPage`, `ExtractMetadata`, `ProcessDocumentMetadataAndText`) and the `Handle_Pdf_IgnoresExtractedTextField` handler test. Drop Infrastructure tests against the dropped fields. Net deletion: 221 → 51 lines.

Resolves RECEIPTS-646.

## Notes

- **Surgical with respect to RECEIPTS-638**: `IPdfConversionService.MaxPages` is left in place — RECEIPTS-638 (IOptions<T>) owns that change and will rebase.
- **Targeted at parent branch** `feat/receipts-616-vlm-receipt-extraction` per the parent/child branching model.

## Test plan

- [x] `dotnet build Receipts.slnx` — 0 errors
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — all suites pass (Application 472, Infrastructure 702, Presentation 1027, Domain 137, VlmEval 81, Common 18)
- [x] Pre-commit hook (full mode, 11 checks) — passed including `dotnet format --verify-no-changes`, OpenAPI lint, build with `TreatWarningsAsErrors`, drift check, .NET tests, TS check, ESLint, vitest (1923 passed)
- [x] `grep -r "ExtractedText\|PdfMetadata"` — no remaining references in code, tests, or docs