### PR TITLE
fix(infrastructure): seed Card in PurgeTrashServiceTests for Transaction FK

### DIFF
--- a/tests/Infrastructure.IntegrationTests/PurgeTrashServiceTests.cs
+++ b/tests/Infrastructure.IntegrationTests/PurgeTrashServiceTests.cs
@@ -23,6 +23,10 @@ public class PurgeTrashServiceTests(PostgresFixture fixture)
 
 		// Parents (needed for FK-valid child inserts)
 		AccountEntity account = AccountEntityGenerator.Generate();
+		// Card must reference the seeded Account (RECEIPTS-575: Card.AccountId NOT NULL).
+		// Transactions reference this Card (RECEIPTS-574: Transaction.CardId NOT NULL).
+		CardEntity card = CardEntityGenerator.Generate();
+		card.AccountId = account.Id;
 		ReceiptEntity activeReceipt = ReceiptEntityGenerator.Generate();
 		ReceiptEntity deletedReceipt = ReceiptEntityGenerator.Generate();
 		deletedReceipt.DeletedAt = deletedAt;
@@ -48,8 +52,8 @@ public class PurgeTrashServiceTests(PostgresFixture fixture)
 		ReceiptItemEntity deletedReceiptItem = ReceiptItemEntityGenerator.Generate(activeReceipt.Id);
 		deletedReceiptItem.DeletedAt = deletedAt;
 
-		TransactionEntity activeTransaction = TransactionEntityGenerator.Generate(activeReceipt.Id, account.Id);
-		TransactionEntity deletedTransaction = TransactionEntityGenerator.Generate(activeReceipt.Id, account.Id);
+		TransactionEntity activeTransaction = TransactionEntityGenerator.Generate(activeReceipt.Id, account.Id, card.Id);
+		TransactionEntity deletedTransaction = TransactionEntityGenerator.Generate(activeReceipt.Id, account.Id, card.Id);
 		deletedTransaction.DeletedAt = deletedAt;
 
 		AdjustmentEntity activeAdjustment = AdjustmentEntityGenerator.Generate();
@@ -69,6 +73,7 @@ public class PurgeTrashServiceTests(PostgresFixture fixture)
 		await using (ApplicationDbContext setup = fixture.CreateDbContext())
 		{
 			setup.Accounts.Add(account);
+			setup.Cards.Add(card);
 			setup.Receipts.AddRange(activeReceipt, deletedReceipt);
 			setup.Categories.AddRange(activeCategory, deletedCategory);
 			await setup.SaveChangesAsync();


### PR DESCRIPTION
## Summary

- `PurgeAllDeletedAsync_RemovesSoftDeletedRowsFromEverySoftDeletableTable_AndPreservesActiveRows` fails with `FK_Transactions_Cards_CardId` violation when the test database has no other Cards present.
- The test was order-dependent in CI — passing only when prior tests left a Card row whose ID happened to coincide with `account.Id`.
- Fix: seed a `CardEntity` linked to the test's Account, pass `card.Id` to `TransactionEntityGenerator.Generate(...)`, add the Card before saving Transactions.

This is a pre-existing bug from RECEIPTS-574 (Transaction.CardId NOT NULL) / RECEIPTS-575 (Card.AccountId NOT NULL); discovered while running the full test suite post-Phase-14 reviews.

## Test plan

- [x] `dotnet test tests/Infrastructure.IntegrationTests` → 36/36 pass.
- [x] Full `dotnet test Receipts.slnx` → 2,596 passed, 0 failed.
- [x] Full client `npm test` → 1,932 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)