### PR TITLE
fix(infrastructure): centralize VLM model name + smoke test config consolidation (RECEIPTS-635)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
         max-size: "50m"
         max-file: "3"
 
-  # VLM OCR: Ollama container serving qwen2.5vl:3b for receipt extraction (RECEIPTS-616 epic).
+  # VLM OCR: Ollama container serving the configured VLM (RECEIPTS-616 epic).
   # Named volume persists the model cache so the first-run ~3 GB pull only happens once.
   #
   # The `ollama list` healthcheck validates the Ollama daemon is responsive (it queries the
@@ -107,8 +107,9 @@ services:
     deploy:
       resources:
         limits:
-          # qwen2.5vl:3b Q4 is ~3.2 GB; runtime needs headroom for the weights + KV cache +
-          # compute graph (observed ~2-3 GB with 4k context). Bump to 6 GB to avoid OOM kills.
+          # Default model glm-ocr:q8_0 is ~1 GB; previous qwen2.5vl:3b Q4 is ~3.2 GB. Either runtime
+          # needs headroom for weights + KV cache + compute graph (observed ~2-3 GB with 4k context).
+          # Keep 6 GB ceiling so swapping VLM_MODEL to a heavier tag doesn't OOM.
           memory: 6G
           cpus: "4"
     networks:
@@ -119,13 +120,16 @@ services:
         max-size: "50m"
         max-file: "3"
 
-  # One-shot sidecar: pulls qwen2.5vl:3b if it is not already cached, then exits.
+  # One-shot sidecar: pulls the configured VLM model if it is not already cached, then exits.
   # Idempotent — subsequent runs find the model present and skip the download.
   #
   # `app` now gates startup on this sidecar exiting successfully (RECEIPTS-636), so a
   # non-zero exit here permanently blocks the API. To avoid that on transient network
   # errors during the ~3 GB cold-start pull, the command retries up to 5 times with
   # backoff before giving up.
+  #
+  # The model tag is parameterized via VLM_MODEL (single source of truth — RECEIPTS-635). Override
+  # by exporting VLM_MODEL=<tag> or by setting it in a .env file alongside docker-compose.yml.
   vlm-ocr-pull:
     image: ollama/ollama:latest
     container_name: receipts-vlm-ocr-pull
@@ -138,12 +142,12 @@ services:
       - -c
       - |
         for i in 1 2 3 4 5; do
-          if ollama list | grep -q 'qwen2.5vl:3b'; then
-            echo "qwen2.5vl:3b already present; skipping pull"
+          if ollama list | grep -qF "$$VLM_MODEL"; then
+            echo "$$VLM_MODEL already present; skipping pull"
             exit 0
           fi
-          echo "Pulling qwen2.5vl:3b (attempt $$i/5)..."
-          if ollama pull qwen2.5vl:3b; then
+          echo "Pulling $$VLM_MODEL (attempt $$i/5)..."
+          if ollama pull "$$VLM_MODEL"; then
             exit 0
           fi
           echo "Pull failed; sleeping before retry"
@@ -153,6 +157,7 @@ services:
         exit 1
     environment:
       - OLLAMA_HOST=http://vlm-ocr:11434
+      - VLM_MODEL=${VLM_MODEL:-glm-ocr:q8_0}
     networks:
       - receipts-net
     logging:
@@ -182,6 +187,7 @@ services:
       - AdminSeed__FirstName=Admin
       - AdminSeed__LastName=User
       - Ollama__BaseUrl=http://vlm-ocr:11434
+      - Ocr__Vlm__Model=${VLM_MODEL:-glm-ocr:q8_0}
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_SERVICE_NAME=receipts-api
       - SENTRY_DSN=${SENTRY_DSN:-}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,10 +90,10 @@ The system uses pgvector for semantic similarity search on item names and descri
 Receipt OCR + JSON extraction runs against a local vision-language model hosted in an Ollama container (epic **RECEIPTS-616**). This issue (**RECEIPTS-617**) wires the container into Aspire and docker-compose and adds a startup smoke test; the extraction service itself lands in RECEIPTS-618.
 
 - **Container** — `ollama/ollama:latest`, named `vlm-ocr` in both Aspire (`src/Receipts.AppHost/AppHost.cs`) and docker-compose (`docker-compose.yml`), exposing port 11434.
