### PR TITLE
fix(infra): vlm eval scoring + CLI honesty (RECEIPTS-634)

### DIFF
--- a/src/Tools/VlmEval/EvalRunner.cs
+++ b/src/Tools/VlmEval/EvalRunner.cs
@@ -13,27 +13,37 @@ public sealed class EvalRunner(
 	VlmEvalOptions options,
 	ILogger<EvalRunner> logger)
 {
+	/// <summary>POSIX exit code for SIGINT (cancellation).</summary>
+	private const int ExitCodeCancelled = 130;
+
 	public async Task<int> RunAsync(string fixturesDirectory, CancellationToken cancellationToken)
 	{
 		string ollamaUrl = vlmOptions.OllamaUrl ?? "(unset)";
+		DateTimeOffset startedAt = DateTimeOffset.UtcNow;
 		reporter.PrintHeader(ollamaUrl, fixturesDirectory);
 
+		// Missing fixtures dir is a configuration error: a typo'd FixturesPath looks identical
+		// to "no fixtures yet" if we silently mkdir. Treat it as failure when the strict flag
+		// is set; otherwise warn and exit 0 to preserve the "always green when flag off" contract.
 		if (!Directory.Exists(fixturesDirectory))
 		{
-			try
-			{
-				Directory.CreateDirectory(fixturesDirectory);
-			}
-			catch (Exception ex)
-			{
-				logger.LogError(ex, "Failed to create fixtures directory at {Path}", fixturesDirectory);
-				return 1;
-			}
+			reporter.PrintMissingFixturesDirectory(fixturesDirectory);
+			reporter.WriteReport(
+				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
+				results: [],
+				totalElapsed: TimeSpan.Zero,
+				cancelled: false);
+			return options.FailOnAnyFixtureFailure ? 1 : 0;
 		}
 
 		if (!await IsOllamaReachableAsync(cancellationToken))
 		{
 			reporter.PrintOllamaUnreachable(ollamaUrl);
+			reporter.WriteReport(
+				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
+				results: [],
+				totalElapsed: TimeSpan.Zero,
+				cancelled: false);
 			return 1;
 		}
 
@@ -42,7 +52,12 @@ public sealed class EvalRunner(
 		if (loaded.Fixtures.Count == 0 && loaded.OrphanFiles.Count == 0)
 		{
 			reporter.PrintEmptyFixturesDirectory(fixturesDirectory);
-			return 0;
+			reporter.WriteReport(
+				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
+				results: [],
+				totalElapsed: TimeSpan.Zero,
+				cancelled: false);
+			return options.FailOnAnyFixtureFailure ? 1 : 0;
 		}
 
 		foreach (string orphan in loaded.OrphanFiles)
@@ -53,15 +68,22 @@ public sealed class EvalRunner(
 		if (loaded.Fixtures.Count == 0)
 		{
 			reporter.PrintNoValidFixtures();
-			return 0;
+			reporter.WriteReport(
+				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
+				results: [],
+				totalElapsed: TimeSpan.Zero,
+				cancelled: false);
+			return options.FailOnAnyFixtureFailure ? 1 : 0;
 		}
 
 		Stopwatch total = Stopwatch.StartNew();
 		List<FixtureResult> results = [];
+		bool cancelled = false;
 		foreach (Fixture fixture in loaded.Fixtures)
 		{
 			if (cancellationToken.IsCancellationRequested)
 			{
+				cancelled = true;
 				break;
 			}
 
@@ -71,7 +93,23 @@ public sealed class EvalRunner(
 		}
 		total.Stop();
 
+		if (cancelled)
+		{
+			reporter.PrintCancelled(results.Count, loaded.Fixtures.Count);
+			reporter.WriteReport(
+				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
+				results,
+				total.Elapsed,
+				cancelled: true);
+			return ExitCodeCancelled;
+		}
+
 		reporter.PrintSummary(results, total.Elapsed);
+		reporter.WriteReport(
+			new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
+			results,
+			total.Elapsed,
+			cancelled: false);
 
 		if (!options.FailOnAnyFixtureFailure)
 		{

--- a/src/Tools/VlmEval/EvalRunner.cs
+++ b/src/Tools/VlmEval/EvalRunner.cs
@@ -90,6 +90,17 @@ public sealed class EvalRunner(
 			FixtureResult result = await fixtureEvaluator.EvaluateAsync(fixture, cancellationToken);
 			reporter.PrintFixtureResult(result);
 			results.Add(result);
+
+			// EvaluateAsync's broad catch blocks (file IO, VLM call) swallow
+			// OperationCanceledException and return a normal failure result. Without this
+			// post-iteration check, cancellation that fires during the LAST fixture would not
+			// be detected — the loop would exit naturally and we'd return 0 or 1 instead of 130
+			// (and the structured report's `cancelled` field would lie). RECEIPTS-634 follow-up.
+			if (cancellationToken.IsCancellationRequested)
+			{
+				cancelled = true;
+				break;
+			}
 		}
 		total.Stop();
 

--- a/src/Tools/VlmEval/ExpectedReceipt.cs
+++ b/src/Tools/VlmEval/ExpectedReceipt.cs
@@ -30,6 +30,14 @@ public sealed class ExpectedReceipt
 
 	[JsonPropertyName("notes")]
 	public string? Notes { get; set; }
+
+	/// <summary>
+	/// Optional per-fixture override for money comparison tolerance. When unset, falls back to
+	/// <see cref="VlmEvalOptions.MoneyTolerance"/> (default $0.01). Useful for receipts where the
+	/// VLM is known to round to a different precision (e.g. $0.05 for some POS systems).
+	/// </summary>
+	[JsonPropertyName("moneyTolerance")]
+	public decimal? MoneyTolerance { get; set; }
 }
 
 public sealed class ExpectedTaxLine

--- a/src/Tools/VlmEval/FixtureEvaluator.cs
+++ b/src/Tools/VlmEval/FixtureEvaluator.cs
@@ -8,9 +8,15 @@ namespace VlmEval;
 
 public sealed class FixtureEvaluator(
 	IReceiptExtractionService extractionService,
+	VlmEvalOptions options,
 	ILogger<FixtureEvaluator> logger)
 {
-	private const decimal MoneyTolerance = 0.01m;
+	/// <summary>
+	/// Default money comparison tolerance used when no <see cref="VlmEvalOptions"/> or sidecar
+	/// override is provided. Kept as a constant so the static diff helpers (called by tests)
+	/// have a deterministic default. Comparisons are inclusive: <c>|delta| &lt;= tolerance</c>.
+	/// </summary>
+	internal const decimal DefaultMoneyTolerance = 0.01m;
 
 	public async Task<FixtureResult> EvaluateAsync(Fixture fixture, CancellationToken cancellationToken)
 	{
@@ -40,15 +46,17 @@ public sealed class FixtureEvaluator(
 
 		stopwatch.Stop();
 
+		decimal tolerance = fixture.Expected.MoneyTolerance ?? options.MoneyTolerance;
+
 		List<FieldDiff> diffs = [];
 		diffs.Add(DiffStore(fixture.Expected.Store, parsed.StoreName));
 		diffs.Add(DiffDate(fixture.Expected.Date, parsed.Date));
-		diffs.Add(DiffMoney("subtotal", fixture.Expected.Subtotal, parsed.Subtotal));
-		diffs.Add(DiffMoney("total", fixture.Expected.Total, parsed.Total));
-		diffs.Add(DiffTaxLines(fixture.Expected.TaxLines, parsed.TaxLines));
+		diffs.Add(DiffMoney("subtotal", fixture.Expected.Subtotal, parsed.Subtotal, tolerance));
+		diffs.Add(DiffMoney("total", fixture.Expected.Total, parsed.Total, tolerance));
+		diffs.Add(DiffTaxLines(fixture.Expected.TaxLines, parsed.TaxLines, tolerance));
 		diffs.Add(DiffPaymentMethod(fixture.Expected.PaymentMethod, parsed.PaymentMethod));
 		diffs.Add(DiffMinItemCount(fixture.Expected.MinItemCount, parsed.Items));
-		diffs.AddRange(DiffItems(fixture.Expected.Items, parsed.Items));
+		diffs.AddRange(DiffItems(fixture.Expected.Items, parsed.Items, tolerance));
 
 		bool allDeclaredPassed = diffs.All(d => d.Status != DiffStatus.Fail);
 
@@ -97,7 +105,7 @@ public sealed class FixtureEvaluator(
 			null);
 	}
 
-	internal static FieldDiff DiffMoney(string field, decimal? expected, FieldConfidence<decimal> actual)
+	internal static FieldDiff DiffMoney(string field, decimal? expected, FieldConfidence<decimal> actual, decimal tolerance = DefaultMoneyTolerance)
 	{
 		if (expected is null)
 		{
@@ -110,7 +118,7 @@ public sealed class FixtureEvaluator(
 		}
 
 		decimal delta = Math.Abs(actual.Value - expected.Value);
-		bool match = delta < MoneyTolerance;
+		bool match = delta <= tolerance;
 		return new FieldDiff(
 			field,
 			match ? DiffStatus.Pass : DiffStatus.Fail,
@@ -122,13 +130,18 @@ public sealed class FixtureEvaluator(
 			f.IsPresent ? f.Value.ToString("0.00", CultureInfo.InvariantCulture) : null;
 	}
 
-	internal static FieldDiff DiffTaxLines(List<ExpectedTaxLine>? expected, List<ParsedTaxLine> actual)
+	internal static FieldDiff DiffTaxLines(List<ExpectedTaxLine>? expected, List<ParsedTaxLine> actual, decimal tolerance = DefaultMoneyTolerance)
 	{
 		if (expected is null || expected.Count == 0)
 		{
 			return new FieldDiff("taxLines", DiffStatus.NotDeclared, null, $"actual={actual.Count}", null);
 		}
 
+		// Greedy, input-order-stable matching: expected tax lines are matched against the actual
+		// pool in declaration order. Each pass picks the closest still-unmatched actual amount
+		// within `tolerance` and removes it from the pool. With duplicate prices the first
+		// expected line consumes the first matching actual, so behavior is deterministic but
+		// not optimal (no global assignment / Hungarian algorithm). Documented in README.
 		List<decimal> actualAmounts = [.. actual
 			.Where(t => t.Amount.IsPresent)
 			.Select(t => t.Amount.Value)];
@@ -143,10 +156,10 @@ public sealed class FixtureEvaluator(
 			}
 
 			decimal wanted = declared.Amount.Value;
-			int idx = FindClosest(actualAmounts, wanted, MoneyTolerance);
+			int idx = FindClosest(actualAmounts, wanted, tolerance);
 			if (idx < 0)
 			{
-				failures.Add($"no tax line within ${MoneyTolerance:0.00} of ${wanted:0.00}");
+				failures.Add($"no tax line within ${tolerance.ToString("0.00", CultureInfo.InvariantCulture)} of ${wanted.ToString("0.00", CultureInfo.InvariantCulture)}");
 				continue;
 			}
 
@@ -170,7 +183,10 @@ public sealed class FixtureEvaluator(
 		for (int i = 0; i < pool.Count; i++)
 		{
 			decimal delta = Math.Abs(pool[i] - target);
-			if (delta < tolerance && delta < bestDelta)
+			// Inclusive bound (delta == tolerance must pass) — see RECEIPTS-634. On ties (delta
+			// equality with bestDelta) the earlier index wins because we use `<` here, which makes
+			// the result stable and input-order-deterministic for duplicates in the pool.
+			if (delta <= tolerance && delta < bestDelta)
 			{
 				bestDelta = delta;
 				bestIndex = i;
@@ -216,13 +232,20 @@ public sealed class FixtureEvaluator(
 			match ? null : $"expected at least {expected.Value} items, got {actual.Count}");
 	}
 
-	internal static List<FieldDiff> DiffItems(List<ExpectedItem>? expected, List<ParsedReceiptItem> actual)
+	internal static List<FieldDiff> DiffItems(List<ExpectedItem>? expected, List<ParsedReceiptItem> actual, decimal tolerance = DefaultMoneyTolerance)
 	{
 		if (expected is null || expected.Count == 0)
 		{
 			return [];
 		}
 
+		// Matching strategy (greedy, deterministic — see README "Diff rules"):
+		//   1. If expected has a totalPrice, match against the unmatched pool entry with the
+		//      closest price within `tolerance`.
+		//   2. If no price match (or expected has no price), fall back to the FIRST pool entry
+		//      whose description contains expected.Description (substring, case-insensitive).
+		//   3. The matched pool entry is removed so it cannot be matched again.
+		// Item-list ordering of `expected` matters: earlier entries claim pool entries first.
 		List<ParsedReceiptItem> pool = [.. actual];
 		List<FieldDiff> results = [];
 
@@ -249,7 +272,8 @@ public sealed class FixtureEvaluator(
 						continue;
 					}
 					decimal delta = Math.Abs(pool[p].TotalPrice.Value - target);
-					if (delta < MoneyTolerance && delta < best)
+					// Inclusive bound — RECEIPTS-634. Tie-break by earlier index.
+					if (delta <= tolerance && delta < best)
 					{
 						best = delta;
 						matchedIndex = p;
@@ -259,6 +283,7 @@ public sealed class FixtureEvaluator(
 
 			if (matchedIndex < 0 && item.Description is not null)
 			{
+				// First-substring-hit fallback. Documented in README "Diff rules".
 				for (int p = 0; p < pool.Count; p++)
 				{
 					if (!string.IsNullOrWhiteSpace(pool[p].Description.Value)
@@ -298,7 +323,7 @@ public sealed class FixtureEvaluator(
 				{
 					issues.Add("missing totalPrice");
 				}
-				else if (Math.Abs(matched.TotalPrice.Value - item.TotalPrice.Value) >= MoneyTolerance)
+				else if (Math.Abs(matched.TotalPrice.Value - item.TotalPrice.Value) > tolerance)
 				{
 					issues.Add($"totalPrice mismatch (expected={item.TotalPrice.Value:0.00}, actual={matched.TotalPrice.Value:0.00})");
 				}

--- a/src/Tools/VlmEval/FixtureResult.cs
+++ b/src/Tools/VlmEval/FixtureResult.cs
@@ -20,3 +20,12 @@ public sealed record FieldDiff(
 	string? Expected,
 	string? Actual,
 	string? Detail);
+
+/// <summary>
+/// Per-run metadata embedded in structured reports. Captured at run start so the report
+/// reflects the configured environment (Ollama URL, fixtures path) at the time of the run.
+/// </summary>
+public sealed record RunInfo(
+	DateTimeOffset StartedAt,
+	string OllamaUrl,
+	string FixturesPath);

--- a/src/Tools/VlmEval/Program.cs
+++ b/src/Tools/VlmEval/Program.cs
@@ -26,6 +26,14 @@ if (evalOptions.OllamaTimeoutSeconds > 0)
 	vlmOptions.TimeoutSeconds = evalOptions.OllamaTimeoutSeconds;
 }
 
+// CLI args take precedence over env/appsettings — typical for tools where you want to override
+// just one knob (--report-path) without unsetting it from your shell. Supported:
+//   --output console|json|markdown   (sets VlmEval:OutputFormat)
+//   --report-path <path>             (sets VlmEval:ReportPath)
+// Unknown flags are ignored to remain compatible with future hosts (e.g. Aspire) that may pass
+// extra args.
+ParseCliArgs(args, evalOptions);
+
 string fixturesPath = Path.GetFullPath(evalOptions.FixturesPath);
 
 builder.Services.AddSingleton(evalOptions);
@@ -64,4 +72,24 @@ catch (Exception ex)
 	ILogger logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("VlmEval");
 	logger.LogCritical(ex, "VlmEval terminated with an unhandled exception.");
 	return 1;
+}
+
+static void ParseCliArgs(string[] args, VlmEvalOptions options)
+{
+	for (int i = 0; i < args.Length; i++)
+	{
+		string arg = args[i];
+		if (string.Equals(arg, "--output", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+		{
+			string value = args[++i];
+			if (Enum.TryParse(value, ignoreCase: true, out ReportOutputFormat format))
+			{
+				options.OutputFormat = format;
+			}
+		}
+		else if (string.Equals(arg, "--report-path", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+		{
+			options.ReportPath = args[++i];
+		}
+	}
 }

--- a/src/Tools/VlmEval/README.md
+++ b/src/Tools/VlmEval/README.md
@@ -26,11 +26,23 @@ You can also run it outside Aspire:
 ```bash
 # requires a reachable Ollama with glm-ocr:q8_0 (or whatever model is configured)
 dotnet run --project src/Tools/VlmEval
+
+# write a structured artifact alongside the console log
+dotnet run --project src/Tools/VlmEval -- --output json --report-path eval-report.json
 ```
 
-Exit code `0` means every fixture passed its declared assertions; `1` means
-at least one failed or Ollama was unreachable. Set
-`VlmEval__FailOnAnyFixtureFailure=false` to always exit `0`.
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All declared fixtures passed (or `VlmEval__FailOnAnyFixtureFailure=false` and no hard error). |
+| `1` | At least one fixture failed, Ollama was unreachable, the fixtures directory was missing, or no valid fixtures were found while `FailOnAnyFixtureFailure=true`. |
+| `130` | Cancelled mid-run (Ctrl+C / SIGINT). The structured report still flushes with the partial results. |
+
+`FailOnAnyFixtureFailure=true` (the default) is strict: missing/empty fixtures
+exit `1` so a typo'd `VlmEval__FixturesPath` cannot pass green. Set
+`VlmEval__FailOnAnyFixtureFailure=false` to relax this and exit `0` whenever
+the run completes without an infrastructure error.
 
 ## Fixtures
 
@@ -72,15 +84,42 @@ expected values.
 |-------|------|
 | `store` | case-insensitive substring match |
 | `date` | exact match |
-| `subtotal`, `total` | within $0.01 of expected |
-| `taxLines[].amount` | each expected amount must match some actual amount within $0.01; actual may contain more lines |
+| `subtotal`, `total` | inclusive within `MoneyTolerance` of expected (default $0.01: a delta of exactly $0.01 passes) |
+| `taxLines[].amount` | each expected amount must match some actual amount within `MoneyTolerance`; actual may contain more lines |
 | `taxLines[].label` | case-insensitive substring when declared |
 | `paymentMethod` | case-insensitive substring (`"MASTERCARD"` matches `"MasterCard ****1234"`) |
 | `minItemCount` | `actual items count >= expected` |
-| `items[].description` | case-insensitive substring, matched against the line with the closest `totalPrice` if declared, else by index |
-| `items[].totalPrice` | within $0.01 |
+| `items[].description` | case-insensitive substring; matched against the line with the closest `totalPrice` if declared, else first-substring-hit fallback |
+| `items[].totalPrice` | inclusive within `MoneyTolerance` |
 
 Undeclared fields are ignored (reported as `NotDeclared`), never failed.
+
+#### Tolerance overrides
+
+`MoneyTolerance` defaults to `$0.01` and can be overridden per run via
+`VlmEval__MoneyTolerance` or per fixture by adding `"moneyTolerance": 0.05` to
+the sidecar JSON. Per-fixture overrides take precedence and apply to
+`subtotal`, `total`, `taxLines[].amount`, and `items[].totalPrice` for that
+single fixture only.
+
+#### Matching algorithm
+
+The tax-line and item matchers are **greedy and input-order-stable**:
+
+- Expected entries are processed in declaration order.
+- For each expected entry, the matcher picks the still-unmatched actual entry
+  with the smallest delta within `MoneyTolerance`. On ties, the earlier index
+  wins.
+- The matched actual entry is consumed and cannot be reused.
+- For `items[]`, if no price-based match exists (or no price was declared),
+  the matcher falls back to the **first** unmatched actual line whose
+  description contains the expected description (case-insensitive substring).
+  This is deterministic but not optimal — when multiple actual lines share a
+  description, the earlier one wins.
+
+This is not a globally optimal assignment (no Hungarian algorithm) — it is
+deliberately predictable so failures point at a specific actual line rather
+than shuffling on every run.
 
 ### Naming convention
 
@@ -126,6 +165,9 @@ If the suite passes on those values, RECEIPTS-611 is closed end-to-end.
 | `VlmEval:FixturesPath` | `fixtures/vlm-eval` | `appsettings.json`, env (`VlmEval__FixturesPath`), Aspire injects an absolute path |
 | `VlmEval:OllamaTimeoutSeconds` | `180` | `appsettings.json`, env (`VlmEval__OllamaTimeoutSeconds`) |
 | `VlmEval:FailOnAnyFixtureFailure` | `true` | `appsettings.json`, env (`VlmEval__FailOnAnyFixtureFailure`) |
+| `VlmEval:MoneyTolerance` | `0.01` | `appsettings.json`, env (`VlmEval__MoneyTolerance`); per-fixture override via sidecar `"moneyTolerance"` |
+| `VlmEval:OutputFormat` | `Console` | `appsettings.json`, env (`VlmEval__OutputFormat`), CLI `--output console\|json\|markdown` |
+| `VlmEval:ReportPath` | *(unset)* | `appsettings.json`, env (`VlmEval__ReportPath`), CLI `--report-path <path>` |
 | `Ocr:Vlm:OllamaUrl` | *(unset)* | env (`Ocr__Vlm__OllamaUrl`), takes precedence over `Ollama:BaseUrl` |
 | `Ollama:BaseUrl` | *(Aspire-injected)* | env; falls back to `http://localhost:11434` |
 | `Ocr:Vlm:Model` | `glm-ocr:q8_0` | env (`Ocr__Vlm__Model`) |

--- a/src/Tools/VlmEval/Reporter.cs
+++ b/src/Tools/VlmEval/Reporter.cs
@@ -1,10 +1,23 @@
 using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace VlmEval;
 
-public sealed class Reporter(ILogger<Reporter> logger)
+public sealed class Reporter(VlmEvalOptions options, ILogger<Reporter> logger)
 {
+	// Indented + camelCase so the artifact is human-diffable in CI logs and obvious to consume
+	// from JS/TS regression-baseline tooling. JsonStringEnumConverter keeps DiffStatus readable
+	// (e.g. "Pass") rather than as integers.
+	private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+	{
+		WriteIndented = true,
+		Converters = { new JsonStringEnumConverter() },
+		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+	};
+
 	public void PrintHeader(string ollamaUrl, string fixturesPath)
 	{
 		logger.LogInformation("VLM accuracy eval — {Timestamp}", DateTimeOffset.UtcNow.ToString("u", CultureInfo.InvariantCulture));
@@ -15,6 +28,13 @@ public sealed class Reporter(ILogger<Reporter> logger)
 	public void PrintOllamaUnreachable(string ollamaUrl)
 	{
 		logger.LogError("Ollama is not reachable at {Url}. Verify the vlm-ocr container is running.", ollamaUrl);
+	}
+
+	public void PrintMissingFixturesDirectory(string path)
+	{
+		logger.LogError(
+			"Fixtures directory does not exist: {Path}. Check VlmEval__FixturesPath — a typo'd path is treated as a hard error to avoid silently passing on no input.",
+			path);
 	}
 
 	public void PrintEmptyFixturesDirectory(string path)
@@ -89,6 +109,150 @@ public sealed class Reporter(ILogger<Reporter> logger)
 		}
 	}
 
+	public void PrintCancelled(int processed, int total)
+	{
+		logger.LogWarning(
+			"Eval cancelled — {Processed} of {Total} fixtures evaluated.",
+			processed,
+			total);
+	}
+
+	/// <summary>
+	/// Writes a structured machine-readable report to <see cref="VlmEvalOptions.ReportPath"/> if
+	/// configured. Honors <see cref="VlmEvalOptions.OutputFormat"/>: <c>Console</c> is a no-op
+	/// (only loggers run), <c>Json</c> emits the canonical artifact, <c>Markdown</c> emits a
+	/// human-diffable scorecard. Idempotent on empty results — used by EvalRunner to flush a
+	/// report even on early-exit paths so CI always finds an artifact at the configured path.
+	/// </summary>
+	public void WriteReport(RunInfo run, IReadOnlyList<FixtureResult> results, TimeSpan totalElapsed, bool cancelled)
+	{
+		if (options.OutputFormat == ReportOutputFormat.Console)
+		{
+			return;
+		}
+
+		if (string.IsNullOrWhiteSpace(options.ReportPath))
+		{
+			logger.LogWarning(
+				"OutputFormat={Format} but ReportPath is not set; skipping artifact write.",
+				options.OutputFormat);
+			return;
+		}
+
+		try
+		{
+			string? directory = Path.GetDirectoryName(options.ReportPath);
+			if (!string.IsNullOrEmpty(directory))
+			{
+				Directory.CreateDirectory(directory);
+			}
+
+			string content = options.OutputFormat switch
+			{
+				ReportOutputFormat.Json => RenderJson(run, results, totalElapsed, cancelled),
+				ReportOutputFormat.Markdown => RenderMarkdown(run, results, totalElapsed, cancelled),
+				_ => string.Empty,
+			};
+
+			File.WriteAllText(options.ReportPath, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+			logger.LogInformation("Report written: {Path}", options.ReportPath);
+		}
+		catch (Exception ex)
+		{
+			// Failing to write the artifact must not crash the eval loop; logging it is
+			// sufficient because the exit code already reflects the eval outcome.
+			logger.LogError(ex, "Failed to write report to {Path}", options.ReportPath);
+		}
+	}
+
+	internal static string RenderJson(RunInfo run, IReadOnlyList<FixtureResult> results, TimeSpan totalElapsed, bool cancelled)
+	{
+		ReportArtifact artifact = BuildArtifact(run, results, totalElapsed, cancelled);
+		return JsonSerializer.Serialize(artifact, JsonOptions);
+	}
+
+	internal static string RenderMarkdown(RunInfo run, IReadOnlyList<FixtureResult> results, TimeSpan totalElapsed, bool cancelled)
+	{
+		StringBuilder sb = new();
+		sb.AppendLine("# VLM eval report");
+		sb.AppendLine();
+		sb.Append("- Started: `").Append(run.StartedAt.ToString("u", CultureInfo.InvariantCulture)).AppendLine("`");
+		sb.Append("- Ollama URL: `").Append(run.OllamaUrl).AppendLine("`");
+		sb.Append("- Fixtures path: `").Append(run.FixturesPath).AppendLine("`");
+		sb.Append("- Cancelled: ").AppendLine(cancelled ? "yes" : "no");
+		sb.AppendLine();
+
+		int passed = results.Count(r => r.Passed);
+		int failed = results.Count - passed;
+		sb.AppendLine("## Summary");
+		sb.AppendLine();
+		sb.Append("- Total: ").AppendLine(results.Count.ToString(CultureInfo.InvariantCulture));
+		sb.Append("- Passed: ").AppendLine(passed.ToString(CultureInfo.InvariantCulture));
+		sb.Append("- Failed: ").AppendLine(failed.ToString(CultureInfo.InvariantCulture));
+		sb.Append("- Elapsed: ").AppendLine(FormatElapsed(totalElapsed));
+		sb.AppendLine();
+
+		sb.AppendLine("## Fixtures");
+		sb.AppendLine();
+		if (results.Count == 0)
+		{
+			sb.AppendLine("_No fixtures evaluated._");
+			return sb.ToString();
+		}
+
+		sb.AppendLine("| Fixture | Result | Elapsed | Notes |");
+		sb.AppendLine("|---------|--------|---------|-------|");
+		foreach (FixtureResult result in results)
+		{
+			string status = result.Passed ? "PASS" : "FAIL";
+			string note;
+			if (result.Error is not null)
+			{
+				note = $"ERROR: {EscapeMarkdownCell(result.Error)}";
+			}
+			else
+			{
+				IEnumerable<FieldDiff> failures = result.FieldDiffs.Where(d => d.Status == DiffStatus.Fail);
+				note = string.Join("; ", failures.Select(f => EscapeMarkdownCell($"{f.Field}: {f.Detail ?? "fail"}")));
+				if (string.IsNullOrEmpty(note))
+				{
+					note = "—";
+				}
+			}
+			sb.Append("| ").Append(EscapeMarkdownCell(result.FixtureName))
+				.Append(" | ").Append(status)
+				.Append(" | ").Append(FormatElapsed(result.Elapsed))
+				.Append(" | ").Append(note)
+				.AppendLine(" |");
+		}
+		return sb.ToString();
+	}
+
+	private static ReportArtifact BuildArtifact(RunInfo run, IReadOnlyList<FixtureResult> results, TimeSpan totalElapsed, bool cancelled)
+	{
+		int passed = results.Count(r => r.Passed);
+		int failed = results.Count - passed;
+		List<FixtureReport> fixtures = [.. results.Select(r => new FixtureReport(
+			r.FixtureName,
+			r.Passed,
+			(long)r.Elapsed.TotalMilliseconds,
+			r.Error,
+			[.. r.FieldDiffs.Select(d => new FieldDiffReport(d.Field, d.Status, d.Expected, d.Actual, d.Detail))]))];
+
+		return new ReportArtifact(
+			new RunReport(run.StartedAt, run.OllamaUrl, run.FixturesPath, cancelled),
+			fixtures,
+			new SummaryReport(results.Count, passed, failed, (long)totalElapsed.TotalMilliseconds));
+	}
+
+	private static string EscapeMarkdownCell(string value)
+	{
+		// Pipes break Markdown table cells; newlines collapse the row. Escape both.
+		return value.Replace("|", "\\|", StringComparison.Ordinal)
+			.Replace("\r\n", " ", StringComparison.Ordinal)
+			.Replace("\n", " ", StringComparison.Ordinal);
+	}
+
 	private static string FormatElapsed(TimeSpan elapsed)
 	{
 		return elapsed.TotalSeconds < 60
@@ -116,4 +280,37 @@ public sealed class Reporter(ILogger<Reporter> logger)
 		}
 		return string.Join(" ", parts);
 	}
+
+	// Internal serialization shapes — kept private records so the public Reporter API stays
+	// decoupled from the on-disk format (we can rev the artifact without breaking callers).
+	internal sealed record ReportArtifact(
+		[property: JsonPropertyName("run")] RunReport Run,
+		[property: JsonPropertyName("fixtures")] IReadOnlyList<FixtureReport> Fixtures,
+		[property: JsonPropertyName("summary")] SummaryReport Summary);
+
+	internal sealed record RunReport(
+		[property: JsonPropertyName("startedAt")] DateTimeOffset StartedAt,
+		[property: JsonPropertyName("ollamaUrl")] string OllamaUrl,
+		[property: JsonPropertyName("fixturesPath")] string FixturesPath,
+		[property: JsonPropertyName("cancelled")] bool Cancelled);
+
+	internal sealed record FixtureReport(
+		[property: JsonPropertyName("name")] string Name,
+		[property: JsonPropertyName("passed")] bool Passed,
+		[property: JsonPropertyName("elapsedMs")] long ElapsedMs,
+		[property: JsonPropertyName("error")] string? Error,
+		[property: JsonPropertyName("diffs")] IReadOnlyList<FieldDiffReport> Diffs);
+
+	internal sealed record FieldDiffReport(
+		[property: JsonPropertyName("field")] string Field,
+		[property: JsonPropertyName("status")] DiffStatus Status,
+		[property: JsonPropertyName("expected")] string? Expected,
+		[property: JsonPropertyName("actual")] string? Actual,
+		[property: JsonPropertyName("detail")] string? Detail);
+
+	internal sealed record SummaryReport(
+		[property: JsonPropertyName("total")] int Total,
+		[property: JsonPropertyName("passed")] int Passed,
+		[property: JsonPropertyName("failed")] int Failed,
+		[property: JsonPropertyName("elapsedMs")] long ElapsedMs);
 }

--- a/src/Tools/VlmEval/VlmEvalOptions.cs
+++ b/src/Tools/VlmEval/VlmEvalOptions.cs
@@ -7,4 +7,30 @@ public sealed class VlmEvalOptions
 	public int OllamaTimeoutSeconds { get; set; } = 180;
 
 	public bool FailOnAnyFixtureFailure { get; set; } = true;
+
+	/// <summary>
+	/// Default tolerance applied when comparing money fields (subtotal, total, tax line amounts,
+	/// item totalPrice). The check is inclusive: <c>|expected - actual| &lt;= MoneyTolerance</c>
+	/// passes. A fixture sidecar may override this via <c>"moneyTolerance": 0.05</c>.
+	/// </summary>
+	public decimal MoneyTolerance { get; set; } = 0.01m;
+
+	/// <summary>
+	/// When set, a structured report of the run is written to this file path. The format is
+	/// determined by <see cref="OutputFormat"/>.
+	/// </summary>
+	public string? ReportPath { get; set; }
+
+	/// <summary>
+	/// Format used when writing <see cref="ReportPath"/>. Console output to logs always happens
+	/// regardless. <c>Console</c> means the file output is skipped.
+	/// </summary>
+	public ReportOutputFormat OutputFormat { get; set; } = ReportOutputFormat.Console;
+}
+
+public enum ReportOutputFormat
+{
+	Console,
+	Json,
+	Markdown,
 }

--- a/tests/VlmEval.Tests/EvalRunnerTests.cs
+++ b/tests/VlmEval.Tests/EvalRunnerTests.cs
@@ -1,0 +1,338 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using Application.Interfaces.Services;
+using Application.Models.Ocr;
+using FluentAssertions;
+using Infrastructure.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+
+namespace VlmEval.Tests;
+
+/// <summary>
+/// Tests covering <see cref="EvalRunner"/> exit codes and the cancellation /
+/// missing-fixtures-directory semantics introduced in RECEIPTS-634.
+///
+/// <para>
+/// These tests fake just enough HTTP and extraction-service plumbing to drive the runner
+/// without spinning up Aspire. The reporter is a real instance writing to a temp directory so
+/// the structured-artifact behavior is exercised end-to-end.
+/// </para>
+/// </summary>
+public class EvalRunnerTests : IDisposable
+{
+	private readonly string _tempDir;
+
+	public EvalRunnerTests()
+	{
+		_tempDir = Path.Combine(Path.GetTempPath(), "vlmeval-runner-tests-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDir);
+	}
+
+	public void Dispose()
+	{
+		try
+		{
+			if (Directory.Exists(_tempDir))
+			{
+				Directory.Delete(_tempDir, recursive: true);
+			}
+		}
+		catch
+		{
+			// Best-effort cleanup.
+		}
+		GC.SuppressFinalize(this);
+	}
+
+	[Fact]
+	public async Task RunAsync_MissingFixturesDirectory_FailFlagOn_ReturnsOne()
+	{
+		// RECEIPTS-634: a missing fixtures directory must NOT be silently created and reported
+		// as success. With FailOnAnyFixtureFailure=true (the default), it returns exit 1.
+		string missing = Path.Combine(_tempDir, "does-not-exist");
+		EvalRunner runner = BuildRunner(
+			fixturesDir: missing,
+			ollamaReachable: true,
+			extractionResult: null,
+			options: new VlmEvalOptions { FailOnAnyFixtureFailure = true });
+
+		int exit = await runner.RunAsync(missing, CancellationToken.None);
+
+		exit.Should().Be(1);
+		Directory.Exists(missing).Should().BeFalse(because: "the runner must not auto-create the directory");
+	}
+
+	[Fact]
+	public async Task RunAsync_MissingFixturesDirectory_FailFlagOff_ReturnsZero()
+	{
+		// With FailOnAnyFixtureFailure=false the contract is "always green when the run
+		// completes without infra error". Missing directory still doesn't get auto-created
+		// silently — but the exit code is 0 to honor the flag.
+		string missing = Path.Combine(_tempDir, "still-missing");
+		EvalRunner runner = BuildRunner(
+			fixturesDir: missing,
+			ollamaReachable: true,
+			extractionResult: null,
+			options: new VlmEvalOptions { FailOnAnyFixtureFailure = false });
+
+		int exit = await runner.RunAsync(missing, CancellationToken.None);
+
+		exit.Should().Be(0);
+		Directory.Exists(missing).Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task RunAsync_EmptyFixturesDirectory_FailFlagOn_ReturnsOne()
+	{
+		// Directory exists but contains no fixture files. With the strict flag, this is also
+		// a hard error (covers the "I committed an empty fixtures dir to CI" case).
+		EvalRunner runner = BuildRunner(
+			fixturesDir: _tempDir,
+			ollamaReachable: true,
+			extractionResult: null,
+			options: new VlmEvalOptions { FailOnAnyFixtureFailure = true });
+
+		int exit = await runner.RunAsync(_tempDir, CancellationToken.None);
+
+		exit.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task RunAsync_OllamaUnreachable_AlwaysReturnsOne()
+	{
+		// Infra error: Ollama unreachable always returns 1, regardless of the fail flag.
+		EvalRunner runner = BuildRunner(
+			fixturesDir: _tempDir,
+			ollamaReachable: false,
+			extractionResult: null,
+			options: new VlmEvalOptions { FailOnAnyFixtureFailure = false });
+
+		int exit = await runner.RunAsync(_tempDir, CancellationToken.None);
+
+		exit.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task RunAsync_CancellationMidRun_ReturnsExitCode130()
+	{
+		// RECEIPTS-634: Ctrl+C halfway must return SIGINT exit code, not silent success.
+		// Drop two valid fixtures; cancel the token after the first call begins.
+		WriteFixture("a.jpg", new ExpectedReceipt { Store = "Walmart" });
+		WriteFixture("b.jpg", new ExpectedReceipt { Store = "Walmart" });
+
+		using CancellationTokenSource cts = new();
+		ParsedReceipt parsed = MakeParsed("Walmart");
+
+		Mock<IReceiptExtractionService> service = new();
+		service
+			.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(() =>
+			{
+				// Cancel after the first fixture has been processed so the loop's check at top
+				// of the next iteration trips and breaks out of the loop.
+				cts.Cancel();
+				return parsed;
+			});
+
+		EvalRunner runner = BuildRunner(
+			fixturesDir: _tempDir,
+			ollamaReachable: true,
+			extractionResult: parsed,
+			options: new VlmEvalOptions { FailOnAnyFixtureFailure = true },
+			extractionServiceOverride: service.Object);
+
+		int exit = await runner.RunAsync(_tempDir, cts.Token);
+
+		exit.Should().Be(130, because: "RECEIPTS-634: cancellation must propagate as POSIX SIGINT (130)");
+	}
+
+	[Fact]
+	public async Task RunAsync_AllFixturesPass_ReturnsZero()
+	{
+		WriteFixture("ok.jpg", new ExpectedReceipt { Store = "Walmart" });
+		ParsedReceipt parsed = MakeParsed("Walmart Supercenter");
+		EvalRunner runner = BuildRunner(
+			fixturesDir: _tempDir,
+			ollamaReachable: true,
+			extractionResult: parsed,
+			options: new VlmEvalOptions { FailOnAnyFixtureFailure = true });
+
+		int exit = await runner.RunAsync(_tempDir, CancellationToken.None);
+
+		exit.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task RunAsync_OneFixtureFails_FailFlagOn_ReturnsOne()
+	{
+		WriteFixture("fail.jpg", new ExpectedReceipt { Store = "Walmart" });
+		ParsedReceipt parsed = MakeParsed("Target"); // mismatch
+		EvalRunner runner = BuildRunner(
+			fixturesDir: _tempDir,
+			ollamaReachable: true,
+			extractionResult: parsed,
+			options: new VlmEvalOptions { FailOnAnyFixtureFailure = true });
+
+		int exit = await runner.RunAsync(_tempDir, CancellationToken.None);
+
+		exit.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task RunAsync_JsonReport_WritesStructuredArtifact()
+	{
+		WriteFixture("ok.jpg", new ExpectedReceipt { Store = "Walmart" });
+		ParsedReceipt parsed = MakeParsed("Walmart Supercenter");
+		string reportPath = Path.Combine(_tempDir, "report.json");
+		VlmEvalOptions options = new()
+		{
+			FailOnAnyFixtureFailure = true,
+			OutputFormat = ReportOutputFormat.Json,
+			ReportPath = reportPath,
+		};
+		EvalRunner runner = BuildRunner(_tempDir, ollamaReachable: true, extractionResult: parsed, options);
+
+		int exit = await runner.RunAsync(_tempDir, CancellationToken.None);
+
+		exit.Should().Be(0);
+		File.Exists(reportPath).Should().BeTrue();
+
+		string json = File.ReadAllText(reportPath);
+		using JsonDocument doc = JsonDocument.Parse(json);
+		JsonElement root = doc.RootElement;
+		root.GetProperty("run").GetProperty("ollamaUrl").GetString().Should().NotBeNullOrEmpty();
+		root.GetProperty("run").GetProperty("cancelled").GetBoolean().Should().BeFalse();
+		root.GetProperty("fixtures").GetArrayLength().Should().Be(1);
+		JsonElement fixture0 = root.GetProperty("fixtures")[0];
+		fixture0.GetProperty("name").GetString().Should().Be("ok.jpg");
+		fixture0.GetProperty("passed").GetBoolean().Should().BeTrue();
+		fixture0.GetProperty("elapsedMs").GetInt64().Should().BeGreaterThanOrEqualTo(0);
+		fixture0.GetProperty("diffs").GetArrayLength().Should().BeGreaterThan(0);
+		root.GetProperty("summary").GetProperty("total").GetInt32().Should().Be(1);
+		root.GetProperty("summary").GetProperty("passed").GetInt32().Should().Be(1);
+		root.GetProperty("summary").GetProperty("failed").GetInt32().Should().Be(0);
+	}
+
+	[Fact]
+	public async Task RunAsync_MarkdownReport_WritesHumanReadableArtifact()
+	{
+		WriteFixture("ok.jpg", new ExpectedReceipt { Store = "Walmart" });
+		ParsedReceipt parsed = MakeParsed("Walmart Supercenter");
+		string reportPath = Path.Combine(_tempDir, "report.md");
+		VlmEvalOptions options = new()
+		{
+			FailOnAnyFixtureFailure = true,
+			OutputFormat = ReportOutputFormat.Markdown,
+			ReportPath = reportPath,
+		};
+		EvalRunner runner = BuildRunner(_tempDir, ollamaReachable: true, extractionResult: parsed, options);
+
+		int exit = await runner.RunAsync(_tempDir, CancellationToken.None);
+
+		exit.Should().Be(0);
+		string md = File.ReadAllText(reportPath);
+		md.Should().Contain("# VLM eval report");
+		md.Should().Contain("## Summary");
+		md.Should().Contain("## Fixtures");
+		md.Should().Contain("ok.jpg");
+		md.Should().Contain("PASS");
+	}
+
+	[Fact]
+	public async Task RunAsync_JsonReport_OnMissingDirectory_StillEmitsArtifact()
+	{
+		// Even on early-exit paths (missing dir, infra error) the runner must flush a report so
+		// a CI consumer always finds a parseable artifact at the configured path.
+		string missing = Path.Combine(_tempDir, "missing");
+		string reportPath = Path.Combine(_tempDir, "early-exit.json");
+		VlmEvalOptions options = new()
+		{
+			FailOnAnyFixtureFailure = true,
+			OutputFormat = ReportOutputFormat.Json,
+			ReportPath = reportPath,
+		};
+		EvalRunner runner = BuildRunner(missing, ollamaReachable: true, extractionResult: null, options);
+
+		int exit = await runner.RunAsync(missing, CancellationToken.None);
+
+		exit.Should().Be(1);
+		File.Exists(reportPath).Should().BeTrue();
+		using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(reportPath));
+		doc.RootElement.GetProperty("fixtures").GetArrayLength().Should().Be(0);
+		doc.RootElement.GetProperty("summary").GetProperty("total").GetInt32().Should().Be(0);
+	}
+
+	private void WriteFixture(string name, ExpectedReceipt expected)
+	{
+		string imagePath = Path.Combine(_tempDir, name);
+		File.WriteAllBytes(imagePath, [0xFF, 0xD8, 0xFF]); // JPEG magic
+		string sidecar = imagePath + ".expected.json";
+		File.WriteAllText(sidecar, JsonSerializer.Serialize(expected, new JsonSerializerOptions { WriteIndented = true }));
+	}
+
+	private static ParsedReceipt MakeParsed(string store) =>
+		new(
+			StoreName: FieldConfidence<string>.High(store),
+			Date: FieldConfidence<DateOnly>.None(),
+			Items: [],
+			Subtotal: FieldConfidence<decimal>.None(),
+			TaxLines: [],
+			Total: FieldConfidence<decimal>.None(),
+			PaymentMethod: FieldConfidence<string?>.None());
+
+	private static EvalRunner BuildRunner(
+		string fixturesDir,
+		bool ollamaReachable,
+		ParsedReceipt? extractionResult,
+		VlmEvalOptions options,
+		IReceiptExtractionService? extractionServiceOverride = null)
+	{
+		// Stub the Ollama probe to either succeed or fail — the runner only cares that
+		// IsOllamaReachableAsync returns true/false, and the probe is a single GET to /api/tags.
+		Mock<HttpMessageHandler> probeHandler = new();
+		probeHandler
+			.Protected()
+			.Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+			.ReturnsAsync(new HttpResponseMessage(ollamaReachable ? HttpStatusCode.OK : HttpStatusCode.ServiceUnavailable));
+
+		Mock<IHttpClientFactory> httpFactory = new();
+		httpFactory
+			.Setup(f => f.CreateClient(It.IsAny<string>()))
+			.Returns(() => new HttpClient(probeHandler.Object));
+
+		VlmOcrOptions vlmOptions = new()
+		{
+			OllamaUrl = "http://localhost:11434",
+		};
+
+		IReceiptExtractionService extractionService = extractionServiceOverride ?? BuildExtractionService(extractionResult);
+
+		FixtureLoader loader = new(NullLogger<FixtureLoader>.Instance);
+		FixtureEvaluator evaluator = new(extractionService, options, NullLogger<FixtureEvaluator>.Instance);
+		Reporter reporter = new(options, NullLogger<Reporter>.Instance);
+
+		return new EvalRunner(
+			httpFactory.Object,
+			vlmOptions,
+			loader,
+			evaluator,
+			reporter,
+			options,
+			NullLogger<EvalRunner>.Instance);
+	}
+
+	private static IReceiptExtractionService BuildExtractionService(ParsedReceipt? result)
+	{
+		Mock<IReceiptExtractionService> mock = new();
+		if (result is not null)
+		{
+			mock
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(result);
+		}
+		return mock.Object;
+	}
+}

--- a/tests/VlmEval.Tests/EvalRunnerTests.cs
+++ b/tests/VlmEval.Tests/EvalRunnerTests.cs
@@ -150,6 +150,42 @@ public class EvalRunnerTests : IDisposable
 	}
 
 	[Fact]
+	public async Task RunAsync_CancellationDuringLastFixture_ReturnsExitCode130()
+	{
+		// RECEIPTS-634 (find-bugs follow-up): EvaluateAsync's broad catch blocks swallow
+		// OperationCanceledException from File.ReadAllBytesAsync / ExtractAsync and return a
+		// normal failure result. If cancellation fires during the LAST fixture, the foreach
+		// loop exits without the top-of-iteration guard tripping, and (without the post-Add
+		// cancellation check) we'd return 0 or 1 instead of 130. Pin the corrected behavior.
+		WriteFixture("only.jpg", new ExpectedReceipt { Store = "Walmart" });
+
+		using CancellationTokenSource cts = new();
+
+		Mock<IReceiptExtractionService> service = new();
+		service
+			.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.Returns<byte[], string, CancellationToken>((_, _, _) =>
+			{
+				// Cancel during the call so the OCE inside EvaluateAsync is swallowed by its
+				// catch (Exception) and turned into a normal failure result. The runner must
+				// still detect cancellation post-iteration on what is the final fixture.
+				cts.Cancel();
+				throw new OperationCanceledException(cts.Token);
+			});
+
+		EvalRunner runner = BuildRunner(
+			fixturesDir: _tempDir,
+			ollamaReachable: true,
+			extractionResult: null,
+			options: new VlmEvalOptions { FailOnAnyFixtureFailure = true },
+			extractionServiceOverride: service.Object);
+
+		int exit = await runner.RunAsync(_tempDir, cts.Token);
+
+		exit.Should().Be(130, because: "cancellation absorbed by EvaluateAsync's catch on the last fixture must still surface as SIGINT");
+	}
+
+	[Fact]
 	public async Task RunAsync_AllFixturesPass_ReturnsZero()
 	{
 		WriteFixture("ok.jpg", new ExpectedReceipt { Store = "Walmart" });

--- a/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
+++ b/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
@@ -10,10 +10,7 @@ namespace VlmEval.Tests;
 /// Tests for <see cref="FixtureEvaluator"/> scoring helpers and the end-to-end
 /// <see cref="FixtureEvaluator.EvaluateAsync(Fixture, CancellationToken)"/> flow.
 ///
-/// These tests document <em>current</em> behavior. Where current behavior is known to be
-/// buggy (e.g., money tolerance off-by-one — RECEIPTS-634), the test pins the existing
-/// behavior with a TODO comment so the fix in the follow-up issue will turn red and
-/// force the test to be flipped at the same time.
+/// Money tolerance is inclusive: <c>|delta| &lt;= MoneyTolerance</c> passes (RECEIPTS-634).
 /// </summary>
 public class FixtureEvaluatorTests
 {
@@ -213,27 +210,51 @@ public class FixtureEvaluatorTests
 	}
 
 	[Fact]
-	public void DiffMoney_DeltaExactlyOneCent_ReturnsFail_BugDocumentedRECEIPTS634()
+	public void DiffMoney_DeltaExactlyOneCent_ReturnsPass()
 	{
-		// TODO RECEIPTS-634: This test pins the off-by-one bug — line 113 of FixtureEvaluator
-		// uses `<` instead of `<=`, so a delta of EXACTLY $0.01 fails even though the README
-		// says "within $0.01 of expected". When RECEIPTS-634 fixes the comparison to `<=`,
-		// flip this assertion to `DiffStatus.Pass` and remove this comment.
+		// RECEIPTS-634: tolerance is inclusive — a delta of EXACTLY $0.01 must pass per the
+		// README's "within $0.01 of expected" contract.
 		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 1.00m, FieldConfidence<decimal>.High(1.01m));
 
-		diff.Status.Should().Be(DiffStatus.Fail);
-		diff.Detail.Should().Contain("delta=$0.01");
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffMoney_NegativeDeltaExactlyOneCent_ReturnsPass()
+	{
+		// RECEIPTS-634: |actual - expected| = $0.01 with actual below expected must also pass.
+		FieldDiff diff = FixtureEvaluator.DiffMoney("subtotal", 1.00m, FieldConfidence<decimal>.High(0.99m));
+
+		diff.Status.Should().Be(DiffStatus.Pass);
 	}
 
 	[Fact]
 	public void DiffMoney_DeltaOverTolerance_ReturnsFail()
 	{
-		// delta = 0.011 > tolerance (0.01) → fail (this fails today AND after the fix)
+		// delta = 0.011 > tolerance (0.01) → fail
 		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 1.000m, FieldConfidence<decimal>.High(1.011m));
 
 		diff.Status.Should().Be(DiffStatus.Fail);
 		diff.Expected.Should().Be("1.00");
 		diff.Actual.Should().Be("1.01");
+	}
+
+	[Fact]
+	public void DiffMoney_HonorsCustomTolerance_DeltaUnderCustomBound_ReturnsPass()
+	{
+		// With a $0.05 tolerance, a $0.04 delta passes (where it would fail at default).
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 10.00m, FieldConfidence<decimal>.High(10.04m), tolerance: 0.05m);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffMoney_HonorsCustomTolerance_DeltaOverCustomBound_ReturnsFail()
+	{
+		// With a $0.05 tolerance, a $0.06 delta fails.
+		FieldDiff diff = FixtureEvaluator.DiffMoney("total", 10.00m, FieldConfidence<decimal>.High(10.06m), tolerance: 0.05m);
+
+		diff.Status.Should().Be(DiffStatus.Fail);
 	}
 
 	[Fact]
@@ -460,6 +481,61 @@ public class FixtureEvaluatorTests
 		diff.Status.Should().Be(DiffStatus.Pass);
 	}
 
+	[Fact]
+	public void DiffTaxLines_DeltaExactlyOneCent_ReturnsPass()
+	{
+		// RECEIPTS-634: tax-line tolerance is inclusive too — $0.01 delta must pass.
+		List<ExpectedTaxLine> expected = [new ExpectedTaxLine { Amount = 0.75m }];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax"), FieldConfidence<decimal>.High(0.76m)),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffTaxLines_DuplicatePrices_GreedyByInputOrder_StableOnTies()
+	{
+		// Pin documented greedy-by-input-order behavior: when expected has two identical
+		// amounts and pool has multiple matching candidates, FindClosest picks the earlier
+		// index on tied deltas. The first expected consumes pool[0]; the second consumes pool[0]
+		// after removal (i.e. the originally-at-index-1 entry).
+		List<ExpectedTaxLine> expected =
+		[
+			new ExpectedTaxLine { Amount = 1.00m },
+			new ExpectedTaxLine { Amount = 1.00m },
+		];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("A"), FieldConfidence<decimal>.High(1.00m)),
+			new ParsedTaxLine(FieldConfidence<string>.High("B"), FieldConfidence<decimal>.High(1.00m)),
+			new ParsedTaxLine(FieldConfidence<string>.High("C"), FieldConfidence<decimal>.High(1.00m)),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual);
+
+		// Both expected lines must find a match; behavior is deterministic.
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffTaxLines_HonorsCustomTolerance_MultiplePassUnderCustomBound()
+	{
+		// With a $0.05 tolerance, a $0.04 delta passes.
+		List<ExpectedTaxLine> expected = [new ExpectedTaxLine { Amount = 0.75m }];
+		List<ParsedTaxLine> actual =
+		[
+			new ParsedTaxLine(FieldConfidence<string>.High("Tax"), FieldConfidence<decimal>.High(0.79m)),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffTaxLines(expected, actual, tolerance: 0.05m);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
 	#endregion
 
 	#region DiffPaymentMethod
@@ -605,9 +681,9 @@ public class FixtureEvaluatorTests
 	[Fact]
 	public void DiffItems_PriceMatchPicksClosestPrice()
 	{
-		// Two candidate prices: 0.99 and 1.05. With expected=1.00, neither is within $0.01
-		// (1.05 delta = 0.05; 0.99 delta = 0.01 — the boundary value, currently rejected).
-		// Bring 0.99 within tolerance (delta=0.005) and confirm it wins over 1.05.
+		// Two candidate prices: 1.05 (delta 0.05) and 0.995 (delta 0.005). Both 0.995 and 1.005
+		// would tie within tolerance now that the bound is inclusive (RECEIPTS-634), but 0.995 is
+		// closer than 1.05 and should win.
 		List<ExpectedItem> expected = [new ExpectedItem { Description = "Apple", TotalPrice = 1.000m }];
 		List<ParsedReceiptItem> actual =
 		[
@@ -619,6 +695,81 @@ public class FixtureEvaluatorTests
 
 		diffs[0].Status.Should().Be(DiffStatus.Pass);
 		diffs[0].Actual.Should().Contain("Apple");
+	}
+
+	[Fact]
+	public void DiffItems_PriceExactlyOneCentDelta_ReturnsPass()
+	{
+		// RECEIPTS-634: a $0.01 item-price delta must pass (the items-side off-by-one was line 252).
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "Apple", TotalPrice = 1.000m }];
+		List<ParsedReceiptItem> actual = [MakeItem("Apple", 1.010m)];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffItems_PriceMatchedThenSecondaryValidationOneCent_ReturnsPass()
+	{
+		// RECEIPTS-634: when the price-match step finds a candidate, the subsequent in-line
+		// totalPrice validation (formerly `>= MoneyTolerance` on line 301) must also use the
+		// inclusive bound. Description fallback locks an item with a $0.01 delta — the secondary
+		// check should not flag that as a mismatch.
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "milk", TotalPrice = 4.99m }];
+		List<ParsedReceiptItem> actual = [MakeItem("Whole Milk Gallon", 5.00m)];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
+		diffs[0].Detail.Should().BeNull();
+	}
+
+	[Fact]
+	public void DiffItems_DescriptionFallback_FirstSubstringHitWins_DeterministicOrder()
+	{
+		// Pin the documented description-only fallback behavior: when no price is declared (or
+		// no price within tolerance), the matcher takes the FIRST pool entry whose description
+		// contains the expected substring. README's "Diff rules" calls this out explicitly.
+		List<ExpectedItem> expected = [new ExpectedItem { Description = "milk" }];
+		List<ParsedReceiptItem> actual =
+		[
+			MakeItem("Skim Milk Quart", 2.99m),
+			MakeItem("Whole Milk Gallon", 4.99m),
+		];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
+		// First pool entry wins — Skim Milk Quart, NOT the longer/closer-overlap Whole Milk Gallon.
+		diffs[0].Actual.Should().Contain("Skim Milk Quart");
+	}
+
+	[Fact]
+	public void DiffItems_DuplicatePrices_GreedyByInputOrder_FirstExpectedConsumesFirstActual()
+	{
+		// Pin the greedy, input-order-stable matching for items with duplicate prices: the first
+		// expected entry consumes the first matching pool entry (closest delta, earlier index on
+		// ties). README "Matching algorithm" subsection documents this.
+		List<ExpectedItem> expected =
+		[
+			new ExpectedItem { Description = "X", TotalPrice = 1.00m },
+			new ExpectedItem { Description = "Y", TotalPrice = 1.00m },
+		];
+		List<ParsedReceiptItem> actual =
+		[
+			MakeItem("X", 1.00m),
+			MakeItem("Y", 1.00m),
+		];
+
+		List<FieldDiff> diffs = FixtureEvaluator.DiffItems(expected, actual);
+
+		diffs.Should().HaveCount(2);
+		// X went to actual[0], Y went to actual[1]; both pass.
+		diffs[0].Status.Should().Be(DiffStatus.Pass);
+		diffs[0].Actual.Should().Contain("X");
+		diffs[1].Status.Should().Be(DiffStatus.Pass);
+		diffs[1].Actual.Should().Contain("Y");
 	}
 
 	[Fact]
@@ -774,7 +925,7 @@ public class FixtureEvaluatorTests
 	public async Task EvaluateAsync_FileMissing_ReturnsFailWithReadError()
 	{
 		Mock<IReceiptExtractionService> service = new();
-		FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+		FixtureEvaluator evaluator = new(service.Object, new VlmEvalOptions(), NullLogger<FixtureEvaluator>.Instance);
 
 		Fixture fixture = new(
 			Name: "missing.jpg",
@@ -801,7 +952,7 @@ public class FixtureEvaluatorTests
 				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
 				.ThrowsAsync(new InvalidOperationException("VLM down"));
 
-			FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+			FixtureEvaluator evaluator = new(service.Object, new VlmEvalOptions(), NullLogger<FixtureEvaluator>.Instance);
 
 			Fixture fixture = new("test.jpg", tempFile, "image/jpeg", new ExpectedReceipt());
 
@@ -838,7 +989,7 @@ public class FixtureEvaluatorTests
 				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(parsed);
 
-			FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+			FixtureEvaluator evaluator = new(service.Object, new VlmEvalOptions(), NullLogger<FixtureEvaluator>.Instance);
 
 			Fixture fixture = new(
 				Name: "test.jpg",
@@ -891,7 +1042,7 @@ public class FixtureEvaluatorTests
 				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(parsed);
 
-			FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+			FixtureEvaluator evaluator = new(service.Object, new VlmEvalOptions(), NullLogger<FixtureEvaluator>.Instance);
 
 			Fixture fixture = new("test.jpg", tempFile, "image/jpeg", new ExpectedReceipt());
 
@@ -927,7 +1078,7 @@ public class FixtureEvaluatorTests
 				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(parsed);
 
-			FixtureEvaluator evaluator = new(service.Object, NullLogger<FixtureEvaluator>.Instance);
+			FixtureEvaluator evaluator = new(service.Object, new VlmEvalOptions(), NullLogger<FixtureEvaluator>.Instance);
 
 			Fixture fixture = new(
 				"test.jpg",
@@ -939,6 +1090,101 @@ public class FixtureEvaluatorTests
 
 			result.Passed.Should().BeFalse();
 			result.FieldDiffs.Should().Contain(d => d.Field == "store" && d.Status == DiffStatus.Fail);
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_OptionsTolerance_AppliedToMoneyDiffs()
+	{
+		// VlmEvalOptions.MoneyTolerance widens the bound for an entire run. With a $0.05 default,
+		// a $0.04 subtotal delta must pass.
+		string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".jpg");
+		await File.WriteAllBytesAsync(tempFile, [0x01, 0x02, 0x03]);
+		try
+		{
+			ParsedReceipt parsed = new(
+				StoreName: FieldConfidence<string>.High("Walmart"),
+				Date: FieldConfidence<DateOnly>.None(),
+				Items: [],
+				Subtotal: FieldConfidence<decimal>.High(10.04m),
+				TaxLines: [],
+				Total: FieldConfidence<decimal>.None(),
+				PaymentMethod: FieldConfidence<string?>.None());
+
+			Mock<IReceiptExtractionService> service = new();
+			service
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(parsed);
+
+			FixtureEvaluator evaluator = new(
+				service.Object,
+				new VlmEvalOptions { MoneyTolerance = 0.05m },
+				NullLogger<FixtureEvaluator>.Instance);
+
+			Fixture fixture = new(
+				"test.jpg",
+				tempFile,
+				"image/jpeg",
+				new ExpectedReceipt { Store = "Walmart", Subtotal = 10.00m });
+
+			FixtureResult result = await evaluator.EvaluateAsync(fixture, CancellationToken.None);
+
+			result.Passed.Should().BeTrue();
+			result.FieldDiffs.Should().Contain(d => d.Field == "subtotal" && d.Status == DiffStatus.Pass);
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_SidecarToleranceOverride_TakesPrecedenceOverOptions()
+	{
+		// The sidecar's MoneyTolerance overrides the run-wide default for that single fixture.
+		// Run-wide is $0.01 (would fail $0.04); sidecar pushes it to $0.05 → pass.
+		string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".jpg");
+		await File.WriteAllBytesAsync(tempFile, [0x01, 0x02, 0x03]);
+		try
+		{
+			ParsedReceipt parsed = new(
+				StoreName: FieldConfidence<string>.High("Walmart"),
+				Date: FieldConfidence<DateOnly>.None(),
+				Items: [],
+				Subtotal: FieldConfidence<decimal>.High(10.04m),
+				TaxLines: [],
+				Total: FieldConfidence<decimal>.None(),
+				PaymentMethod: FieldConfidence<string?>.None());
+
+			Mock<IReceiptExtractionService> service = new();
+			service
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(parsed);
+
+			FixtureEvaluator evaluator = new(
+				service.Object,
+				new VlmEvalOptions { MoneyTolerance = 0.01m },
+				NullLogger<FixtureEvaluator>.Instance);
+
+			Fixture fixture = new(
+				"test.jpg",
+				tempFile,
+				"image/jpeg",
+				new ExpectedReceipt
+				{
+					Store = "Walmart",
+					Subtotal = 10.00m,
+					MoneyTolerance = 0.05m,
+				});
+
+			FixtureResult result = await evaluator.EvaluateAsync(fixture, CancellationToken.None);
+
+			result.Passed.Should().BeTrue();
+			result.FieldDiffs.Should().Contain(d => d.Field == "subtotal" && d.Status == DiffStatus.Pass);
 		}
 		finally
 		{


### PR DESCRIPTION
## Summary

Multiple correctness and CLI-honesty bugs in the VlmEval tool that undermine its CI use case:

- **Money tolerance is inclusive.** `delta < 0.01m` was rejecting an exactly-one-cent delta even though the README says "within $0.01 of expected." Now `<=` (and `>` for the rejection branches in `DiffItems`/`FindClosest`) so the boundary value passes.
- **Cancellation returns 130 (SIGINT).** Ctrl+C halfway through no longer silently returns 0 — the runner detects cancellation, logs `Eval cancelled — N of M fixtures evaluated.`, and exits with the POSIX signal-cancellation code.
- **Missing fixtures directory is now a hard error.** A typo'd `VlmEval__FixturesPath` previously created the directory and exited 0. With `FailOnAnyFixtureFailure=true` (default), the runner now exits 1 with a clear "check VlmEval__FixturesPath" message. Same treatment for an empty fixtures directory.
- **Reporter emits a machine-readable artifact.** New `--output json|markdown|console` and `--report-path <path>` CLI options (also bindable via `VlmEval__OutputFormat` / `VlmEval__ReportPath`). JSON shape: `{ run, fixtures: [{ name, passed, elapsedMs, error?, diffs }], summary }`. Report flushes even on early-exit paths so CI always finds an artifact.
- **`MoneyTolerance` is configurable.** Default $0.01 via `VlmEvalOptions.MoneyTolerance`. Per-fixture override via sidecar's `"moneyTolerance": 0.05`.
- **README documents matching algorithm and exit codes.** New "Exit codes" subsection (0 / 1 / 130). New "Matching algorithm" subsection documents greedy-by-input-order tax-line/item matching and the description-only first-substring-hit fallback (deliberate, deterministic, not optimal).

Resolves RECEIPTS-634.

## Test plan

- [x] `dotnet test tests/VlmEval.Tests/` — all 103 tests pass (10 new). The previously pinned `DiffMoney_DeltaExactlyOneCent_ReturnsFail_BugDocumentedRECEIPTS634` is flipped to `_ReturnsPass`. New tests pin: items[].totalPrice $0.01 boundary, taxLines[].amount $0.01 boundary, custom-tolerance options + sidecar override, EvalRunner exit codes (missing-dir / empty / Ollama-unreachable / cancellation / JSON-and-markdown artifact / structured artifact on early-exit).
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — all 2444 backend tests pass; pre-commit ran the full vitest suite (1923 tests) plus tsc + eslint with no errors.
- [x] `dotnet format Receipts.slnx --verify-no-changes` — clean.
- [x] `dotnet build Receipts.slnx -p:TreatWarningsAsErrors=true` — clean (only pre-existing nuget vulnerability warnings, none introduced by this change).
- [x] Manual exit-code checks against the binary:
  - Missing dir + flag on → exit `1`.
  - Missing dir + flag off → exit `0`.
  - Empty dir + flag on → exit `1`.
  - Ollama unreachable → exit `1`.
  - JSON report on missing-dir early exit → file written with empty `fixtures[]` and `summary.total=0`.

## Related

- Depends on RECEIPTS-616 (parent epic, target branch).
- Closes the `// TODO RECEIPTS-634` markers added in RECEIPTS-633 (`FixtureEvaluatorTests.cs`) by flipping the test assertion.
- Surfaces inclusive-tolerance math used elsewhere in `FixtureEvaluator` (DiffItems line 252 + the secondary item-price check formerly at line 301).