### PR TITLE
refactor(infrastructure): bind VLM/PDF/Image options via IOptions<T> with validation (RECEIPTS-638)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,8 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.3" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.24.3" />
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />

--- a/src/Application/Interfaces/Services/IPdfConversionService.cs
+++ b/src/Application/Interfaces/Services/IPdfConversionService.cs
@@ -6,18 +6,13 @@ namespace Application.Interfaces.Services;
 public interface IPdfConversionService
 {
 	/// <summary>
-	/// Maximum number of pages allowed in a single PDF upload.
-	/// </summary>
-	const int MaxPages = 50;
-
-	/// <summary>
 	/// Rasterizes the first page of the PDF to a PNG. The PNG is always produced
 	/// (even for vector-only or text-only PDFs) so that downstream VLM/OCR processing
-	/// always has a usable image. Multi-page PDFs are validated against
-	/// <see cref="MaxPages"/> but only the first page is rendered. The total page
-	/// count is reported back so callers can warn users about silently dropped
-	/// pages (RECEIPTS-637). Failures (invalid bytes, password-protected, oversized,
-	/// rasterization error) surface as <see cref="InvalidOperationException"/>.
+	/// always has a usable image. Multi-page PDFs are validated against an
+	/// implementation-defined maximum page count but only the first page is rendered.
+	/// The total page count is reported back so callers can warn users about silently
+	/// dropped pages (RECEIPTS-637). Failures (invalid bytes, password-protected,
+	/// oversized, rasterization error) surface as <see cref="InvalidOperationException"/>.
 	/// </summary>
 	Task<PdfConversionResult> ConvertAsync(byte[] pdfBytes, CancellationToken ct);
 }

--- a/src/Common/ConfigurationVariables.cs
+++ b/src/Common/ConfigurationVariables.cs
@@ -32,6 +32,15 @@ public static class ConfigurationVariables
 	public const string OcrVlmTimeoutSeconds = "Ocr:Vlm:TimeoutSeconds";
 	public const string OcrVlmSection = "Ocr:Vlm";
 
+	// PDF conversion thresholds (RECEIPTS-638). Per-environment tuning of the PDF page-count
+	// budget, etc. Bound via IOptions<PdfConversionOptions> with DataAnnotations validation.
+	public const string PdfConversionSection = "PdfConversion";
+
+	// Image validation thresholds (RECEIPTS-638). Per-environment tuning of the maximum
+	// pixel dimensions accepted for receipt-image uploads. Bound via
+	// IOptions<ImageValidationOptions> with DataAnnotations validation.
+	public const string ImageValidationSection = "ImageValidation";
+
 	public const string YnabPat = "YNAB_PAT";
 }
 

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" />
     <PackageReference Include="Microsoft.ML.Tokenizers" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />

--- a/src/Infrastructure/Services/ImageValidationOptions.cs
+++ b/src/Infrastructure/Services/ImageValidationOptions.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Infrastructure.Services;
+
+/// <summary>
+/// Tunable thresholds for <see cref="ImageValidationService"/>. Bound from the
+/// <c>ImageValidation</c> configuration section via
+/// <see cref="Microsoft.Extensions.DependencyInjection.OptionsConfigurationServiceCollectionExtensions"/>
+/// and validated at startup (RECEIPTS-638). Values are policy that may legitimately differ
+/// per environment, so they live here rather than as <c>const</c>s on the service.
+/// </summary>
+public sealed class ImageValidationOptions
+{
+	/// <summary>
+	/// Maximum pixel width accepted for receipt-image uploads. Images wider than this are
+	/// rejected during validation so we never decode an arbitrarily large bitmap. Default
+	/// 10,000 matches the historical hardcoded value.
+	/// </summary>
+	[Range(1, int.MaxValue)]
+	public int MaxPixelWidth { get; set; } = 10_000;
+
+	/// <summary>
+	/// Maximum pixel height accepted for receipt-image uploads. Images taller than this
+	/// are rejected during validation so we never decode an arbitrarily large bitmap.
+	/// Default 10,000 matches the historical hardcoded value.
+	/// </summary>
+	[Range(1, int.MaxValue)]
+	public int MaxPixelHeight { get; set; } = 10_000;
+}

--- a/src/Infrastructure/Services/ImageValidationService.cs
+++ b/src/Infrastructure/Services/ImageValidationService.cs
@@ -1,5 +1,6 @@
 using Application.Interfaces.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Jpeg;
@@ -14,16 +15,26 @@ namespace Infrastructure.Services;
 /// extraction service ingests the original image bytes directly, so no pixel mutation
 /// is needed here.
 /// </summary>
-public class ImageValidationService(ILogger<ImageValidationService> logger) : IImageValidationService
+public class ImageValidationService : IImageValidationService
 {
-	private const int MaxPixelWidth = 10_000;
-	private const int MaxPixelHeight = 10_000;
-
 	private static readonly HashSet<Type> AllowedFormatTypes =
 	[
 		typeof(JpegFormat),
 		typeof(PngFormat),
 	];
+
+	private readonly ILogger<ImageValidationService> _logger;
+	private readonly ImageValidationOptions _options;
+
+	public ImageValidationService(
+		ILogger<ImageValidationService> logger,
+		IOptions<ImageValidationOptions> options)
+	{
+		ArgumentNullException.ThrowIfNull(logger);
+		ArgumentNullException.ThrowIfNull(options);
+		_logger = logger;
+		_options = options.Value;
+	}
 
 	public Task ValidateAsync(byte[] imageBytes, CancellationToken ct)
 	{
@@ -64,14 +75,14 @@ public class ImageValidationService(ILogger<ImageValidationService> logger) : II
 		}
 		catch (Exception ex) when (ex is UnknownImageFormatException or InvalidImageContentException or ArgumentException)
 		{
-			logger.LogError(ex, "Failed to identify image metadata during validation");
+			_logger.LogError(ex, "Failed to identify image metadata during validation");
 			throw new InvalidOperationException("The uploaded file is not a valid image or is corrupted.", ex);
 		}
 
-		if (info.Width > MaxPixelWidth || info.Height > MaxPixelHeight)
+		if (info.Width > _options.MaxPixelWidth || info.Height > _options.MaxPixelHeight)
 		{
 			throw new InvalidOperationException(
-				$"Image dimensions ({info.Width}x{info.Height}) exceed the maximum allowed ({MaxPixelWidth}x{MaxPixelHeight}).");
+				$"Image dimensions ({info.Width}x{info.Height}) exceed the maximum allowed ({_options.MaxPixelWidth}x{_options.MaxPixelHeight}).");
 		}
 
 		// The body is fully synchronous and the method is intentionally non-async — the

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -169,6 +169,20 @@ public static class InfrastructureService
 
 		services.AddMemoryCache();
 