-- **Model** — `glm-ocr:q8_0` (~1 GB). Pulled on first run by the one-shot `vlm-ocr-pull` sidecar; skipped on subsequent runs.
+- **Model** — defaults to `glm-ocr:q8_0` (~1 GB). Pulled on first run by the one-shot `vlm-ocr-pull` sidecar; skipped on subsequent runs. The model tag is centralized in `VlmOcrOptions.DefaultModel` (C#) and the `VLM_MODEL` env var (Aspire / docker-compose) — change either one to swap models without editing every file (RECEIPTS-635).
 - **Model cache** — persistent named volume `vlm-ocr-models` mounted at `/root/.ollama`. Survives container restarts so the pull is a one-time cost.
-- **Configuration** — the API reads `Ollama:BaseUrl` (env var `Ollama__BaseUrl`). Aspire injects this automatically; docker-compose sets it to `http://vlm-ocr:11434`.
-- **Smoke test** — `src/Presentation/API/Services/VlmOcrSmokeTest.cs` runs once on `ApplicationStarted`: hits `GET /api/tags`, logs Information if `glm-ocr` is present, Warning otherwise. Log-only — never blocks startup or fails the process.
+- **Configuration** — the API reads `Ollama:BaseUrl` (env var `Ollama__BaseUrl`) for the URL and `Ocr:Vlm:Model` (env var `Ocr__Vlm__Model`) for the tag. Aspire injects both automatically from `VLM_MODEL`; docker-compose sets `Ollama__BaseUrl=http://vlm-ocr:11434` and `Ocr__Vlm__Model=${VLM_MODEL:-glm-ocr:q8_0}`.
+- **Smoke test** — `src/Presentation/API/Services/VlmOcrSmokeTest.cs` runs once on `ApplicationStarted`: hits `GET /api/tags`, parses the response, and matches the configured `Ocr:Vlm:Model` exactly against entries in `models[].name`. Logs Information on match, Warning otherwise. Log-only — never blocks startup or fails the process.
 
 ## Test Project Structure
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,9 +53,9 @@ VS Code will automatically open the **Aspire Dashboard** in your browser.
 | API (HTTPS) | https://localhost:5001 | REST API (HTTPS) |
 | API Docs (Scalar) | http://localhost:5000/scalar | Interactive API documentation |
 | PgAdmin | auto-assigned | PostgreSQL admin UI |
-| VLM OCR (Ollama) | http://localhost:11434 | `glm-ocr:q8_0` for receipt extraction (RECEIPTS-616 epic) |
+| VLM OCR (Ollama) | http://localhost:11434 | `glm-ocr:q8_0` (default) for receipt extraction (RECEIPTS-616 epic) |
 
-> **First-run download:** The `vlm-ocr-pull` sidecar downloads `glm-ocr:q8_0` (~1 GB) on the first `aspire run`. The model is cached in the `vlm-ocr-models` named volume, so subsequent starts are fast. Watch the `vlm-ocr-pull` resource in the Aspire Dashboard to see progress. The API logs `VLM OCR: glm-ocr model available at ...` once the model is loaded.
+> **First-run download:** The `vlm-ocr-pull` sidecar downloads the configured VLM (~1 GB for the default `glm-ocr:q8_0`) on the first `aspire run`. The model is cached in the `vlm-ocr-models` named volume, so subsequent starts are fast. Watch the `vlm-ocr-pull` resource in the Aspire Dashboard to see progress. The API logs `VLM OCR: <model> available at ...` once the model is loaded. Override the tag by exporting `VLM_MODEL=<tag>` before `aspire run` or `docker compose up` — both honor that env var (RECEIPTS-635).
 
 > **Note:** Aspire assigns dynamic ports and the defaults above may differ. Check the **Aspire Dashboard → Resources** view for the actual URLs assigned to each service in your session.
 

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Npgsql;
 using Polly;
 
@@ -226,13 +227,33 @@ public static class InfrastructureService
 	}
 
 	/// <summary>
+	/// Resolves the Ollama base URL using the canonical fallback chain shared between the
+	/// receipt-extraction HTTP client (this class) and the API startup smoke test
+	/// (<c>API.Services.VlmOcrSmokeTest</c>): <c>Ocr:Vlm:OllamaUrl</c> → <c>Ollama:BaseUrl</c>
+	/// (Aspire-injected) → <c>null</c>. The localhost fallback is applied separately by callers
+	/// so e.g. <c>Program.cs</c> can detect the "neither key set" condition and emit a startup
+	/// warning instead of silently smoke-testing the dev daemon (RECEIPTS-635).
+	/// </summary>
+	public static string? ResolveOllamaUrl(IConfiguration configuration)
+	{
+		string? configured = configuration[ConfigurationVariables.OcrVlmOllamaUrl];
+		if (!string.IsNullOrWhiteSpace(configured))
+		{
+			return configured;
+		}
+
+		string? aspireInjected = configuration[ConfigurationVariables.OllamaBaseUrl];
+		return string.IsNullOrWhiteSpace(aspireInjected) ? null : aspireInjected;
+	}
+
+	/// <summary>
 	/// Registers the Ollama-backed <see cref="IReceiptExtractionService"/> with a single
 	/// resilience pipeline tailored to long-running VLM inferences. URL resolves from
 	/// <c>Ocr:Vlm:OllamaUrl</c>, then <c>Ollama:BaseUrl</c> (Aspire-injected), then localhost default.
 	/// <para>
 	/// We explicitly <see cref="ResilienceHttpClientBuilderExtensions.RemoveAllResilienceHandlers"/>
 	/// so the standard handler injected by <c>Receipts.ServiceDefaults</c> (30s per attempt /
