### PR TITLE
fix(application): surface multi-page PDF dropped pages on scan response (RECEIPTS-637)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -1921,8 +1921,10 @@ paths:
         Accepts a JPEG image, PNG image, or PDF document. Images are sent
         directly to the receipt extraction service (a local vision-language
         model). For PDFs, the first page is rasterized to a PNG at 200 DPI and
-        sent to the VLM. PDFs are accepted up to 50 pages, but only the first
-        page is currently used for extraction. Returns a proposed receipt with
+        sent to the VLM. Additional pages are silently ignored: when a PDF has
+        more than one page, the response carries `droppedPageCount` set to the
+        number of skipped pages so clients can warn the user that the proposal
+        represents only the first page. Returns a proposed receipt with
         per-field confidence scores. The proposal is NOT persisted — it is a
         transient suggestion for review.
       security:
@@ -6300,6 +6302,7 @@ components:
         - receiptIdConfidence
         - storeNumberConfidence
         - terminalIdConfidence
+        - droppedPageCount
       properties:
         storeName:
           type:
@@ -6376,6 +6379,17 @@ components:
             - "null"
         terminalIdConfidence:
           $ref: "#/components/schemas/ConfidenceLevel"
+        droppedPageCount:
+          type: integer
+          format: int32
+          minimum: 0
+          description: >
+            Number of source pages that were silently dropped during extraction.
+            For multi-page PDFs only the first page is rasterized and sent to the
+            VLM; this count reports the number of additional pages that were
+            ignored (e.g., a 3-page PDF yields `droppedPageCount = 2`). Always 0
+            for single-page sources (images or single-page PDFs). Clients should
+            surface a warning to the user when this value is greater than 0.
 
     ProposedReceiptItemResponse:
       type: object