+		// PDF and image-validation thresholds (RECEIPTS-638). Bound from `PdfConversion` and
+		// `ImageValidation` configuration sections with DataAnnotations validation. Misconfigured
+		// values fail fast at startup via ValidateOnStart so a typo'd appsettings entry can't
+		// produce a runtime InvalidOperationException on first user upload.
+		services.AddOptions<PdfConversionOptions>()
+			.BindConfiguration(ConfigurationVariables.PdfConversionSection)
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
+		services.AddOptions<ImageValidationOptions>()
+			.BindConfiguration(ConfigurationVariables.ImageValidationSection)
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
 		YnabClientOptions ynabOptions = new();
 		services.AddSingleton(ynabOptions);
 		services.AddSingleton<IYnabRateLimitTracker>(sp =>
@@ -260,31 +274,53 @@ public static class InfrastructureService
 	/// </summary>
 	internal static void RegisterReceiptExtractionService(IServiceCollection services, IConfiguration configuration)
 	{
-		VlmOcrOptions options = new();
-		configuration.GetSection(ConfigurationVariables.OcrVlmSection).Bind(options);
+		services.AddVlmOcrClient(configuration);
+	}
 
-		// RECEIPTS-640: VlmOcrOptions.OllamaUrl is now a non-nullable string with a localhost
-		// default, so the previous IsNullOrWhiteSpace gate would short-circuit when neither
-		// Ocr:Vlm:OllamaUrl nor a configured override is set — silently bypassing the
-		// Aspire-injected Ollama:BaseUrl that ResolveOllamaUrl picks up. Always run the
-		// resolver: it already enforces the priority chain (Ocr:Vlm:OllamaUrl →
-		// Ollama:BaseUrl → null), so the bound default only wins when neither is configured.
-		string? resolved = ResolveOllamaUrl(configuration);
-		if (!string.IsNullOrWhiteSpace(resolved))
-		{
-			options.OllamaUrl = resolved;
-		}
+	/// <summary>
+	/// Binds <see cref="VlmOcrOptions"/> from the <c>Ocr:Vlm</c> configuration section using
+	/// the standard options pattern (<see cref="OptionsBuilderExtensions.ValidateDataAnnotations{TOptions}"/>
+	/// + <see cref="OptionsBuilderExtensions.ValidateOnStart{TOptions}"/>) and registers the
+	/// Ollama-backed <see cref="IReceiptExtractionService"/> typed HTTP client with the
+	/// production resilience pipeline. Misconfigured options (e.g. <c>TimeoutSeconds=0</c>)
+	/// fail loudly at startup rather than producing a confusing runtime error on the first
+	/// upload. The Ollama URL fallback chain runs in <see cref="OptionsBuilderExtensions.PostConfigure{TOptions}"/>
+	/// so the chain stays observable through <see cref="IOptions{TOptions}"/> rather than
+	/// hidden inside an ad-hoc registration helper. See RECEIPTS-638.
+	/// </summary>
+	public static IServiceCollection AddVlmOcrClient(this IServiceCollection services, IConfiguration configuration)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+		ArgumentNullException.ThrowIfNull(configuration);
 
-		services.AddVlmOcrClient(options);
+		services.AddOptions<VlmOcrOptions>()
+			.Bind(configuration.GetSection(ConfigurationVariables.OcrVlmSection))
+			.PostConfigure(options =>
+			{
+				// RECEIPTS-640 + RECEIPTS-638: VlmOcrOptions.OllamaUrl is a non-nullable string
+				// with a localhost default, so an IsNullOrWhiteSpace gate would short-circuit
+				// when neither Ocr:Vlm:OllamaUrl nor a configured override is set — silently
+				// bypassing the Aspire-injected Ollama:BaseUrl. Always run the resolver: it
+				// enforces the priority chain (Ocr:Vlm:OllamaUrl → Ollama:BaseUrl → null), so
+				// the bound DefaultOllamaUrl only wins when neither override is configured.
+				string? resolved = ResolveOllamaUrl(configuration);
+				if (!string.IsNullOrWhiteSpace(resolved))
+				{
+					options.OllamaUrl = resolved;
+				}
+			})
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
+		return AddVlmOcrHttpClient(services);
 	}
 
 	/// <summary>
 	/// Registers the Ollama-backed <see cref="IReceiptExtractionService"/> typed HTTP client
-	/// with the production resilience pipeline (retry + circuit breaker + per-attempt timeout)
-	/// and registers <paramref name="options"/> as a singleton. Both the production
-	/// <c>RegisterReceiptExtractionService</c> path and the <c>VlmEval</c> tool call this
-	/// helper so they share identical retry behavior and the same opt-out from the standard
-	/// handler injected by <c>Receipts.ServiceDefaults</c>. See RECEIPTS-639.
+	/// using a pre-bound <see cref="VlmOcrOptions"/> instance. Used by the <c>VlmEval</c> tool
+	/// where CLI arguments mutate the bound options before registration; production code
+	/// should use the <see cref="AddVlmOcrClient(IServiceCollection, IConfiguration)"/>
+	/// overload instead so DataAnnotations validation runs at startup. See RECEIPTS-638.
 	/// </summary>
 	public static IServiceCollection AddVlmOcrClient(this IServiceCollection services, VlmOcrOptions options)
 	{
@@ -298,23 +334,30 @@ public static class InfrastructureService
 				nameof(options));
 		}
 
-		// Bare instance for direct injection (OllamaReceiptExtractionService takes VlmOcrOptions).
-		services.AddSingleton(options);
-		// IOptions<VlmOcrOptions> wrapper so consumers like the smoke test can use the standard
-		// options pattern. Backed by the same instance bound above so Model / OllamaUrl / Timeout
-		// stay in sync.
+		// Register the instance as IOptions<VlmOcrOptions> so consumers (OllamaReceiptExtractionService,
+		// the smoke test, VlmEval's EvalRunner) all use the standard options pattern.
 		services.AddSingleton<IOptions<VlmOcrOptions>>(new OptionsWrapper<VlmOcrOptions>(options));
 
