### PR TITLE
feat(infrastructure): auto-download ONNX model files on first build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ This file is **checked into git** (via Track B of RECEIPTS-534). It is a materia
 ```bash
 dotnet build Receipts.slnx                                    # Build entire solution
 dotnet test Receipts.slnx --filter "Category!=Integration"    # Unit tests only (CI + pre-commit)
-dotnet test Receipts.slnx                                     # All tests (requires ONNX model)
+dotnet test Receipts.slnx                                     # All tests (ONNX model auto-downloaded on first build; opt out with -p:SkipOnnxModelDownload=true)
 ```
 
 The API does not self-migrate or self-seed. See **[docs/development.md](docs/development.md#running-without-aspire)** for full commands including migrations, seeding, and single-project tests.

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,10 +30,13 @@ dotnet restore Receipts.slnx
 
 # Install Node dependencies (OpenAPI linting tools)
 npm install
-
-# Download the ONNX embedding model (~90MB, required at runtime)
-dotnet run scripts/download-onnx-model.cs
 ```
+
+The ONNX embedding model (~1.34 GB) is downloaded automatically the first time
+you build the `Infrastructure` project (e.g. `dotnet build` or `dotnet test`).
+To opt out (e.g. on a CI runner with a pre-cached model), pass
+`-p:SkipOnnxModelDownload=true`. To download manually, run
+`dotnet run scripts/download-onnx-model.cs`.
 
 ## F5 Debugging (Recommended)
 

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -12,9 +12,56 @@
     <InternalsVisibleTo Include="Infrastructure.IntegrationTests" />
   </ItemGroup>
 
+  <!--
+    BGE-large ONNX model files are pulled at build time on a fresh clone (~1.34 GB on first run,
+    cached thereafter). Without these, OnnxEmbeddingService throws FileNotFoundException at
+    runtime and ~13 OnnxEmbedding* tests fail. The static `Content Include` block below uses
+    `Condition="Exists(...)"` so the build never errors when the files are absent — the download
+    target below populates them, and a separate target adds them as dynamic Content items after
+    the download so the first `dotnet build` after a clone is enough to produce a working bin/.
+    Set `-p:SkipOnnxModelDownload=true` to opt out (e.g., on CI runners that pre-cache the files
+    or in build environments without internet).
+  -->
+  <PropertyGroup>
+    <OnnxModelDir>$(MSBuildProjectDirectory)\Models\BgeLargeEnV15</OnnxModelDir>
+    <OnnxModelPath>$(OnnxModelDir)\model.onnx</OnnxModelPath>
+    <OnnxVocabPath>$(OnnxModelDir)\vocab.txt</OnnxVocabPath>
+  </PropertyGroup>
+
+  <Target Name="EnsureOnnxModelFiles"
+          BeforeTargets="AssignTargetPaths"
+          Condition="'$(SkipOnnxModelDownload)' != 'true'">
+    <MakeDir Directories="$(OnnxModelDir)" Condition="!Exists('$(OnnxModelDir)')" />
+    <Message Importance="high"
+             Text="Downloading bge-large-en-v1.5 ONNX model (~1.34 GB)..."
+             Condition="!Exists('$(OnnxModelPath)')" />
+    <DownloadFile SourceUrl="https://huggingface.co/BAAI/bge-large-en-v1.5/resolve/main/onnx/model.onnx"
+                  DestinationFolder="$(OnnxModelDir)"
+                  Condition="!Exists('$(OnnxModelPath)')" />
+    <Message Importance="high"
+             Text="Downloading bge-large-en-v1.5 vocab.txt..."
+             Condition="!Exists('$(OnnxVocabPath)')" />
+    <DownloadFile SourceUrl="https://huggingface.co/BAAI/bge-large-en-v1.5/resolve/main/vocab.txt"
+                  DestinationFolder="$(OnnxModelDir)"
+                  Condition="!Exists('$(OnnxVocabPath)')" />
+    <ItemGroup>
+      <Content Include="$(OnnxModelPath)"
+               Link="Models\BgeLargeEnV15\model.onnx"
+               CopyToOutputDirectory="PreserveNewest"
+               Condition="Exists('$(OnnxModelPath)')" />
+      <Content Include="$(OnnxVocabPath)"
+               Link="Models\BgeLargeEnV15\vocab.txt"
+               CopyToOutputDirectory="PreserveNewest"
+               Condition="Exists('$(OnnxVocabPath)')" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
-    <Content Include="Models\BgeLargeEnV15\model.onnx" Condition="Exists('Models\BgeLargeEnV15\model.onnx')" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="Models\BgeLargeEnV15\vocab.txt" Condition="Exists('Models\BgeLargeEnV15\vocab.txt')" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Fallback Content items for the SkipOnnxModelDownload=true path: if the files happen
+         to be present (CI cache, manual download), include them; otherwise they're absent and
+         the runtime will throw a clear FileNotFoundException pointing the dev at the script. -->
+    <Content Include="Models\BgeLargeEnV15\model.onnx" Condition="'$(SkipOnnxModelDownload)' == 'true' AND Exists('Models\BgeLargeEnV15\model.onnx')" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Models\BgeLargeEnV15\vocab.txt" Condition="'$(SkipOnnxModelDownload)' == 'true' AND Exists('Models\BgeLargeEnV15\vocab.txt')" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

A fresh `git clone && dotnet test Receipts.slnx` failed with 13 `OnnxEmbedding*` test failures because the bge-large-en-v1.5 model files weren't on disk. Previously, devs had to manually run `scripts/download-onnx-model.cs` before tests would pass.

This PR wires the download into the build:

- New `EnsureOnnxModelFiles` MSBuild target on `Infrastructure.csproj`, running `BeforeTargets="AssignTargetPaths"`. Uses the built-in `<DownloadFile>` task to fetch from HuggingFace if either file is missing. Idempotent.
- Dynamic `<Content>` items added inside the target (after download) with `CopyToOutputDirectory="PreserveNewest"`, so the test bin/ picks them up on a single `dotnet build`.
- `-p:SkipOnnxModelDownload=true` opts out (CI with pre-cached cache, offline builds). The fallback static `<Content>` items with `Condition="Exists(...)"` still copy any pre-placed files in that case.

`scripts/download-onnx-model.cs` stays as the manual escape hatch.

## Test plan

- [x] Deleted `vocab.txt` from source + test bin → ran `dotnet build src/Infrastructure/Infrastructure.csproj` → vocab.txt downloaded automatically.
- [x] Built `Infrastructure.Tests` → vocab.txt copied to bin output.
- [x] Ran `OnnxEmbedding*` tests → 13/13 passed.
- [x] Full `dotnet test Receipts.slnx` → 2,596 passed, 0 failed.
- [x] Pre-commit (full backend + 1932 client tests) → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)