### PR TITLE
fix(infra): normalize CRLF in Aspire vlm-ocr-pull bash heredoc

### DIFF
--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -73,9 +73,13 @@ const string vlmOcrPullCommand = """
 	echo "All pull attempts failed" >&2
 	exit 1
 	""";
+// Normalize CRLF → LF so the bash heredoc parses correctly on Linux. Without this, a Windows
+// .editorconfig that mandates CRLF for *.cs files causes /bin/sh -c to see `do\r` as a non-keyword
+// and fail with "Syntax error: word unexpected (expecting \"do\")".
+string vlmOcrPullCommandLf = vlmOcrPullCommand.Replace("\r\n", "\n");
 IResourceBuilder<ContainerResource> vlmOcrPull = builder.AddContainer("vlm-ocr-pull", "ollama/ollama", "latest")
 	.WithEntrypoint("/bin/sh")
-	.WithArgs("-c", vlmOcrPullCommand)
+	.WithArgs("-c", vlmOcrPullCommandLf)
 	.WithEnvironment("OLLAMA_HOST", "http://vlm-ocr:11434")
 	.WithEnvironment("VLM_MODEL", vlmModel)
 	.WaitFor(vlmOcr);


### PR DESCRIPTION
## Summary

The vlm-ocr-pull retry loop added in RECEIPTS-636 is a C# raw string literal containing a multi-line bash script. `.editorconfig` mandates CRLF on `*.cs`, so embedded `\r` characters survive into the container args. Linux `/bin/sh -c` sees `for i in 1 2 3 4 5; do\r` and fails with:

```
/bin/sh: 1: Syntax error: word unexpected (expecting "do")
```

The container exits non-zero, and `WaitForCompletion(vlmOcrPull)` on api/vlm-eval blocks them from starting.

Fix: `command.Replace("\r\n", "\n")` before `WithArgs`. Inline comment explains the editorconfig + raw-string interaction.

`docker-compose.yml` already uses LF, so only AppHost needed the fix.

## Test plan

- [x] Pre-commit (full backend + 1932 client tests) → green.
- [ ] User to verify by restarting `dotnet run --project src/Receipts.AppHost` and confirming vlm-ocr-pull, api, and vlm-eval all reach Running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)