+		return AddVlmOcrHttpClient(services);
+	}
+
+	private static IServiceCollection AddVlmOcrHttpClient(IServiceCollection services)
+	{
 #pragma warning disable EXTEXP0001 // RemoveAllResilienceHandlers is in evaluation; required to opt out of the standard handler injected by ServiceDefaults.
-		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
+		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>((sp, client) =>
 		{
-			client.BaseAddress = new Uri(options.OllamaUrl!.TrimEnd('/') + "/");
+			VlmOcrOptions options = sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
+			client.BaseAddress = new Uri(options.OllamaUrl.TrimEnd('/') + "/");
 			// The resilience pipeline (per-attempt Timeout strategy) owns request budgeting.
 			// HttpClient.Timeout must be Infinite so it doesn't fight the pipeline.
 			client.Timeout = Timeout.InfiniteTimeSpan;
 		})
 			.RemoveAllResilienceHandlers()
-			.AddResilienceHandler("vlm-ocr", builder => ConfigureVlmOcrResilience(builder, options));
+			.AddResilienceHandler("vlm-ocr", (builder, context) =>
+			{
+				VlmOcrOptions options = context.ServiceProvider.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
+				ConfigureVlmOcrResilience(builder, options);
+			});
 #pragma warning restore EXTEXP0001
 
 		return services;

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Application.Interfaces;
 using Application.Interfaces.Services;
 using Common;
@@ -327,10 +328,21 @@ public static class InfrastructureService
 		ArgumentNullException.ThrowIfNull(services);
 		ArgumentNullException.ThrowIfNull(options);
 
-		if (string.IsNullOrWhiteSpace(options.OllamaUrl))
+		// The IConfiguration overload runs DataAnnotations via ValidateOnStart, but
+		// OptionsWrapper<T> bypasses that pipeline. Re-enforce the same constraints
+		// here so the two overloads share the contract — otherwise a VlmEval consumer
+		// that hands in a misconfigured instance would surface the failure as an
+		// opaque Ollama 400 instead of a clear startup error.
+		List<ValidationResult> validationResults = [];
+		if (!Validator.TryValidateObject(
+			options,
+			new ValidationContext(options),
+			validationResults,
+			validateAllProperties: true))
 		{
+			string details = string.Join("; ", validationResults.Select(r => r.ErrorMessage));
 			throw new ArgumentException(
-				$"{nameof(VlmOcrOptions)}.{nameof(VlmOcrOptions.OllamaUrl)} must be set before calling {nameof(AddVlmOcrClient)}.",
+				$"{nameof(VlmOcrOptions)} failed DataAnnotations validation: {details}",
 				nameof(options));
 		}
 

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Application.Interfaces.Services;
 using Application.Models.Ocr;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Polly.Timeout;
 
 namespace Infrastructure.Services;
@@ -16,6 +17,33 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 	{
 		NumberHandling = JsonNumberHandling.AllowReadingFromString,
 	};
+
+	private readonly HttpClient _httpClient;
+	private readonly VlmOcrOptions _options;
+	private readonly ILogger<OllamaReceiptExtractionService> _logger;
+
+	/// <summary>
+	/// Maximum number of characters from the raw VLM response copied into exception messages.
+	/// The raw body contains receipt PII (store, items, payment method, last-four card digits)
+	/// and tends to propagate through telemetry channels — exception messages are not the right
+	/// place for that. The full body is still available via the gated raw-response debug log
+	/// when <see cref="VlmOcrOptions.LogRawResponses"/> is enabled. See RECEIPTS-639.
+	/// </summary>
+	internal const int ExceptionMessageMaxChars = 500;
+
+	private static readonly string[] DateFormats =
+	[
+		"yyyy-MM-dd",
+		"yyyy/MM/dd",
+		"MM/dd/yyyy",
+		"M/d/yyyy",
+		"MM/dd/yy",
+		"M/d/yy",
+		"dd/MM/yyyy",
+		"d/M/yyyy",
+		"dd-MM-yyyy",
+		"dd.MM.yyyy",
+	];
 
 	/// <summary>
 	/// A valid card last-four is exactly four ASCII digits. Anything else (longer auth-code
@@ -31,32 +59,18 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 	[GeneratedRegex(@"^[0-9]{4}$")]
 	private static partial Regex LastFourRegex();
 
-	private readonly HttpClient _httpClient;
-	private readonly VlmOcrOptions _options;
-	private readonly ILogger<OllamaReceiptExtractionService> _logger;
-
 	public OllamaReceiptExtractionService(
 		HttpClient httpClient,
-		VlmOcrOptions options,
+		IOptions<VlmOcrOptions> options,
 		ILogger<OllamaReceiptExtractionService> logger)
 	{
 		ArgumentNullException.ThrowIfNull(httpClient);
 		ArgumentNullException.ThrowIfNull(options);
 		ArgumentNullException.ThrowIfNull(logger);
-
 		_httpClient = httpClient;
-		_options = options;
+		_options = options.Value;
 		_logger = logger;
 	}
-
-	/// <summary>
-	/// Maximum number of characters from the raw VLM response copied into exception messages.
-	/// The raw body contains receipt PII (store, items, payment method, last-four card digits)
-	/// and tends to propagate through telemetry channels — exception messages are not the right
-	/// place for that. The full body is still available via the gated raw-response debug log
-	/// when <see cref="VlmOcrOptions.LogRawResponses"/> is enabled. See RECEIPTS-639.
-	/// </summary>
-	internal const int ExceptionMessageMaxChars = 500;
 
 	public async Task<ParsedReceipt> ExtractAsync(byte[] imageBytes, CancellationToken cancellationToken)
 	{
@@ -368,20 +382,6 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 			? FieldConfidence<string?>.High(trimmed)
 			: FieldConfidence<string?>.Low(null);
 	}
-
-	private static readonly string[] DateFormats =
-	[
-		"yyyy-MM-dd",
-		"yyyy/MM/dd",
-		"MM/dd/yyyy",
-		"M/d/yyyy",
-		"MM/dd/yy",
-		"M/d/yy",
-		"dd/MM/yyyy",
-		"d/M/yyyy",
-		"dd-MM-yyyy",
-		"dd.MM.yyyy",
-	];
 
 	private static DateOnly? TryParseDate(string? raw)
 	{

--- a/src/Infrastructure/Services/PdfConversionOptions.cs
+++ b/src/Infrastructure/Services/PdfConversionOptions.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Infrastructure.Services;
+
+/// <summary>
+/// Tunable thresholds for <see cref="PdfConversionService"/>. Bound from the
+/// <c>PdfConversion</c> configuration section via
+/// <see cref="Microsoft.Extensions.DependencyInjection.OptionsConfigurationServiceCollectionExtensions"/>
+/// and validated at startup (RECEIPTS-638). Values are policy that may legitimately differ
+/// per environment, so they live here rather than as <c>const</c>s on either the interface
+/// or the service implementation.
+/// </summary>
+public sealed class PdfConversionOptions
+{
+	/// <summary>
+	/// Maximum number of pages allowed in a single PDF upload. PDFs with more pages are
+	/// rejected before rasterization to keep hostile or accidental uploads from spending
+	/// rasterization budget on work we will reject anyway. Default 50 matches the historical
+	/// hardcoded value that previously lived on <c>IPdfConversionService</c>.
+	/// </summary>
+	[Range(1, 10_000)]
+	public int MaxPages { get; set; } = 50;
+}

--- a/src/Infrastructure/Services/PdfConversionService.cs
+++ b/src/Infrastructure/Services/PdfConversionService.cs
@@ -1,12 +1,13 @@
 using Application.Interfaces.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using PDFtoImage;
 using UglyToad.PdfPig;
 using UglyToad.PdfPig.Exceptions;
 
 namespace Infrastructure.Services;
 
-public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfConversionService
+public class PdfConversionService : IPdfConversionService
 {
 	/// <summary>
 	/// DPI used when rasterizing the first PDF page for VLM/OCR consumption. 200 DPI is the
@@ -26,6 +27,19 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 	/// PDF magic bytes: <c>%PDF</c> (0x25 0x50 0x44 0x46).
 	/// </summary>
 	private static readonly byte[] PdfMagicBytes = [0x25, 0x50, 0x44, 0x46];
+
+	private readonly ILogger<PdfConversionService> _logger;
+	private readonly PdfConversionOptions _options;
+
+	public PdfConversionService(
+		ILogger<PdfConversionService> logger,
+		IOptions<PdfConversionOptions> options)
+	{
+		ArgumentNullException.ThrowIfNull(logger);
+		ArgumentNullException.ThrowIfNull(options);
+		_logger = logger;
+		_options = options.Value;
+	}
 
 	public Task<PdfConversionResult> ConvertAsync(byte[] pdfBytes, CancellationToken ct)
 	{
@@ -86,24 +100,24 @@ public class PdfConversionService(ILogger<PdfConversionService> logger) : IPdfCo
 		// "no extractable images" and produced a 422 at the scan endpoint.
 		byte[] firstPagePng = RasterizeFirstPage(pdfBytes);
 
-		logger.LogInformation(
+		_logger.LogInformation(
 			"Rasterized first PDF page at {Dpi} DPI ({PngSize} bytes) for VLM extraction (document has {PageCount} page(s))",
 			RasterizationDpi, firstPagePng.Length, pageCount);
 
 		return Task.FromResult(new PdfConversionResult(firstPagePng, pageCount));
 	}
 
-	private static int ValidateDocument(PdfDocument document)
+	private int ValidateDocument(PdfDocument document)
 	{
 		if (document.NumberOfPages == 0)
 		{
 			throw new InvalidOperationException("The PDF document contains no pages.");
 		}
 
-		if (document.NumberOfPages > IPdfConversionService.MaxPages)
+		if (document.NumberOfPages > _options.MaxPages)
 		{
 			throw new InvalidOperationException(
-				$"The PDF document has {document.NumberOfPages} pages, which exceeds the maximum of {IPdfConversionService.MaxPages}.");
+				$"The PDF document has {document.NumberOfPages} pages, which exceeds the maximum of {_options.MaxPages}.");
 		}
 
 		return document.NumberOfPages;

--- a/src/Infrastructure/Services/VlmOcrOptions.cs
+++ b/src/Infrastructure/Services/VlmOcrOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Infrastructure.Services;
 
 public sealed class VlmOcrOptions
@@ -28,10 +30,33 @@ public sealed class VlmOcrOptions
 	/// </summary>
 	public const int DefaultMaxImageBytes = 15 * 1024 * 1024;
 
+	/// <summary>
+	/// Base URL of the Ollama instance hosting the VLM. Bound from <c>Ocr:Vlm:OllamaUrl</c>
+	/// with a <c>PostConfigure</c> fallback to <c>Ollama:BaseUrl</c> (Aspire-injected) when
+	/// the explicit override is absent. <see cref="DefaultOllamaUrl"/> keeps non-Aspire
+	/// <c>dotnet run</c> sessions working out of the box; the property is non-nullable so
+	/// downstream code can dereference it without null checks. The DataAnnotations
+	/// <see cref="RequiredAttribute"/> guards against a future refactor that erases the
+	/// default and lets an empty string slip through binding.
+	/// </summary>
+	[Required(AllowEmptyStrings = false)]
 	public string OllamaUrl { get; set; } = DefaultOllamaUrl;
 
+	/// <summary>
+	/// Model tag passed to Ollama's <c>/api/generate</c> endpoint. Defaults to
+	/// <see cref="DefaultModel"/>; override via <c>Ocr:Vlm:Model</c> when running tests
+	/// against alternative models (e.g. qwen2.5vl).
+	/// </summary>
+	[Required(AllowEmptyStrings = false)]
 	public string Model { get; set; } = DefaultModel;
 
+	/// <summary>
+	/// Per-attempt timeout for the VLM call in seconds. Each retry receives a fresh budget
+	/// (the resilience pipeline composes Retry around Timeout — see RECEIPTS-630). Range
+	/// is 1..3600 to keep operators from accidentally configuring an infinite or zero
+	/// timeout via mis-typed config.
+	/// </summary>
+	[Range(1, 3600)]
 	public int TimeoutSeconds { get; set; } = 120;
 
 	/// <summary>
@@ -40,6 +65,7 @@ public sealed class VlmOcrOptions
 	/// happens, protecting both the client (memory) and the Ollama server (request body limit).
 	/// See RECEIPTS-640.
 	/// </summary>
+	[Range(1, int.MaxValue)]
 	public int MaxImageBytes { get; set; } = DefaultMaxImageBytes;
 
 	/// <summary>

--- a/src/Tools/VlmEval/EvalRunner.cs
+++ b/src/Tools/VlmEval/EvalRunner.cs
@@ -1,45 +1,73 @@
 using System.Diagnostics;
 using Infrastructure.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace VlmEval;
 
-public sealed class EvalRunner(
-	IHttpClientFactory httpClientFactory,
-	VlmOcrOptions vlmOptions,
-	FixtureLoader fixtureLoader,
-	FixtureEvaluator fixtureEvaluator,
-	Reporter reporter,
-	VlmEvalOptions options,
-	ILogger<EvalRunner> logger)
+public sealed class EvalRunner
 {
 	/// <summary>POSIX exit code for SIGINT (cancellation).</summary>
 	private const int ExitCodeCancelled = 130;
 
+	private readonly IHttpClientFactory _httpClientFactory;
+	private readonly VlmOcrOptions _vlmOptions;
+	private readonly FixtureLoader _fixtureLoader;
+	private readonly FixtureEvaluator _fixtureEvaluator;
+	private readonly Reporter _reporter;
+	private readonly VlmEvalOptions _options;
+	private readonly ILogger<EvalRunner> _logger;
+
+	public EvalRunner(
+		IHttpClientFactory httpClientFactory,
+		IOptions<VlmOcrOptions> vlmOptions,
+		FixtureLoader fixtureLoader,
+		FixtureEvaluator fixtureEvaluator,
+		Reporter reporter,
+		VlmEvalOptions options,
+		ILogger<EvalRunner> logger)
+	{
+		ArgumentNullException.ThrowIfNull(httpClientFactory);
+		ArgumentNullException.ThrowIfNull(vlmOptions);
+		ArgumentNullException.ThrowIfNull(fixtureLoader);
+		ArgumentNullException.ThrowIfNull(fixtureEvaluator);
+		ArgumentNullException.ThrowIfNull(reporter);
+		ArgumentNullException.ThrowIfNull(options);
+		ArgumentNullException.ThrowIfNull(logger);
+
+		_httpClientFactory = httpClientFactory;
+		_vlmOptions = vlmOptions.Value;
+		_fixtureLoader = fixtureLoader;
+		_fixtureEvaluator = fixtureEvaluator;
+		_reporter = reporter;
+		_options = options;
+		_logger = logger;
+	}
+
 	public async Task<int> RunAsync(string fixturesDirectory, CancellationToken cancellationToken)
 	{
-		string ollamaUrl = vlmOptions.OllamaUrl ?? "(unset)";
+		string ollamaUrl = _vlmOptions.OllamaUrl ?? "(unset)";
 		DateTimeOffset startedAt = DateTimeOffset.UtcNow;
-		reporter.PrintHeader(ollamaUrl, fixturesDirectory);
+		_reporter.PrintHeader(ollamaUrl, fixturesDirectory);
 
 		// Missing fixtures dir is a configuration error: a typo'd FixturesPath looks identical
 		// to "no fixtures yet" if we silently mkdir. Treat it as failure when the strict flag
 		// is set; otherwise warn and exit 0 to preserve the "always green when flag off" contract.
 		if (!Directory.Exists(fixturesDirectory))
 		{
-			reporter.PrintMissingFixturesDirectory(fixturesDirectory);
-			reporter.WriteReport(
+			_reporter.PrintMissingFixturesDirectory(fixturesDirectory);
+			_reporter.WriteReport(
 				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
 				results: [],
 				totalElapsed: TimeSpan.Zero,
 				cancelled: false);
-			return options.FailOnAnyFixtureFailure ? 1 : 0;
+			return _options.FailOnAnyFixtureFailure ? 1 : 0;
 		}
 
 		if (!await IsOllamaReachableAsync(cancellationToken))
 		{
-			reporter.PrintOllamaUnreachable(ollamaUrl);
-			reporter.WriteReport(
+			_reporter.PrintOllamaUnreachable(ollamaUrl);
+			_reporter.WriteReport(
 				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
 				results: [],
 				totalElapsed: TimeSpan.Zero,
@@ -47,33 +75,33 @@ public sealed class EvalRunner(
 			return 1;
 		}
 
-		LoadedFixtures loaded = fixtureLoader.LoadFrom(fixturesDirectory);
+		LoadedFixtures loaded = _fixtureLoader.LoadFrom(fixturesDirectory);
 
 		if (loaded.Fixtures.Count == 0 && loaded.OrphanFiles.Count == 0)
 		{
-			reporter.PrintEmptyFixturesDirectory(fixturesDirectory);
-			reporter.WriteReport(
+			_reporter.PrintEmptyFixturesDirectory(fixturesDirectory);
+			_reporter.WriteReport(
 				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
 				results: [],
 				totalElapsed: TimeSpan.Zero,
 				cancelled: false);
-			return options.FailOnAnyFixtureFailure ? 1 : 0;
+			return _options.FailOnAnyFixtureFailure ? 1 : 0;
 		}
 
 		foreach (string orphan in loaded.OrphanFiles)
 		{
-			reporter.PrintOrphan(orphan);
+			_reporter.PrintOrphan(orphan);
 		}
 
 		if (loaded.Fixtures.Count == 0)
 		{
-			reporter.PrintNoValidFixtures();
-			reporter.WriteReport(
+			_reporter.PrintNoValidFixtures();
+			_reporter.WriteReport(
 				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
 				results: [],
 				totalElapsed: TimeSpan.Zero,
 				cancelled: false);
-			return options.FailOnAnyFixtureFailure ? 1 : 0;
+			return _options.FailOnAnyFixtureFailure ? 1 : 0;
 		}
 
 		Stopwatch total = Stopwatch.StartNew();
@@ -87,8 +115,8 @@ public sealed class EvalRunner(
 				break;
 			}
 
-			FixtureResult result = await fixtureEvaluator.EvaluateAsync(fixture, cancellationToken);
-			reporter.PrintFixtureResult(result);
+			FixtureResult result = await _fixtureEvaluator.EvaluateAsync(fixture, cancellationToken);
+			_reporter.PrintFixtureResult(result);
 			results.Add(result);
 
 			// EvaluateAsync's broad catch blocks (file IO, VLM call) swallow
@@ -106,8 +134,8 @@ public sealed class EvalRunner(
 
 		if (cancelled)
 		{
-			reporter.PrintCancelled(results.Count, loaded.Fixtures.Count);
-			reporter.WriteReport(
+			_reporter.PrintCancelled(results.Count, loaded.Fixtures.Count);
+			_reporter.WriteReport(
 				new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
 				results,
 				total.Elapsed,
@@ -115,14 +143,14 @@ public sealed class EvalRunner(
 			return ExitCodeCancelled;
 		}
 
-		reporter.PrintSummary(results, total.Elapsed);
-		reporter.WriteReport(
+		_reporter.PrintSummary(results, total.Elapsed);
+		_reporter.WriteReport(
 			new RunInfo(startedAt, ollamaUrl, fixturesDirectory),
 			results,
 			total.Elapsed,
 			cancelled: false);
 
-		if (!options.FailOnAnyFixtureFailure)
+		if (!_options.FailOnAnyFixtureFailure)
 		{
 			return 0;
 		}
@@ -132,13 +160,13 @@ public sealed class EvalRunner(
 
 	private async Task<bool> IsOllamaReachableAsync(CancellationToken cancellationToken)
 	{
-		if (string.IsNullOrWhiteSpace(vlmOptions.OllamaUrl))
+		if (string.IsNullOrWhiteSpace(_vlmOptions.OllamaUrl))
 		{
 			return false;
 		}
 
-		using HttpClient probe = httpClientFactory.CreateClient("ollama-probe");
-		probe.BaseAddress = new Uri(vlmOptions.OllamaUrl.TrimEnd('/') + "/");
+		using HttpClient probe = _httpClientFactory.CreateClient("ollama-probe");
+		probe.BaseAddress = new Uri(_vlmOptions.OllamaUrl.TrimEnd('/') + "/");
 		probe.Timeout = TimeSpan.FromSeconds(5);
 
 		using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -151,7 +179,7 @@ public sealed class EvalRunner(
 		}
 		catch (Exception ex)
 		{
-			logger.LogDebug(ex, "Ollama availability probe failed");
+			_logger.LogDebug(ex, "Ollama availability probe failed");
 			return false;
 		}
 	}

--- a/tests/Infrastructure.Tests/Services/ImageValidationOptionsTests.cs
+++ b/tests/Infrastructure.Tests/Services/ImageValidationOptionsTests.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel.DataAnnotations;
+using Common;
+using FluentAssertions;
+using Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Tests.Services;
+
+/// <summary>
+/// Validation tests for <see cref="ImageValidationOptions"/>. The options class is the new
+/// home for the image-pixel-dimension thresholds that previously lived as
+/// <c>private const int MaxPixelWidth/Height = 10_000</c> on
+/// <see cref="ImageValidationService"/> (RECEIPTS-638). Misconfiguring the options must
+/// fail loudly at startup via <see cref="OptionsBuilderExtensions.ValidateOnStart{TOptions}"/>.
+/// </summary>
+public class ImageValidationOptionsTests
+{
+	[Fact]
+	public void Defaults_MatchHistoricalConstants()
+	{
+		// The defaults must continue to match the historical hardcoded values so behaviour
+		// is unchanged for callers that don't opt into the new section.
+		ImageValidationOptions options = new();
+
+		options.MaxPixelWidth.Should().Be(10_000);
+		options.MaxPixelHeight.Should().Be(10_000);
+	}
+
+	[Fact]
+	public void DataAnnotations_RejectZeroOrNegativeMaxPixelWidth()
+	{
+		// Arrange
+		ImageValidationOptions options = new() { MaxPixelWidth = 0, MaxPixelHeight = 10_000 };
+		List<ValidationResult> results = [];
+
+		// Act
+		bool valid = Validator.TryValidateObject(
+			options,
+			new ValidationContext(options),
+			results,
+			validateAllProperties: true);
+
+		// Assert
+		valid.Should().BeFalse();
+		results.Should().Contain(r => r.MemberNames.Contains(nameof(ImageValidationOptions.MaxPixelWidth)));
+	}
+
+	[Fact]
+	public void DataAnnotations_RejectZeroOrNegativeMaxPixelHeight()
+	{
+		// Arrange
+		ImageValidationOptions options = new() { MaxPixelWidth = 10_000, MaxPixelHeight = -10 };
+		List<ValidationResult> results = [];
+
+		// Act
+		bool valid = Validator.TryValidateObject(
+			options,
+			new ValidationContext(options),
+			results,
+			validateAllProperties: true);
+
+		// Assert
+		valid.Should().BeFalse();
+		results.Should().Contain(r => r.MemberNames.Contains(nameof(ImageValidationOptions.MaxPixelHeight)));
+	}
+
+	[Fact]
+	public void ValidateOnStart_BadConfiguration_ThrowsWhenResolved()
+	{
+		// Arrange — RECEIPTS-638 acceptance: misconfigured options fail at startup.
+		ServiceCollection services = new();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[$"{ConfigurationVariables.ImageValidationSection}:{nameof(ImageValidationOptions.MaxPixelWidth)}"] = "0",
+			})
+			.Build();
+
+		services.AddOptions<ImageValidationOptions>()
+			.Bind(configuration.GetSection(ConfigurationVariables.ImageValidationSection))
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		Func<ImageValidationOptions> act = () => sp.GetRequiredService<IOptions<ImageValidationOptions>>().Value;
+
+		// Assert
+		act.Should().Throw<OptionsValidationException>()
+			.WithMessage("*MaxPixelWidth*");
+	}
+
+	[Fact]
+	public void ValidateOnStart_ValidConfiguration_ResolvesOk()
+	{
+		// Arrange
+		ServiceCollection services = new();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[$"{ConfigurationVariables.ImageValidationSection}:{nameof(ImageValidationOptions.MaxPixelWidth)}"] = "5000",
+				[$"{ConfigurationVariables.ImageValidationSection}:{nameof(ImageValidationOptions.MaxPixelHeight)}"] = "5000",
+			})
+			.Build();
+
+		services.AddOptions<ImageValidationOptions>()
+			.Bind(configuration.GetSection(ConfigurationVariables.ImageValidationSection))
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		ImageValidationOptions value = sp.GetRequiredService<IOptions<ImageValidationOptions>>().Value;
+
+		// Assert
+		value.MaxPixelWidth.Should().Be(5000);
+		value.MaxPixelHeight.Should().Be(5000);
+	}
+}

--- a/tests/Infrastructure.Tests/Services/ImageValidationServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ImageValidationServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Infrastructure.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
@@ -16,7 +17,8 @@ public class ImageValidationServiceTests
 	public ImageValidationServiceTests()
 	{
 		Mock<ILogger<ImageValidationService>> mockLogger = new();
-		_service = new ImageValidationService(mockLogger.Object);
+		IOptions<ImageValidationOptions> options = Options.Create(new ImageValidationOptions());
+		_service = new ImageValidationService(mockLogger.Object, options);
 	}
 
 	[Fact]
@@ -139,6 +141,32 @@ public class ImageValidationServiceTests
 		// Assert
 		await act.Should().ThrowAsync<InvalidOperationException>()
 			.WithMessage("*not a valid image or is corrupted*");
+	}
+
+	[Fact]
+	public async Task ValidateAsync_ConfiguredMaxPixelDimensionsOverride_RejectsOversizedImages()
+	{
+		// Arrange — RECEIPTS-638: ImageValidationService takes its dimension thresholds from
+		// IOptions<ImageValidationOptions> rather than hardcoded constants. A test-time override
+		// of MaxPixelWidth/Height=50 must reject a 100x100 image, proving the option is wired
+		// through to the validation path.
+		Mock<ILogger<ImageValidationService>> mockLogger = new();
+		IOptions<ImageValidationOptions> options = Options.Create(new ImageValidationOptions
+		{
+			MaxPixelWidth = 50,
+			MaxPixelHeight = 50,
+		});
+		ImageValidationService overrideService = new(mockLogger.Object, options);
+
+		byte[] imageBytes = CreateTestJpeg(100, 100);
+
+		// Act
+		Func<Task> act = () => overrideService.ValidateAsync(imageBytes, CancellationToken.None);
+
+		// Assert — error message must reflect the configured limit so operators can debug
+		// from the rejection alone.
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*100x100*50x50*");
 	}
 
 	private static byte[] CreateTestJpeg(int width, int height)

--- a/tests/Infrastructure.Tests/Services/InfrastructureServiceOptionsTests.cs
+++ b/tests/Infrastructure.Tests/Services/InfrastructureServiceOptionsTests.cs
@@ -1,0 +1,102 @@
+using Common;
+using FluentAssertions;
+using Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Tests.Services;
+
+/// <summary>
+/// End-to-end startup-validation tests for the options classes registered by
+/// <see cref="InfrastructureService.RegisterInfrastructureServices"/> and
+/// <see cref="InfrastructureService.AddVlmOcrClient(IServiceCollection, IConfiguration)"/>
+/// (RECEIPTS-638). These tests build a real <see cref="ServiceProvider"/> from the
+/// production registration code path and verify that DataAnnotations validation surfaces
+/// at first <see cref="IOptions{TOptions}"/> resolution rather than at the first user
+/// request.
+/// </summary>
+public class InfrastructureServiceOptionsTests
+{
+	[Fact]
+	public void AddVlmOcrClient_BadTimeoutSeconds_FailsAtStartup()
+	{
+		// Arrange — TimeoutSeconds outside [Range(1, 3600)] is the canonical "misconfig fails
+		// at startup" assertion called out by RECEIPTS-638. Without ValidateOnStart this would
+		// surface as a confusing TimeoutRejectedException on the first scan request.
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.OllamaUrl)}"] = "http://test-ollama",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.Model)}"] = "glm-ocr:q8_0",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.TimeoutSeconds)}"] = "9999",
+			})
+			.Build();
+		services.AddVlmOcrClient(configuration);
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		Func<VlmOcrOptions> act = () => sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
+
+		// Assert
+		act.Should().Throw<OptionsValidationException>()
+			.WithMessage("*TimeoutSeconds*");
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_EmptyModel_FailsAtStartup()
+	{
+		// Arrange — empty Model violates [Required(AllowEmptyStrings = false)]. Smoke test
+		// (VlmOcrSmokeTest) and OllamaReceiptExtractionService both depend on a non-empty
+		// model name; validating at startup keeps the failure mode obvious.
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.OllamaUrl)}"] = "http://test-ollama",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.Model)}"] = string.Empty,
+			})
+			.Build();
+		services.AddVlmOcrClient(configuration);
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		Func<VlmOcrOptions> act = () => sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
+
+		// Assert
+		act.Should().Throw<OptionsValidationException>()
+			.WithMessage("*Model*");
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_HappyPath_ResolvesValidOptions()
+	{
+		// Arrange — sanity check that valid configuration resolves without throwing and that
+		// every property round-trips through the binder.
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.OllamaUrl)}"] = "http://test-ollama:11434",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.Model)}"] = "qwen2.5vl:7b",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.TimeoutSeconds)}"] = "60",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.LogRawResponses)}"] = "true",
+			})
+			.Build();
+		services.AddVlmOcrClient(configuration);
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		VlmOcrOptions value = sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
+
+		// Assert
+		value.OllamaUrl.Should().Be("http://test-ollama:11434");
+		value.Model.Should().Be("qwen2.5vl:7b");
+		value.TimeoutSeconds.Should().Be(60);
+		value.LogRawResponses.Should().BeTrue();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/InfrastructureServiceOptionsTests.cs
+++ b/tests/Infrastructure.Tests/Services/InfrastructureServiceOptionsTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Infrastructure.Tests.Services;
@@ -69,6 +70,38 @@ public class InfrastructureServiceOptionsTests
 		// Assert
 		act.Should().Throw<OptionsValidationException>()
 			.WithMessage("*Model*");
+	}
+
+	[Fact]
+	public async Task AddVlmOcrClient_BadConfiguration_HostStartAsyncFailsAtStartup()
+	{
+		// Arrange — RECEIPTS-638 acceptance: misconfigured options must fail when the host
+		// starts, before any user request reaches the API. ValidateOnStart() registers an
+		// IHostedService that runs validation during IHost.StartAsync(); without that
+		// hosted service, misconfig would only surface on first IOptions<T>.Value access.
+		// This test exercises the full lifecycle (StartAsync) so a future regression that
+		// removes ValidateOnStart() from production registrations would be caught here.
+		HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings());
+		builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+		{
+			[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.OllamaUrl)}"] = "http://test-ollama",
+			[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.Model)}"] = "glm-ocr:q8_0",
+			[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.TimeoutSeconds)}"] = "0",
+		});
+		builder.Services.AddLogging();
+		builder.Services.AddVlmOcrClient(builder.Configuration);
+
+		using IHost host = builder.Build();
+
+		// Act
+		Func<Task> act = () => host.StartAsync();
+
+		// Assert — ValidateOnStart triggers via the hosted-service pipeline. The framework
+		// surfaces the validation failure as OptionsValidationException raised inside
+		// StartAsync, signaling that the app would have aborted during boot rather than
+		// limping along until the first scan request.
+		await act.Should().ThrowAsync<OptionsValidationException>()
+			.WithMessage("*TimeoutSeconds*");
 	}
 
 	[Fact]

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
 using Polly;
