### PR TITLE
fix(infrastructure): handle Ollama NDJSON streaming despite stream=false

### DIFF
--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -115,7 +115,7 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 		// The per-attempt timeout is enforced by the resilience pipeline (Polly Timeout
 		// strategy registered in InfrastructureService). Each retry receives a fresh
 		// VlmOcrOptions.TimeoutSeconds budget — see RECEIPTS-630.
-		OllamaGenerateResponse? generateResponse;
+		string responseBody;
 		try
 		{
 			using HttpResponseMessage httpResponse = await _httpClient.PostAsJsonAsync(
@@ -123,28 +123,35 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 
 			httpResponse.EnsureSuccessStatusCode();
 
-			generateResponse = await httpResponse.Content.ReadFromJsonAsync<OllamaGenerateResponse>(
-				JsonOptions, cancellationToken);
+			responseBody = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
 		}
 		catch (TimeoutRejectedException)
 		{
 			throw new TimeoutException($"Ollama VLM call timed out after {_options.TimeoutSeconds}s.");
 		}
 
+		// Ollama's /api/generate returns either:
+		//   1. A single JSON object (when stream=false honored by the server — what we ask for)
+		//   2. NDJSON: one JSON object per line, each a partial chunk, the last with done=true
+		//      (some Ollama versions stream image-input responses despite stream=false on the
+		//      request — observed on glm-ocr with rasterized-PDF inputs)
+		// We handle both transparently: parse line-by-line, concatenate the `response` chunks,
+		// take the final object's `done` flag. A single-object body is just a one-line NDJSON.
+		// See RECEIPTS-640 (the original done=false guard) and the hardening that motivated this.
+		OllamaGenerateResponse? generateResponse = ParseOllamaResponse(responseBody);
+
 		if (generateResponse is null || string.IsNullOrWhiteSpace(generateResponse.Response))
 		{
 			throw new InvalidOperationException("Ollama VLM returned an empty response.");
 		}
 
-		// done=false signals a partial/streamed response — the body is mid-stream and the JSON
-		// payload is truncated, so any downstream JsonException would be a confusing red herring.
-		// We send stream=false (Ollama's per-request default) so any done=false here means the
-		// daemon is misconfigured (e.g. someone flipped the default at the server). Surface the
-		// real cause early rather than letting a JsonException mask it. See RECEIPTS-640.
+		// After NDJSON consolidation, done=false means the stream was truncated mid-flight (the
+		// connection closed before the model reached its done=true terminal chunk). The JSON in
+		// `Response` will be partial and any downstream JsonException would mask the real cause.
 		if (!generateResponse.Done)
 		{
 			throw new InvalidOperationException(
-				"Ollama VLM returned a non-final response (done=false); the request was streamed or truncated. Confirm the daemon is configured for stream=false.");
+				"Ollama VLM response was truncated (no done=true chunk received); the upstream connection likely dropped mid-stream. Retry, or confirm the daemon is reachable for the full response.");
 		}
 
 		// The raw response carries PII (store, items, payment method, last-four). Logging is gated
@@ -203,6 +210,61 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 			: maxChars;
 
 		return string.Concat(value.AsSpan(0, safeMax), "... [truncated]");
