### PR TITLE
fix(infrastructure): vlm extraction observability + pii gating (RECEIPTS-639)

### DIFF
--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -248,6 +248,29 @@ public static class InfrastructureService
 				?? "http://localhost:11434";
 		}
 
+		services.AddVlmOcrClient(options);
+	}
+
+	/// <summary>
+	/// Registers the Ollama-backed <see cref="IReceiptExtractionService"/> typed HTTP client
+	/// with the production resilience pipeline (retry + circuit breaker + per-attempt timeout)
+	/// and registers <paramref name="options"/> as a singleton. Both the production
+	/// <c>RegisterReceiptExtractionService</c> path and the <c>VlmEval</c> tool call this
+	/// helper so they share identical retry behavior and the same opt-out from the standard
+	/// handler injected by <c>Receipts.ServiceDefaults</c>. See RECEIPTS-639.
+	/// </summary>
+	public static IServiceCollection AddVlmOcrClient(this IServiceCollection services, VlmOcrOptions options)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+		ArgumentNullException.ThrowIfNull(options);
+
+		if (string.IsNullOrWhiteSpace(options.OllamaUrl))
+		{
+			throw new ArgumentException(
+				$"{nameof(VlmOcrOptions)}.{nameof(VlmOcrOptions.OllamaUrl)} must be set before calling {nameof(AddVlmOcrClient)}.",
+				nameof(options));
+		}
+
 		services.AddSingleton(options);
 
 #pragma warning disable EXTEXP0001 // RemoveAllResilienceHandlers is in evaluation; required to opt out of the standard handler injected by ServiceDefaults.
@@ -261,6 +284,8 @@ public static class InfrastructureService
 			.RemoveAllResilienceHandlers()
 			.AddResilienceHandler("vlm-ocr", builder => ConfigureVlmOcrResilience(builder, options));
 #pragma warning restore EXTEXP0001
+
+		return services;
 	}
 
 	/// <summary>

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -45,6 +45,15 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 		_logger = logger;
 	}
 
+	/// <summary>
+	/// Maximum number of characters from the raw VLM response copied into exception messages.
+	/// The raw body contains receipt PII (store, items, payment method, last-four card digits)
+	/// and tends to propagate through telemetry channels — exception messages are not the right
+	/// place for that. The full body is still available via the gated raw-response debug log
+	/// when <see cref="VlmOcrOptions.LogRawResponses"/> is enabled. See RECEIPTS-639.
+	/// </summary>
+	internal const int ExceptionMessageMaxChars = 500;
+
 	public async Task<ParsedReceipt> ExtractAsync(byte[] imageBytes, string contentType, CancellationToken cancellationToken)
 	{
 		ArgumentNullException.ThrowIfNull(imageBytes);
@@ -53,14 +62,25 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 			throw new ArgumentException("Image bytes cannot be empty.", nameof(imageBytes));
 		}
 
+		ReceiptExtractionPromptValue prompt = ReceiptExtractionPrompt.Current;
+
+		// All logs in this request — including those raised from inner helpers and the resilience
+		// pipeline — get the prompt version stamped on them so a regression can be traced back to
+		// the prompt that produced it. See RECEIPTS-639.
+		using IDisposable? promptScope = _logger.BeginScope(new Dictionary<string, object>
+		{
+			["VlmPromptVersion"] = prompt.Version,
+			["VlmModel"] = _options.Model,
+		});
+
 		_logger.LogDebug(
-			"Extracting receipt via Ollama VLM (model={Model}, bytes={Bytes}, contentType={ContentType})",
-			_options.Model, imageBytes.Length, contentType);
+			"Extracting receipt via Ollama VLM (model={Model}, promptVersion={PromptVersion}, bytes={Bytes}, contentType={ContentType})",
+			_options.Model, prompt.Version, imageBytes.Length, contentType);
 
 		string base64 = Convert.ToBase64String(imageBytes);
 		OllamaGenerateRequest request = new(
 			Model: _options.Model,
-			Prompt: ReceiptExtractionPrompt.Current,
+			Prompt: prompt.Text,
 			Images: [base64]);
 
 		// The per-attempt timeout is enforced by the resilience pipeline (Polly Timeout
@@ -87,7 +107,12 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 			throw new InvalidOperationException("Ollama VLM returned an empty response.");
 		}
 
-		_logger.LogDebug("Ollama VLM raw response: {Response}", generateResponse.Response);
+		// The raw response carries PII (store, items, payment method, last-four). Logging is gated
+		// behind VlmOcrOptions.LogRawResponses (default off in production) — see RECEIPTS-639.
+		if (_options.LogRawResponses)
+		{
+			_logger.LogDebug("Ollama VLM raw response: {Response}", generateResponse.Response);
+		}
 
 		VlmReceiptPayload payload;
 		try
