### PR TITLE
fix(infrastructure): opt vlm-ocr client out of standard resilience handler (RECEIPTS-630)

### DIFF
--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -178,36 +178,7 @@ public static class InfrastructureService
 		{
 			client.BaseAddress = new Uri(ynabOptions.BaseUrl.TrimEnd('/') + "/");
 		})
-		.AddResilienceHandler("ynab", builder =>
-		{
-			builder.AddRetry(new HttpRetryStrategyOptions
-			{
-				MaxRetryAttempts = 3,
-				BackoffType = DelayBackoffType.Exponential,
-				UseJitter = true,
-				ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
-					.Handle<HttpRequestException>()
-					.HandleResult(r => r.StatusCode is System.Net.HttpStatusCode.TooManyRequests
-						or System.Net.HttpStatusCode.ServiceUnavailable
-						or System.Net.HttpStatusCode.GatewayTimeout),
-				DelayGenerator = args =>
-				{
-					if (args.Outcome.Result?.Headers.RetryAfter?.Delta is TimeSpan delta)
-					{
-						return ValueTask.FromResult<TimeSpan?>(delta);
-					}
-
-					return ValueTask.FromResult<TimeSpan?>(null); // fall back to exponential backoff
-				},
-			});
-			builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
-			{
-				SamplingDuration = TimeSpan.FromSeconds(30),
-				FailureRatio = 0.5,
-				MinimumThroughput = 5,
-				BreakDuration = TimeSpan.FromSeconds(60),
-			});
-		});
+		.AddResilienceHandler("ynab", AddRetryAndCircuitBreaker);
 
 		RegisterReceiptExtractionService(services, configuration);
 
@@ -255,9 +226,16 @@ public static class InfrastructureService
 	}
 
 	/// <summary>
-	/// Registers the Ollama-backed <see cref="IReceiptExtractionService"/> with resilience
-	/// (retry + circuit breaker) matching the YNAB client pattern. URL resolves from
+	/// Registers the Ollama-backed <see cref="IReceiptExtractionService"/> with a single
+	/// resilience pipeline tailored to long-running VLM inferences. URL resolves from
 	/// <c>Ocr:Vlm:OllamaUrl</c>, then <c>Ollama:BaseUrl</c> (Aspire-injected), then localhost default.
+	/// <para>
+	/// We explicitly <see cref="ResilienceHttpClientBuilderExtensions.RemoveAllResilienceHandlers"/>
+	/// so the standard handler injected by <c>Receipts.ServiceDefaults</c> (30s per attempt /
+	/// 90s total) does NOT stack on top of our pipeline. Real glm-ocr inferences routinely
+	/// exceed 30s; without removal the documented <see cref="VlmOcrOptions.TimeoutSeconds"/>
+	/// budget would never apply. See RECEIPTS-630.
+	/// </para>
 	/// </summary>
 	internal static void RegisterReceiptExtractionService(IServiceCollection services, IConfiguration configuration)
 	{
@@ -272,20 +250,39 @@ public static class InfrastructureService
 
 		services.AddSingleton(options);
 
+#pragma warning disable EXTEXP0001 // RemoveAllResilienceHandlers is in evaluation; required to opt out of the standard handler injected by ServiceDefaults.
 		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
 		{
 			client.BaseAddress = new Uri(options.OllamaUrl!.TrimEnd('/') + "/");
-			// The per-call CancellationTokenSource inside the service owns the timeout.
+			// The resilience pipeline (per-attempt Timeout strategy) owns request budgeting.
+			// HttpClient.Timeout must be Infinite so it doesn't fight the pipeline.
 			client.Timeout = Timeout.InfiniteTimeSpan;
 		})
-		.AddResilienceHandler("vlm-ocr", ConfigureVlmOcrResilience);
+			.RemoveAllResilienceHandlers()
+			.AddResilienceHandler("vlm-ocr", builder => ConfigureVlmOcrResilience(builder, options));
+#pragma warning restore EXTEXP0001
 	}
 
 	/// <summary>