@@ -34,7 +35,7 @@ public class OllamaReceiptExtractionServiceTests
 		};
 		return new OllamaReceiptExtractionService(
 			httpClient,
-			options,
+			Options.Create(options),
 			NullLogger<OllamaReceiptExtractionService>.Instance);
 	}
 
@@ -78,7 +79,7 @@ public class OllamaReceiptExtractionServiceTests
 	{
 		ServiceCollection services = new();
 		services.AddLogging();
-		services.AddSingleton(options);
+		services.AddSingleton<IOptions<VlmOcrOptions>>(Options.Create(options));
 #pragma warning disable EXTEXP0001
 		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
 		{
@@ -1294,12 +1295,12 @@ public class OllamaReceiptExtractionServiceTests
 
 		ServiceCollection services = new();
 		services.AddLogging();
-		services.AddSingleton(new VlmOcrOptions
+		services.AddSingleton<IOptions<VlmOcrOptions>>(Options.Create(new VlmOcrOptions
 		{
 			OllamaUrl = "http://test-ollama",
 			Model = "glm-ocr:q8_0",
 			TimeoutSeconds = 30,
-		});
+		}));
 		services.AddHttpClient<IReceiptExtractionService, OllamaReceiptExtractionService>(client =>
 		{
 			client.BaseAddress = new Uri("http://test-ollama/");
@@ -1417,7 +1418,7 @@ public class OllamaReceiptExtractionServiceTests
 			TimeoutSeconds = 30,
 			// Default — LogRawResponses left false.
 		};
-		OllamaReceiptExtractionService service = new(httpClient, options, logger);
+		OllamaReceiptExtractionService service = new(httpClient, Options.Create(options), logger);
 
 		// Act
 		await service.ExtractAsync(FakeImage, CancellationToken.None);
@@ -1455,7 +1456,7 @@ public class OllamaReceiptExtractionServiceTests
 			TimeoutSeconds = 30,
 			LogRawResponses = true,
 		};
-		OllamaReceiptExtractionService service = new(httpClient, options, logger);
+		OllamaReceiptExtractionService service = new(httpClient, Options.Create(options), logger);
 
 		// Act
 		await service.ExtractAsync(FakeImage, CancellationToken.None);
@@ -1489,7 +1490,7 @@ public class OllamaReceiptExtractionServiceTests
 			Model = "glm-ocr:q8_0",
 			TimeoutSeconds = 30,
 		};
