### PR TITLE
fix(infra): guard DiffDate NotDeclared branch on IsPresent (RECEIPTS-650)

### DIFF
--- a/src/Tools/VlmEval/FixtureEvaluator.cs
+++ b/src/Tools/VlmEval/FixtureEvaluator.cs
@@ -88,7 +88,13 @@ public sealed class FixtureEvaluator(
 	{
 		if (expected is null)
 		{
-			return new FieldDiff("date", DiffStatus.NotDeclared, null, actual.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), null);
+			// Confidence guard mirrors DiffMoney's Format() helper (RECEIPTS-650): when the VLM
+			// did not extract a date, FieldConfidence<DateOnly>.None() carries default(DateOnly),
+			// so unconditionally formatting it would emit "0001-01-01" — emit null instead.
+			string? actualStr = actual.IsPresent
+				? actual.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+				: null;
+			return new FieldDiff("date", DiffStatus.NotDeclared, null, actualStr, null);
 		}
 
 		if (!actual.IsPresent)

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceFixtureTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceFixtureTests.cs
@@ -53,7 +53,7 @@ public class PdfConversionServiceFixtureTests
 		byte[] pdfBytes = LoadFixture("cmyk-receipt.pdf");
 
 		// Act
-		byte[] firstPagePng = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] firstPagePng = (await _service.ConvertAsync(pdfBytes, CancellationToken.None)).FirstPagePng;
 
 		// Assert
 		AssertValidPng(firstPagePng, minWidth: 100, minHeight: 100);
@@ -68,7 +68,7 @@ public class PdfConversionServiceFixtureTests
 		byte[] pdfBytes = LoadFixture("indexed-receipt.pdf");
 
 		// Act
-		byte[] firstPagePng = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] firstPagePng = (await _service.ConvertAsync(pdfBytes, CancellationToken.None)).FirstPagePng;
 
 		// Assert
 		AssertValidPng(firstPagePng, minWidth: 100, minHeight: 100);
@@ -83,7 +83,7 @@ public class PdfConversionServiceFixtureTests
 		byte[] pdfBytes = LoadFixture("calrgb-receipt.pdf");
 
 		// Act
-		byte[] firstPagePng = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] firstPagePng = (await _service.ConvertAsync(pdfBytes, CancellationToken.None)).FirstPagePng;
 
 		// Assert
 		AssertValidPng(firstPagePng, minWidth: 100, minHeight: 100);
@@ -97,7 +97,7 @@ public class PdfConversionServiceFixtureTests
 		byte[] pdfBytes = LoadFixture("lab-receipt.pdf");
 
 		// Act
-		byte[] firstPagePng = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] firstPagePng = (await _service.ConvertAsync(pdfBytes, CancellationToken.None)).FirstPagePng;
 
 		// Assert
 		AssertValidPng(firstPagePng, minWidth: 100, minHeight: 100);

--- a/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
+++ b/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
@@ -143,6 +143,20 @@ public class FixtureEvaluatorTests
 		diff.Actual.Should().Be("2026-01-14");
 	}
 
+	[Fact]
+	public void DiffDate_ExpectedNull_NoneConfidenceActual_FormatsActualAsNull()
+	{
+		// RECEIPTS-650: when the VLM did not extract a date, FieldConfidence<DateOnly>.None()
+		// carries default(DateOnly). The NotDeclared branch must guard on IsPresent and emit
+		// null for Actual, not the bogus "0001-01-01" placeholder.
+		FieldDiff diff = FixtureEvaluator.DiffDate(null, FieldConfidence<DateOnly>.None());
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+		diff.Expected.Should().BeNull();
+		diff.Actual.Should().BeNull();
+		diff.Detail.Should().BeNull();
+	}
+
 	[Theory]
 	[InlineData("de-DE")]
 	[InlineData("fr-FR")]


### PR DESCRIPTION
## Summary

- `DiffDate` in `src/Tools/VlmEval/FixtureEvaluator.cs` was emitting `"0001-01-01"` (i.e. `default(DateOnly)`) for the diff `Actual` when the VLM did not extract a date. After RECEIPTS-631, `FieldConfidence<DateOnly>.None()` returns `(default(DateOnly), ConfidenceLevel.None)`, but the NotDeclared branch (when expected is `null`) wasn't guarding on `IsPresent`. Mirror `DiffMoney`'s `Format()` helper — emit `null` when `!actual.IsPresent`.
- Adds `DiffDate_ExpectedNull_NoneConfidenceActual_FormatsActualAsNull` to `tests/VlmEval.Tests/FixtureEvaluatorTests.cs`, mirroring the existing `DiffMoney` analog.
- Bundles a small repair for four pre-existing build errors in `tests/Infrastructure.Tests/Services/PdfConversionServiceFixtureTests.cs` that block the parent branch from building. RECEIPTS-651 (PR #499) added the fixture tests assuming `ConvertAsync` returned `byte[]`; RECEIPTS-637 (PR #502) later changed the return type to `PdfConversionResult`. The tests were never updated. Mechanical fix: dereference `.FirstPagePng`.

Resolves RECEIPTS-650.

## Test plan

- `dotnet test tests/VlmEval.Tests/VlmEval.Tests.csproj` — 105 passing (was 104), with the new test exercising the corrected NotDeclared/None path.
- `dotnet build tests/Infrastructure.Tests/Infrastructure.Tests.csproj` — 0 errors after the type fixup (was 4).
- No behavior change for any code path where actual is present (Low/Medium/High confidence): formatting and tolerance comparisons unchanged.