### PR TITLE
fix(client): payments section dead-end UX + render-cycle polish (RECEIPTS-644)

### DIFF
--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -478,6 +478,62 @@ describe("NewReceiptPage", () => {
     );
   });
 
+  it("keeps the payments section visible after the user removes every detected payment", async () => {
+    // Regression for RECEIPTS-644: gating visibility on the live `payments`
+    // array length trapped users — emptying the list hid the entire section
+    // (including the Add Payment button) with no path to recover. The fix
+    // pins visibility to initial presence captured at mount.
+    const user = userEvent.setup();
+    renderWithProviders(
+      <NewReceiptPage
+        initialValues={{
+          header: {
+            location: "Walmart",
+            date: "2024-06-15",
+            taxAmount: 0,
+            storeAddress: "",
+            storePhone: "",
+          },
+          metadata: { receiptId: "", storeNumber: "", terminalId: "" },
+          payments: [
+            { method: "MASTERCARD", amount: 54.32, lastFour: "4538" },
+          ],
+          items: [],
+        }}
+      />,
+    );
+
+    // Initially shown with one payment.
+    expect(screen.getByTestId("payments-section")).toBeInTheDocument();
+    expect(screen.getByTestId("payments-count")).toHaveTextContent("1");
+
+    // The mocked PaymentsSection exposes a "Clear Payments" button that
+    // sends an empty array to onChange — equivalent to the user removing
+    // every payment row.
+    await user.click(screen.getByText("Clear Payments"));
+
+    // Section still rendered — only the count drops to zero.
+    expect(screen.getByTestId("payments-section")).toBeInTheDocument();
+    expect(screen.getByTestId("payments-count")).toHaveTextContent("0");
+  });
+
+  it("uses the pageTitle prop for the visible heading", () => {
+    renderWithProviders(<NewReceiptPage pageTitle="Scan Receipt" />);
+    expect(
+      screen.getByRole("heading", { name: /scan receipt/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /^new receipt$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to 'New Receipt' for the heading when pageTitle is omitted", () => {
+    renderWithProviders(<NewReceiptPage />);
+    expect(
+      screen.getByRole("heading", { name: /new receipt/i }),
+    ).toBeInTheDocument();
+  });
+
   it("builds an item-confidence Map keyed by item id when scan items are present", () => {
     renderWithProviders(
       <NewReceiptPage

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -64,6 +64,11 @@ export default function NewReceiptPage({
   );
   const [payments, setPayments] = useState(initialPaymentsBundle.payments);
   const paymentConfidenceById = initialPaymentsBundle.paymentConfidenceById;
+  // Section visibility is gated on initial-presence (captured once at mount), not
+  // current-array-length. Otherwise removing every detected payment would hide the
+  // entire section — including the "Add Payment" button — leaving the user no path
+  // back. See RECEIPTS-644.
+  const hasInitialPayments = initialPaymentsBundle.payments.length > 0;
 
   const [showDiscard, setShowDiscard] = useState(false);
 
@@ -118,7 +123,7 @@ export default function NewReceiptPage({
     (metadata.receiptId !== "" ||
       metadata.storeNumber !== "" ||
       metadata.terminalId !== "");
-  const showPaymentsSection = payments.length > 0;
+  const showPaymentsSection = hasInitialPayments;
 
   const hasData =
     location !== "" ||
@@ -145,7 +150,9 @@ export default function NewReceiptPage({
 
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-bold tracking-tight">New Receipt</h1>
+      <h1 className="text-3xl font-bold tracking-tight">
+        {pageTitle ?? "New Receipt"}
+      </h1>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_280px]">
         {/* Left column — form sections */}

--- a/src/client/src/pages/new-receipt/PaymentsSection.tsx
+++ b/src/client/src/pages/new-receipt/PaymentsSection.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { generateId } from "@/lib/id";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
@@ -47,32 +46,28 @@ export function PaymentsSection({
   onChange,
   confidenceById,
 }: PaymentsSectionProps) {
-  const handleAdd = useCallback(() => {
+  // Plain functions (not useCallback): the JSX below uses inline arrow handlers
+  // that allocate every render anyway, so memoising these would not stabilise
+  // any prop. Memoise only when a stable identity is actually consumed (e.g.
+  // when passing a handler to a memoised child or as a hook dependency).
+  const handleAdd = () => {
     onChange([
       ...payments,
       { id: generateId(), method: "", amount: 0, lastFour: "" },
     ]);
-  }, [payments, onChange]);
+  };
 
-  const handleRemove = useCallback(
-    (id: string) => {
-      onChange(payments.filter((p) => p.id !== id));
-    },
-    [payments, onChange],
-  );
+  const handleRemove = (id: string) => {
+    onChange(payments.filter((p) => p.id !== id));
+  };
 
-  const handleField = useCallback(
-    <K extends keyof Omit<ReceiptPayment, "id">>(
-      id: string,
-      field: K,
-      value: ReceiptPayment[K],
-    ) => {
-      onChange(
-        payments.map((p) => (p.id === id ? { ...p, [field]: value } : p)),
-      );
-    },
-    [payments, onChange],
-  );
+  const handleField = <K extends keyof Omit<ReceiptPayment, "id">>(
+    id: string,
+    field: K,
+    value: ReceiptPayment[K],
+  ) => {
+    onChange(payments.map((p) => (p.id === id ? { ...p, [field]: value } : p)));
+  };
 
   const total = payments.reduce((sum, p) => sum + (p.amount || 0), 0);
 

--- a/src/client/src/pages/new-receipt/ReceiptDetailsPanel.tsx
+++ b/src/client/src/pages/new-receipt/ReceiptDetailsPanel.tsx
@@ -8,7 +8,10 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { ConfidenceIndicator } from "@/pages/scan-receipt/ConfidenceIndicator";
-import type { ReceiptConfidenceMap } from "@/pages/scan-receipt/types";
+import type {
+  ConfidenceLevel,
+  ReceiptConfidenceMap,
+} from "@/pages/scan-receipt/types";
 
 interface ReceiptDetailsPanelProps {
   metadata: { receiptId: string; storeNumber: string; terminalId: string };
@@ -20,10 +23,15 @@ export function ReceiptDetailsPanel({
   confidenceMap,
 }: ReceiptDetailsPanelProps) {
   const [isOpen, setIsOpen] = useState(false);
+  // The three metadata fields all have scalar `ConfidenceLevel | undefined`
+  // shapes on `ReceiptConfidenceMap`. Typing the row directly as
+  // `ConfidenceLevel | undefined` avoids the indexed-access widening
+  // (which would let in the array shapes for `payments`/`items`) and
+  // removes the downstream cast where we forward to `ConfidenceIndicator`.
   const rows: Array<{
     label: string;
     value: string;
-    confidence?: ReceiptConfidenceMap[keyof ReceiptConfidenceMap];
+    confidence?: ConfidenceLevel;
   }> = [];
 
   if (metadata.receiptId) {
@@ -83,16 +91,7 @@ export function ReceiptDetailsPanel({
                   <dt className="text-muted-foreground">{row.label}</dt>
                   <dd className="flex items-center gap-2 font-mono">
                     <span>{row.value}</span>
-                    <ConfidenceIndicator
-                      confidence={
-                        row.confidence as
-                          | ReceiptConfidenceMap[
-                              | "receiptId"
-                              | "storeNumber"
-                              | "terminalId"]
-                          | undefined
-                      }
-                    />
+                    <ConfidenceIndicator confidence={row.confidence} />
                   </dd>
                 </div>
               ))}

--- a/src/client/src/pages/scan-receipt/ScanReceiptPage.tsx
+++ b/src/client/src/pages/scan-receipt/ScanReceiptPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReceiptScan } from "@/hooks/useReceiptScan";
 import { isTimeoutError } from "@/lib/api-client";
@@ -39,6 +39,12 @@ export default function ScanReceiptPage() {
   const [proposal, setProposal] = useState<ProposedReceiptResponse | null>(
     null,
   );
+  // Monotonic counter incremented on every successful scan. Used as a
+  // remount key on <NewReceiptPage> so a future "rescan" flow that updates
+  // `proposal` after the first scan would correctly reset the wizard's
+  // lazy initialisers (items/payments bundles, react-hook-form defaults).
+  // Without this key, a second scan would keep the original initial state.
+  const [scanVersion, setScanVersion] = useState(0);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleScan = useCallback(
@@ -48,6 +54,7 @@ export default function ScanReceiptPage() {
       scanMutation.mutate(file, {
         onSuccess: (data) => {
           setProposal(data ?? null);
+          setScanVersion((v) => v + 1);
           setStatus("success");
         },
         onError: (error) => {
@@ -61,12 +68,22 @@ export default function ScanReceiptPage() {
     [],
   );
 
-  if (status === "success" && proposal) {
-    const initialValues = mapProposalToInitialValues(proposal);
-    const confidenceMap = mapProposalToConfidenceMap(proposal);
+  // Memoise: both mappers are pure but allocate fresh objects/maps each call,
+  // so wrapping them keeps prop identities stable across re-renders that do
+  // not change `proposal` (e.g. status flicker on retry). Cheap, but cleaner.
+  const initialValues = useMemo(
+    () => (proposal ? mapProposalToInitialValues(proposal) : null),
+    [proposal],
+  );
+  const confidenceMap = useMemo(
+    () => (proposal ? mapProposalToConfidenceMap(proposal) : null),
+    [proposal],
+  );
 
+  if (status === "success" && proposal && initialValues && confidenceMap) {
     return (
       <NewReceiptPage
+        key={scanVersion}
         initialValues={initialValues}
         confidenceMap={confidenceMap}
         pageTitle="Scan Receipt"

--- a/src/client/src/pages/scan-receipt/proposalMappers.test.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.test.ts
@@ -315,6 +315,11 @@ describe("mapProposalToConfidenceMap", () => {
 
     const result = mapProposalToConfidenceMap(proposal);
 
+    // The empty object `{}` for the all-high-confidence "Cash" payment is
+    // intentional: the array is positional (entry N corresponds to payment N),
+    // so we cannot omit "high"-only payments without misaligning indices.
+    // Each high-confidence field is dropped from its entry, leaving an empty
+    // object that contributes nothing to the UI but preserves position.
     expect(result.payments).toEqual([
       { amount: "low", lastFour: "medium" },
       {},


### PR DESCRIPTION
## Summary

Seven small client-side polish fixes flagged by the bug-finder review of RECEIPTS-616 / 643:

- **PaymentsSection dead-end UX** — visibility now keyed on initial-presence (`hasInitialPayments`) captured once at mount, not on the live `payments.length`. Removing every detected payment no longer hides the entire section (and its "Add Payment" button), trapping the user.
- **`pageTitle` reaches the heading** — `<h1>` now renders `pageTitle ?? "New Receipt"` so `ScanReceiptPage`'s `pageTitle="Scan Receipt"` shows in the page heading, matching the document title that `usePageTitle` was already setting.
- **PaymentsSection useCallback cleanup** — dropped three `useCallback` wrappers whose memoisation was defeated by inline-arrow JSX call sites. Now plain functions; allocation profile is unchanged but intent is honest.
- **ReceiptDetailsPanel confidence type** — replaced `confidence?: ReceiptConfidenceMap[keyof ReceiptConfidenceMap]` (over-broad union including the `payments`/`items` array shapes) with `confidence?: ConfidenceLevel`. Removes the `as` cast at the `<ConfidenceIndicator>` call site.
- **ScanReceiptPage proposal mappers** — `mapProposalToInitialValues` and `mapProposalToConfidenceMap` now run inside `useMemo` keyed on `proposal`, so they don't allocate fresh objects on incidental re-renders.
- **NewReceiptPage remount key for future rescan** — added `key={scanVersion}` (a counter incremented on each successful scan) so a future rescan flow that updates `proposal` correctly resets the wizard's lazy initialisers (item/payment id maps + RHF defaults).
- **proposalMappers test comment** — added an explanatory comment on the `{}`-for-fully-high-confidence assertion: empty object preserves positional indexing into the payments array, by design.

Resolves RECEIPTS-644.

## Test plan

- `npx tsc -b --noEmit` — clean.
- `npx eslint src` — only pre-existing warnings (none from this PR).
- `npx vitest run` — 1926/1926 pass, including three new tests:
  - `keeps the payments section visible after the user removes every detected payment`
  - `uses the pageTitle prop for the visible heading`
  - `falls back to 'New Receipt' for the heading when pageTitle is omitted`
- Pre-commit hook ran the full pipeline (.NET build + format + tests + client TS/lint/vitest) — all green.

## Notes

- Branched from and targets `feat/receipts-616-vlm-receipt-extraction` (the VLM extraction epic). Picked up the post-RECEIPTS-643 refactor that extracted `HeaderSection`/`ReceiptDetailsPanel`/etc. so the line numbers in the issue mapped to slightly different files.
- No backend changes.