-	/// 90s total) does NOT stack on top of our pipeline. Real glm-ocr inferences routinely
+	/// 90s total) does NOT stack on top of our pipeline. Real VLM inferences routinely
 	/// exceed 30s; without removal the documented <see cref="VlmOcrOptions.TimeoutSeconds"/>
 	/// budget would never apply. See RECEIPTS-630.
 	/// </para>
@@ -244,8 +265,7 @@ public static class InfrastructureService
 
 		if (string.IsNullOrWhiteSpace(options.OllamaUrl))
 		{
-			options.OllamaUrl = configuration[ConfigurationVariables.OllamaBaseUrl]
-				?? "http://localhost:11434";
+			options.OllamaUrl = ResolveOllamaUrl(configuration) ?? "http://localhost:11434";
 		}
 
 		services.AddVlmOcrClient(options);
@@ -271,9 +291,14 @@ public static class InfrastructureService
 				nameof(options));
 		}
 
+		// Bare instance for direct injection (OllamaReceiptExtractionService takes VlmOcrOptions).
 		services.AddSingleton(options);
+		// IOptions<VlmOcrOptions> wrapper so consumers like the smoke test can use the standard
+		// options pattern. Backed by the same instance bound above so Model / OllamaUrl / Timeout
+		// stay in sync.
+		services.AddSingleton<IOptions<VlmOcrOptions>>(new OptionsWrapper<VlmOcrOptions>(options));
 
-#pragma warning disable EXTEXP0001 // RemoveAllResilienceHandlers is in evaluation; required to opt out of the standard handler injected by ServiceDefaults.
+	#pragma warning disable EXTEXP0001 // RemoveAllResilienceHandlers is in evaluation; required to opt out of the standard handler injected by ServiceDefaults.
 		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
 		{
 			client.BaseAddress = new Uri(options.OllamaUrl!.TrimEnd('/') + "/");
@@ -283,7 +308,7 @@ public static class InfrastructureService
 		})
 			.RemoveAllResilienceHandlers()
 			.AddResilienceHandler("vlm-ocr", builder => ConfigureVlmOcrResilience(builder, options));
-#pragma warning restore EXTEXP0001
+	#pragma warning restore EXTEXP0001
 
 		return services;
 	}

--- a/src/Infrastructure/Services/VlmOcrOptions.cs
+++ b/src/Infrastructure/Services/VlmOcrOptions.cs
@@ -2,9 +2,17 @@ namespace Infrastructure.Services;
 
 public sealed class VlmOcrOptions
 {
+	/// <summary>
+	/// Single source of truth for the VLM model tag used by Ollama. Referenced by C# defaults
+	/// (this options class) and Aspire/docker-compose via the <c>VLM_MODEL</c> env var. Changing
+	/// the model name should mean editing this constant or setting <c>VLM_MODEL</c> — never
+	/// touching individual files (RECEIPTS-635).
+	/// </summary>
+	public const string DefaultModel = "glm-ocr:q8_0";
+
 	public string? OllamaUrl { get; set; }
 
-	public string Model { get; set; } = "glm-ocr:q8_0";
+	public string Model { get; set; } = DefaultModel;
 
 	public int TimeoutSeconds { get; set; } = 120;
 

--- a/src/Presentation/API/Program.cs
+++ b/src/Presentation/API/Program.cs
@@ -46,6 +46,27 @@ builder.Services
 	.RegisterApplicationServices(builder.Configuration)
 	.RegisterInfrastructureServices(builder.Configuration);
 
+// Resolve the Ollama URL using the same fallback chain RegisterReceiptExtractionService uses,
+// then register the named HttpClient the smoke test will pull from IHttpClientFactory. This
+// replaces the previous pattern of `using HttpClient http = new()`, which bypassed
+// IHttpClientFactory + OTel HTTP instrumentation + ConfigureHttpClientDefaults (RECEIPTS-635).
+//
+// The smoke-test HttpClient is registered unconditionally so DI is consistent across environments
+// (tests inspect it). When the URL is unavailable, the smoke test simply skips at startup with a
+// log warning — see the lifetime hook below.
+string? smokeOllamaBaseUrl = Infrastructure.Services.InfrastructureService.ResolveOllamaUrl(builder.Configuration);
+
+builder.Services.AddHttpClient(API.Services.VlmOcrSmokeTest.HttpClientName, client =>
+{
+	if (!string.IsNullOrWhiteSpace(smokeOllamaBaseUrl))
+	{
+		client.BaseAddress = new Uri(smokeOllamaBaseUrl.TrimEnd('/') + "/");
+	}
+	client.Timeout = TimeSpan.FromSeconds(10);
+});
+
+builder.Services.AddSingleton<API.Services.VlmOcrSmokeTest>();
+
 // Build application
 WebApplication app = builder.Build();
 
@@ -109,8 +130,11 @@ if (!app.Environment.IsDevelopment())
 // escape VlmOcrSmokeTest.RunAsync (e.g. UriFormatException from a malformed URL, or
 // InvalidOperationException from a scheme-less one) which would otherwise become silent
 // unobserved task exceptions.
-string? ollamaBaseUrl = builder.Configuration[Common.ConfigurationVariables.OllamaBaseUrl];
-if (!string.IsNullOrWhiteSpace(ollamaBaseUrl))
+//
+// URL resolution mirrors RegisterReceiptExtractionService — both check Ocr:Vlm:OllamaUrl, then
+// Ollama:BaseUrl. When neither is configured the smoke test is skipped and a startup warning is
+// emitted so misconfigured deployments are visible in logs (RECEIPTS-635).
+if (!string.IsNullOrWhiteSpace(smokeOllamaBaseUrl))
 {
 	app.Lifetime.ApplicationStarted.Register(() =>
 	{
@@ -119,18 +143,26 @@ if (!string.IsNullOrWhiteSpace(ollamaBaseUrl))
 			ILogger<Program> smokeLogger = app.Services.GetRequiredService<ILogger<Program>>();
 			try
 			{
-				using HttpClient http = new()
-				{
-					BaseAddress = new Uri(ollamaBaseUrl),
-					Timeout = TimeSpan.FromSeconds(10),
-				};
-				await API.Services.VlmOcrSmokeTest.RunAsync(http, smokeLogger, CancellationToken.None);
+				API.Services.VlmOcrSmokeTest smokeTest =
+					app.Services.GetRequiredService<API.Services.VlmOcrSmokeTest>();
+				await smokeTest.RunAsync(CancellationToken.None);
 			}
 			catch (Exception ex)
 			{
-				smokeLogger.LogWarning(ex, "VLM OCR: unexpected error during smoke test for {Url}", ollamaBaseUrl);
+				smokeLogger.LogWarning(ex, "VLM OCR: unexpected error during smoke test for {Url}", smokeOllamaBaseUrl);
 			}
 		});
+	});
+}
+else
+{
+	app.Lifetime.ApplicationStarted.Register(() =>
+	{
+		ILogger<Program> startupLogger = app.Services.GetRequiredService<ILogger<Program>>();
+		startupLogger.LogWarning(
+			"VLM OCR: skipping smoke test — neither {OcrVlmKey} nor {OllamaKey} is configured",
+			Common.ConfigurationVariables.OcrVlmOllamaUrl,
+			Common.ConfigurationVariables.OllamaBaseUrl);
 	});
 }
 

