### PR TITLE
refactor(application): scan-receipt pipeline hardening (RECEIPTS-640)

### DIFF
--- a/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
+++ b/src/Application/Commands/Receipt/Scan/ScanReceiptCommandHandler.cs
@@ -10,14 +10,13 @@ public class ScanReceiptCommandHandler(
 	IPdfConversionService pdfConversionService) : IRequestHandler<ScanReceiptCommand, ScanReceiptResult>
 {
 	internal const string PdfContentType = "application/pdf";
-	internal const string PdfPageImageContentType = "image/png";
 
 	public async Task<ScanReceiptResult> Handle(ScanReceiptCommand request, CancellationToken cancellationToken)
 	{
-		(byte[] imageBytes, string contentType, int droppedPageCount) =
+		(byte[] imageBytes, int droppedPageCount) =
 			await ResolveImageAsync(request, cancellationToken);
 
-		ParsedReceipt parsed = await extractionService.ExtractAsync(imageBytes, contentType, cancellationToken);
+		ParsedReceipt parsed = await extractionService.ExtractAsync(imageBytes, cancellationToken);
 
 		if (IsEmpty(parsed))
 		{
@@ -27,12 +26,12 @@ public class ScanReceiptCommandHandler(
 		return new ScanReceiptResult(parsed, droppedPageCount);
 	}
 
-	private async Task<(byte[] ImageBytes, string ContentType, int DroppedPageCount)> ResolveImageAsync(
+	private async Task<(byte[] ImageBytes, int DroppedPageCount)> ResolveImageAsync(
 		ScanReceiptCommand request, CancellationToken cancellationToken)
 	{
 		if (!string.Equals(request.ContentType, PdfContentType, StringComparison.OrdinalIgnoreCase))
 		{
-			return (request.ImageBytes, request.ContentType, 0);
+			return (request.ImageBytes, 0);
 		}
 
 		PdfConversionResult conversion = await pdfConversionService.ConvertAsync(
@@ -42,7 +41,7 @@ public class ScanReceiptCommandHandler(
 		// with InvalidOperationException), so this subtraction is always >= 0.
 		int droppedPageCount = conversion.TotalPageCount - 1;
 
-		return (conversion.FirstPagePng, PdfPageImageContentType, droppedPageCount);
+		return (conversion.FirstPagePng, droppedPageCount);
 	}
 
 	/// <summary>

--- a/src/Application/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandler.cs
+++ b/src/Application/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandler.cs
@@ -1,12 +1,14 @@
 using Application.Interfaces.Services;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Commands.Receipt.UploadImage;
 
 public class UploadReceiptImageCommandHandler(
 	IReceiptService receiptService,
 	IImageStorageService imageStorageService,
-	IImageValidationService imageValidationService) : IRequestHandler<UploadReceiptImageCommand, UploadReceiptImageResult>
+	IImageValidationService imageValidationService,
+	ILogger<UploadReceiptImageCommandHandler> logger) : IRequestHandler<UploadReceiptImageCommand, UploadReceiptImageResult>
 {
 	public async Task<UploadReceiptImageResult> Handle(UploadReceiptImageCommand request, CancellationToken cancellationToken)
 	{
@@ -29,9 +31,35 @@ public class UploadReceiptImageCommandHandler(
 
 			return new UploadReceiptImageResult(originalPath);
 		}
-		catch
+		catch (Exception ex) when (ex is not OperationCanceledException)
 		{
-			await imageStorageService.DeleteReceiptImagesAsync(request.ReceiptId, cancellationToken);
+			// If the path-update fails (e.g. DB offline) the just-saved blob would otherwise
+			// be orphaned. Cleanup is best-effort:
+			//
+			// 1) Pass CancellationToken.None — if the caller's token was already canceled, we
+			//    still want the orphan removed. Without this the cleanup itself silently aborts
+			//    and the operator never sees the orphan.
+			// 2) Catch-and-log any cleanup failure so the original exception (the actual
+			//    root cause the operator needs to see) is the one that propagates. Without this
+			//    a cleanup throw replaces the originating exception and we lose the root cause.
+			// 3) Skip the destructive delete entirely on cancellation — a canceled upload should
+			//    leave the saved blob in place rather than racing the user's cancel against the
+			//    disk so a retry can re-attach it. The exception filter on the catch achieves this.
+			//
+			// See RECEIPTS-640.
+			try
+			{
+				await imageStorageService.DeleteReceiptImagesAsync(
+					request.ReceiptId, CancellationToken.None);
+			}
+			catch (Exception cleanupEx)
+			{
+				logger.LogError(
+					cleanupEx,
+					"Failed to clean up orphaned blob for receipt {ReceiptId} after path-update failure; original error: {OriginalError}",
+					request.ReceiptId, ex.Message);
+			}
+
 			throw;
 		}
 	}

--- a/src/Application/Interfaces/Services/IReceiptExtractionService.cs
+++ b/src/Application/Interfaces/Services/IReceiptExtractionService.cs
@@ -4,5 +4,11 @@ namespace Application.Interfaces.Services;
 
 public interface IReceiptExtractionService
 {
-	Task<ParsedReceipt> ExtractAsync(byte[] imageBytes, string contentType, CancellationToken cancellationToken);
+	/// <summary>
+	/// Extracts a structured <see cref="ParsedReceipt"/> from raw image bytes. The bytes are
+	/// transmitted to the VLM verbatim — no MIME type is propagated downstream because Ollama's
+	/// <c>/api/generate</c> accepts a base64 image with no per-image format hint (the model
+	/// auto-detects PNG/JPEG/etc. from the bytes themselves). See RECEIPTS-640.
+	/// </summary>
+	Task<ParsedReceipt> ExtractAsync(byte[] imageBytes, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -263,9 +263,16 @@ public static class InfrastructureService
 		VlmOcrOptions options = new();
 		configuration.GetSection(ConfigurationVariables.OcrVlmSection).Bind(options);
 
-		if (string.IsNullOrWhiteSpace(options.OllamaUrl))
+		// RECEIPTS-640: VlmOcrOptions.OllamaUrl is now a non-nullable string with a localhost
+		// default, so the previous IsNullOrWhiteSpace gate would short-circuit when neither
+		// Ocr:Vlm:OllamaUrl nor a configured override is set — silently bypassing the
+		// Aspire-injected Ollama:BaseUrl that ResolveOllamaUrl picks up. Always run the
+		// resolver: it already enforces the priority chain (Ocr:Vlm:OllamaUrl →
+		// Ollama:BaseUrl → null), so the bound default only wins when neither is configured.
+		string? resolved = ResolveOllamaUrl(configuration);
+		if (!string.IsNullOrWhiteSpace(resolved))
 		{
-			options.OllamaUrl = ResolveOllamaUrl(configuration) ?? "http://localhost:11434";
+			options.OllamaUrl = resolved;
 		}
 
 		services.AddVlmOcrClient(options);

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -40,6 +40,10 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 		VlmOcrOptions options,
 		ILogger<OllamaReceiptExtractionService> logger)
 	{
+		ArgumentNullException.ThrowIfNull(httpClient);
+		ArgumentNullException.ThrowIfNull(options);
+		ArgumentNullException.ThrowIfNull(logger);
+
 		_httpClient = httpClient;
 		_options = options;
 		_logger = logger;
@@ -54,12 +58,23 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 	/// </summary>
 	internal const int ExceptionMessageMaxChars = 500;
 
-	public async Task<ParsedReceipt> ExtractAsync(byte[] imageBytes, string contentType, CancellationToken cancellationToken)
+	public async Task<ParsedReceipt> ExtractAsync(byte[] imageBytes, CancellationToken cancellationToken)
 	{
 		ArgumentNullException.ThrowIfNull(imageBytes);
 		if (imageBytes.Length == 0)
 		{
 			throw new ArgumentException("Image bytes cannot be empty.", nameof(imageBytes));
+		}
+
+		// Reject oversized images before allocating a base64 buffer (~133% of the input). Ollama's
+		// default request body limit is well below 50 MB+ camera dumps mobile clients can produce;
+		// rejecting here gives a clear ArgumentException at the boundary instead of an opaque
+		// HttpRequestException or RequestEntityTooLarge from the daemon. See RECEIPTS-640.
+		if (imageBytes.Length > _options.MaxImageBytes)
+		{
+			throw new ArgumentException(
+				$"Image is {imageBytes.Length} bytes, exceeding the configured maximum of {_options.MaxImageBytes} bytes.",
+				nameof(imageBytes));
 		}
 
 		ReceiptExtractionPromptValue prompt = ReceiptExtractionPrompt.Current;
@@ -74,8 +89,8 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 		});
 
 		_logger.LogDebug(
-			"Extracting receipt via Ollama VLM (model={Model}, promptVersion={PromptVersion}, bytes={Bytes}, contentType={ContentType})",
-			_options.Model, prompt.Version, imageBytes.Length, contentType);
+			"Extracting receipt via Ollama VLM (model={Model}, promptVersion={PromptVersion}, bytes={Bytes})",
+			_options.Model, prompt.Version, imageBytes.Length);
 
 		string base64 = Convert.ToBase64String(imageBytes);
 		OllamaGenerateRequest request = new(
@@ -105,6 +120,17 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 		if (generateResponse is null || string.IsNullOrWhiteSpace(generateResponse.Response))
 		{
 			throw new InvalidOperationException("Ollama VLM returned an empty response.");
+		}
+
+		// done=false signals a partial/streamed response — the body is mid-stream and the JSON
+		// payload is truncated, so any downstream JsonException would be a confusing red herring.
+		// We send stream=false (Ollama's per-request default) so any done=false here means the
+		// daemon is misconfigured (e.g. someone flipped the default at the server). Surface the
+		// real cause early rather than letting a JsonException mask it. See RECEIPTS-640.
+		if (!generateResponse.Done)
+		{
+			throw new InvalidOperationException(
+				"Ollama VLM returned a non-final response (done=false); the request was streamed or truncated. Confirm the daemon is configured for stream=false.");
 		}
 
 		// The raw response carries PII (store, items, payment method, last-four). Logging is gated

--- a/src/Infrastructure/Services/VlmOcrOptions.cs
+++ b/src/Infrastructure/Services/VlmOcrOptions.cs
@@ -10,11 +10,37 @@ public sealed class VlmOcrOptions
 	/// </summary>
 	public const string DefaultModel = "glm-ocr:q8_0";
 
-	public string? OllamaUrl { get; set; }
+	/// <summary>
+	/// Default Ollama base URL when no other configuration source is wired up. The production
+	/// path overrides this via <c>Ocr:Vlm:OllamaUrl</c> or the Aspire-injected
+	/// <c>Ollama:BaseUrl</c>; see <c>InfrastructureService.ResolveOllamaUrl</c>. The default
+	/// keeps local <c>dotnet run</c> sessions (no Aspire, no env vars) talking to a developer's
+	/// localhost daemon instead of crashing at startup.
+	/// </summary>
+	public const string DefaultOllamaUrl = "http://localhost:11434";
+
+	/// <summary>
+	/// Default upper bound on the raw image byte length accepted by the VLM extraction service.
+	/// Base64 inflates the request body by ~33%, and Ollama's default request body limit is
+	/// well below the kind of camera dumps mobile clients can produce (50 MB+ on modern phones).
+	/// 15 MB is generous for receipt photos at typical rasterization resolutions while keeping
+	/// the post-base64 body comfortably under Ollama's threshold. See RECEIPTS-640.
+	/// </summary>
+	public const int DefaultMaxImageBytes = 15 * 1024 * 1024;
+
+	public string OllamaUrl { get; set; } = DefaultOllamaUrl;
 
 	public string Model { get; set; } = DefaultModel;
 
 	public int TimeoutSeconds { get; set; } = 120;
+
+	/// <summary>
+	/// Maximum image byte length accepted by <c>OllamaReceiptExtractionService.ExtractAsync</c>.
+	/// Inputs larger than this throw <see cref="ArgumentException"/> before any base64 encoding
+	/// happens, protecting both the client (memory) and the Ollama server (request body limit).
+	/// See RECEIPTS-640.
+	/// </summary>
+	public int MaxImageBytes { get; set; } = DefaultMaxImageBytes;
 
 	/// <summary>
 	/// When <c>true</c>, the raw VLM response body is logged at <c>Debug</c> level after each

--- a/src/Tools/VlmEval/FixtureEvaluator.cs
+++ b/src/Tools/VlmEval/FixtureEvaluator.cs
@@ -35,7 +35,7 @@ public sealed class FixtureEvaluator(
 		ParsedReceipt parsed;
 		try
 		{
-			parsed = await extractionService.ExtractAsync(bytes, fixture.ContentType, cancellationToken);
+			parsed = await extractionService.ExtractAsync(bytes, cancellationToken);
 		}
 		catch (Exception ex)
 		{

--- a/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/Scan/ScanReceiptCommandHandlerTests.cs
@@ -109,14 +109,17 @@ public class ScanReceiptCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task Handle_Image_CallsExtractionServiceWithBytesAndContentType()
+	public async Task Handle_Image_CallsExtractionServiceWithBytes()
 	{
-		// Arrange
+		// Arrange — RECEIPTS-640: the contentType parameter was dropped from
+		// IReceiptExtractionService.ExtractAsync because Ollama auto-detects PNG/JPEG/etc.
+		// from the bytes themselves and the parameter was only being logged. The handler must
+		// pass image bytes through verbatim.
 		byte[] imageBytes = [0xFF, 0xD8, 0xFF, 0xE0];
 		ScanReceiptCommand command = new(imageBytes, "image/jpeg");
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(BuildPopulatedReceipt());
 
 		// Act
@@ -124,7 +127,7 @@ public class ScanReceiptCommandHandlerTests
 
 		// Assert
 		_mockExtractionService.Verify(
-			s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()),
+			s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()),
 			Times.Once);
 		_mockPdfConversionService.Verify(
 			s => s.ConvertAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
@@ -140,7 +143,7 @@ public class ScanReceiptCommandHandlerTests
 		ParsedReceipt parsed = BuildPopulatedReceipt("COSTCO", 42.99m);
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, "image/png", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(parsed);
 
 		// Act
@@ -165,7 +168,7 @@ public class ScanReceiptCommandHandlerTests
 
 		ParsedReceipt parsed = BuildPopulatedReceipt();
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(firstPageImage, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(parsed);
 
 		// Act
@@ -174,7 +177,7 @@ public class ScanReceiptCommandHandlerTests
 		// Assert
 		actual.ParsedReceipt.Should().BeSameAs(parsed);
 		_mockExtractionService.Verify(
-			s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()),
+			s => s.ExtractAsync(firstPageImage, It.IsAny<CancellationToken>()),
 			Times.Once);
 	}
 
@@ -193,7 +196,7 @@ public class ScanReceiptCommandHandlerTests
 			.ReturnsAsync(new PdfConversionResult(firstPageImage, TotalPageCount: 3));
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(firstPageImage, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(BuildPopulatedReceipt());
 
 		// Act
@@ -217,7 +220,7 @@ public class ScanReceiptCommandHandlerTests
 			.ReturnsAsync(new PdfConversionResult(firstPageImage, TotalPageCount: 1));
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(firstPageImage, "image/png", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(firstPageImage, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(BuildPopulatedReceipt());
 
 		// Act
@@ -235,7 +238,7 @@ public class ScanReceiptCommandHandlerTests
 		ScanReceiptCommand command = new(imageBytes, "image/jpeg");
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(BuildPopulatedReceipt());
 
 		// Act
@@ -253,7 +256,7 @@ public class ScanReceiptCommandHandlerTests
 		ScanReceiptCommand command = new(imageBytes, "image/jpeg");
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(BuildEmptyReceipt());
 
 		// Act
@@ -285,7 +288,7 @@ public class ScanReceiptCommandHandlerTests
 		);
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(parsed);
 
 		// Act
@@ -318,7 +321,7 @@ public class ScanReceiptCommandHandlerTests
 		);
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(parsed);
 
 		// Act
@@ -356,7 +359,7 @@ public class ScanReceiptCommandHandlerTests
 		);
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(parsed);
 
 		// Act
@@ -375,7 +378,7 @@ public class ScanReceiptCommandHandlerTests
 		ScanReceiptCommand command = new(imageBytes, "image/jpeg");
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()))
 			.ThrowsAsync(new InvalidOperationException("VLM returned unparseable JSON."));
 
 		// Act
@@ -405,7 +408,7 @@ public class ScanReceiptCommandHandlerTests
 			.WithMessage("*not a valid PDF*");
 
 		_mockExtractionService.Verify(
-			s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
 			Times.Never);
 	}
 
@@ -420,7 +423,7 @@ public class ScanReceiptCommandHandlerTests
 		ScanReceiptCommand command = new(imageBytes, contentType);
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, contentType, It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(imageBytes, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(BuildPopulatedReceipt());
 
 		// Act
@@ -446,7 +449,7 @@ public class ScanReceiptCommandHandlerTests
 		CancellationToken expected = cts.Token;
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(imageBytes, "image/jpeg", It.Is<CancellationToken>(t => t == expected)))
+			.Setup(s => s.ExtractAsync(imageBytes, It.Is<CancellationToken>(t => t == expected)))
 			.ReturnsAsync(BuildPopulatedReceipt());
 
 		// Act
@@ -454,7 +457,7 @@ public class ScanReceiptCommandHandlerTests
 
 		// Assert
 		_mockExtractionService.Verify(
-			s => s.ExtractAsync(imageBytes, "image/jpeg", It.Is<CancellationToken>(t => t == expected)),
+			s => s.ExtractAsync(imageBytes, It.Is<CancellationToken>(t => t == expected)),
 			Times.Once);
 	}
 
@@ -475,7 +478,7 @@ public class ScanReceiptCommandHandlerTests
 			.ReturnsAsync(new PdfConversionResult(firstPageImage, TotalPageCount: 1));
 
 		_mockExtractionService
-			.Setup(s => s.ExtractAsync(firstPageImage, "image/png", It.Is<CancellationToken>(t => t == expected)))
+			.Setup(s => s.ExtractAsync(firstPageImage, It.Is<CancellationToken>(t => t == expected)))
 			.ReturnsAsync(BuildPopulatedReceipt());
 
 		// Act
@@ -486,7 +489,7 @@ public class ScanReceiptCommandHandlerTests
 			s => s.ConvertAsync(pdfBytes, It.Is<CancellationToken>(t => t == expected)),
 			Times.Once);
 		_mockExtractionService.Verify(
-			s => s.ExtractAsync(firstPageImage, "image/png", It.Is<CancellationToken>(t => t == expected)),
+			s => s.ExtractAsync(firstPageImage, It.Is<CancellationToken>(t => t == expected)),
 			Times.Once);
 	}
 }

--- a/tests/Application.Tests/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandlerTests.cs
@@ -1,6 +1,8 @@
 using Application.Commands.Receipt.UploadImage;
 using Application.Interfaces.Services;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace Application.Tests.Commands.Receipt.UploadImage;
@@ -90,7 +92,8 @@ public class UploadReceiptImageCommandHandlerTests
 		_handler = new UploadReceiptImageCommandHandler(
 			_mockReceiptService.Object,
 			_mockStorageService.Object,
-			_mockValidationService.Object);
+			_mockValidationService.Object,
+			NullLogger<UploadReceiptImageCommandHandler>.Instance);
 	}
 
 	[Fact]