-		OllamaReceiptExtractionService service = new(httpClient, options, logger);
+		OllamaReceiptExtractionService service = new(httpClient, Options.Create(options), logger);
 
 		// Act
 		await service.ExtractAsync(FakeImage, CancellationToken.None);
@@ -1601,10 +1602,12 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	[Fact]
-	public void AddVlmOcrClient_RegistersServiceAndOptions()
+	public void AddVlmOcrClient_Instance_RegistersServiceAndOptions()
 	{
-		// Arrange — verify the shared helper wires the typed client and exposes the options
-		// as a singleton (so OllamaReceiptExtractionService can resolve them).
+		// Arrange — verify the instance overload (used by VlmEval) wires the typed client
+		// and exposes the same VlmOcrOptions instance via IOptions<VlmOcrOptions>. Since
+		// RECEIPTS-638 the helper no longer registers the bare VlmOcrOptions instance —
+		// consumers resolve it through IOptions<VlmOcrOptions>.
 		ServiceCollection services = new();
 		services.AddLogging();
 		VlmOcrOptions options = new()
@@ -1617,9 +1620,10 @@ public class OllamaReceiptExtractionServiceTests
 		// Act
 		services.AddVlmOcrClient(options);
 
-		// Assert
+		// Assert — both the typed client and IOptions<VlmOcrOptions> are wired, with the
+		// IOptions wrapper backed by the same instance the caller passed in.
 		using ServiceProvider sp = services.BuildServiceProvider();
-		sp.GetRequiredService<VlmOcrOptions>().Should().BeSameAs(options);
+		sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value.Should().BeSameAs(options);
 		sp.GetRequiredService<IReceiptExtractionService>().Should().BeOfType<OllamaReceiptExtractionService>();
 	}
 