@@ -98,10 +123,35 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 		catch (JsonException ex)
 		{
 			throw new InvalidOperationException(
-				$"Failed to parse Ollama VLM response as JSON. Raw response: {generateResponse.Response}", ex);
+				$"Failed to parse Ollama VLM response as JSON. Raw response (truncated): {Truncate(generateResponse.Response, ExceptionMessageMaxChars)}", ex);
+		}
+
+		if (payload.SchemaVersion != VlmReceiptPayload.CurrentSchemaVersion)
+		{
+			// Don't include the raw payload in this message — it is PII-bearing and exception
+			// messages routinely propagate through telemetry. The version mismatch alone is
+			// enough to identify the root cause; full bodies are available via the LogRawResponses
+			// flag for local diagnostics.
+			throw new InvalidOperationException(
+				$"Ollama VLM payload schema_version mismatch (expected={VlmReceiptPayload.CurrentSchemaVersion}, actual={payload.SchemaVersion?.ToString(CultureInfo.InvariantCulture) ?? "null"}, promptVersion={prompt.Version}).");
 		}
 
 		return MapToParsedReceipt(payload);
+	}
+
+	/// <summary>
+	/// Truncates <paramref name="value"/> to at most <paramref name="maxChars"/> characters,
+	/// appending an ellipsis suffix when the string is cut. Used to keep exception messages
+	/// from leaking the entire VLM payload (PII) into telemetry. See RECEIPTS-639.
+	/// </summary>
+	internal static string Truncate(string value, int maxChars)
+	{
+		if (value.Length <= maxChars)
+		{
+			return value;
+		}
+
+		return string.Concat(value.AsSpan(0, maxChars), "... [truncated]");
 	}
 
 	private static ParsedReceipt MapToParsedReceipt(VlmReceiptPayload payload)

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -140,9 +140,16 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 	}
 
 	/// <summary>
-	/// Truncates <paramref name="value"/> to at most <paramref name="maxChars"/> characters,
-	/// appending an ellipsis suffix when the string is cut. Used to keep exception messages
-	/// from leaking the entire VLM payload (PII) into telemetry. See RECEIPTS-639.
+	/// Truncates <paramref name="value"/> to at most <paramref name="maxChars"/> UTF-16 code
+	/// units, appending an ellipsis suffix when the string is cut. Used to keep exception
+	/// messages from leaking the entire VLM payload (PII) into telemetry. See RECEIPTS-639.
+	/// <para>
+	/// If the cut boundary lands between the two halves of a UTF-16 surrogate pair, the high
+	/// surrogate is dropped rather than orphaned. An unpaired high surrogate would produce an
+	/// ill-formed string that <see cref="System.Text.Json"/> (the default formatter for many
+	/// structured log sinks) rejects with an <see cref="InvalidOperationException"/> in strict
+	/// mode, masking the original exception in telemetry.
+	/// </para>
 	/// </summary>
 	internal static string Truncate(string value, int maxChars)
 	{
@@ -151,7 +158,11 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 			return value;
 		}
 
-		return string.Concat(value.AsSpan(0, maxChars), "... [truncated]");
+		int safeMax = maxChars > 0 && char.IsHighSurrogate(value[maxChars - 1])
+			? maxChars - 1
+			: maxChars;
+
+		return string.Concat(value.AsSpan(0, safeMax), "... [truncated]");
 	}
 
 	private static ParsedReceipt MapToParsedReceipt(VlmReceiptPayload payload)

--- a/src/Infrastructure/Services/ReceiptExtractionPrompt.cs
+++ b/src/Infrastructure/Services/ReceiptExtractionPrompt.cs
@@ -1,12 +1,20 @@
 namespace Infrastructure.Services;
 