--- a/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
+++ b/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
@@ -14,7 +14,8 @@ public class ScanReceiptCommandHandler(
 
 	public async Task<ScanReceiptResult> Handle(ScanReceiptCommand request, CancellationToken cancellationToken)
 	{
-		(byte[] imageBytes, string contentType) = await ResolveImageAsync(request, cancellationToken);
+		(byte[] imageBytes, string contentType, int droppedPageCount) =
+			await ResolveImageAsync(request, cancellationToken);
 
 		ParsedReceipt parsed = await extractionService.ExtractAsync(imageBytes, contentType, cancellationToken);
 
@@ -23,21 +24,25 @@ public class ScanReceiptCommandHandler(
 			throw new OcrNoTextException("The receipt could not be extracted from the provided file.");
 		}
 
-		return new ScanReceiptResult(parsed);
+		return new ScanReceiptResult(parsed, droppedPageCount);
 	}
 
-	private async Task<(byte[] ImageBytes, string ContentType)> ResolveImageAsync(
+	private async Task<(byte[] ImageBytes, string ContentType, int DroppedPageCount)> ResolveImageAsync(
 		ScanReceiptCommand request, CancellationToken cancellationToken)
 	{
 		if (!string.Equals(request.ContentType, PdfContentType, StringComparison.OrdinalIgnoreCase))
 		{
-			return (request.ImageBytes, request.ContentType);
+			return (request.ImageBytes, request.ContentType, 0);
 		}
 
-		byte[] firstPageImage = await pdfConversionService.ConvertAsync(
+		PdfConversionResult conversion = await pdfConversionService.ConvertAsync(
 			request.ImageBytes, cancellationToken);
 
-		return (firstPageImage, PdfPageImageContentType);
+		// PdfConversionService guarantees TotalPageCount >= 1 (it rejects empty PDFs
+		// with InvalidOperationException), so this subtraction is always >= 0.
+		int droppedPageCount = conversion.TotalPageCount - 1;
+
+		return (conversion.FirstPagePng, PdfPageImageContentType, droppedPageCount);
 	}
 
 	/// <summary>

--- a/src/Application/Commands/Receipt/Scan/ScanReceiptResult.cs
+++ b/src/Application/Commands/Receipt/Scan/ScanReceiptResult.cs
@@ -2,4 +2,14 @@ using Application.Models.Ocr;
 
 namespace Application.Commands.Receipt.Scan;
 
-public record ScanReceiptResult(ParsedReceipt ParsedReceipt);
+/// <summary>
+/// Result of a receipt scan.
+/// </summary>
+/// <param name="ParsedReceipt">The receipt extracted from the source file.</param>
+/// <param name="DroppedPageCount">
+/// Number of source pages that were silently ignored during extraction. For PDFs,
+/// only the first page is rasterized and sent to the VLM; pages 2..N are dropped.
+/// This count lets callers warn the user that the proposal represents only part of
+/// the document. Always 0 for single-page sources (images or single-page PDFs).
+/// </param>
+public record ScanReceiptResult(ParsedReceipt ParsedReceipt, int DroppedPageCount = 0);

--- a/src/Application/Interfaces/Services/IPdfConversionService.cs
+++ b/src/Application/Interfaces/Services/IPdfConversionService.cs
@@ -14,9 +14,22 @@ public interface IPdfConversionService
 	/// Rasterizes the first page of the PDF to a PNG. The PNG is always produced
 	/// (even for vector-only or text-only PDFs) so that downstream VLM/OCR processing
 	/// always has a usable image. Multi-page PDFs are validated against
-	/// <see cref="MaxPages"/> but only the first page is rendered. Failures (invalid
-	/// bytes, password-protected, oversized, rasterization error) surface as
-	/// <see cref="InvalidOperationException"/>.
+	/// <see cref="MaxPages"/> but only the first page is rendered. The total page
+	/// count is reported back so callers can warn users about silently dropped
+	/// pages (RECEIPTS-637). Failures (invalid bytes, password-protected, oversized,
+	/// rasterization error) surface as <see cref="InvalidOperationException"/>.
 	/// </summary>
-	Task<byte[]> ConvertAsync(byte[] pdfBytes, CancellationToken ct);
+	Task<PdfConversionResult> ConvertAsync(byte[] pdfBytes, CancellationToken ct);
 }
+
+/// <summary>
+/// Result of converting a PDF to a single rasterized page image.
+/// </summary>
+/// <param name="FirstPagePng">PNG bytes of the rasterized first page.</param>
+/// <param name="TotalPageCount">
+/// Total page count of the source PDF. Always &gt;= 1 (the conversion service rejects
+/// empty PDFs with <see cref="InvalidOperationException"/>). Used by the scan handler
+/// to report the number of dropped pages (<c>TotalPageCount - 1</c>) when more than
+/// one page was present.
+/// </param>
+public record PdfConversionResult(byte[] FirstPagePng, int TotalPageCount);

--- a/src/Infrastructure/Services/PdfConversionService.cs
+++ b/src/Infrastructure/Services/PdfConversionService.cs
@@ -27,7 +27,7 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 	/// </summary>
 	private static readonly byte[] PdfMagicBytes = [0x25, 0x50, 0x44, 0x46];
 
-	public Task<byte[]> ConvertAsync(byte[] pdfBytes, CancellationToken ct)
+	public Task<PdfConversionResult> ConvertAsync(byte[] pdfBytes, CancellationToken ct)
 	{
 		ct.ThrowIfCancellationRequested();
 
@@ -90,7 +90,7 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 			"Rasterized first PDF page at {Dpi} DPI ({PngSize} bytes) for VLM extraction (document has {PageCount} page(s))",
 			RasterizationDpi, firstPagePng.Length, pageCount);
 
-		return Task.FromResult(firstPagePng);
+		return Task.FromResult(new PdfConversionResult(firstPagePng, pageCount));
 	}
 
 	private static int ValidateDocument(PdfDocument document)

--- a/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
@@ -32,7 +32,7 @@ public class ReceiptScanController(
 	[HttpPost("scan")]
 	[RequestSizeLimit(20 * 1024 * 1024)]
 	[EndpointSummary("Scan a receipt image or PDF and return a proposed receipt")]
-	[EndpointDescription("Accepts a JPEG or PNG image, or a PDF document. Images are sent directly to the receipt extraction service (a local vision-language model). PDFs have their first page rasterized to a PNG at 200 DPI; the rendered image is then sent to the VLM. Additional pages are ignored. Returns a proposed receipt with per-field confidence scores. The proposal is NOT persisted.")]
+	[EndpointDescription("Accepts a JPEG or PNG image, or a PDF document. Images are sent directly to the receipt extraction service (a local vision-language model). PDFs have their first page rasterized to a PNG at 200 DPI; the rendered image is then sent to the VLM. Additional pages are silently ignored — when a PDF has more than one page, the response carries droppedPageCount set to the number of skipped pages so clients can warn the user that the proposal represents only the first page. Returns a proposed receipt with per-field confidence scores. The proposal is NOT persisted.")]
 	[ProducesResponseType(StatusCodes.Status415UnsupportedMediaType)]
 	public async Task<Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>>> ScanReceipt(
 		IFormFile? file,
@@ -118,6 +118,7 @@ public class ReceiptScanController(
 			StoreNumberConfidence = MapConfidence(parsed.StoreNumber.Confidence),
 			TerminalId = parsed.TerminalId.Value,
 			TerminalIdConfidence = MapConfidence(parsed.TerminalId.Confidence),
+			DroppedPageCount = result.DroppedPageCount,
 		};
 	}
 

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -796,7 +796,7 @@ export interface paths {
         put?: never;
         /**
          * Scan a receipt image or PDF and return a proposed receipt
-         * @description Accepts a JPEG image, PNG image, or PDF document. Images are sent directly to the receipt extraction service (a local vision-language model). For PDFs, the first page is rasterized to a PNG at 200 DPI and sent to the VLM. PDFs are accepted up to 50 pages, but only the first page is currently used for extraction. Returns a proposed receipt with per-field confidence scores. The proposal is NOT persisted — it is a transient suggestion for review.
+         * @description Accepts a JPEG image, PNG image, or PDF document. Images are sent directly to the receipt extraction service (a local vision-language model). For PDFs, the first page is rasterized to a PNG at 200 DPI and sent to the VLM. Additional pages are silently ignored: when a PDF has more than one page, the response carries `droppedPageCount` set to the number of skipped pages so clients can warn the user that the proposal represents only the first page. Returns a proposed receipt with per-field confidence scores. The proposal is NOT persisted — it is a transient suggestion for review.
          */
         post: operations["ScanReceipt"];
         delete?: never;
@@ -3144,6 +3144,11 @@ export interface components {
             storeNumberConfidence: components["schemas"]["ConfidenceLevel"];
             terminalId?: string | null;
             terminalIdConfidence: components["schemas"]["ConfidenceLevel"];
+            /**
+             * Format: int32
+             * @description Number of source pages that were silently dropped during extraction. For multi-page PDFs only the first page is rasterized and sent to the VLM; this count reports the number of additional pages that were ignored (e.g., a 3-page PDF yields `droppedPageCount = 2`). Always 0 for single-page sources (images or single-page PDFs). Clients should surface a warning to the user when this value is greater than 0.
+             */
+            droppedPageCount: number;
         };
         ProposedReceiptItemResponse: {
             code?: string | null;

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -606,6 +606,44 @@ describe("NewReceiptPage", () => {
     );
   });
 
+  // --- Dropped-page warning (RECEIPTS-637) ---
+
+  it("does not render dropped-pages warning when droppedPageCount is 0", () => {
+    renderWithProviders(<NewReceiptPage droppedPageCount={0} />);
+    expect(
+      screen.queryByTestId("dropped-pages-warning"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render dropped-pages warning when droppedPageCount is undefined", () => {
+    renderWithProviders(<NewReceiptPage />);
+    expect(
+      screen.queryByTestId("dropped-pages-warning"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders dropped-pages warning with singular phrasing for one dropped page", () => {
+    renderWithProviders(<NewReceiptPage droppedPageCount={1} />);
+    expect(screen.getByTestId("dropped-pages-warning")).toBeInTheDocument();
+    expect(
+      screen.getByText(/this pdf had 2 pages.*only page 1 was extracted/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/missing details from page 2 manually/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders dropped-pages warning with plural phrasing for multiple dropped pages", () => {
+    renderWithProviders(<NewReceiptPage droppedPageCount={4} />);
+    expect(screen.getByTestId("dropped-pages-warning")).toBeInTheDocument();
+    expect(
+      screen.getByText(/this pdf had 5 pages.*only page 1 was extracted/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/missing details from pages 2-5 manually/i),
+    ).toBeInTheDocument();
+  });
+
   it("validates the store phone format on submit", async () => {
     const user = userEvent.setup();
     renderWithProviders(<NewReceiptPage />);

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -4,6 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useLocationHistory } from "@/hooks/useLocationHistory";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   TransactionsSection,
   type ReceiptTransaction,
@@ -29,12 +30,20 @@ interface NewReceiptPageProps {
   initialValues?: ScanInitialValues;
   confidenceMap?: ReceiptConfidenceMap;
   pageTitle?: string;
+  /**
+   * Number of source pages silently dropped during scan. For multi-page PDFs
+   * the VLM only sees page 1; this prop surfaces a banner so the user is not
+   * left with the false impression that the proposal covers the whole document.
+   * 0 (or undefined) means no banner. Always 0 for single-page sources.
+   */
+  droppedPageCount?: number;
 }
 
 export default function NewReceiptPage({
   initialValues,
   confidenceMap,
   pageTitle,
+  droppedPageCount,
 }: NewReceiptPageProps = {}) {
   usePageTitle(pageTitle ?? "New Receipt");
   const navigate = useNavigate();
@@ -148,11 +157,24 @@ export default function NewReceiptPage({
     navigate("/receipts");
   }, [navigate]);
 
+  const droppedPages = droppedPageCount ?? 0;
+
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold tracking-tight">
         {pageTitle ?? "New Receipt"}
       </h1>
+
+      {droppedPages > 0 && (
+        <Alert data-testid="dropped-pages-warning">
+          <AlertTitle>Multi-page PDF: only page 1 was scanned</AlertTitle>
+          <AlertDescription>
+            {droppedPages === 1
+              ? "This PDF had 2 pages, but only page 1 was extracted. Review the proposal and add any missing details from page 2 manually."
+              : `This PDF had ${droppedPages + 1} pages, but only page 1 was extracted. Review the proposal and add any missing details from pages 2-${droppedPages + 1} manually.`}
+          </AlertDescription>
+        </Alert>
+      )}
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_280px]">
         {/* Left column — form sections */}

--- a/src/client/src/pages/scan-receipt/ScanReceiptPage.test.tsx
+++ b/src/client/src/pages/scan-receipt/ScanReceiptPage.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/pages/new-receipt/NewReceiptPage", () => ({
   default: ({
     initialValues,
     confidenceMap,
+    droppedPageCount,
   }: {
     initialValues?: {
       header: { location: string; storeAddress: string; storePhone: string };
@@ -29,6 +30,7 @@ vi.mock("@/pages/new-receipt/NewReceiptPage", () => ({
       payments: Array<{ method: string; amount: number; lastFour: string }>;
     };
     confidenceMap?: Record<string, unknown>;
+    droppedPageCount?: number;
   }) => (
     <div data-testid="new-receipt-page">
       {initialValues?.header.location && (
@@ -58,6 +60,9 @@ vi.mock("@/pages/new-receipt/NewReceiptPage", () => ({
       )}
       {confidenceMap && (
         <span data-testid="confidence-map">{JSON.stringify(confidenceMap)}</span>
+      )}
+      {droppedPageCount !== undefined && (
+        <span data-testid="dropped-page-count">{droppedPageCount}</span>
       )}
     </div>
   ),
@@ -97,6 +102,7 @@ function makeProposal(
     storeNumberConfidence: "high",
     terminalId: null,
     terminalIdConfidence: "high",
+    droppedPageCount: 0,
     ...overrides,
   };
 }
@@ -244,6 +250,56 @@ describe("ScanReceiptPage", () => {
       screen.getByTestId("confidence-map").textContent!,
     );
     expect(confidenceMap).toEqual({ location: "low" });
+  });
+
+  it("forwards droppedPageCount to the wizard so the warning banner can render", async () => {
+    mockMutate.mockImplementation(
+      (
+        _file: File,
+        options: { onSuccess: (data: unknown) => void },
+      ) => {
+        options.onSuccess(makeProposal({ droppedPageCount: 2 }));
+      },
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ScanReceiptPage />);
+
+    const fileInput = screen.getByTestId("file-input");
+    const file = createTestFile("multi-page.pdf", "application/pdf", 4096);
+    await user.upload(fileInput, file);
+    await user.click(screen.getByRole("button", { name: /scan receipt/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dropped-page-count")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("dropped-page-count")).toHaveTextContent("2");
+  });
+
+  it("forwards droppedPageCount of 0 for single-page sources", async () => {
+    mockMutate.mockImplementation(
+      (
+        _file: File,
+        options: { onSuccess: (data: unknown) => void },
+      ) => {
+        options.onSuccess(makeProposal({ droppedPageCount: 0 }));
+      },
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ScanReceiptPage />);
+
+    const fileInput = screen.getByTestId("file-input");
+    const file = createTestFile();
+    await user.upload(fileInput, file);
+    await user.click(screen.getByRole("button", { name: /scan receipt/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dropped-page-count")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("dropped-page-count")).toHaveTextContent("0");
   });
 
   it("forwards new fields (address, phone, metadata, payments) to the wizard", async () => {

--- a/src/client/src/pages/scan-receipt/ScanReceiptPage.tsx
+++ b/src/client/src/pages/scan-receipt/ScanReceiptPage.tsx
@@ -87,6 +87,7 @@ export default function ScanReceiptPage() {
         initialValues={initialValues}
         confidenceMap={confidenceMap}
         pageTitle="Scan Receipt"
+        droppedPageCount={proposal.droppedPageCount}
       />
     );
   }

--- a/src/client/src/pages/scan-receipt/proposalMappers.test.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.test.ts
@@ -37,6 +37,7 @@ function makeProposal(
     storeNumberConfidence: "high",
     terminalId: null,
     terminalIdConfidence: "high",
+    droppedPageCount: 0,
     ...overrides,
   };
 }

--- a/src/client/src/test/msw/fixtures/scan.test.ts
+++ b/src/client/src/test/msw/fixtures/scan.test.ts
@@ -63,6 +63,7 @@ describe("scanProposal fixture", () => {
     expect(scanProposal).toHaveProperty("storeNumberConfidence");
     expect(scanProposal).toHaveProperty("terminalId");
     expect(scanProposal).toHaveProperty("terminalIdConfidence");
+    expect(scanProposal).toHaveProperty("droppedPageCount");
   });
 
   it("exercises every confidence level (high, medium, low) across its fields", () => {

--- a/src/client/src/test/msw/fixtures/scan.ts
+++ b/src/client/src/test/msw/fixtures/scan.ts
@@ -82,4 +82,5 @@ export const scanProposal: ProposedReceiptResponse = {
   storeNumberConfidence: "medium",
   terminalId: "T01",
   terminalIdConfidence: "low",
+  droppedPageCount: 0,
 };

--- a/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
@@ -161,7 +161,7 @@ public class ScanReceiptCommandHandlerTests
 
 		_mockPdfConversionService
 			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))
-			.ReturnsAsync(firstPageImage);
+			.ReturnsAsync(new PdfConversionResult(firstPageImage, TotalPageCount: 1));
 
 		ParsedReceipt parsed = BuildPopulatedReceipt();
 		_mockExtractionService
@@ -176,6 +176,73 @@ public class ScanReceiptCommandHandlerTests
 		_mockExtractionService.Verify(
 			s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()),
 			Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PdfWithMultiplePages_ReportsDroppedPageCount()
+	{
+		// Arrange — RECEIPTS-637: a 3-page PDF must surface DroppedPageCount = 2 so
+		// the caller can warn the user that pages 2..N were silently ignored.
+		byte[] pdfBytes = [0x25, 0x50, 0x44, 0x46];
+		ScanReceiptCommand command = new(pdfBytes, "application/pdf");
+
+		byte[] firstPageImage = [0x89, 0x50, 0x4E, 0x47];
+
+		_mockPdfConversionService
+			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PdfConversionResult(firstPageImage, TotalPageCount: 3));
+
+		_mockExtractionService
+			.Setup(s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(BuildPopulatedReceipt());
+
+		// Act
+		ScanReceiptResult actual = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.DroppedPageCount.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task Handle_PdfWithSinglePage_ReportsZeroDroppedPages()
+	{
+		// Arrange — single-page PDF: the count must be 0 (nothing was dropped).
+		byte[] pdfBytes = [0x25, 0x50, 0x44, 0x46];
+		ScanReceiptCommand command = new(pdfBytes, "application/pdf");
+
+		byte[] firstPageImage = [0x89, 0x50, 0x4E, 0x47];
+
+		_mockPdfConversionService
+			.Setup(s => s.ConvertAsync(pdfBytes, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PdfConversionResult(firstPageImage, TotalPageCount: 1));
+
+		_mockExtractionService
+			.Setup(s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(BuildPopulatedReceipt());
+
+		// Act
+		ScanReceiptResult actual = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.DroppedPageCount.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task Handle_Image_ReportsZeroDroppedPages()
+	{
+		// Arrange — image input: nothing to drop, count must be 0.
+		byte[] imageBytes = [0xFF, 0xD8];
+		ScanReceiptCommand command = new(imageBytes, "image/jpeg");
+
+		_mockExtractionService
+			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(BuildPopulatedReceipt());
+
+		// Act
+		ScanReceiptResult actual = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		actual.DroppedPageCount.Should().Be(0);
 	}
 
 	[Fact]

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
@@ -35,10 +35,10 @@ public class PdfConversionServiceTests
 		byte[] pdfBytes = CreateTextPdf("WALMART MILK 2% $3.49 TOTAL $3.74");
 
 		// Act
-		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		AssertValidPng(result);
+		AssertValidPng(result.FirstPagePng);
 	}
 
 	[Fact]
@@ -52,10 +52,10 @@ public class PdfConversionServiceTests
 		byte[] pdfBytes = CreateTextPdf("Vector PDF receipt content with more than ten characters of text");
 
 		// Act
-		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		AssertPngHasDimensions(result, minWidth: 100, minHeight: 100);
+		AssertPngHasDimensions(result.FirstPagePng, minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -71,10 +71,43 @@ public class PdfConversionServiceTests
 		]);
 
 		// Act
-		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		AssertPngHasDimensions(result, minWidth: 100, minHeight: 100);
+		AssertPngHasDimensions(result.FirstPagePng, minWidth: 100, minHeight: 100);
+	}
+
+	[Fact]
+	public async Task ConvertAsync_MultiPagePdf_ReportsTotalPageCount()
+	{
+		// Arrange — RECEIPTS-637: the converter must report the total page count so the
+		// scan handler can compute DroppedPageCount = TotalPageCount - 1 and the client
+		// can warn the user about silently dropped pages.
+		byte[] pdfBytes = CreateMultiPageTextPdf(
+		[
+			"Page one content from WALMART store",
+			"Page two content with MILK for $3.49",
+			"Page three content with the receipt total"
+		]);
+
+		// Act
+		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+
+		// Assert
+		result.TotalPageCount.Should().Be(3);
+	}
+
+	[Fact]
+	public async Task ConvertAsync_SinglePagePdf_ReportsTotalPageCountOfOne()
+	{
+		// Arrange — single-page PDF: TotalPageCount must be 1 (no pages dropped).
+		byte[] pdfBytes = CreateTextPdf("WALMART MILK 2% $3.49 TOTAL $3.74");
+
+		// Act
+		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+
+		// Assert
+		result.TotalPageCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -158,10 +191,10 @@ public class PdfConversionServiceTests
 		byte[] pdfBytes = CreateTextPdf("Hi");
 
 		// Act
-		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		AssertPngHasDimensions(result, minWidth: 100, minHeight: 100);
+		AssertPngHasDimensions(result.FirstPagePng, minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -179,10 +212,10 @@ public class PdfConversionServiceTests
 			imageHeight: 800);
 
 		// Act
-		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert — the rasterized first page is what the scan handler will use.
-		AssertPngHasDimensions(result, minWidth: 100, minHeight: 100);
+		AssertPngHasDimensions(result.FirstPagePng, minWidth: 100, minHeight: 100);
 	}
 
 	[Fact]
@@ -199,10 +232,10 @@ public class PdfConversionServiceTests
 			imageHeight: 64);
 
 		// Act
-		byte[] result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		PdfConversionResult result = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
 
 		// Assert
-		AssertValidPng(result);
+		AssertValidPng(result.FirstPagePng);
 	}
 
 	[Fact]

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
@@ -277,6 +277,64 @@ public class ReceiptScanControllerTests
 	}
 
 	[Fact]
+	public async Task ScanReceipt_DroppedPageCount_PropagatesToResponse()
+	{
+		// Arrange — RECEIPTS-637: when the handler reports dropped pages, the
+		// controller must surface the count on ProposedReceiptResponse so the
+		// client can render a warning banner.
+		IFormFile file = CreateMockFormFile("multi.pdf", "application/pdf", 4096);
+
+		ParsedReceipt parsedReceipt = new(
+			FieldConfidence<string>.High("WALMART"),
+			FieldConfidence<DateOnly>.High(new DateOnly(2026, 3, 15)),
+			[],
+			FieldConfidence<decimal>.High(40m),
+			[],
+			FieldConfidence<decimal>.High(40m),
+			FieldConfidence<string?>.None()
+		);
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<ScanReceiptCommand>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ScanReceiptResult(parsedReceipt, DroppedPageCount: 2));
+
+		// Act
+		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
+
+		// Assert
+		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
+		response.DroppedPageCount.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task ScanReceipt_NoDroppedPages_ResponseDroppedPageCountIsZero()
+	{
+		// Arrange — image scan: no pages dropped, count must be 0.
+		IFormFile file = CreateMockFormFile("receipt.jpg", "image/jpeg", 1024);
+
+		ParsedReceipt parsedReceipt = new(
+			FieldConfidence<string>.High("WALMART"),
+			FieldConfidence<DateOnly>.High(new DateOnly(2026, 3, 15)),
+			[],
+			FieldConfidence<decimal>.High(10m),
+			[],
+			FieldConfidence<decimal>.High(10m),
+			FieldConfidence<string?>.None()
+		);
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<ScanReceiptCommand>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ScanReceiptResult(parsedReceipt));
+
+		// Act
+		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
+
+		// Assert
+		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
+		response.DroppedPageCount.Should().Be(0);
+	}
+
+	[Fact]
 	public async Task ScanReceipt_MultiPayment_ReturnsAllPaymentsInResponse()
 	{
 		// Arrange — split-tender receipt (gift card + card). The response must carry both


### PR DESCRIPTION
## Summary

- `ScanReceiptResult` now carries `DroppedPageCount`, set to the number of PDF pages silently ignored during VLM extraction (page 2..N for multi-page PDFs, 0 otherwise).
- Plumbed through to `ProposedReceiptResponse` (OpenAPI spec, generated DTO, controller mapping, generated TypeScript types).
- React new-receipt wizard renders a banner when `droppedPageCount > 0`, telling the user the proposal only covers page 1.
- Updated OpenAPI endpoint description and controller `[EndpointDescription]` to match reality (RECEIPTS-629 already corrected the rasterization claim — this adds the warning piece).

Resolves RECEIPTS-637.

## Test plan

- Handler tests cover 3-page PDF -> `DroppedPageCount = 2`, single-page PDF -> 0, image -> 0.
- Controller tests verify the count propagates onto `ProposedReceiptResponse`.
- React tests cover the banner showing/hiding logic and `ScanReceiptPage` propagating `droppedPageCount` to the wizard.
- MSW fixture and shape-locking test updated.
- Full suites: `dotnet test Receipts.slnx --filter "Category!=Integration"` (2445 tests pass), `npm run test` (1929 tests pass), `spectral lint`, `dotnet format --verify-no-changes`, `npm run generate:types:check`.

## Notes

- Conflict alert acknowledged: minimal touch to `ScanReceiptCommandHandler.cs` (kept `LogInformation` line, only computed `droppedPageCount`). RECEIPTS-640 hardening should rebase cleanly.
- Base branch is the parent epic `feat/receipts-616-vlm-receipt-extraction` (per the issue tree).