@@ -1782,7 +1786,7 @@ public class OllamaReceiptExtractionServiceTests
 		// RECEIPTS-640: tighten ctor null-check pattern so all three injected dependencies have
 		// the same guard. Previously only imageBytes had a guard; ctor params were unchecked.
 		Action act = () => new OllamaReceiptExtractionService(
-			null!, new VlmOcrOptions { OllamaUrl = "http://test" }, NullLogger<OllamaReceiptExtractionService>.Instance);
+			null!, Options.Create(new VlmOcrOptions { OllamaUrl = "http://test" }), NullLogger<OllamaReceiptExtractionService>.Instance);
 
 		act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("httpClient");
 	}
@@ -1803,10 +1807,112 @@ public class OllamaReceiptExtractionServiceTests
 	{
 		Action act = () => new OllamaReceiptExtractionService(
 			new HttpClient { BaseAddress = new Uri("http://test/") },
-			new VlmOcrOptions { OllamaUrl = "http://test" },
+			Options.Create(new VlmOcrOptions { OllamaUrl = "http://test" }),
 			null!);
 
 		act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_Configuration_ValidatesOnStart()
+	{
+		// Arrange — bind from a configuration source missing TimeoutSeconds (out of [Range(1, 3600)]
+		// only when explicitly 0; default is 120). Use an out-of-range TimeoutSeconds=0 to trigger
+		// validation. ValidateOnStart causes the failure to surface when IOptions<VlmOcrOptions>
+		// is first resolved (or when the host starts) rather than at the first request.
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.OllamaUrl)}"] = "http://test-ollama",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.Model)}"] = "glm-ocr:q8_0",
+				[$"{ConfigurationVariables.OcrVlmSection}:{nameof(VlmOcrOptions.TimeoutSeconds)}"] = "0",
+			})
+			.Build();
+
+		services.AddVlmOcrClient(configuration);
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		Func<VlmOcrOptions> act = () => sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
+
+		// Assert — DataAnnotations [Range(1, 3600)] rejects TimeoutSeconds=0 with a clear message.
+		act.Should().Throw<OptionsValidationException>()
+			.WithMessage("*TimeoutSeconds*");
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_Configuration_AppliesPostConfigureFallback()
+	{
+		// Arrange — when neither Ocr:Vlm:OllamaUrl nor Ollama:BaseUrl is set, PostConfigure
+		// must fall back to localhost so the bound options pass [Required] validation. This
+		// preserves the historical fallback chain RegisterReceiptExtractionService used.
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection([])
+			.Build();
+
+		services.AddVlmOcrClient(configuration);
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		VlmOcrOptions value = sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
+
+		// Assert — fallback applied; defaults preserved for everything else.
+		value.OllamaUrl.Should().Be("http://localhost:11434");
+		value.Model.Should().Be(VlmOcrOptions.DefaultModel);
+		value.TimeoutSeconds.Should().Be(120);
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_Configuration_PrefersExplicitOllamaUrlOverAspireBaseUrl()
+	{
+		// Arrange — when both Ocr:Vlm:OllamaUrl and Ollama:BaseUrl are present, the explicit
+		// Ocr:Vlm:OllamaUrl wins. This guards against the canonical fallback chain regressing.
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[ConfigurationVariables.OcrVlmOllamaUrl] = "http://explicit-ollama:11434",
+				[ConfigurationVariables.OllamaBaseUrl] = "http://aspire-ollama:11434",
+			})
+			.Build();
+
+		services.AddVlmOcrClient(configuration);
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		VlmOcrOptions value = sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
+
+		// Assert — explicit override beat the Aspire-injected base URL.
+		value.OllamaUrl.Should().Be("http://explicit-ollama:11434");
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_Configuration_FallsBackToAspireBaseUrlWhenExplicitMissing()
+	{
+		// Arrange — Aspire-injected Ollama:BaseUrl wins when the explicit Ocr:Vlm:OllamaUrl
+		// is absent. This is the production-Aspire case (no explicit override).
+		ServiceCollection services = new();
+		services.AddLogging();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[ConfigurationVariables.OllamaBaseUrl] = "http://aspire-ollama:11434",
+			})
+			.Build();
+
+		services.AddVlmOcrClient(configuration);
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		VlmOcrOptions value = sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
+
+		// Assert
+		value.OllamaUrl.Should().Be("http://aspire-ollama:11434");
 	}
 
 	/// <summary>

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -1699,7 +1699,7 @@ public class OllamaReceiptExtractionServiceTests
 		// Assert — the registered VlmOcrOptions points at the Aspire-injected URL, not the
 		// localhost default that would otherwise leak through.
 		using ServiceProvider sp = services.BuildServiceProvider();