+	}
+
+	/// <summary>
+	/// Parses an Ollama <c>/api/generate</c> response body, transparently handling both the
+	/// single-JSON-object form (returned when <c>stream=false</c> is honored) and the NDJSON
+	/// streaming form (one JSON object per line, the last carrying <c>done=true</c>).
+	/// Concatenates the per-chunk <c>response</c> strings and returns a synthetic
+	/// <see cref="OllamaGenerateResponse"/> carrying the joined text plus the final
+	/// <c>done</c>/<c>model</c> values. Returns <c>null</c> when the body is empty or only
+	/// whitespace.
+	/// </summary>
+	internal static OllamaGenerateResponse? ParseOllamaResponse(string body)
+	{
+		if (string.IsNullOrWhiteSpace(body))
+		{
+			return null;
+		}
+
+		// Single-line JSON-object body: parse directly. This is the happy path on Ollama
+		// builds that respect stream=false.
+		string trimmed = body.TrimStart();
+		bool looksLikeNdjson = trimmed.IndexOf('\n') >= 0;
+		if (!looksLikeNdjson)
+		{
+			return JsonSerializer.Deserialize<OllamaGenerateResponse>(body, JsonOptions);
+		}
+
+		// NDJSON: parse each non-blank line as an OllamaGenerateResponse, concatenate the
+		// `response` chunks, take the last object's metadata. The final chunk in a healthy
+		// stream has done=true and an empty response; truncated streams have all done=false.
+		System.Text.StringBuilder accumulator = new();
+		string? lastModel = null;
+		bool lastDone = false;
+		foreach (string line in body.Split('\n'))
+		{
+			if (string.IsNullOrWhiteSpace(line))
+			{
+				continue;
+			}
+
+			OllamaGenerateResponse? chunk = JsonSerializer.Deserialize<OllamaGenerateResponse>(line, JsonOptions);
+			if (chunk is null)
+			{
+				continue;
+			}
+
+			if (!string.IsNullOrEmpty(chunk.Response))
+			{
+				accumulator.Append(chunk.Response);
+			}
+			lastModel = chunk.Model;
+			lastDone = chunk.Done;
+		}
+
+		return new OllamaGenerateResponse(lastModel ?? string.Empty, accumulator.ToString(), lastDone);
 	}
 
 	internal static ParsedReceipt MapToParsedReceipt(VlmReceiptPayload payload)

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -1748,13 +1748,14 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	[Fact]
-	public async Task ExtractAsync_DoneFalse_Throws()
+	public async Task ExtractAsync_DoneFalse_SingleObject_ThrowsTruncationError()
 	{
-		// Arrange — RECEIPTS-640: a done=false response signals a streamed/truncated body. The
-		// payload is mid-stream and the JSON is incomplete, so any downstream JsonException would
-		// be a confusing red herring. We ship stream=false (Ollama's per-request default), so any
-		// done=false here means the daemon was misconfigured to streaming mode. Fail fast and
-		// loudly with a message that points at the actual cause.
+		// Arrange — a single-line JSON response with done=false (e.g. an unhealthy daemon
+		// returning the first chunk only, or a truncated response that arrived as a single
+		// non-streaming object). The payload is mid-stream and the JSON is incomplete, so
+		// any downstream JsonException would be a confusing red herring. Surface the real
+		// cause early. See RECEIPTS-640 (original guard) and the NDJSON consolidation that
+		// motivated rephrasing the error around truncation rather than streaming.
 		string envelope = JsonSerializer.Serialize(new
 		{
 			model = "glm-ocr:q8_0",
@@ -1768,7 +1769,7 @@ public class OllamaReceiptExtractionServiceTests
 
 		// Assert
 		await act.Should().ThrowAsync<InvalidOperationException>()
-			.WithMessage("*non-final response*done=false*");
+			.WithMessage("*truncated*done=true*");
 	}
 
 	[Fact]
@@ -1959,6 +1960,85 @@ public class OllamaReceiptExtractionServiceTests
 
 		// Assert
 		value.OllamaUrl.Should().Be("http://aspire-ollama:11434");
+	}
+
+	// ParseOllamaResponse: handles both single-JSON-object and NDJSON streaming responses
+	// transparently. Some Ollama versions stream image-input responses despite stream=false on
+	// the request; the parser folds the chunks back into one synthetic OllamaGenerateResponse
+	// so callers see a single coherent object.
+
+	[Fact]
+	public async Task ExtractAsync_NdjsonStreamedResponse_ReassemblesToFullPayload()
+	{
+		// Arrange — Ollama streamed the response across 3 chunks despite our stream=false
+		// (observed on glm-ocr with rasterized-PDF inputs). Each line is a valid
+		// OllamaGenerateResponse; chunks 1-2 carry partial JSON in `response`, chunk 3 has
+		// done=true and an empty `response`.
+		string ndjsonBody = string.Join('\n',
+			"""{"model":"glm-ocr:q8_0","response":"{ \"schema_version\": 1, \"store\": { \"name\": \"Walmart\" },","done":false}""",
+			"""{"model":"glm-ocr:q8_0","response":" \"datetime\": \"2026-04-01\", \"total\": 9.71 }","done":false}""",
+			"""{"model":"glm-ocr:q8_0","response":"","done":true}""");
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(ndjsonBody));
+
+		// Act
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
+
+		// Assert — the joined chunks reconstruct a valid VLM payload that maps cleanly.
+		receipt.StoreName.Value.Should().Be("Walmart");
+		receipt.Date.Value.Should().Be(new DateOnly(2026, 4, 1));
+		receipt.Total.Value.Should().Be(9.71m);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_NdjsonTruncatedStream_NoDoneTrueChunk_ThrowsTruncationError()
+	{
+		// Arrange — connection dropped before Ollama emitted the final done=true chunk. The
+		// reassembled response is partial JSON, but the truncation detector fires before any
+		// downstream JsonException can mask the cause.
+		string truncatedNdjson = string.Join('\n',
+			"""{"model":"glm-ocr:q8_0","response":"{ \"schema_version\": 1, \"store\":","done":false}""",
+			"""{"model":"glm-ocr:q8_0","response":" { \"name\": \"Walmart\"","done":false}""");
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(truncatedNdjson));
+
+		// Act
+		Func<Task> act = () => service.ExtractAsync(FakeImage, CancellationToken.None);
+
+		// Assert
+		ExceptionAssertions<InvalidOperationException> thrown =
+			await act.Should().ThrowAsync<InvalidOperationException>()
+				.WithMessage("*truncated*");
+		thrown.Which.Message.Should().Contain("done=true");
+	}
+
+	[Fact]
+	public void ParseOllamaResponse_EmptyBody_ReturnsNull()
+	{
+		// Arrange — defensive: a literally empty / whitespace-only body must not throw and
+		// must not produce a synthetic OllamaGenerateResponse with stale defaults.
+		OllamaGenerateResponse? r1 = OllamaReceiptExtractionService.ParseOllamaResponse(string.Empty);
+		OllamaGenerateResponse? r2 = OllamaReceiptExtractionService.ParseOllamaResponse("   \n  \n");
+
+		// Assert
+		r1.Should().BeNull();
+		r2.Should().BeNull();
+	}
+
+	[Fact]
+	public void ParseOllamaResponse_SingleJsonObject_ParsesDirectly()
+	{
+		// Arrange — the happy path: stream=false honored by the daemon, body is a single
+		// JSON object on one line.
+		string singleObject =
+			"""{"model":"glm-ocr:q8_0","response":"{ \"schema_version\": 1 }","done":true}""";
+
+		// Act
+		OllamaGenerateResponse? response = OllamaReceiptExtractionService.ParseOllamaResponse(singleObject);
+
+		// Assert
+		response.Should().NotBeNull();
+		response!.Done.Should().BeTrue();
+		response.Response.Should().Contain("schema_version");
+		response.Model.Should().Be("glm-ocr:q8_0");
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary

Real-world VLM test on a rasterized PDF hit the RECEIPTS-640 `done=false` guard:

> Ollama VLM returned a non-final response (done=false); the request was streamed or truncated.

**Root cause**: some Ollama versions stream image-input responses despite `stream=false` on the request. The body comes back as NDJSON (one JSON object per line, the last with `done=true`). `ReadFromJsonAsync<OllamaGenerateResponse>` only reads the first object — which has `done=false` — so the guard fired on a healthy response.

**Fix**: new `ParseOllamaResponse` helper that transparently handles both:
- Single-line JSON object (server honored `stream=false`) — parse directly.
- NDJSON streaming — parse each non-blank line, concatenate the per-chunk `response` fields, take the final chunk's `done`/`model` values, return one synthetic `OllamaGenerateResponse`.

The `done=false` guard now means "no `done=true` chunk arrived" — the upstream connection genuinely dropped mid-stream — which is the actionable case (retry). Error message rephrased accordingly.

## Tests

4 new tests + 1 updated:
- `ExtractAsync_NdjsonStreamedResponse_ReassemblesToFullPayload`
- `ExtractAsync_NdjsonTruncatedStream_NoDoneTrueChunk_ThrowsTruncationError`
- `ParseOllamaResponse_EmptyBody_ReturnsNull`
- `ParseOllamaResponse_SingleJsonObject_ParsesDirectly`
- `ExtractAsync_DoneFalse_Throws` → renamed and updated for new error wording.

Backend suite: 2,600 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)