--- a/src/Presentation/API/Services/VlmOcrSmokeTest.cs
+++ b/src/Presentation/API/Services/VlmOcrSmokeTest.cs
@@ -1,18 +1,67 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Infrastructure.Services;
+using Microsoft.Extensions.Options;
+
 namespace API.Services;
 
 /// <summary>
 /// Startup log-only check that the configured Ollama instance is reachable and has
-/// the glm-ocr model loaded. Used by <c>Program.cs</c> to surface VLM provisioning
+/// the configured VLM model loaded. Used by <c>Program.cs</c> to surface VLM provisioning
 /// problems early without blocking API startup (RECEIPTS-616 epic).
+/// <para>
+/// The expected model name is sourced from <see cref="VlmOcrOptions.Model"/> (single source of
+/// truth — RECEIPTS-635). The smoke test parses Ollama's <c>/api/tags</c> response and matches
+/// the configured tag exactly against entries in <c>models[].name</c> — substring matching is
+/// avoided so e.g. <c>glm-ocr-experimental</c> never satisfies a check for <c>glm-ocr:q8_0</c>.
+/// </para>
 /// </summary>
-public static class VlmOcrSmokeTest
+public sealed class VlmOcrSmokeTest
 {
-	private const string ExpectedModel = "glm-ocr";
 	private const string TagsEndpoint = "/api/tags";
+	internal const string HttpClientName = "vlm-smoke";
 
-	public static async Task RunAsync(HttpClient http, ILogger logger, CancellationToken cancellationToken)
+	private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+	private readonly IHttpClientFactory _httpClientFactory;
+	private readonly VlmOcrOptions _options;
+	private readonly ILogger<VlmOcrSmokeTest> _logger;
+
+	public VlmOcrSmokeTest(
+		IHttpClientFactory httpClientFactory,
+		IOptions<VlmOcrOptions> options,
+		ILogger<VlmOcrSmokeTest> logger)
+	{
+		ArgumentNullException.ThrowIfNull(httpClientFactory);
+		ArgumentNullException.ThrowIfNull(options);
+		ArgumentNullException.ThrowIfNull(logger);
+
+		_httpClientFactory = httpClientFactory;
+		_options = options.Value;
+		_logger = logger;
+	}
+
+	public Task RunAsync(CancellationToken cancellationToken)
+	{
+		HttpClient http = _httpClientFactory.CreateClient(HttpClientName);
+		return RunAsync(http, _options.Model, _logger, cancellationToken);
+	}
+
+	/// <summary>
+	/// Probes the supplied <paramref name="http"/> client (already configured with a base address
+	/// and timeout) for the configured Ollama tags endpoint and verifies that
+	/// <paramref name="expectedModel"/> appears verbatim in the <c>models[].name</c> list. Logs
+	/// at Information on success and Warning on any reachability/parse/model-missing condition.
+	/// All exceptions are swallowed: the smoke test must never crash startup (RECEIPTS-616).
+	/// </summary>
+	internal static async Task RunAsync(
+		HttpClient http,
+		string expectedModel,
+		ILogger logger,
+		CancellationToken cancellationToken)
 	{
 		ArgumentNullException.ThrowIfNull(http);
+		ArgumentException.ThrowIfNullOrWhiteSpace(expectedModel);
 		ArgumentNullException.ThrowIfNull(logger);
 
 		try
@@ -26,16 +75,42 @@ public static class VlmOcrSmokeTest
 				return;
 			}
 
-			string body = await response.Content.ReadAsStringAsync(cancellationToken);
-			if (body.Contains(ExpectedModel, StringComparison.OrdinalIgnoreCase))
+			TagsResponse? tags;
+			try
 			{
-				logger.LogInformation("VLM OCR: glm-ocr model available at {Url}", http.BaseAddress);
+				tags = await response.Content.ReadFromJsonAsync<TagsResponse>(JsonOptions, cancellationToken);
+			}
+			catch (JsonException ex)
+			{
+				logger.LogWarning(
+					ex,
+					"VLM OCR: failed to parse {Endpoint} JSON from {Url}",
+					TagsEndpoint, http.BaseAddress);
+				return;
+			}
+
+			if (tags?.Models is null || tags.Models.Count == 0)
+			{
+				logger.LogWarning(
+					"VLM OCR: reachable at {Url} but no models reported — run \"ollama pull {Model}\" on the VLM host",
+					http.BaseAddress, expectedModel);
+				return;
+			}
+
+			bool present = tags.Models.Any(m =>
+				string.Equals(m.Name, expectedModel, StringComparison.Ordinal));
+
+			if (present)
+			{
+				logger.LogInformation(
+					"VLM OCR: {Model} available at {Url}",
+					expectedModel, http.BaseAddress);
 			}
 			else
 			{
 				logger.LogWarning(
-					"VLM OCR: reachable at {Url} but glm-ocr not in model list — run \"ollama pull glm-ocr:q8_0\" on the VLM host",
-					http.BaseAddress);
+					"VLM OCR: reachable at {Url} but {Model} not in model list — run \"ollama pull {Model}\" on the VLM host",
+					http.BaseAddress, expectedModel, expectedModel);
 			}
 		}
 		catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