-		VlmOcrOptions registered = sp.GetRequiredService<VlmOcrOptions>();
+		VlmOcrOptions registered = sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
 		registered.OllamaUrl.Should().Be("http://aspire-injected:11434");
 	}
 
@@ -1724,7 +1724,7 @@ public class OllamaReceiptExtractionServiceTests
 
 		// Assert
 		using ServiceProvider sp = services.BuildServiceProvider();
-		VlmOcrOptions registered = sp.GetRequiredService<VlmOcrOptions>();
+		VlmOcrOptions registered = sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
 		registered.OllamaUrl.Should().Be("http://override:11434");
 	}
 
@@ -1743,7 +1743,7 @@ public class OllamaReceiptExtractionServiceTests
 
 		// Assert
 		using ServiceProvider sp = services.BuildServiceProvider();
-		VlmOcrOptions registered = sp.GetRequiredService<VlmOcrOptions>();
+		VlmOcrOptions registered = sp.GetRequiredService<IOptions<VlmOcrOptions>>().Value;
 		registered.OllamaUrl.Should().Be(VlmOcrOptions.DefaultOllamaUrl);
 	}
 

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -1586,10 +1586,12 @@ public class OllamaReceiptExtractionServiceTests
 	[Fact]
 	public void AddVlmOcrClient_BlankOllamaUrl_Throws()
 	{
-		// Arrange — RECEIPTS-640: VlmOcrOptions.OllamaUrl is now non-nullable with a localhost
+		// Arrange — RECEIPTS-640: VlmOcrOptions.OllamaUrl is non-nullable with a localhost
 		// default, so to exercise the helper's guard we explicitly clear the URL to whitespace.
-		// The helper still enforces a non-blank URL so production and VlmEval cannot silently
-		// register a useless client.
+		// RECEIPTS-638: VlmOcrOptions.OllamaUrl is decorated with [Required(AllowEmptyStrings =
+		// false)] and the instance overload runs full DataAnnotations validation so the error
+		// message surfaces the constraint that failed (consistent with the IConfiguration
+		// overload's ValidateOnStart pipeline).
 		ServiceCollection services = new();
 		services.AddLogging();
 		VlmOcrOptions options = new() { Model = "glm-ocr:q8_0", OllamaUrl = "   " };
@@ -1599,6 +1601,50 @@ public class OllamaReceiptExtractionServiceTests
 
 		// Assert
 		act.Should().Throw<ArgumentException>().WithMessage("*OllamaUrl*");
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_Instance_EmptyModel_Throws()
+	{
+		// Arrange — the instance overload must enforce the same DataAnnotations contract as
+		// the IConfiguration overload. Without this, a VlmEval consumer that misconfigures
+		// Ocr:Vlm:Model="" would surface the failure as an opaque Ollama 400 instead of a
+		// clear startup error. RECEIPTS-638 follow-up bug fix.
+		ServiceCollection services = new();
+		services.AddLogging();
+		VlmOcrOptions options = new()
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "",
+		};
+
+		// Act
+		Action act = () => services.AddVlmOcrClient(options);
+
+		// Assert
+		act.Should().Throw<ArgumentException>().WithMessage("*Model*");
+	}
+
+	[Fact]
+	public void AddVlmOcrClient_Instance_OutOfRangeTimeout_Throws()
+	{
+		// Arrange — TimeoutSeconds=0 is outside [Range(1, 3600)]. The instance overload must
+		// catch this at registration so VlmEval doesn't silently register a client whose every
+		// retry expires immediately.
+		ServiceCollection services = new();
+		services.AddLogging();
+		VlmOcrOptions options = new()
+		{
+			OllamaUrl = "http://test-ollama",
+			Model = "glm-ocr:q8_0",
+			TimeoutSeconds = 0,
+		};
+
+		// Act
+		Action act = () => services.AddVlmOcrClient(options);
+
+		// Assert
+		act.Should().Throw<ArgumentException>().WithMessage("*TimeoutSeconds*");
 	}
 
 	[Fact]

--- a/tests/Infrastructure.Tests/Services/PdfConversionOptionsTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionOptionsTests.cs
@@ -1,0 +1,123 @@
+using System.ComponentModel.DataAnnotations;
+using Common;
+using FluentAssertions;
+using Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Tests.Services;
+
+/// <summary>
+/// Validation tests for <see cref="PdfConversionOptions"/>. The options class is the new home
+/// for the PDF page-count threshold that previously lived as <c>const int MaxPages = 50</c>
+/// on <c>IPdfConversionService</c> (RECEIPTS-638). Misconfiguring the options must fail
+/// loudly at startup via <see cref="OptionsBuilderExtensions.ValidateOnStart{TOptions}"/>
+/// rather than at the first user upload.
+/// </summary>
+public class PdfConversionOptionsTests
+{
+	[Fact]
+	public void Defaults_MatchHistoricalConstant()
+	{
+		// The default MaxPages must continue to match the historical hardcoded value
+		// (previously `const int MaxPages = 50` on the interface) so behaviour is unchanged
+		// for callers that don't opt into the new section.
+		PdfConversionOptions options = new();
+
+		options.MaxPages.Should().Be(50);
+	}
+
+	[Fact]
+	public void DataAnnotations_RejectMaxPagesZero()
+	{
+		// Arrange
+		PdfConversionOptions options = new() { MaxPages = 0 };
+		List<ValidationResult> results = [];
+
+		// Act
+		bool valid = Validator.TryValidateObject(
+			options,
+			new ValidationContext(options),
+			results,
+			validateAllProperties: true);
+
+		// Assert
+		valid.Should().BeFalse();
+		results.Should().Contain(r => r.MemberNames.Contains(nameof(PdfConversionOptions.MaxPages)));
+	}
+
+	[Fact]
+	public void DataAnnotations_RejectNegativeMaxPages()
+	{
+		// Arrange
+		PdfConversionOptions options = new() { MaxPages = -1 };
+		List<ValidationResult> results = [];
+
+		// Act
+		bool valid = Validator.TryValidateObject(
+			options,
+			new ValidationContext(options),
+			results,
+			validateAllProperties: true);
+
+		// Assert
+		valid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ValidateOnStart_BadConfiguration_ThrowsWhenResolved()
+	{
+		// Arrange — the canonical "misconfigured options fail at startup" assertion that
+		// RECEIPTS-638 calls out as an acceptance criterion. ValidateOnStart causes
+		// DataAnnotations errors to surface when IOptions<T> is first resolved (or when
+		// the host starts via IHostedService).
+		ServiceCollection services = new();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[$"{ConfigurationVariables.PdfConversionSection}:{nameof(PdfConversionOptions.MaxPages)}"] = "0",
+			})
+			.Build();
+
+		services.AddOptions<PdfConversionOptions>()
+			.Bind(configuration.GetSection(ConfigurationVariables.PdfConversionSection))
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		Func<PdfConversionOptions> act = () => sp.GetRequiredService<IOptions<PdfConversionOptions>>().Value;
+
+		// Assert
+		act.Should().Throw<OptionsValidationException>()
+			.WithMessage("*MaxPages*");
+	}
+
+	[Fact]
+	public void ValidateOnStart_ValidConfiguration_ResolvesOk()
+	{
+		// Arrange — happy path: a valid override resolves without throwing and reports the
+		// configured value. Guards against a bad refactor accidentally rejecting all
+		// configurations (e.g. inverted Range bounds).
+		ServiceCollection services = new();
+		IConfiguration configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				[$"{ConfigurationVariables.PdfConversionSection}:{nameof(PdfConversionOptions.MaxPages)}"] = "100",
+			})
+			.Build();
+
+		services.AddOptions<PdfConversionOptions>()
+			.Bind(configuration.GetSection(ConfigurationVariables.PdfConversionSection))
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
+		// Act
+		using ServiceProvider sp = services.BuildServiceProvider();
+		PdfConversionOptions value = sp.GetRequiredService<IOptions<PdfConversionOptions>>().Value;
+
+		// Assert
+		value.MaxPages.Should().Be(100);
+	}
+}

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceFixtureTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceFixtureTests.cs
@@ -3,6 +3,7 @@ using Application.Interfaces.Services;
 using FluentAssertions;
 using Infrastructure.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -42,7 +43,8 @@ public class PdfConversionServiceFixtureTests
 	public PdfConversionServiceFixtureTests()
 	{
 		Mock<ILogger<PdfConversionService>> mockLogger = new();
-		_service = new PdfConversionService(mockLogger.Object);
+		IOptions<PdfConversionOptions> options = Options.Create(new PdfConversionOptions());
+		_service = new PdfConversionService(mockLogger.Object, options);
 	}
 
 	[Fact]

