### PR TITLE
fix(infra): make Aspire vlm-provider and anthropic-api-key parameters required

### DIFF
--- a/docs/vlm-providers.md
+++ b/docs/vlm-providers.md
@@ -90,20 +90,21 @@ The Anthropic provider needs an API key. Get one from
 
 #### Aspire (recommended for dev)
 
-The provider switch and the API key are exposed as Aspire **parameters**, so
-they show up in the dashboard's *Parameters* panel and persist across runs
-via .NET user-secrets. Set them once:
+The provider switch and the API key are exposed as **required** Aspire
+parameters — Aspire fails fast at startup if either is unset, surfacing
+misconfiguration early instead of silently defaulting. Set them once via
+.NET user-secrets (gitignored, persists across runs):
 
 ```bash
 dotnet user-secrets --project src/Receipts.AppHost set "Parameters:vlm-provider" "anthropic"
 dotnet user-secrets --project src/Receipts.AppHost set "Parameters:anthropic-api-key" "sk-ant-..."
 ```
 
-The secret parameter is masked in the dashboard. To flip back to the local
-model for a single run, change the value of `vlm-provider` to `ollama` in the
-dashboard or via `dotnet user-secrets set`. Defaults are sourced from the
-`Ocr__Vlm__Provider` and `ANTHROPIC_API_KEY` env vars when set, so existing
-shells already configured for previous releases continue to work.
+The secret parameter is masked in the dashboard's Parameters panel. To flip
+back to the local model for a single run, set `vlm-provider` to `ollama`.
+You can also set the values via `appsettings.AppHost.json` under
+`Parameters:` or via `Parameters__vlm-provider` /
+`Parameters__anthropic-api-key` environment variables.
 
 #### Standalone / docker-compose
 

--- a/src/Receipts.AppHost/AppHost.cs
+++ b/src/Receipts.AppHost/AppHost.cs
@@ -89,24 +89,20 @@ IResourceBuilder<ContainerResource> vlmOcrPull = builder.AddContainer("vlm-ocr-p
 // before the API boots so the smoke test in InfrastructureService never catches Ollama mid-pull
 // (RECEIPTS-636).
 //
-// RECEIPTS-652: VLM provider + Anthropic API key are exposed as Aspire parameters so they
-// surface in the dashboard's Parameters panel and persist across runs via user-secrets:
+// RECEIPTS-652: VLM provider + Anthropic API key are exposed as required Aspire parameters.
+// Aspire fails fast at startup if either is missing, so the user is forced to set them
+// intentionally rather than landing on a silent default that masks misconfiguration.
+//
+// Set once via .NET user-secrets (recommended for dev, persists across runs and is gitignored):
 //
 //   dotnet user-secrets --project src/Receipts.AppHost set "Parameters:vlm-provider" "anthropic"
 //   dotnet user-secrets --project src/Receipts.AppHost set "Parameters:anthropic-api-key" "sk-ant-..."
 //
-// or set them once in the dashboard UI. Defaults are sourced from the same env vars the
-// previous wiring used, so existing setups (ANTHROPIC_API_KEY exported, Ocr__Vlm__Provider
-// set) continue to work without changes. The secret parameter is masked in the dashboard.
-IResourceBuilder<ParameterResource> vlmProviderParam = builder.AddParameter(
-	"vlm-provider",
-	Environment.GetEnvironmentVariable("Ocr__Vlm__Provider")
-		?? Environment.GetEnvironmentVariable("OCR__VLM__PROVIDER")
-		?? "ollama");
-IResourceBuilder<ParameterResource> anthropicApiKeyParam = builder.AddParameter(
-	"anthropic-api-key",
-	Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY") ?? string.Empty,
-	secret: true);
+// or via appsettings.AppHost.json under the `Parameters` section, or via
+// `Parameters__vlm-provider` / `Parameters__anthropic-api-key` env vars. The secret
+// parameter is masked in the Aspire dashboard's Parameters panel.
+IResourceBuilder<ParameterResource> vlmProviderParam = builder.AddParameter("vlm-provider");
+IResourceBuilder<ParameterResource> anthropicApiKeyParam = builder.AddParameter("anthropic-api-key", secret: true);
 
 IResourceBuilder<ProjectResource> api = builder.AddProject<Projects.API>("api")
 	.WithReference(db)


### PR DESCRIPTION
## Summary

Follow-up to #517. Previously the parameter defaults silently sourced from the host's env vars (`Ocr__Vlm__Provider`, `ANTHROPIC_API_KEY`) — that masked the "you forgot to set this" case. Aspire would boot with `provider=ollama`+empty API key and fail later instead of upfront.

Drop the env-var defaults; both parameters are now **required**. Aspire fails fast at startup with a clear missing-parameter error pointing the user at the `dotnet user-secrets set "Parameters:..."` command.

Existing user-secrets / `appsettings.AppHost.json` / `Parameters__name` env-var config continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)