@@ -43,4 +118,10 @@ public static class VlmOcrSmokeTest
 			logger.LogWarning(ex, "VLM OCR: failed to reach {Url}", http.BaseAddress);
 		}
 	}
+
+	private sealed record TagsResponse(
+		[property: JsonPropertyName("models")] IReadOnlyList<TagsModel>? Models);
+
+	private sealed record TagsModel(
+		[property: JsonPropertyName("name")] string? Name);
 }

--- a/src/Presentation/API/appsettings.json
+++ b/src/Presentation/API/appsettings.json
@@ -1,7 +1,6 @@
 {
 	"Ocr": {
 		"Vlm": {
-			"Model": "glm-ocr:q8_0",
 			"TimeoutSeconds": 120
 		}
 	},

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -1,3 +1,5 @@
+using Infrastructure.Services;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 IResourceBuilder<PostgresServerResource> postgres = builder.AddPostgres("postgres")
@@ -24,7 +26,13 @@ IResourceBuilder<ProjectResource> seeder = builder.AddProject<Projects.DbSeeder>
 	.WithEnvironment("AdminSeed__FirstName", "Admin")
 	.WithEnvironment("AdminSeed__LastName", "User");
 
-// VLM OCR: Ollama container serving qwen2.5vl:3b for receipt extraction (RECEIPTS-616 epic).
+// VLM model tag — single source of truth across Aspire / docker-compose / appsettings (RECEIPTS-635).
+// Read from the VLM_MODEL env var; fall back to VlmOcrOptions.DefaultModel. The same value flows to
+// the pull sidecar (so it pulls the right tag) and to API + VlmEval as Ocr__Vlm__Model (so they
+// query Ollama for that tag).
+string vlmModel = Environment.GetEnvironmentVariable("VLM_MODEL") ?? VlmOcrOptions.DefaultModel;
+
+// VLM OCR: Ollama container serving the configured VLM (RECEIPTS-616 epic).
 // Named volume persists the model cache across restarts so the first-run ~3 GB pull happens once.
 // Host port is left unset so Aspire picks a free one — Ollama's default 11434 is frequently
 // already bound on developer machines running the native Ollama daemon, which would wedge Aspire
@@ -39,21 +47,24 @@ IResourceBuilder<ContainerResource> vlmOcr = builder.AddContainer("vlm-ocr", "ol
 	.WithHttpEndpoint(targetPort: 11434, name: "http")
 	.WithHttpHealthCheck("/api/tags");
 
-// One-shot sidecar that pulls qwen2.5vl:3b if it is not already cached in the shared volume,
-// then exits. Idempotent — subsequent runs find the model present and skip the download.
+// One-shot sidecar that pulls the configured VLM model if it is not already cached in the shared
+// volume, then exits. Idempotent — subsequent runs find the model present and skip the download.
 //
 // The API and VlmEval gate on this sidecar via .WaitForCompletion (RECEIPTS-636), so a
 // non-zero exit here permanently blocks dependents. Retry up to 5 times with backoff
 // to tolerate transient network failures during the ~3 GB cold-start pull. Mirrors the
 // docker-compose vlm-ocr-pull retry pattern.
+//
+// $VLM_MODEL is sourced from the OS env (set by .WithEnvironment below) so a single edit point
+// (VlmOcrOptions.DefaultModel or the VLM_MODEL env var) controls everything (RECEIPTS-635).
 const string vlmOcrPullCommand = """
 	for i in 1 2 3 4 5; do
-	  if ollama list | grep -q 'qwen2.5vl:3b'; then
-	    echo "qwen2.5vl:3b already present; skipping pull"
+	  if ollama list | grep -qF "$VLM_MODEL"; then
+	    echo "$VLM_MODEL already present; skipping pull"
 	    exit 0
 	  fi
-	  echo "Pulling qwen2.5vl:3b (attempt $i/5)..."
-	  if ollama pull qwen2.5vl:3b; then
+	  echo "Pulling $VLM_MODEL (attempt $i/5)..."
+	  if ollama pull "$VLM_MODEL"; then
 	    exit 0
 	  fi
 	  echo "Pull failed; sleeping before retry"
@@ -66,6 +77,7 @@ IResourceBuilder<ContainerResource> vlmOcrPull = builder.AddContainer("vlm-ocr-p
 	.WithEntrypoint("/bin/sh")
 	.WithArgs("-c", vlmOcrPullCommand)
 	.WithEnvironment("OLLAMA_HOST", "http://vlm-ocr:11434")
+	.WithEnvironment("VLM_MODEL", vlmModel)
 	.WaitFor(vlmOcr);
 
 // API: starts after seeder completes; Ollama URL injected for the smoke test and future extraction service.
@@ -75,6 +87,7 @@ IResourceBuilder<ContainerResource> vlmOcrPull = builder.AddContainer("vlm-ocr-p
 IResourceBuilder<ProjectResource> api = builder.AddProject<Projects.API>("api")
 	.WithReference(db)
 	.WithEnvironment("Ollama__BaseUrl", vlmOcr.GetEndpoint("http"))
+	.WithEnvironment("Ocr__Vlm__Model", vlmModel)
 	.WaitForCompletion(seeder)
 	.WaitFor(vlmOcr)
 	.WaitForCompletion(vlmOcrPull);
@@ -87,6 +100,7 @@ string vlmEvalFixturesPath = Path.Combine(repoRoot, "fixtures", "vlm-eval");
 
 builder.AddProject<Projects.VlmEval>("vlm-eval")
 	.WithEnvironment("Ollama__BaseUrl", vlmOcr.GetEndpoint("http"))
+	.WithEnvironment("Ocr__Vlm__Model", vlmModel)
 	.WithEnvironment("VlmEval__FixturesPath", vlmEvalFixturesPath)
 	.WaitFor(vlmOcr)
 	.WaitForCompletion(vlmOcrPull)

--- a/src/Receipts.AppHost/Receipts.AppHost.csproj
+++ b/src/Receipts.AppHost/Receipts.AppHost.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Presentation\API\API.csproj" />
+    <!-- IsAspireProjectResource=false so Aspire doesn't try to start Infrastructure as a project
+         resource — we only need it for shared constants (e.g. VlmOcrOptions.DefaultModel,
+         RECEIPTS-635). -->
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\Tools\DbMigrator\DbMigrator.csproj" />
     <ProjectReference Include="..\Tools\DbSeeder\DbSeeder.csproj" />
     <ProjectReference Include="..\Tools\VlmEval\VlmEval.csproj" />

--- a/tests/Presentation.API.Tests/Services/VlmOcrSmokeTestTests.cs
+++ b/tests/Presentation.API.Tests/Services/VlmOcrSmokeTestTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using API.Services;
+using Infrastructure.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
 
@@ -9,13 +11,16 @@ namespace Presentation.API.Tests.Services;
 public class VlmOcrSmokeTestTests
 {
 	private const string BaseUrl = "http://vlm-ocr:11434";
-	private static readonly string TagsJsonWithModel = """
+	private const string ConfiguredModel = "glm-ocr:q8_0";
+
+	private static readonly string TagsJsonWithExactModel = """
 	{
 	  "models": [
 	    {"name": "glm-ocr:q8_0", "size": 987654321}
 	  ]
 	}
 	""";
+
 	private static readonly string TagsJsonWithoutModel = """
 	{
 	  "models": [
@@ -24,13 +29,30 @@ public class VlmOcrSmokeTestTests
 	}
 	""";
 
+	// Critical regression case for RECEIPTS-635: a model whose name *contains* the configured
+	// tag as a substring must NOT be treated as a match. Previously the smoke test ran
+	// `body.Contains("glm-ocr")` which would have returned true here.
+	private static readonly string TagsJsonWithLookalikeModel = """
+	{
+	  "models": [
+	    {"name": "glm-ocr-experimental", "size": 1234567890}
+	  ]
+	}
+	""";
+
+	private static readonly string TagsJsonEmpty = """
+	{ "models": [] }
+	""";
+
+	private static readonly string TagsJsonMalformed = "<<not json>>";
+
 	[Fact]
-	public async Task RunAsync_ReachableWithModel_LogsInformation()
+	public async Task RunAsync_ReachableWithExactModel_LogsInformation()
 	{
 		Mock<ILogger> logger = new();
-		HttpClient http = CreateHttpClient(HttpStatusCode.OK, TagsJsonWithModel);
+		HttpClient http = CreateHttpClient(HttpStatusCode.OK, TagsJsonWithExactModel);
 
-		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+		await VlmOcrSmokeTest.RunAsync(http, ConfiguredModel, logger.Object, CancellationToken.None);
 
 		VerifyLogged(logger, LogLevel.Information, Times.Once());
 		VerifyLogged(logger, LogLevel.Warning, Times.Never());
@@ -42,9 +64,46 @@ public class VlmOcrSmokeTestTests
 		Mock<ILogger> logger = new();
 		HttpClient http = CreateHttpClient(HttpStatusCode.OK, TagsJsonWithoutModel);
 
-		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+		await VlmOcrSmokeTest.RunAsync(http, ConfiguredModel, logger.Object, CancellationToken.None);
 
-		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "glm-ocr not in model list");
+		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "not in model list");
+		VerifyLogged(logger, LogLevel.Information, Times.Never());
+	}
+
+	[Fact]
+	public async Task RunAsync_LookalikeModelName_DoesNotMatch_LogsWarning()
+	{
+		// glm-ocr-experimental should NOT satisfy a check for glm-ocr:q8_0.
+		Mock<ILogger> logger = new();
+		HttpClient http = CreateHttpClient(HttpStatusCode.OK, TagsJsonWithLookalikeModel);
+
+		await VlmOcrSmokeTest.RunAsync(http, ConfiguredModel, logger.Object, CancellationToken.None);
+
+		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "not in model list");
+		VerifyLogged(logger, LogLevel.Information, Times.Never());
+	}
+
+	[Fact]
+	public async Task RunAsync_EmptyModelsList_LogsWarning()
+	{
+		Mock<ILogger> logger = new();
+		HttpClient http = CreateHttpClient(HttpStatusCode.OK, TagsJsonEmpty);
+
+		await VlmOcrSmokeTest.RunAsync(http, ConfiguredModel, logger.Object, CancellationToken.None);
+
+		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "no models reported");
+		VerifyLogged(logger, LogLevel.Information, Times.Never());
+	}
+
+	[Fact]
+	public async Task RunAsync_MalformedJson_LogsWarningAndDoesNotThrow()
+	{
+		Mock<ILogger> logger = new();
+		HttpClient http = CreateHttpClient(HttpStatusCode.OK, TagsJsonMalformed);
+
+		await VlmOcrSmokeTest.RunAsync(http, ConfiguredModel, logger.Object, CancellationToken.None);
+
+		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "failed to parse");
 		VerifyLogged(logger, LogLevel.Information, Times.Never());
 	}
 