+/// <summary>
+/// A receipt-extraction prompt and its version tag. The version flows through the
+/// <see cref="OllamaReceiptExtractionService"/> log scope so any extraction can be traced
+/// back to the prompt that produced it. See RECEIPTS-639.
+/// </summary>
+public sealed record ReceiptExtractionPromptValue(string Version, string Text);
+
 public static class ReceiptExtractionPrompt
 {
 	public const string V1 = """
 		You are a receipt data extraction assistant. Read the receipt image carefully and return a single JSON object with the purchase details.
 
-		Output schema (all fields are optional — omit any field you cannot read from the receipt):
+		Output schema (all fields are optional except `schema_version` — omit any field you cannot read from the receipt):
 		{
+		  "schema_version": 1,           // REQUIRED: integer literal 1
 		  "store": string,              // Merchant name
 		  "date": string,               // Purchase date, ISO-8601 YYYY-MM-DD
 		  "items": [
@@ -31,23 +39,26 @@ public static class ReceiptExtractionPrompt
 
 		Rules:
 		- Output ONLY the JSON object. No markdown fences, no prose, no "```json" markers.
+		- ALWAYS include `"schema_version": 1` as the first field of the object.
 		- Use `.` as the decimal separator.
 		- Emit numbers as JSON numbers, not strings.
-		- Do not invent data. If a field is not visible on the receipt, omit it entirely.
+		- Do not invent data. If a field is not visible on the receipt, omit it entirely (except `schema_version`).
 		""";
 
 	public const string V2 = """
 		Extract receipt data from the image as a single JSON object.
 
 		Rules:
+		- ALWAYS include `"schema_version": 1` as the first field of the object.
 		- If a field is not printed on the receipt, use null. NEVER compute, estimate, or guess.
 		- quantity and unitPrice are null unless the line explicitly shows a weight or multi-quantity (e.g. "2.460 lb. @ /0.50" or "3 @ $1.99"). Never default them to 1 or to the line total.
 		- code is the long digit string (UPC/SKU/PLU) printed on the item line. If none, null.
 		- Copy numbers exactly as printed. Do not sum, multiply, or divide.
 		- Output ONLY the JSON object. No markdown fences, no prose.
 
-		Schema (all fields optional):
+		Schema (all fields optional except `schema_version`):
 		{
+		  "schema_version": 1,
 		  "store": { "name": string, "address": string|null, "phone": string|null },
 		  "datetime": string|null,
 		  "items": [
@@ -70,6 +81,7 @@ public static class ReceiptExtractionPrompt
 		Extract receipt data from the image as a single JSON object.
 
 		Rules:
+		- ALWAYS include `"schema_version": 1` as the first field of the object.
 		- If a field is not printed on the receipt, use null. NEVER compute, estimate, or guess.
 		- code is the long digit string (UPC/SKU/PLU) printed on the item line. If none, null.
 		- Copy numbers exactly as printed. Do not sum, multiply, or divide.
@@ -96,8 +108,9 @@ public static class ReceiptExtractionPrompt
 
 		CRITICAL: For unweighted items, quantity is null, NOT 1. unitPrice is null, NOT equal to lineTotal.
 
-		Schema (all fields optional; use null when not printed):
+		Schema (all fields optional except `schema_version`; use null when not printed):
 		{
+		  "schema_version": 1,
 		  "store": { "name": string, "address": string|null, "phone": string|null },
 		  "datetime": string|null,
 		  "items": [
@@ -120,6 +133,7 @@ public static class ReceiptExtractionPrompt
 		Extract receipt data from the image as a single JSON object.
 
 		Rules:
+		- ALWAYS include `"schema_version": 1` as the first field of the object.
 		- If a field is not printed on the receipt, use null. NEVER compute, estimate, or guess.
 		- code is the long digit string (UPC/SKU/PLU) printed on the item line. If none, null.
 		- Copy numbers exactly as printed. Do not sum, multiply, or divide.
@@ -167,8 +181,9 @@ public static class ReceiptExtractionPrompt
 		Output:
 		  { "method": "CASH", "amount": 10.00, "lastFour": null }
 
-		Schema (all fields optional; use null when not printed):
+		Schema (all fields optional except `schema_version`; use null when not printed):
 		{
+		  "schema_version": 1,
 		  "store": { "name": string, "address": string|null, "phone": string|null },
 		  "datetime": string|null,
 		  "items": [
@@ -187,5 +202,9 @@ public static class ReceiptExtractionPrompt
 		When unsure, prefer null over guessing.
 		""";
 
-	public const string Current = V4;
+	/// <summary>
+	/// The active prompt used by the production extraction service. Returns the version tag
+	/// alongside the prompt text so the version can be attached to the request log scope.
+	/// </summary>
+	public static ReceiptExtractionPromptValue Current { get; } = new("V4", V4);
 }

--- a/src/Infrastructure/Services/VlmOcrOptions.cs
+++ b/src/Infrastructure/Services/VlmOcrOptions.cs
@@ -7,4 +7,13 @@ public sealed class VlmOcrOptions
 	public string Model { get; set; } = "glm-ocr:q8_0";
 
 	public int TimeoutSeconds { get; set; } = 120;
+
+	/// <summary>
+	/// When <c>true</c>, the raw VLM response body is logged at <c>Debug</c> level after each
+	/// successful call. The raw body contains receipt PII — store name, item descriptions,
+	/// payment method, and last-four card digits — so this flag MUST stay <c>false</c> in
+	/// production. It exists for local diagnostics and the <c>VlmEval</c> tool only. See
+	/// RECEIPTS-639.
+	/// </summary>
+	public bool LogRawResponses { get; set; }
 }