-	/// Resilience policy for VLM OCR HTTP calls: 3 retries with exponential backoff + jitter,
-	/// circuit breaker on sustained failure. Matches the YNAB client pattern.
+	/// Resilience pipeline for VLM OCR HTTP calls. Order matters: retry wraps the
+	/// per-attempt timeout so each retry receives a fresh <see cref="VlmOcrOptions.TimeoutSeconds"/>
+	/// budget (Polly executes strategies in registration order — first added is outermost).
 	/// </summary>
-	internal static void ConfigureVlmOcrResilience(ResiliencePipelineBuilder<HttpResponseMessage> builder)
+	internal static void ConfigureVlmOcrResilience(
+		ResiliencePipelineBuilder<HttpResponseMessage> builder,
+		VlmOcrOptions options)
+	{
+		AddRetryAndCircuitBreaker(builder);
+		// Per-attempt timeout sits INSIDE the retry — each retry resets the clock.
+		builder.AddTimeout(TimeSpan.FromSeconds(options.TimeoutSeconds));
+	}
+
+	/// <summary>
+	/// Shared retry + circuit-breaker policy used by the YNAB and VLM-OCR HTTP clients:
+	/// 3 retries with exponential backoff + jitter (honoring <c>Retry-After</c> when the
+	/// server provides it), and a circuit breaker on sustained failure.
+	/// </summary>
+	private static void AddRetryAndCircuitBreaker(ResiliencePipelineBuilder<HttpResponseMessage> builder)
 	{
 		builder.AddRetry(new HttpRetryStrategyOptions
 		{
@@ -304,7 +301,7 @@ public static class InfrastructureService
 					return ValueTask.FromResult<TimeSpan?>(delta);
 				}
 
-				return ValueTask.FromResult<TimeSpan?>(null);
+				return ValueTask.FromResult<TimeSpan?>(null); // fall back to exponential backoff
 			},
 		});
 		builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Application.Interfaces.Services;
 using Application.Models.Ocr;
 using Microsoft.Extensions.Logging;
+using Polly.Timeout;
 
 namespace Infrastructure.Services;
 
@@ -62,21 +63,21 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 			Prompt: ReceiptExtractionPrompt.Current,
 			Images: [base64]);
 
-		using CancellationTokenSource timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-		timeoutSource.CancelAfter(TimeSpan.FromSeconds(_options.TimeoutSeconds));
-
+		// The per-attempt timeout is enforced by the resilience pipeline (Polly Timeout
+		// strategy registered in InfrastructureService). Each retry receives a fresh
+		// VlmOcrOptions.TimeoutSeconds budget — see RECEIPTS-630.
 		OllamaGenerateResponse? generateResponse;
 		try
 		{
 			using HttpResponseMessage httpResponse = await _httpClient.PostAsJsonAsync(
-				"api/generate", request, JsonOptions, timeoutSource.Token);
+				"api/generate", request, JsonOptions, cancellationToken);
 
 			httpResponse.EnsureSuccessStatusCode();
 
 			generateResponse = await httpResponse.Content.ReadFromJsonAsync<OllamaGenerateResponse>(
-				JsonOptions, timeoutSource.Token);
+				JsonOptions, cancellationToken);
 		}
-		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+		catch (TimeoutRejectedException)
 		{
 			throw new TimeoutException($"Ollama VLM call timed out after {_options.TimeoutSeconds}s.");
 		}

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -63,15 +63,17 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	/// <summary>
-	/// Builds an <see cref="IReceiptExtractionService"/> through DI exactly as the
-	/// production code does (<see cref="InfrastructureService.RegisterReceiptExtractionService"/>),
-	/// including the per-attempt Polly Timeout strategy. Used to exercise pipeline behavior
-	/// (timeout, retry-with-fresh-budget) that is not visible when constructing the service
-	/// in isolation.
+	/// Runs <paramref name="action"/> against an <see cref="IReceiptExtractionService"/>
+	/// resolved from a DI container configured exactly as the production code does
+	/// (<see cref="InfrastructureService.RegisterReceiptExtractionService"/>), including
+	/// the per-attempt Polly Timeout strategy. The container is disposed after the action
+	/// completes so the underlying <see cref="IHttpClientFactory"/> and any other
+	/// <see cref="IDisposable"/> singletons do not leak across tests.
 	/// </summary>