@@ -319,5 +322,133 @@ public class UploadReceiptImageCommandHandlerTests
 		_mockReceiptService.Verify(
 			s => s.UpdateOriginalImagePathAsync(receiptId, expectedPath, It.Is<CancellationToken>(t => t == expected)),
 			Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_UpdateImagePathsThrows_CleanupUsesNoneToken()
+	{
+		// Arrange — RECEIPTS-640: the cleanup path must use CancellationToken.None so a
+		// caller-canceled token does not silently abort the orphan removal. Without this,
+		// an upload that races a user-cancel against a path-update failure would leave
+		// the saved blob orphaned on disk.
+		Guid receiptId = Guid.NewGuid();
+		byte[] imageBytes = [0xFF, 0xD8];
+		UploadReceiptImageCommand command = new(receiptId, imageBytes, "image/jpeg", ".jpg");
+		string savedPath = $"{receiptId}/original.jpg";
+		using CancellationTokenSource cts = new();
+		CancellationToken caller = cts.Token;
+
+		_mockReceiptService
+			.Setup(s => s.ExistsAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+		_mockStorageService
+			.Setup(s => s.SaveOriginalAsync(receiptId, imageBytes, ".jpg", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(savedPath);
+		_mockReceiptService
+			.Setup(s => s.UpdateOriginalImagePathAsync(receiptId, savedPath, It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("DB offline"));
+
+		// Act
+		Func<Task> act = () => _handler.Handle(command, caller);
+
+		// Assert — original exception propagates; cleanup ran with CancellationToken.None
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("DB offline");
+
+		_mockStorageService.Verify(
+			s => s.DeleteReceiptImagesAsync(
+				receiptId,
+				It.Is<CancellationToken>(t => t == CancellationToken.None)),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_UpdateImagePathsThrows_CleanupAlsoThrows_PreservesOriginalException()
+	{
+		// Arrange — RECEIPTS-640: when both UpdateOriginalImagePathAsync and the cleanup
+		// DeleteReceiptImagesAsync throw, the original exception (the actual root cause the
+		// operator needs to see) must propagate, not the cleanup failure. The previous catch
+		// block did NOT swallow the cleanup exception, which silently replaced the originating
+		// exception in the operator's logs.
+		Guid receiptId = Guid.NewGuid();
+		byte[] imageBytes = [0xFF, 0xD8];
+		UploadReceiptImageCommand command = new(receiptId, imageBytes, "image/jpeg", ".jpg");
+		string savedPath = $"{receiptId}/original.jpg";
+
+		_mockReceiptService
+			.Setup(s => s.ExistsAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+		_mockStorageService
+			.Setup(s => s.SaveOriginalAsync(receiptId, imageBytes, ".jpg", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(savedPath);
+		_mockReceiptService
+			.Setup(s => s.UpdateOriginalImagePathAsync(receiptId, savedPath, It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("DB offline"));
+		_mockStorageService
+			.Setup(s => s.DeleteReceiptImagesAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new IOException("Blob storage offline"));
+
+		// Use a captured logger so we can assert the cleanup-failure log fired.
+		Mock<ILogger<UploadReceiptImageCommandHandler>> logger = new();
+		UploadReceiptImageCommandHandler handler = new(
+			_mockReceiptService.Object,
+			_mockStorageService.Object,
+			_mockValidationService.Object,
+			logger.Object);
+
+		// Act
+		Func<Task> act = () => handler.Handle(command, CancellationToken.None);
+
+		// Assert — the originating exception (DB offline) wins, not the cleanup failure
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("DB offline");
+
+		// Cleanup was attempted (and it threw)
+		_mockStorageService.Verify(
+			s => s.DeleteReceiptImagesAsync(receiptId, It.IsAny<CancellationToken>()),
+			Times.Once);
+
+		// Cleanup failure was logged at Error level so the operator can still see it
+		logger.Verify(
+			x => x.Log(
+				LogLevel.Error,
+				It.IsAny<EventId>(),
+				It.IsAny<It.IsAnyType>(),
+				It.IsAny<Exception?>(),
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_CallerCanceled_DoesNotTriggerCleanup()
+	{
+		// Arrange — RECEIPTS-640: a caller cancellation (OperationCanceledException) must NOT
+		// trigger the destructive blob cleanup. Cancellation is a user choice; the saved blob
+		// should remain in place so a retry can re-attach it. Previously the unfiltered
+		// catch-all called DeleteReceiptImagesAsync on every exception including OCE.
+		Guid receiptId = Guid.NewGuid();
+		byte[] imageBytes = [0xFF, 0xD8];
+		UploadReceiptImageCommand command = new(receiptId, imageBytes, "image/jpeg", ".jpg");
+		string savedPath = $"{receiptId}/original.jpg";
+
+		_mockReceiptService
+			.Setup(s => s.ExistsAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+		_mockStorageService
+			.Setup(s => s.SaveOriginalAsync(receiptId, imageBytes, ".jpg", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(savedPath);
+		_mockReceiptService
+			.Setup(s => s.UpdateOriginalImagePathAsync(receiptId, savedPath, It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new OperationCanceledException("Caller canceled"));
+
+		// Act
+		Func<Task> act = () => _handler.Handle(command, CancellationToken.None);
+
+		// Assert — OCE propagates and no destructive cleanup ran
+		await act.Should().ThrowAsync<OperationCanceledException>();
+
+		_mockStorageService.Verify(
+			s => s.DeleteReceiptImagesAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+			Times.Never);
 	}
 }

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -1624,6 +1624,80 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	[Fact]
+	public void RegisterReceiptExtractionService_AspireOnlyConfig_PrefersOllamaBaseUrl()
+	{
+		// Arrange — RECEIPTS-640 regression: when the production Aspire deployment injects
+		// only Ollama:BaseUrl (no Ocr:Vlm:OllamaUrl override), the registration must pick that
+		// URL up. Before the fix, the non-null DefaultOllamaUrl on VlmOcrOptions short-circuited
+		// the IsNullOrWhiteSpace gate, ResolveOllamaUrl was never called, and every production
+		// scan request ended up targeting localhost:11434 inside the API container — silent
+		// connection-refused failures. Pin the corrected behavior.
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				// No Ocr:Vlm:OllamaUrl key — only the Aspire-injected Ollama:BaseUrl
+				[ConfigurationVariables.OllamaBaseUrl] = "http://aspire-injected:11434",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.Model)}"] = "glm-ocr:q8_0",
+			})
+			.Build();
+
+		// Act
+		InfrastructureService.RegisterReceiptExtractionService(services, configuration);
+
+		// Assert — the registered VlmOcrOptions points at the Aspire-injected URL, not the
+		// localhost default that would otherwise leak through.
+		using ServiceProvider sp = services.BuildServiceProvider();
+		VlmOcrOptions registered = sp.GetRequiredService<VlmOcrOptions>();
+		registered.OllamaUrl.Should().Be("http://aspire-injected:11434");
+	}
+
+	[Fact]
+	public void RegisterReceiptExtractionService_OcrVlmOverrideTakesPrecedence()
+	{
+		// Arrange — when both Ocr:Vlm:OllamaUrl and Ollama:BaseUrl are set, the explicit
+		// Ocr:Vlm:OllamaUrl override wins. ResolveOllamaUrl encodes this priority chain;
+		// pin it here so a future refactor can't reverse the precedence silently.
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[ConfigurationVariables.OcrVlmOllamaUrl] = "http://override:11434",
+				[ConfigurationVariables.OllamaBaseUrl] = "http://aspire-injected:11434",
+			})
+			.Build();
+
+		// Act
+		InfrastructureService.RegisterReceiptExtractionService(services, configuration);
+
+		// Assert
+		using ServiceProvider sp = services.BuildServiceProvider();
+		VlmOcrOptions registered = sp.GetRequiredService<VlmOcrOptions>();
+		registered.OllamaUrl.Should().Be("http://override:11434");
+	}
+
+	[Fact]
+	public void RegisterReceiptExtractionService_NoConfig_FallsBackToLocalhostDefault()
+	{
+		// Arrange — when neither key is set (a developer running `dotnet run` without Aspire
+		// and without env vars), the localhost default kicks in so the service still builds.
+		// AddVlmOcrClient enforces non-blank URL — this is the only place the default applies.
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder().Build();
+
+		// Act
+		InfrastructureService.RegisterReceiptExtractionService(services, configuration);
+
+		// Assert
+		using ServiceProvider sp = services.BuildServiceProvider();
+		VlmOcrOptions registered = sp.GetRequiredService<VlmOcrOptions>();
+		registered.OllamaUrl.Should().Be(VlmOcrOptions.DefaultOllamaUrl);
+	}
+
+	[Fact]
 	public async Task ExtractAsync_DoneFalse_Throws()
 	{
 		// Arrange — RECEIPTS-640: a done=false response signals a streamed/truncated body. The

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -143,7 +143,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.StoreName.Value.Should().Be("Walmart Supercenter");
@@ -216,7 +216,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.Date.Value.Should().Be(new DateOnly(expectedYear, expectedMonth, expectedDay));
@@ -238,7 +238,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.Date.Value.Should().Be(default(DateOnly));
@@ -269,7 +269,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — sub-line is absorbed; only the parent remains with the weight data
 		receipt.Items.Should().HaveCount(1);
@@ -300,7 +300,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — both rows kept; BREAD is untouched
 		receipt.Items.Should().HaveCount(2);
@@ -329,7 +329,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — parent is preserved; second "item" is kept as a distinct row
 		receipt.Items.Should().HaveCount(2);
@@ -419,7 +419,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.PaymentMethod.Value.Should().BeNull();
@@ -449,7 +449,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — legacy field keeps the first method
 		receipt.PaymentMethod.Value.Should().Be("GIFT CARD");
@@ -482,7 +482,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.StoreName.Confidence.Should().Be(ConfidenceLevel.None);
@@ -511,7 +511,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.ReceiptId.Value.Should().BeNull();
@@ -543,7 +543,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — value is nulled, confidence drops to Low. Other payment fields untouched.
 		receipt.Payments.Should().HaveCount(1);
@@ -655,7 +655,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.Payments[0].LastFour.Value.Should().Be("3409");
@@ -681,7 +681,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — the payment is preserved with correct confidence
 		receipt.Payments.Should().HaveCount(1);
@@ -703,7 +703,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(envelope));
 
 		// Act
-		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		ExceptionAssertions<InvalidOperationException> thrown = await act.Should().ThrowAsync<InvalidOperationException>();
@@ -718,7 +718,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(envelope));
 
 		// Act
-		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		await act.Should().ThrowAsync<InvalidOperationException>()
@@ -744,7 +744,7 @@ public class OllamaReceiptExtractionServiceTests
 		cts.CancelAfter(TimeSpan.FromMilliseconds(50));
 
 		// Act
-		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", cts.Token);
+		Func<Task> act = () => service.ExtractAsync(FakeImage, cts.Token);
 
 		// Assert — caller-initiated cancellation surfaces as OperationCanceledException
 		await act.Should().ThrowAsync<OperationCanceledException>();
@@ -776,7 +776,7 @@ public class OllamaReceiptExtractionServiceTests
 		await RunWithPipelineServiceAsync(handlerMock.Object, options, async service =>
 		{
 			// Act
-			Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+			Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
 
 			// Assert
 			await act.Should().ThrowAsync<TimeoutException>()
@@ -811,7 +811,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(handlerMock.Object);
 
 		// Act
-		await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		capturedRequest.Should().NotBeNull();
@@ -899,7 +899,7 @@ public class OllamaReceiptExtractionServiceTests
 		IReceiptExtractionService service = sp.GetRequiredService<IReceiptExtractionService>();
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — call completed without being cancelled by ServiceDefaults' 200ms standard
 		// handler. With the bug present, this throws TimeoutRejectedException at ~200ms.
@@ -941,7 +941,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — every numeric-as-string value parsed without loss
 		receipt.Subtotal.Value.Should().Be(9.10m);
@@ -988,7 +988,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.Date.Value.Should().Be(default(DateOnly));
@@ -1016,7 +1016,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		ExceptionAssertions<InvalidOperationException> thrown =
@@ -1041,7 +1041,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		ExceptionAssertions<InvalidOperationException> thrown =
@@ -1076,7 +1076,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — known fields parsed; unknown fields silently dropped
 		receipt.StoreName.Value.Should().Be("Walmart");
@@ -1112,7 +1112,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — negatives preserved at High confidence
 		receipt.Subtotal.Value.Should().Be(-3.49m);
@@ -1180,7 +1180,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.Total.Value.Should().Be(default(decimal));
@@ -1205,7 +1205,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.Total.Value.Should().Be(default(decimal));
@@ -1325,7 +1325,7 @@ public class OllamaReceiptExtractionServiceTests
 		IReceiptExtractionService service = sp.GetRequiredService<IReceiptExtractionService>();
 
 		// Act
-		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		receipt.StoreName.Value.Should().Be("Walmart");
@@ -1353,7 +1353,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — the exception message must NOT contain the raw payload (PII gate) but MUST
 		// describe the version mismatch clearly enough to debug from telemetry.
@@ -1380,7 +1380,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
 
 		// Act
-		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		ExceptionAssertions<InvalidOperationException> thrown = await act.Should().ThrowAsync<InvalidOperationException>();
@@ -1420,7 +1420,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = new(httpClient, options, logger);
 
 		// Act
-		await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — every captured log message is free of PII fragments from the body.
 		logger.Records.Should().NotBeEmpty();
@@ -1458,7 +1458,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = new(httpClient, options, logger);
 
 		// Act
-		await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		logger.Records.Should().Contain(record =>
@@ -1492,7 +1492,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = new(httpClient, options, logger);
 
 		// Act
-		await service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		await service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert — at least one record carries a scope with VlmPromptVersion=V4.
 		logger.Records.Should().NotBeEmpty();
@@ -1514,7 +1514,7 @@ public class OllamaReceiptExtractionServiceTests
 		OllamaReceiptExtractionService service = CreateService(CreateHandler(envelope));
 
 		// Act
-		Func<Task> act = () => service.ExtractAsync(FakeImage, "image/png", CancellationToken.None);
+		Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
 
 		// Assert
 		ExceptionAssertions<InvalidOperationException> thrown = await act.Should().ThrowAsync<InvalidOperationException>();
@@ -1583,18 +1583,20 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	[Fact]
-	public void AddVlmOcrClient_NullOllamaUrl_Throws()
+	public void AddVlmOcrClient_BlankOllamaUrl_Throws()
 	{
-		// Arrange
+		// Arrange — RECEIPTS-640: VlmOcrOptions.OllamaUrl is now non-nullable with a localhost
+		// default, so to exercise the helper's guard we explicitly clear the URL to whitespace.
+		// The helper still enforces a non-blank URL so production and VlmEval cannot silently
+		// register a useless client.
 		ServiceCollection services = new();
 		services.AddLogging();
-		VlmOcrOptions options = new() { Model = "glm-ocr:q8_0" };
+		VlmOcrOptions options = new() { Model = "glm-ocr:q8_0", OllamaUrl = "   " };
 
 		// Act
 		Action act = () => services.AddVlmOcrClient(options);
 
-		// Assert — the helper enforces a non-null OllamaUrl so production and VlmEval cannot
-		// silently register a useless client.
+		// Assert
 		act.Should().Throw<ArgumentException>().WithMessage("*OllamaUrl*");
 	}
 
@@ -1619,6 +1621,118 @@ public class OllamaReceiptExtractionServiceTests
 		using ServiceProvider sp = services.BuildServiceProvider();
 		sp.GetRequiredService<VlmOcrOptions>().Should().BeSameAs(options);
 		sp.GetRequiredService<IReceiptExtractionService>().Should().BeOfType<OllamaReceiptExtractionService>();
+	}
+
+	[Fact]
+	public async Task ExtractAsync_DoneFalse_Throws()
+	{
+		// Arrange — RECEIPTS-640: a done=false response signals a streamed/truncated body. The
+		// payload is mid-stream and the JSON is incomplete, so any downstream JsonException would
+		// be a confusing red herring. We ship stream=false (Ollama's per-request default), so any
+		// done=false here means the daemon was misconfigured to streaming mode. Fail fast and
+		// loudly with a message that points at the actual cause.
+		string envelope = JsonSerializer.Serialize(new
+		{
+			model = "glm-ocr:q8_0",
+			response = "{ \"schema_version\": 1, \"store\": { \"name\": \"Walmart\" }, \"total\": 10.0 }",
+			done = false,
+		});
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(envelope));
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*non-final response*done=false*");
+	}
+
+	[Fact]
+	public async Task ExtractAsync_ImageExceedsMaxBytes_ThrowsArgumentException()
+	{
+		// Arrange — RECEIPTS-640: an image larger than VlmOcrOptions.MaxImageBytes must be
+		// rejected before any base64 encoding (which inflates the byte count by ~33%) and before
+		// any HTTP traffic is generated. Ollama's default request body limit is well below 50 MB+
+		// camera dumps; this guard turns an opaque downstream HttpRequestException into a clear
+		// ArgumentException at the boundary.
+		VlmOcrOptions options = new()
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 30,
+			MaxImageBytes = 100, // tiny limit so the test image trips it
+		};
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope("{}")), options);
+		byte[] oversized = new byte[101];
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(oversized, CancellationToken.None);
+
+		// Assert
+		ExceptionAssertions<ArgumentException> thrown = await act.Should().ThrowAsync<ArgumentException>();
+		thrown.Which.ParamName.Should().Be("imageBytes");
+		thrown.Which.Message.Should().Contain("101");
+		thrown.Which.Message.Should().Contain("100");
+	}
+
+	[Fact]
+	public async Task ExtractAsync_ImageAtMaxBytes_DoesNotThrow()
+	{
+		// Arrange — boundary check: an image exactly at MaxImageBytes is allowed (the guard
+		// uses strict `>`, not `>=`). This pins behavior so a future tightening to `>=` would
+		// fail loudly rather than silently rejecting at-size payloads.
+		VlmOcrOptions options = new()
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 30,
+			MaxImageBytes = 100,
+		};
+		string innerJson = """
+			{
+			  "schema_version": 1,
+			  "store": { "name": "Walmart" },
+			  "total": 1.0
+			}
+			""";
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)), options);
+		byte[] atLimit = new byte[100];
+
+		// Act / Assert
+		await service.ExtractAsync(atLimit, CancellationToken.None);
+	}
+
+	[Fact]
+	public void Constructor_NullHttpClient_Throws()
+	{
+		// RECEIPTS-640: tighten ctor null-check pattern so all three injected dependencies have
+		// the same guard. Previously only imageBytes had a guard; ctor params were unchecked.
+		Action act = () => new OllamaReceiptExtractionService(
+			null!, new VlmOcrOptions { OllamaUrl = "http://test" }, NullLogger<OllamaReceiptExtractionService>.Instance);
+
+		act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("httpClient");
+	}
+
+	[Fact]
+	public void Constructor_NullOptions_Throws()
+	{
+		Action act = () => new OllamaReceiptExtractionService(
+			new HttpClient { BaseAddress = new Uri("http://test/") },
+			null!,
+			NullLogger<OllamaReceiptExtractionService>.Instance);
+
+		act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("options");
+	}
+
+	[Fact]
+	public void Constructor_NullLogger_Throws()
+	{
+		Action act = () => new OllamaReceiptExtractionService(
+			new HttpClient { BaseAddress = new Uri("http://test/") },
+			new VlmOcrOptions { OllamaUrl = "http://test" },
+			null!);
+
+		act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
 	}
 
 	/// <summary>

--- a/tests/VlmEval.Tests/EvalRunnerTests.cs
+++ b/tests/VlmEval.Tests/EvalRunnerTests.cs
@@ -128,7 +128,7 @@ public class EvalRunnerTests : IDisposable
 
 		Mock<IReceiptExtractionService> service = new();
 		service
-			.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+			.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
 			.ReturnsAsync(() =>
 			{
 				// Cancel after the first fixture has been processed so the loop's check at top
@@ -163,8 +163,8 @@ public class EvalRunnerTests : IDisposable
 
 		Mock<IReceiptExtractionService> service = new();
 		service
-			.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-			.Returns<byte[], string, CancellationToken>((_, _, _) =>
+			.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+			.Returns<byte[], CancellationToken>((_, _) =>
 			{
 				// Cancel during the call so the OCE inside EvaluateAsync is swallowed by its
 				// catch (Exception) and turned into a normal failure result. The runner must
@@ -366,7 +366,7 @@ public class EvalRunnerTests : IDisposable
 		if (result is not null)
 		{
 			mock
-				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(result);
 		}
 		return mock.Object;

--- a/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
+++ b/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
@@ -963,7 +963,7 @@ public class FixtureEvaluatorTests
 		{
 			Mock<IReceiptExtractionService> service = new();
 			service
-				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
 				.ThrowsAsync(new InvalidOperationException("VLM down"));
 
 			FixtureEvaluator evaluator = new(service.Object, new VlmEvalOptions(), NullLogger<FixtureEvaluator>.Instance);
@@ -1000,7 +1000,7 @@ public class FixtureEvaluatorTests
 
 			Mock<IReceiptExtractionService> service = new();
 			service
-				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(parsed);
 
 			FixtureEvaluator evaluator = new(service.Object, new VlmEvalOptions(), NullLogger<FixtureEvaluator>.Instance);
@@ -1053,7 +1053,7 @@ public class FixtureEvaluatorTests
 
 			Mock<IReceiptExtractionService> service = new();
 			service
-				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(parsed);
 
 			FixtureEvaluator evaluator = new(service.Object, new VlmEvalOptions(), NullLogger<FixtureEvaluator>.Instance);
@@ -1089,7 +1089,7 @@ public class FixtureEvaluatorTests
 
 			Mock<IReceiptExtractionService> service = new();
 			service
-				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(parsed);
 
 			FixtureEvaluator evaluator = new(service.Object, new VlmEvalOptions(), NullLogger<FixtureEvaluator>.Instance);
@@ -1131,7 +1131,7 @@ public class FixtureEvaluatorTests
 
 			Mock<IReceiptExtractionService> service = new();
 			service
-				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(parsed);
 
 			FixtureEvaluator evaluator = new(
@@ -1176,7 +1176,7 @@ public class FixtureEvaluatorTests
 
 			Mock<IReceiptExtractionService> service = new();
 			service
-				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+				.Setup(s => s.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(parsed);
 
 			FixtureEvaluator evaluator = new(


### PR DESCRIPTION
## Summary

Six small but cumulatively important hardening items in the scan/upload pipeline:

1. **`UploadReceiptImageCommandHandler` cleanup** (`UploadReceiptImageCommandHandler.cs`):
   - Wrap cleanup in its own try/catch — a cleanup failure no longer replaces the originating exception in operator logs.
   - Pass `CancellationToken.None` to cleanup so a caller-canceled token does not silently abort orphan removal.
   - Filter `OperationCanceledException` so user-cancel does not trigger destructive blob delete.
2. **Drop unused `contentType` parameter** from `IReceiptExtractionService.ExtractAsync`. Ollama auto-detects PNG/JPEG from the bytes and the parameter was only being logged. Removing it cascades the dead `PdfPageImageContentType = "image/png"` constant out of `ScanReceiptCommandHandler` (item 3 in the issue).
3. **Validate `OllamaGenerateResponse.Done`** after deserialization. A `done=false` body is mid-stream/truncated; surface a clear `InvalidOperationException` pointing at "stream mode misconfigured?" instead of letting a confusing `JsonException` propagate.
4. **`MaxImageBytes` upper bound** on `VlmOcrOptions` (default 15 MB). Reject oversized images with `ArgumentException` before base64 encoding (which inflates ~33%) so we never produce a request body that exceeds Ollama's body limit.
5. **Constructor null-checks consistent** on `OllamaReceiptExtractionService` for `httpClient`, `options`, `logger`. Tighten `VlmOcrOptions.OllamaUrl` from `string?` to `string` with a localhost default.

Resolves RECEIPTS-640.

## Notes / Assumptions

- For item 3 from the issue (hardcoded `PdfPageImageContentType = "image/png"`): chose the surgical pick of **dropping** the constant rather than adding a `string ContentType` field to `PdfConversionResult`. After RECEIPTS-637 thickened the result to include `(byte[] FirstPagePng, int TotalPageCount)` and item 2 dropped the `contentType` parameter from the extraction service, the constant became unused. The producer's name (`FirstPagePng`) carries the format unambiguously.
- `VlmOcrOptions.OllamaUrl` default kept as `"http://localhost:11434"` — matches the existing `RegisterReceiptExtractionService` fallback so DI failures surface earlier.
- No manual CTS reintroduction (RECEIPTS-630 removed it; resilience pipeline owns timeouts).
- `done=false` rejection assumes Ollama stream mode is off (the default per request); the message points at stream-mode misconfiguration as the most common cause.

## Test plan

- [x] Backend unit suite (`dotnet test --filter "Category!=Integration"`) — 2,514 tests, all green.
- [x] `dotnet format --verify-no-changes` clean.
- New tests:
  - [x] `Handle_UpdateImagePathsThrows_CleanupUsesNoneToken` — verifies cleanup uses `CancellationToken.None`.
  - [x] `Handle_UpdateImagePathsThrows_CleanupAlsoThrows_PreservesOriginalException` — verifies original exception wins, cleanup-failure logged.
  - [x] `Handle_CallerCanceled_DoesNotTriggerCleanup` — verifies `OperationCanceledException` skips cleanup.
  - [x] `ExtractAsync_DoneFalse_Throws` — verifies `done=false` rejection.
  - [x] `ExtractAsync_ImageExceedsMaxBytes_ThrowsArgumentException` + `ExtractAsync_ImageAtMaxBytes_DoesNotThrow` — pin the size-guard boundary.
  - [x] `Constructor_Null{HttpClient,Options,Logger}_Throws` — verifies new ctor guards.
- Existing tests updated to drop the `contentType` arg (compile-time enforces removal of item 2).