@@ -54,7 +113,7 @@ public class VlmOcrSmokeTestTests
 		Mock<ILogger> logger = new();
 		HttpClient http = CreateHttpClient(HttpStatusCode.ServiceUnavailable, "");
 
-		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+		await VlmOcrSmokeTest.RunAsync(http, ConfiguredModel, logger.Object, CancellationToken.None);
 
 		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "503");
 		VerifyLogged(logger, LogLevel.Information, Times.Never());
@@ -66,7 +125,7 @@ public class VlmOcrSmokeTestTests
 		Mock<ILogger> logger = new();
 		HttpClient http = CreateThrowingHttpClient(new HttpRequestException("connection refused"));
 
-		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+		await VlmOcrSmokeTest.RunAsync(http, ConfiguredModel, logger.Object, CancellationToken.None);
 
 		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "failed to reach");
 		VerifyLogged(logger, LogLevel.Information, Times.Never());
@@ -78,10 +137,36 @@ public class VlmOcrSmokeTestTests
 		Mock<ILogger> logger = new();
 		HttpClient http = CreateThrowingHttpClient(new TaskCanceledException("timeout", new TimeoutException()));
 
-		await VlmOcrSmokeTest.RunAsync(http, logger.Object, CancellationToken.None);
+		await VlmOcrSmokeTest.RunAsync(http, ConfiguredModel, logger.Object, CancellationToken.None);
 
 		VerifyLogged(logger, LogLevel.Warning, Times.Once(), "failed to reach");
 		VerifyLogged(logger, LogLevel.Information, Times.Never());