-	private static IReceiptExtractionService BuildPipelineService(
+	private static async Task RunWithPipelineServiceAsync(
 		HttpMessageHandler primaryHandler,
-		VlmOcrOptions options)
+		VlmOcrOptions options,
+		Func<IReceiptExtractionService, Task> action)
 	{
 		ServiceCollection services = new();
 		services.AddLogging();
@@ -88,8 +90,9 @@ public class OllamaReceiptExtractionServiceTests
 			InfrastructureService.ConfigureVlmOcrResilience(builder, options));
 #pragma warning restore EXTEXP0001
 
-		ServiceProvider sp = services.BuildServiceProvider();
-		return sp.GetRequiredService<IReceiptExtractionService>();
+		await using ServiceProvider sp = services.BuildServiceProvider();
+		IReceiptExtractionService service = sp.GetRequiredService<IReceiptExtractionService>();
+		await action(service);
 	}
 
 	[Fact]
@@ -755,14 +758,16 @@ public class OllamaReceiptExtractionServiceTests
 			Model = "glm-ocr:q8_0",
 			TimeoutSeconds = 1,
 		};
-		IReceiptExtractionService service = BuildPipelineService(handlerMock.Object, options);
 
-		// Act
-		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		await RunWithPipelineServiceAsync(handlerMock.Object, options, async service =>
+		{
+			// Act
+			Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
 
-		// Assert
-		await act.Should().ThrowAsync<TimeoutException>()
-			.WithMessage("*timed out after 1s*");
+			// Assert
+			await act.Should().ThrowAsync<TimeoutException>()
+				.WithMessage("*timed out after 1s*");
+		});
 	}
 
 	[Fact]

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -2,9 +2,11 @@ using System.Net;
 using System.Text.Json;
 using Application.Interfaces.Services;
 using Application.Models.Ocr;
+using Common;
 using FluentAssertions;
 using FluentAssertions.Specialized;
 using Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -58,6 +60,36 @@ public class OllamaReceiptExtractionServiceTests
 			response = innerJson,
 			done = true,
 		});
+	}
+
+	/// <summary>
+	/// Builds an <see cref="IReceiptExtractionService"/> through DI exactly as the
+	/// production code does (<see cref="InfrastructureService.RegisterReceiptExtractionService"/>),
+	/// including the per-attempt Polly Timeout strategy. Used to exercise pipeline behavior
+	/// (timeout, retry-with-fresh-budget) that is not visible when constructing the service
+	/// in isolation.
+	/// </summary>
+	private static IReceiptExtractionService BuildPipelineService(
+		HttpMessageHandler primaryHandler,
+		VlmOcrOptions options)
+	{
+		ServiceCollection services = new();
+		services.AddLogging();
+		services.AddSingleton(options);
+#pragma warning disable EXTEXP0001
+		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
+		{
+			client.BaseAddress = new Uri(options.OllamaUrl!.TrimEnd('/') + "/");
+			client.Timeout = Timeout.InfiniteTimeSpan;
+		})
+		.ConfigurePrimaryHttpMessageHandler(() => primaryHandler)
+		.RemoveAllResilienceHandlers()
+		.AddResilienceHandler("vlm-ocr-test", builder =>
+			InfrastructureService.ConfigureVlmOcrResilience(builder, options));
+#pragma warning restore EXTEXP0001
+
+		ServiceProvider sp = services.BuildServiceProvider();
+		return sp.GetRequiredService<IReceiptExtractionService>();
 	}
 
 	[Fact]
