### PR TITLE
feat(infra): expose vlm-provider and anthropic-api-key as Aspire parameters

### DIFF
--- a/docs/vlm-providers.md
+++ b/docs/vlm-providers.md
@@ -88,6 +88,25 @@ preserved).
 The Anthropic provider needs an API key. Get one from
 [console.anthropic.com](https://console.anthropic.com).
 
+#### Aspire (recommended for dev)
+
+The provider switch and the API key are exposed as Aspire **parameters**, so
+they show up in the dashboard's *Parameters* panel and persist across runs
+via .NET user-secrets. Set them once:
+
+```bash
+dotnet user-secrets --project src/Receipts.AppHost set "Parameters:vlm-provider" "anthropic"
+dotnet user-secrets --project src/Receipts.AppHost set "Parameters:anthropic-api-key" "sk-ant-..."
+```
+
+The secret parameter is masked in the dashboard. To flip back to the local
+model for a single run, change the value of `vlm-provider` to `ollama` in the
+dashboard or via `dotnet user-secrets set`. Defaults are sourced from the
+`Ocr__Vlm__Provider` and `ANTHROPIC_API_KEY` env vars when set, so existing
+shells already configured for previous releases continue to work.
+
+#### Standalone / docker-compose
+
 ```bash
 # Local dev (no Aspire)
 export Anthropic__ApiKey="sk-ant-..."

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -89,21 +89,31 @@ IResourceBuilder<ContainerResource> vlmOcrPull = builder.AddContainer("vlm-ocr-p
 // before the API boots so the smoke test in InfrastructureService never catches Ollama mid-pull
 // (RECEIPTS-636).
 //
-// RECEIPTS-652: ANTHROPIC_API_KEY is forwarded from the host environment when present so a
-// developer can flip Ocr:Vlm:Provider=anthropic for a single run without separately exporting
-// the key for the API project. The variable name uses the standard config-binder mapping
-// (Anthropic:ApiKey -> Anthropic__ApiKey) so the existing IConfiguration binding picks it up.
-string anthropicApiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY") ?? string.Empty;
-string vlmProvider = Environment.GetEnvironmentVariable("Ocr__Vlm__Provider")
-	?? Environment.GetEnvironmentVariable("OCR__VLM__PROVIDER")
-	?? "ollama";
+// RECEIPTS-652: VLM provider + Anthropic API key are exposed as Aspire parameters so they
+// surface in the dashboard's Parameters panel and persist across runs via user-secrets:
+//
+//   dotnet user-secrets --project src/Receipts.AppHost set "Parameters:vlm-provider" "anthropic"
+//   dotnet user-secrets --project src/Receipts.AppHost set "Parameters:anthropic-api-key" "sk-ant-..."
+//
+// or set them once in the dashboard UI. Defaults are sourced from the same env vars the
+// previous wiring used, so existing setups (ANTHROPIC_API_KEY exported, Ocr__Vlm__Provider
+// set) continue to work without changes. The secret parameter is masked in the dashboard.
+IResourceBuilder<ParameterResource> vlmProviderParam = builder.AddParameter(
+	"vlm-provider",
+	Environment.GetEnvironmentVariable("Ocr__Vlm__Provider")
+		?? Environment.GetEnvironmentVariable("OCR__VLM__PROVIDER")
+		?? "ollama");
+IResourceBuilder<ParameterResource> anthropicApiKeyParam = builder.AddParameter(
+	"anthropic-api-key",
+	Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY") ?? string.Empty,
+	secret: true);
 
 IResourceBuilder<ProjectResource> api = builder.AddProject<Projects.API>("api")
 	.WithReference(db)
 	.WithEnvironment("Ollama__BaseUrl", vlmOcr.GetEndpoint("http"))
 	.WithEnvironment("Ocr__Vlm__Model", vlmModel)
-	.WithEnvironment("Ocr__Vlm__Provider", vlmProvider)
-	.WithEnvironment("Anthropic__ApiKey", anthropicApiKey)
+	.WithEnvironment("Ocr__Vlm__Provider", vlmProviderParam)
+	.WithEnvironment("Anthropic__ApiKey", anthropicApiKeyParam)
 	.WaitForCompletion(seeder)
 	.WaitFor(vlmOcr)
 	.WaitForCompletion(vlmOcrPull);
@@ -121,10 +131,10 @@ builder.AddProject<Projects.VlmEval>("vlm-eval")
 	.WithEnvironment("Ollama__BaseUrl", vlmOcr.GetEndpoint("http"))
 	.WithEnvironment("Ocr__Vlm__Model", vlmModel)
 	.WithEnvironment("VlmEval__FixturesPath", vlmEvalFixturesPath)
-	// RECEIPTS-652: forward the Anthropic API key so VlmEval can run with --provider anthropic
-	// (or VlmEval__Provider=anthropic) without a separate export. Empty is fine; Anthropic
-	// option binding only fires when the provider is selected.
-	.WithEnvironment("Anthropic__ApiKey", anthropicApiKey)
+	// RECEIPTS-652: forward the Anthropic API key parameter so VlmEval can run with
+	// --provider anthropic (or VlmEval__Provider=anthropic) without a separate export.
+	// Empty is fine; Anthropic option binding only fires when the provider is selected.
+	.WithEnvironment("Anthropic__ApiKey", anthropicApiKeyParam)
 	// Dev convenience: an empty fixtures directory is a warning, not a hard error.
 	// CI sets FailOnAnyFixtureFailure=true via env override to make accuracy regressions
 	// fail the pipeline once real fixtures exist.


### PR DESCRIPTION
## Summary

The Haiku POC (RECEIPTS-652) wired the provider switch and Anthropic API key as raw `Environment.GetEnvironmentVariable` reads in `AppHost.cs`. That requires the user to re-export the variables each shell session, and the values aren't visible in the Aspire dashboard.

This PR converts both to Aspire **parameters**:

- `vlm-provider` (non-secret, default `ollama`)
- `anthropic-api-key` (**secret**, default empty — masked in dashboard)

Defaults still source from the existing `Ocr__Vlm__Provider` / `ANTHROPIC_API_KEY` env vars when set, so existing shells/CI keep working. Persistent dev config moves to user-secrets:

```bash
dotnet user-secrets --project src/Receipts.AppHost set "Parameters:vlm-provider" "anthropic"
dotnet user-secrets --project src/Receipts.AppHost set "Parameters:anthropic-api-key" "sk-ant-..."
```

Or change them once in the dashboard's *Parameters* panel between runs. Both API and VlmEval consume the parameter resources via `.WithEnvironment(string, IResourceBuilder<ParameterResource>)`.

`docs/vlm-providers.md` updated with the user-secrets recipe.

## Test plan

- [x] `dotnet build Receipts.slnx` clean.
- [x] AppHost.cs change is `IResourceBuilder<ParameterResource>` everywhere — no string/parameter type mixups.
- [ ] User to set `Parameters:anthropic-api-key` via user-secrets and verify the dashboard masks the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)