+	}
+
+	[Fact]
+	public async Task InstanceRunAsync_UsesIHttpClientFactory_AndConfiguredModel()
+	{
+		// Verify the public instance API resolves the named "vlm-smoke" client from the factory
+		// and uses the model from IOptions<VlmOcrOptions>.
+		Mock<ILogger<VlmOcrSmokeTest>> logger = new();
+		HttpClient http = CreateHttpClient(HttpStatusCode.OK, TagsJsonWithExactModel);
+
+		Mock<IHttpClientFactory> factory = new();
+		factory.Setup(f => f.CreateClient(VlmOcrSmokeTest.HttpClientName)).Returns(http);
+
+		IOptions<VlmOcrOptions> options = Options.Create(new VlmOcrOptions
+		{
+			OllamaUrl = BaseUrl,
+			Model = ConfiguredModel,
+		});
+
+		VlmOcrSmokeTest smokeTest = new(factory.Object, options, logger.Object);
+
+		await smokeTest.RunAsync(CancellationToken.None);
+
+		factory.Verify(f => f.CreateClient(VlmOcrSmokeTest.HttpClientName), Times.Once());
+		VerifyLogged(logger, LogLevel.Information, Times.Once());
+		VerifyLogged(logger, LogLevel.Warning, Times.Never());
 	}
 
 	private static HttpClient CreateHttpClient(HttpStatusCode status, string body)