--- a/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/PdfConversionServiceTests.cs
@@ -2,6 +2,7 @@ using Application.Interfaces.Services;
 using FluentAssertions;
 using Infrastructure.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
@@ -16,12 +17,15 @@ namespace Infrastructure.Tests.Services;
 
 public class PdfConversionServiceTests
 {
+	private const int DefaultMaxPages = 50;
+
 	private readonly PdfConversionService _service;
 
 	public PdfConversionServiceTests()
 	{
 		Mock<ILogger<PdfConversionService>> mockLogger = new();
-		_service = new PdfConversionService(mockLogger.Object);
+		IOptions<PdfConversionOptions> options = Options.Create(new PdfConversionOptions());
+		_service = new PdfConversionService(mockLogger.Object, options);
 	}
 
 	[Fact]
@@ -241,12 +245,12 @@ public class PdfConversionServiceTests
 	[Fact]
 	public async Task ConvertAsync_OversizedPdf_ThrowsBeforeRasterization()
 	{
-		// Arrange — build a PDF with one more page than IPdfConversionService.MaxPages
+		// Arrange — build a PDF with one more page than the default PdfConversionOptions.MaxPages
 		// allows. The converter must reject these cleanly before invoking PDFtoImage,
 		// otherwise a hostile or accidental upload could spend rasterization budget on
 		// work we reject anyway.
 		string[] pages = Enumerable
-			.Range(1, IPdfConversionService.MaxPages + 1)
+			.Range(1, DefaultMaxPages + 1)
 			.Select(i => $"Page {i} content with enough text to satisfy the threshold")
 			.ToArray();
 		byte[] pdfBytes = CreateMultiPageTextPdf(pages);
@@ -257,6 +261,33 @@ public class PdfConversionServiceTests
 		// Assert
 		await act.Should().ThrowAsync<InvalidOperationException>()
 			.WithMessage("*exceeds the maximum*");
+	}
+
+	[Fact]
+	public async Task ConvertAsync_ConfiguredMaxPagesOverride_RejectsAtConfiguredLimit()
+	{
+		// Arrange — RECEIPTS-638: PdfConversionService takes its limit from
+		// IOptions<PdfConversionOptions> rather than a hardcoded constant. A test-time
+		// override of MaxPages=2 must reject a 3-page PDF, proving the option is wired
+		// through to the validation path (and not just shadowed by a stale const).
+		Mock<ILogger<PdfConversionService>> mockLogger = new();
+		IOptions<PdfConversionOptions> options = Options.Create(new PdfConversionOptions { MaxPages = 2 });
+		PdfConversionService overrideService = new(mockLogger.Object, options);
+
+		byte[] pdfBytes = CreateMultiPageTextPdf(
+		[
+			"Page 1 content with enough text to satisfy the threshold",
+			"Page 2 content with enough text to satisfy the threshold",
+			"Page 3 content with enough text to satisfy the threshold",
+		]);
+
+		// Act
+		Func<Task> act = () => overrideService.ConvertAsync(pdfBytes, CancellationToken.None);
+
+		// Assert — error message must reflect the configured limit so operators can debug
+		// from the rejection log alone.
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*exceeds the maximum of 2*");
 	}
 
 	[Fact]

--- a/tests/VlmEval.Tests/EvalRunnerTests.cs
+++ b/tests/VlmEval.Tests/EvalRunnerTests.cs
@@ -6,6 +6,7 @@ using Application.Models.Ocr;
 using FluentAssertions;
 using Infrastructure.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
 
@@ -352,7 +353,7 @@ public class EvalRunnerTests : IDisposable
 
 		return new EvalRunner(
 			httpFactory.Object,
-			vlmOptions,
+			Options.Create(vlmOptions),
 			loader,
 			evaluator,
 			reporter,


### PR DESCRIPTION
## Summary

- Move per-environment thresholds out of hardcoded constants and the `IPdfConversionService` interface into proper options classes bound through `Microsoft.Extensions.Options` with DataAnnotations validation. Misconfigured values now fail loudly at startup via `ValidateOnStart` rather than producing a confusing runtime error on the first user upload.
- Add `PdfConversionOptions` (`MaxPages`) and `ImageValidationOptions` (`MaxPixelWidth`/`MaxPixelHeight`); decorate `VlmOcrOptions` with `[Required]`/`[Range]` annotations.
- `AddVlmOcrClient` gets a new `IConfiguration` overload that uses the standard options pattern (`Bind` + `PostConfigure` for the Ollama URL fallback chain + `ValidateDataAnnotations` + `ValidateOnStart`). The instance overload is preserved for `VlmEval` where CLI args mutate options before registration.
- `OllamaReceiptExtractionService` and `EvalRunner` now take `IOptions<VlmOcrOptions>` instead of a bare singleton.

Resolves RECEIPTS-638

## Notes / Assumptions

- The issue description listed several PDF thresholds (`MinTextLengthPerPage`, `MaxImageDimension`, `MinReceiptImageDimension`, `MaxTotalImageBytes`) that the parent branch had already removed via RECEIPTS-629/-646. Only `MaxPages` (the interface const) remained, so `PdfConversionOptions` carries just that knob today.
- `RasterizationDpi` stayed an internal `const` in `PdfConversionService` because it is a tuning constant, not user-configurable policy — moving it to options would imply per-environment override which we don't currently want.
- The `AddVlmOcrClient(VlmOcrOptions)` overload no longer registers the bare `VlmOcrOptions` instance — only its `IOptions<VlmOcrOptions>` wrapper. Updated the corresponding test (`AddVlmOcrClient_Instance_RegistersServiceAndOptions`) to assert via `IOptions<VlmOcrOptions>`.

## Test plan

- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2,524+ unit tests pass (Common, Domain, Application, Infrastructure, Presentation.API, VlmEval).
- [x] New `PdfConversionOptionsTests` — defaults, DataAnnotations rejection of zero/negative `MaxPages`, `ValidateOnStart` failure surface.
- [x] New `ImageValidationOptionsTests` — defaults, DataAnnotations rejection of zero/negative dimensions, `ValidateOnStart` failure surface.
- [x] New `InfrastructureServiceOptionsTests` — end-to-end `AddVlmOcrClient(IConfiguration)` rejects bad `TimeoutSeconds`/empty `Model` at startup.
- [x] New `AddVlmOcrClient_Configuration_*` tests — happy-path resolution, `PostConfigure` fallback chain (explicit > Aspire > localhost) preserved, `ValidateOnStart` triggers on config-bound `TimeoutSeconds=0`.
- [x] Existing `RegisterReceiptExtractionService_SlowResponse_NotCancelledByServiceDefaultsStandardHandler` regression test still passes — proves `RemoveAllResilienceHandlers()` flow is intact end-to-end.
- [x] `dotnet format Receipts.slnx --verify-no-changes` — no formatting drift.