--- a/src/Infrastructure/Services/VlmReceiptPayload.cs
+++ b/src/Infrastructure/Services/VlmReceiptPayload.cs
@@ -4,6 +4,17 @@ namespace Infrastructure.Services;
 
 internal sealed class VlmReceiptPayload
 {
+	/// <summary>
+	/// The schema version the prompt was authored against. The host validates this against
+	/// <see cref="CurrentSchemaVersion"/> after deserialization and throws on mismatch — this
+	/// prevents an old VLM model that emits a stale shape from passing through silently after
+	/// a future schema bump. See RECEIPTS-639.
+	/// </summary>
+	public const int CurrentSchemaVersion = 1;
+
+	[JsonPropertyName("schema_version")]
+	public int? SchemaVersion { get; set; }
+
 	[JsonPropertyName("store")]
 	public VlmStore? Store { get; set; }
 

--- a/src/Tools/VlmEval/Program.cs
+++ b/src/Tools/VlmEval/Program.cs
@@ -37,15 +37,12 @@ ParseCliArgs(args, evalOptions);
 string fixturesPath = Path.GetFullPath(evalOptions.FixturesPath);
 
 builder.Services.AddSingleton(evalOptions);
-builder.Services.AddSingleton(vlmOptions);
 
-builder.Services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
-{
-	client.BaseAddress = new Uri(vlmOptions.OllamaUrl!.TrimEnd('/') + "/");
-	// Per-call timeout is enforced inside OllamaReceiptExtractionService via its own token source.
-	// Leave HttpClient.Timeout unbounded so resilience handlers don't cancel the long VLM call.
-	client.Timeout = Timeout.InfiniteTimeSpan;
-});
+// Share the production VLM client registration so eval results reflect production behavior
+// (retry + circuit breaker + per-attempt timeout, with the standard ServiceDefaults handler
+// removed). Without this, a flaky local Ollama would inflate the model's apparent failure
+// rate during evaluation. See RECEIPTS-639.
+builder.Services.AddVlmOcrClient(vlmOptions);
 
 builder.Services.AddHttpClient("ollama-probe");
 

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -9,6 +9,7 @@ using Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.Protected;
@@ -103,6 +104,7 @@ public class OllamaReceiptExtractionServiceTests
 		// payments array, receipt/store/terminal identifiers.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": {
 			    "name": "Walmart Supercenter",
 			    "address": "9 BENTON RD, TRAVELERS REST SC 29690",
