### PR TITLE
fix(tests): add schema_version to OllamaReceiptExtractionServiceTests fixtures

### DIFF
--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -298,7 +298,7 @@ public static class InfrastructureService
 		// stay in sync.
 		services.AddSingleton<IOptions<VlmOcrOptions>>(new OptionsWrapper<VlmOcrOptions>(options));
 
-	#pragma warning disable EXTEXP0001 // RemoveAllResilienceHandlers is in evaluation; required to opt out of the standard handler injected by ServiceDefaults.
+#pragma warning disable EXTEXP0001 // RemoveAllResilienceHandlers is in evaluation; required to opt out of the standard handler injected by ServiceDefaults.
 		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
 		{
 			client.BaseAddress = new Uri(options.OllamaUrl!.TrimEnd('/') + "/");
@@ -308,7 +308,7 @@ public static class InfrastructureService
 		})
 			.RemoveAllResilienceHandlers()
 			.AddResilienceHandler("vlm-ocr", builder => ConfigureVlmOcrResilience(builder, options));
-	#pragma warning restore EXTEXP0001
+#pragma warning restore EXTEXP0001
 
 		return services;
 	}

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -927,6 +927,7 @@ public class OllamaReceiptExtractionServiceTests
 		// decimal cleanly, with high confidence on the parsed values.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "datetime": "2026-04-01",
 			  "subtotal": "9.10",
@@ -978,6 +979,7 @@ public class OllamaReceiptExtractionServiceTests
 		// genuinely fail every parse path.
 		string innerJson = $$"""
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "datetime": "{{raw}}",
 			  "total": 9.71
@@ -1005,6 +1007,7 @@ public class OllamaReceiptExtractionServiceTests
 		// included so operators can see the offending payload in the logs.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "items": { "description": "MILK", "lineTotal": 3.49 },
 			  "total": 3.49
@@ -1029,6 +1032,7 @@ public class OllamaReceiptExtractionServiceTests
 		// deserializer rejects with JsonException. Same surface contract.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "items": "see attached",
 			  "total": 3.49
@@ -1057,6 +1061,7 @@ public class OllamaReceiptExtractionServiceTests
 		// not require redeploying the API simultaneously.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart", "regionCode": "SE", "internalId": 4711 },
 			  "datetime": "2026-04-01",
 			  "items": [
@@ -1093,6 +1098,7 @@ public class OllamaReceiptExtractionServiceTests
 		// quality concern.
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "datetime": "2026-04-01",
 			  "items": [
@@ -1164,6 +1170,7 @@ public class OllamaReceiptExtractionServiceTests
 		// have no value to surface).
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "datetime": "2026-04-01",
 			  "total": null,
@@ -1190,6 +1197,7 @@ public class OllamaReceiptExtractionServiceTests
 		// decided not to emit the field" and "the VLM emitted null".
 		string innerJson = """
 			{
+			  "schema_version": 1,
 			  "store": { "name": "Walmart" },
 			  "datetime": "2026-04-01"
 			}


### PR DESCRIPTION
## Summary

- RECEIPTS-639 added strict `schema_version` validation; RECEIPTS-647 added malformed-payload test fixtures (merged concurrently from a base before -639). After both landed, 10 tests fail with `schema_version mismatch (expected=1, actual=null)`.
- Fix: add `"schema_version": 1` to each affected fixture JSON literal. Behavior under test is unchanged.
- Also: small `dotnet format` whitespace fix on `InfrastructureService.cs` pragma indentation drift.

## Test plan

- [x] `dotnet test tests/Infrastructure.Tests/Infrastructure.Tests.csproj --filter "FullyQualifiedName~OllamaReceiptExtractionService"` → 74 passed, 0 failed.
- [x] No production-code logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)