@@ -704,7 +736,9 @@ public class OllamaReceiptExtractionServiceTests
 	[Fact]
 	public async Task ExtractAsync_Timeout_ThrowsTimeoutException()
 	{
-		// Arrange — handler delays longer than TimeoutSeconds
+		// Arrange — handler delays longer than the per-attempt timeout. The Polly Timeout
+		// strategy registered by RegisterReceiptExtractionService aborts the attempt and
+		// surfaces TimeoutRejectedException, which the service translates to TimeoutException.
 		Mock<HttpMessageHandler> handlerMock = new();
 		handlerMock.Protected()
 			.Setup<Task<HttpResponseMessage>>("SendAsync",
@@ -721,7 +755,7 @@ public class OllamaReceiptExtractionServiceTests
 			Model = "glm-ocr:q8_0",
 			TimeoutSeconds = 1,
 		};
-		OllamaReceiptExtractionService service = CreateService(handlerMock.Object, options);
+		IReceiptExtractionService service = BuildPipelineService(handlerMock.Object, options);
 
 		// Act
 		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
@@ -769,6 +803,86 @@ public class OllamaReceiptExtractionServiceTests
 		doc.RootElement.GetProperty("stream").GetBoolean().Should().BeFalse();
 		doc.RootElement.GetProperty("images")[0].GetString().Should().Be(Convert.ToBase64String(FakeImage));
 		doc.RootElement.GetProperty("prompt").GetString().Should().Contain("receipt");
+	}
+
+	[Fact]
+	public async Task RegisterReceiptExtractionService_SlowResponse_NotCancelledByServiceDefaultsStandardHandler()
+	{
+		// Regression for RECEIPTS-630. The Receipts.ServiceDefaults registration applies
+		// AddStandardResilienceHandler globally via ConfigureHttpClientDefaults (30s per
+		// attempt / 90s total). Real glm-ocr inferences routinely exceed 30s, so the
+		// vlm-ocr typed client MUST opt out of that handler — otherwise every slow VLM
+		// call surfaces as a Polly TimeoutRejectedException long before the documented
+		// VlmOcrOptions.TimeoutSeconds (120s) budget applies.
+		//
+		// This test simulates the production composition: ServiceDefaults registers the
+		// standard handler with an aggressive 200ms attempt timeout, THEN the application
+		// calls RegisterReceiptExtractionService. A handler that delays 1s — well past the
+		// 200ms standard-handler ceiling but well under the test's per-attempt VLM timeout
+		// (5s) — must complete successfully. If the standard handler were not removed by
+		// our registration, the call would die at ~200ms with a TimeoutRejectedException.
+		Mock<HttpMessageHandler> handlerMock = new();
+		string successBody = WrapInOllamaEnvelope("""{ "store": { "name": "Walmart" }, "total": 10.00 }""");
+		handlerMock.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.Returns(async (HttpRequestMessage _, CancellationToken ct) =>
+			{
+				await Task.Delay(TimeSpan.FromSeconds(1), ct);
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent(successBody, System.Text.Encoding.UTF8, "application/json"),
+				};
+			});
+
+		ServiceCollection services = new();
+		services.AddLogging();
+
+		// Replicate Receipts.ServiceDefaults: register an aggressive standard handler
+		// for every HttpClient via ConfigureHttpClientDefaults. If RegisterReceiptExtractionService
+		// fails to remove this handler, the 200ms attempt timeout will cancel any call
+		// that takes longer than 200ms.
+		services.ConfigureHttpClientDefaults(http =>
+		{
+			http.AddStandardResilienceHandler(opts =>
+			{
+				opts.AttemptTimeout.Timeout = TimeSpan.FromMilliseconds(200);
+				opts.TotalRequestTimeout.Timeout = TimeSpan.FromMilliseconds(600);
+				opts.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(2);
+				opts.Retry.ShouldHandle = _ => ValueTask.FromResult(false);
+			});
+		});
+
+		// Configuration mirrors the production VLM section: a real OllamaUrl plus a
+		// TimeoutSeconds well above the 1s simulated work — so success depends solely
+		// on whether the global standard handler was successfully removed.
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.OllamaUrl)}"] = "http://test-ollama",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.Model)}"] = "glm-ocr:q8_0",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.TimeoutSeconds)}"] = "5",
+			})
+			.Build();
+
+		InfrastructureService.RegisterReceiptExtractionService(services, configuration);
+
+		// Override the primary handler so we don't actually hit Ollama. ConfigurePrimaryHttpMessageHandler
+		// is a separate registration that targets the same named client.
+		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>()
+			.ConfigurePrimaryHttpMessageHandler(() => handlerMock.Object);
+
+		using ServiceProvider sp = services.BuildServiceProvider();
+		IReceiptExtractionService service = sp.GetRequiredService<IReceiptExtractionService>();
+
+		// Act
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert — call completed without being cancelled by ServiceDefaults' 200ms standard
+		// handler. With the bug present, this throws TimeoutRejectedException at ~200ms.
+		receipt.StoreName.Value.Should().Be("Walmart");
+		receipt.Total.Value.Should().Be(10.00m);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