@@ -205,6 +207,7 @@ public class OllamaReceiptExtractionServiceTests
 		// (e.g. "01/14/26") despite being asked for ISO-8601. We parse leniently.
 		string innerJson = $$"""
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "datetime": "{{dateString}}",
 			  "total": 10.00
@@ -226,6 +229,7 @@ public class OllamaReceiptExtractionServiceTests
 		// Arrange — a bad date string should not tank the entire extraction
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "datetime": "sometime last week",
 			  "total": 10.00
@@ -251,6 +255,7 @@ public class OllamaReceiptExtractionServiceTests
 		// the "X lb. @ $Y" pattern and carries the actual quantity/unitPrice.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "items": [
 			    { "description": "BANANAS", "code": "000000004011", "lineTotal": 1.23,
@@ -282,6 +287,7 @@ public class OllamaReceiptExtractionServiceTests
 		// This keeps us from accidentally corrupting an unrelated prior item.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "items": [
 			    { "description": "BREAD", "code": "072250049190", "lineTotal": 3.76,
@@ -311,6 +317,7 @@ public class OllamaReceiptExtractionServiceTests
 		// the "sub-line" shouldn't clobber it. Treat it as a distinct item instead.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "items": [
 			    { "description": "BANANAS", "code": "000000004011", "lineTotal": 1.23,
 			      "quantity": 2.460, "unitPrice": 0.50, "taxCode": "N" },
@@ -401,6 +408,7 @@ public class OllamaReceiptExtractionServiceTests
 		// Arrange — no payments, no taxLines, items with unitPrice/quantity omitted (preferred per V2 prompt)
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "datetime": "2026-04-01",
 			  "items": [],
@@ -429,6 +437,7 @@ public class OllamaReceiptExtractionServiceTests
 		// carry every tender with its amount and last-four for downstream reconciliation.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "total": 40.00,
 			  "payments": [
@@ -465,6 +474,7 @@ public class OllamaReceiptExtractionServiceTests
 		// Arrange — the entire store object may be omitted on a hard-to-read receipt
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "datetime": "2026-04-01",
 			  "total": 10.00
 			}
@@ -492,6 +502,7 @@ public class OllamaReceiptExtractionServiceTests
 		// empty Payments list rather than throwing.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Corner Market" },
 			  "datetime": "2026-04-01",
 			  "total": 3.99
@@ -521,6 +532,7 @@ public class OllamaReceiptExtractionServiceTests
 		// never surfaces a hallucinated value with high confidence.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "total": 70.43,
 			  "payments": [
@@ -632,6 +644,7 @@ public class OllamaReceiptExtractionServiceTests
 		// Arrange — sanity check that the post-processing does not regress the happy path.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "total": 70.43,
 			  "payments": [
@@ -657,6 +670,7 @@ public class OllamaReceiptExtractionServiceTests
 		// downstream code can distinguish "truly unknown tender" from legacy-mapper behavior.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "total": 15.00,
 			  "payments": [
@@ -788,7 +802,10 @@ public class OllamaReceiptExtractionServiceTests
 				return new HttpResponseMessage
 				{
 					StatusCode = HttpStatusCode.OK,
-					Content = new StringContent(WrapInOllamaEnvelope("{}"), System.Text.Encoding.UTF8, "application/json"),
+					Content = new StringContent(
+						WrapInOllamaEnvelope("""{ "schema_version": 1 }"""),
+						System.Text.Encoding.UTF8,
+						"application/json"),
 				};
 			});
 		OllamaReceiptExtractionService service = CreateService(handlerMock.Object);
@@ -827,7 +844,7 @@ public class OllamaReceiptExtractionServiceTests
 		// (5s) — must complete successfully. If the standard handler were not removed by
 		// our registration, the call would die at ~200ms with a TimeoutRejectedException.
 		Mock<HttpMessageHandler> handlerMock = new();
-		string successBody = WrapInOllamaEnvelope("""{ "store": { "name": "Walmart" }, "total": 10.00 }""");
+		string successBody = WrapInOllamaEnvelope("""{ "schema_version": 1, "store": { "name": "Walmart" }, "total": 10.00 }""");
 		handlerMock.Protected()
 			.Setup<Task<HttpResponseMessage>>("SendAsync",
 				ItExpr.IsAny<HttpRequestMessage>(),
@@ -895,7 +912,7 @@ public class OllamaReceiptExtractionServiceTests
 	{
 		// Arrange — build a DI pipeline with retry. Fail twice with 503, then succeed.
 		int callCount = 0;
-		string successBody = WrapInOllamaEnvelope("""{ "store": { "name": "Walmart" }, "total": 10.00 }""");
+		string successBody = WrapInOllamaEnvelope("""{ "schema_version": 1, "store": { "name": "Walmart" }, "total": 10.00 }""");
 
 		Mock<HttpMessageHandler> handlerMock = new();
 		handlerMock.Protected()
@@ -956,5 +973,310 @@ public class OllamaReceiptExtractionServiceTests
 		receipt.StoreName.Value.Should().Be("Walmart");
 		receipt.Total.Value.Should().Be(10.00m);
 		callCount.Should().Be(3); // 2 transient failures + 1 success
+	}
+
+	// -------------------------------------------------------------------------
+	// RECEIPTS-639: schema_version, prompt observability, raw-response gating,
+	// exception-message truncation, and shared client registration helper.
+	// -------------------------------------------------------------------------
+
+	[Fact]
+	public async Task ExtractAsync_SchemaVersionMissing_ThrowsInvalidOperationException()
+	{
+		// Arrange — a payload without schema_version represents either an old VLM model that
+		// pre-dates the schema bump or a corrupted/wrong-shape response. Either way, we MUST
+		// fail loudly rather than silently degrade fields.
+		string innerJson = """
+			{
+			  "store": { "name": "Walmart" },
+			  "total": 10.00
+			}
+			""";
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert — the exception message must NOT contain the raw payload (PII gate) but MUST
+		// describe the version mismatch clearly enough to debug from telemetry.
+		ExceptionAssertions<InvalidOperationException> thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+		thrown.Which.Message.Should().Contain("schema_version mismatch");
+		thrown.Which.Message.Should().Contain("expected=1");
+		thrown.Which.Message.Should().Contain("actual=null");
+		thrown.Which.Message.Should().Contain("promptVersion=V4");
+		thrown.Which.Message.Should().NotContain("Walmart");
+	}
+
+	[Fact]
+	public async Task ExtractAsync_SchemaVersionMismatch_ThrowsInvalidOperationException()
+	{
+		// Arrange — a payload claiming schema_version: 2 from a model trained against a newer
+		// schema. Same fail-fast contract — we don't try to interpret a future shape.
+		string innerJson = """
+			{
+			  "schema_version": 2,
+			  "store": { "name": "Walmart" },
+			  "total": 10.00
+			}
+			""";
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		ExceptionAssertions<InvalidOperationException> thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+		thrown.Which.Message.Should().Contain("schema_version mismatch");
+		thrown.Which.Message.Should().Contain("expected=1");
+		thrown.Which.Message.Should().Contain("actual=2");
+		thrown.Which.Message.Should().NotContain("Walmart");
+	}
+
+	[Fact]
+	public async Task ExtractAsync_LogRawResponses_DefaultFalse_DoesNotLogRawBody()
+	{
+		// Arrange — the raw response carries receipt PII. With LogRawResponses unset (default
+		// false) the body MUST NOT appear in any log message.
+		string innerJson = """
+			{
+			  "schema_version": 1,
+			  "store": { "name": "Walmart Supercenter" },
+			  "total": 70.43,
+			  "payments": [
+			    { "method": "MCARD", "amount": 70.43, "lastFour": "3409" }
+			  ]
+			}
+			""";
+		CapturingLogger<OllamaReceiptExtractionService> logger = new();
+		HttpClient httpClient = new(CreateHandler(WrapInOllamaEnvelope(innerJson)))
+		{
+			BaseAddress = new Uri("http://test-ollama/"),
+		};
+		VlmOcrOptions options = new()
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 30,
+			// Default — LogRawResponses left false.
+		};
+		OllamaReceiptExtractionService service = new(httpClient, options, logger);
+
+		// Act
+		await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert — every captured log message is free of PII fragments from the body.
+		logger.Records.Should().NotBeEmpty();
+		logger.Records.Should().NotContain(record => record.FormattedMessage.Contains("Walmart Supercenter"));
+		logger.Records.Should().NotContain(record => record.FormattedMessage.Contains("3409"));
+		logger.Records.Should().NotContain(record => record.FormattedMessage.Contains("MCARD"));
+		logger.Records.Should().NotContain(record => record.FormattedMessage.Contains("raw response", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task ExtractAsync_LogRawResponses_True_DoesLogRawBody()
+	{
+		// Arrange — sanity check: when explicitly enabled (e.g. by VlmEval), the raw body
+		// surfaces in the debug log. This is the only path that should ever expose PII to logs,
+		// and is gated to local diagnostic flows.
+		string innerJson = """
+			{
+			  "schema_version": 1,
+			  "store": { "name": "Walmart Supercenter" },
+			  "total": 70.43
+			}
+			""";
+		CapturingLogger<OllamaReceiptExtractionService> logger = new();
+		HttpClient httpClient = new(CreateHandler(WrapInOllamaEnvelope(innerJson)))
+		{
+			BaseAddress = new Uri("http://test-ollama/"),
+		};
+		VlmOcrOptions options = new()
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 30,
+			LogRawResponses = true,
+		};
+		OllamaReceiptExtractionService service = new(httpClient, options, logger);
+
+		// Act
+		await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		logger.Records.Should().Contain(record =>
+			record.FormattedMessage.Contains("Walmart Supercenter")
+			&& record.FormattedMessage.Contains("raw response", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task ExtractAsync_PromptVersion_FlowsIntoLogScope()
+	{
+		// Arrange — every log emitted during the extraction must inherit a scope containing
+		// the prompt version so a regression can be traced back to the prompt that produced it.
+		string innerJson = """
+			{
+			  "schema_version": 1,
+			  "store": { "name": "Walmart" },
+			  "total": 10.00
+			}
+			""";
+		CapturingLogger<OllamaReceiptExtractionService> logger = new();
+		HttpClient httpClient = new(CreateHandler(WrapInOllamaEnvelope(innerJson)))
+		{
+			BaseAddress = new Uri("http://test-ollama/"),
+		};
+		VlmOcrOptions options = new()
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 30,
+		};
+		OllamaReceiptExtractionService service = new(httpClient, options, logger);
+
+		// Act
+		await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert — at least one record carries a scope with VlmPromptVersion=V4.
+		logger.Records.Should().NotBeEmpty();
+		bool anyRecordHasVersionScope = logger.Records.Any(record =>
+			record.Scopes.Any(scope =>
+				scope.TryGetValue("VlmPromptVersion", out object? v) && v as string == "V4"));
+		anyRecordHasVersionScope.Should().BeTrue("the prompt version must flow into a structured log scope so logs can be filtered by it");
+	}
+
+	[Fact]
+	public async Task ExtractAsync_MalformedJson_TruncatesRawResponseInExceptionMessage()
+	{
+		// Arrange — a malformed response longer than 500 chars must NOT be copied verbatim into
+		// the exception message (telemetry leak risk). The truncation marker confirms the cap
+		// was applied. The full body still flows through the gated raw-response debug log when
+		// the operator opts in.
+		string oversizedGarbage = "this is not JSON " + new string('x', 1000);
+		string envelope = WrapInOllamaEnvelope(oversizedGarbage);
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(envelope));
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+
+		// Assert
+		ExceptionAssertions<InvalidOperationException> thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+		thrown.Which.Message.Should().Contain("[truncated]");
+		thrown.Which.Message.Length.Should().BeLessThan(oversizedGarbage.Length);
+		thrown.Which.InnerException.Should().BeOfType<JsonException>();
+	}
+
+	[Theory]
+	[InlineData("short value", 500, "short value")]
+	[InlineData("", 100, "")]
+	public void Truncate_InputShorterThanOrEqualToLimit_ReturnedVerbatim(string input, int max, string expected)
+	{
+		// Act
+		string result = OllamaReceiptExtractionService.Truncate(input, max);
+
+		// Assert
+		result.Should().Be(expected);
+	}
+
+	[Fact]
+	public void Truncate_InputLongerThanLimit_TruncatedAndAppendedWithMarker()
+	{
+		// Act
+		string result = OllamaReceiptExtractionService.Truncate(new string('a', 1000), 500);
+
+		// Assert — first 500 chars preserved, suffix appended so callers can tell.
+		result.Should().StartWith(new string('a', 500));
+		result.Should().EndWith("[truncated]");
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_NullOllamaUrl_Throws()
+	{
+		// Arrange
+		ServiceCollection services = new();
+		services.AddLogging();
+		VlmOcrOptions options = new() { Model = "glm-ocr:q8_0" };
+
+		// Act
+		Action act = () => services.AddVlmOcrClient(options);
+
+		// Assert — the helper enforces a non-null OllamaUrl so production and VlmEval cannot
+		// silently register a useless client.
+		act.Should().Throw<ArgumentException>().WithMessage("*OllamaUrl*");
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_RegistersServiceAndOptions()
+	{
+		// Arrange — verify the shared helper wires the typed client and exposes the options
+		// as a singleton (so OllamaReceiptExtractionService can resolve them).
+		ServiceCollection services = new();
+		services.AddLogging();
+		VlmOcrOptions options = new()
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 60,
+		};
+
+		// Act
+		services.AddVlmOcrClient(options);
+
+		// Assert
+		using ServiceProvider sp = services.BuildServiceProvider();
+		sp.GetRequiredService<VlmOcrOptions>().Should().BeSameAs(options);
+		sp.GetRequiredService<IReceiptExtractionService>().Should().BeOfType<OllamaReceiptExtractionService>();
+	}
+
+	/// <summary>
+	/// Captures formatted log messages and the active scope chain at log time, so tests can
+	/// assert both message content (for raw-response PII gating) and ambient scope state
+	/// (for prompt-version observability).
+	/// </summary>
+	private sealed class CapturingLogger<T> : ILogger<T>
+	{
+		private readonly List<IReadOnlyDictionary<string, object?>> _activeScopes = [];
+
+		public List<LogRecord> Records { get; } = [];
+
+		IDisposable? ILogger.BeginScope<TState>(TState state)
+			where TState : default
+		{
+			Dictionary<string, object?> snapshot = state is IEnumerable<KeyValuePair<string, object>> pairs
+				? pairs.ToDictionary(p => p.Key, p => (object?)p.Value)
+				: new Dictionary<string, object?> { ["__state"] = state };
+			_activeScopes.Add(snapshot);
+			return new ScopeReleaser(_activeScopes);
+		}
+
+		public bool IsEnabled(LogLevel logLevel) => true;
+
+		public void Log<TState>(
+			LogLevel logLevel,
+			EventId eventId,
+			TState state,
+			Exception? exception,
+			Func<TState, Exception?, string> formatter)
+		{
+			Records.Add(new LogRecord(
+				logLevel,
+				formatter(state, exception),
+				_activeScopes.Select(s => (IReadOnlyDictionary<string, object?>)new Dictionary<string, object?>(s)).ToList()));
+		}
+
+		private sealed class ScopeReleaser(List<IReadOnlyDictionary<string, object?>> scopes) : IDisposable
+		{
+			public void Dispose()
+			{
+				if (scopes.Count > 0)
+				{
+					scopes.RemoveAt(scopes.Count - 1);
+				}
+			}
+		}
+
+		public sealed record LogRecord(
+			LogLevel Level,
+			string FormattedMessage,
+			IReadOnlyList<IReadOnlyDictionary<string, object?>> Scopes);
 	}
 }

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -1189,6 +1189,42 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	[Fact]
+	public void Truncate_CutBoundaryInsideSurrogatePair_DoesNotOrphanHighSurrogate()
+	{
+		// Arrange — RECEIPTS-639 bug-finder follow-up. A supplementary Unicode character (here
+		// U+1F4A9 PILE OF POO, encoded as the surrogate pair D83D DCA9) costs two UTF-16 code
+		// units. If the cut boundary lands precisely between them, a naive slice would produce
+		// a string ending in a lone high surrogate D83D, which System.Text.Json (the default
+		// formatter for many structured log sinks) rejects in strict mode — masking the
+		// original exception in telemetry. Build a string whose code unit at index
+		// `maxChars - 1` is a high surrogate to force the boundary case.
+		const int maxChars = 10;
+		string padding = new('a', maxChars - 1);              // 9 'a' chars
+		string supplementary = "\uD83D\uDCA9";                // single emoji = 2 code units
+		string input = padding + supplementary + new string('b', 100);
+		// input[maxChars - 1] = input[9] = D83D (high surrogate).
+
+		// Act
+		string result = OllamaReceiptExtractionService.Truncate(input, maxChars);
+
+		// Assert — every high surrogate in the result must be followed by a low surrogate.
+		for (int i = 0; i < result.Length; i++)
+		{
+			if (char.IsHighSurrogate(result[i]))
+			{
+				bool hasPair = i + 1 < result.Length && char.IsLowSurrogate(result[i + 1]);
+				hasPair.Should().BeTrue(
+					$"position {i} of the truncated result must not be a lone high surrogate (result={result})");
+			}
+		}
+
+		// Round-trip the result through System.Text.Json — this is what would happen when the
+		// exception message is serialized into a log sink. With the bug present, this throws.
+		Action serialize = () => System.Text.Json.JsonSerializer.Serialize(result);
+		serialize.Should().NotThrow();
+	}
+
+	[Fact]
 	public void AddVlmOcrClient_NullOllamaUrl_Throws()
 	{
 		// Arrange

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceFixtureTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceFixtureTests.cs
@@ -53,7 +53,7 @@ public class PdfConversionServiceFixtureTests
 		byte[] pdfBytes = LoadFixture("cmyk-receipt.pdf");
 
 		// Act
-		byte[] firstPagePng = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] firstPagePng = (await _service.ConvertAsync(pdfBytes, CancellationToken.None)).FirstPagePng;
 
 		// Assert
 		AssertValidPng(firstPagePng, minWidth: 100, minHeight: 100);
@@ -68,7 +68,7 @@ public class PdfConversionServiceFixtureTests
 		byte[] pdfBytes = LoadFixture("indexed-receipt.pdf");
 
 		// Act
-		byte[] firstPagePng = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] firstPagePng = (await _service.ConvertAsync(pdfBytes, CancellationToken.None)).FirstPagePng;
 
 		// Assert
 		AssertValidPng(firstPagePng, minWidth: 100, minHeight: 100);
@@ -83,7 +83,7 @@ public class PdfConversionServiceFixtureTests
 		byte[] pdfBytes = LoadFixture("calrgb-receipt.pdf");
 
 		// Act
-		byte[] firstPagePng = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] firstPagePng = (await _service.ConvertAsync(pdfBytes, CancellationToken.None)).FirstPagePng;
 
 		// Assert
 		AssertValidPng(firstPagePng, minWidth: 100, minHeight: 100);
@@ -97,7 +97,7 @@ public class PdfConversionServiceFixtureTests
 		byte[] pdfBytes = LoadFixture("lab-receipt.pdf");
 
 		// Act
-		byte[] firstPagePng = await _service.ConvertAsync(pdfBytes, CancellationToken.None);
+		byte[] firstPagePng = (await _service.ConvertAsync(pdfBytes, CancellationToken.None)).FirstPagePng;
 
 		// Assert
 		AssertValidPng(firstPagePng, minWidth: 100, minHeight: 100);


### PR DESCRIPTION
## Summary

Three observability + PII gaps in the VLM extraction path, plus a shared client-registration helper so eval and production never drift apart.

- **schema_version negotiation**: prompt + payload now require `"schema_version": 1`. The host validates after deserialization and throws `InvalidOperationException` on mismatch (without including the raw payload). Prevents an old VLM model from silently emitting a stale shape after a future schema bump.
- **Prompt observability**: `ReceiptExtractionPrompt.Current` returns `ReceiptExtractionPromptValue(Version, Text)`. The version is attached to a structured log scope (`VlmPromptVersion`) so any extraction can be traced back to the prompt that produced it.
- **PII gating**: `VlmOcrOptions.LogRawResponses` (default `false`) gates the raw-body debug log. `InvalidOperationException` messages truncate the raw response to 500 chars via `Truncate()` so PII does not leak through telemetry channels.
- **Shared client registration**: extracted `services.AddVlmOcrClient(VlmOcrOptions)` used by both `InfrastructureService.RegisterReceiptExtractionService` and the `VlmEval` tool. Eval and production now share identical retry + circuit-breaker + per-attempt-timeout config — eval results no longer overstate the model's failure rate due to a flaky local Ollama.

Side effect: fixed a pre-existing build error in `PdfConversionServiceFixtureTests` (broken by RECEIPTS-637's `IPdfConversionService` return-type change). The parent branch does not run CI so it went unnoticed; the build is now green.

Resolves RECEIPTS-639.

## Test plan

- [x] `dotnet build Receipts.slnx` clean (was blocked by parent's broken fixture test before the side-effect fix).
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 720 pass, 1 skipped, 0 failed.
- [x] New tests cover:
  - `schema_version` missing/mismatched → `InvalidOperationException` without leaking raw body
  - `LogRawResponses=false` → raw body absent from logs; `LogRawResponses=true` → raw body present
  - prompt version flows into a structured log scope (`VlmPromptVersion=V4`)
  - malformed JSON exception message is truncated and carries `[truncated]` marker; raw body shorter than the cap is preserved verbatim
  - `AddVlmOcrClient` throws on null `OllamaUrl` and registers the typed client + options singleton
- [x] Frontend tests (1932) pass via pre-commit hook.
- [x] `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)