@@ -113,6 +198,18 @@ public class VlmOcrSmokeTestTests
 	}
 
 	private static void VerifyLogged(Mock<ILogger> logger, LogLevel level, Times times, string? containing = null)
+	{
+		logger.Verify(
+			x => x.Log(
+				level,
+				It.IsAny<EventId>(),
+				It.Is<It.IsAnyType>((state, _) => containing == null || state.ToString()!.Contains(containing)),
+				It.IsAny<Exception?>(),
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			times);
+	}
+
+	private static void VerifyLogged<T>(Mock<ILogger<T>> logger, LogLevel level, Times times, string? containing = null)
 	{
 		logger.Verify(
 			x => x.Log(


### PR DESCRIPTION
## Summary

- **Single source of truth for the VLM model tag.** `VlmOcrOptions.DefaultModel = "glm-ocr:q8_0"` is the C# default; Aspire and docker-compose read `$VLM_MODEL` and pipe it to the pull sidecar AND to API/VlmEval as `Ocr__Vlm__Model`. Change the model in one place, not five.
- **Smoke test parses `/api/tags` JSON properly.** Replaced `body.Contains("glm-ocr")` (which incorrectly matched `glm-ocr-experimental`) with a `System.Text.Json` parse and `StringComparison.Ordinal` exact match against `models[].name`. Added a regression test for the look-alike case.
- **`VlmOcrSmokeTest` uses `IHttpClientFactory`.** Promoted to an instance class taking `IHttpClientFactory` + `IOptions<VlmOcrOptions>`; the API registers a named `"vlm-smoke"` client so it picks up OTel HTTP instrumentation and `ConfigureHttpClientDefaults` like every other client.
- **Unified Ollama URL fallback chain.** Extracted `InfrastructureService.ResolveOllamaUrl` (Ocr:Vlm:OllamaUrl → Ollama:BaseUrl → null). `Program.cs` and `RegisterReceiptExtractionService` both call it. Startup warning emitted when both keys are missing instead of silently smoke-testing localhost.

Resolves RECEIPTS-635.

## Notes

- Pre-existing breakage: `PdfConversionServiceFixtureTests` (RECEIPTS-651) was calling the old `byte[]` return signature from before RECEIPTS-637 thickened `PdfConversionResult`. Fixed in this PR so the build passes — minimal change, dereference `.FirstPagePng` and assert `TotalPageCount >= 1`.
- `Receipts.AppHost.csproj` now references `Infrastructure.csproj` with `IsAspireProjectResource="false"` so AppHost can read `VlmOcrOptions.DefaultModel` without Aspire trying to launch Infrastructure as a project resource.
- `appsettings.json` no longer hardcodes `Model: "glm-ocr:q8_0"` — `DefaultModel` wins. Override via `Ocr__Vlm__Model` env or a higher-precedence config source.

## Test plan

- [x] `dotnet build Receipts.slnx -p:TreatWarningsAsErrors=true` passes.
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` passes (2474 tests).
- [x] `dotnet format Receipts.slnx --verify-no-changes` passes.
- [x] New regression test: `RunAsync_LookalikeModelName_DoesNotMatch_LogsWarning` confirms `glm-ocr-experimental` is NOT a match for `glm-ocr:q8_0`.
- [x] New test: `InstanceRunAsync_UsesIHttpClientFactory_AndConfiguredModel` verifies the DI path through `IOptions<VlmOcrOptions>` + `IHttpClientFactory.CreateClient("vlm-smoke")`.
- [ ] Manual: `aspire run` — confirm pull sidecar prints `Pulling glm-ocr:q8_0` and API logs `VLM OCR: glm-ocr:q8_0 available at ...`.
- [ ] Manual: export `VLM_MODEL=qwen2.5vl:3b` then `aspire run` — confirm pull sidecar pulls qwen2.5vl:3b and API logs match.