- Removes the `AddStandardResilienceHandler` (30s/90s) that `Receipts.ServiceDefaults` injects for every HttpClient from the `vlm-ocr` typed client. It was preempting every glm-ocr inference long before the documented 120s `VlmOcrOptions.TimeoutSeconds` budget.
- Replaces the manual `CancellationTokenSource.CancelAfter` in `OllamaReceiptExtractionService` with a Polly `Timeout` strategy inside the resilience pipeline so each retry receives a fresh per-attempt budget (the manual CTS was shared across all 3 retries; a slow first attempt left no time for retries).
- Extracts the duplicated retry+circuit-breaker config (`ynab` and `vlm-ocr`) into a single `AddRetryAndCircuitBreaker` helper.
- Adds a regression test that registers an aggressive 200ms standard handler globally, then exercises the `vlm-ocr` typed client with a 1-second-delayed handler. With the bug present, the call would die at ~200ms; with the fix, it completes successfully.

Resolves RECEIPTS-630.

## Test plan

- [x] Full backend unit test suite passes (`dotnet test --filter "Category!=Integration"`): 2423 tests, 0 failures.
- [x] New regression test `RegisterReceiptExtractionService_SlowResponse_NotCancelledByServiceDefaultsStandardHandler` proves the standard handler is not stacked.
- [x] Existing `ExtractAsync_Timeout_ThrowsTimeoutException` rewired to use the resilience pipeline and confirms `TimeoutException` is still surfaced when the per-attempt timeout fires.
- [x] Existing `ExtractAsync_OperationCanceled_Propagates` confirms caller-token cancellation still propagates.
- [x] Pre-commit hook (full mode): format, drift, build w/ TreatWarningsAsErrors, all 2423 backend + 1923 frontend tests pass.

## Notes for reviewer

- `RemoveAllResilienceHandlers()` is decorated with `[Experimental("EXTEXP0001")]` in `Microsoft.Extensions.Http.Resilience` 10.1.0. Suppressed locally with `#pragma warning disable EXTEXP0001` and a comment explaining why. This is the canonical opt-out path for the standard handler.
- `OllamaReceiptExtractionService` now catches `Polly.Timeout.TimeoutRejectedException` (which is NOT a subclass of `OperationCanceledException`) and translates to `TimeoutException` to preserve the existing service contract.
- Per-attempt timeout sits **inside** the retry strategy (Polly executes strategies in registration order — first added is outermost). Retry wraps timeout, so each retry resets the clock — fixing the "first attempt eats the whole budget" bug.