### PR TITLE
chore(infra): upgrade Aspire to 13.2.4 (RECEIPTS-653)

### DIFF
--- a/src/Receipts.AppHost/Receipts.AppHost.csproj
+++ b/src/Receipts.AppHost/Receipts.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.3">
+<Project Sdk="Aspire.AppHost.Sdk/13.2.4">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.1.3" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.3" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.2.4" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.2.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Bumps Aspire from 13.1.3 to 13.2.4 (latest patch on the 13.x line).

- `Aspire.AppHost.Sdk` 13.1.3 -> 13.2.4
- `Aspire.Hosting.JavaScript` 13.1.3 -> 13.2.4
- `Aspire.Hosting.PostgreSQL` 13.1.3 -> 13.2.4

Resolves RECEIPTS-653.

## Files touched

`src/Receipts.AppHost/Receipts.AppHost.csproj` only. `Directory.Packages.props` has no centralized Aspire pins; `Receipts.ServiceDefaults.csproj` has no `Aspire.Hosting.*` references.

## Verification (all 6 gates)

1. **`dotnet restore Receipts.slnx`** - clean.
2. **`dotnet build Receipts.slnx`** - 47 warnings, 0 errors. Identical warning count to parent `feat/receipts-616-vlm-receipt-extraction` (all 47 are pre-existing `NU1902` / `NU1903` vulnerability advisories on `OpenTelemetry.*` and `System.Security.Cryptography.Xml` - not introduced by this bump). The Aspire upgrade introduces zero new warnings.
3. **`dotnet test Receipts.slnx --filter "Category!=Integration"`** - 2,577 passed, 0 failed, 1 skipped (pre-existing JBIG2 PDF fixture).
4. **`dotnet test Receipts.slnx`** - 2,653 passed, 0 failed, 1 skipped. Includes 36 integration tests (Postgres testcontainer + ONNX model).
5. **Aspire smoke-test** - dashboard at `https://localhost:17054` launched, runtime `Aspire version: 13.2.4+dd5916f8e3280da5dc491e39b19aeb5b8817a669` verified at startup. With `Parameters:vlm-provider` + `Parameters:anthropic-api-key` set in user-secrets the orchestrator reaches "Distributed application started"; postgres + pgadmin + vlm-ocr containers Running, `vlm-ocr-pull` sidecar exited 0, `WithHttpHealthCheck("/api/tags")` polled every 30s with 200, `WaitForCompletion(vlmOcrPull)` honored, API steady, DbMigrator + DbSeeder ran-and-exited, VlmEval correctly parked (`WithExplicitStart`). With params unset, resources gated on the parameters never reach Running (RECEIPTS-652 behavior unchanged).
6. **Release-notes scan (13.2.0 -> 13.2.4)** - none of the breaking changes affect this codebase. See below.

## Release-notes findings (13.2.0 -> 13.2.4)

- **13.2.4** (target): patch - bumped OpenTelemetry deps for CVE-2026-40894.
- **13.2.3**: CLI fixes (`aspire stop` cleanup on Windows, signing, Playwright provenance, service discovery env vars).
- **13.2.2**: SqlClient runtime fix on macOS/Linux, IDE execution fix for Azure Functions / class libraries, `NpmRunner` multi-version output fix, name validation skip for internal resources, ASP.NET Core dev cert for DCP.
- **13.2.1**: TypeScript AppHost SDK rename (`runAsExistingFromParameters` -> `runAsExisting`), endpoint filtering with `ExcludeReferenceEndpoint`, dashboard short trace ID resolution, `Aspire.Hosting.NodeJs` deprecated in favor of `Aspire.Hosting.JavaScript` (we already use the new package).
- **13.2.0** breaking changes - all reviewed; **none affect this codebase**:
  - Service discovery env vars now use endpoint scheme (we use `GetEndpoint("http")` - internal refactor, transparent to us).
  - `aspire.config.json` consolidation (no custom legacy file automation).
  - AIFoundry -> Foundry (not used).
  - `WithSecretBuildArg` -> `WithBuildSecret` (not used).
  - `DefaultAzureCredential` change (no Azure).
  - `BeforeResourceStartedEvent` fires only on actual start (not subscribed).
  - `IAzureContainerRegistry` deprecated (not used).
  - CLI `resource-start/stop/restart` renames (we use C# API).

`RemoveAllResilienceHandlers` (`EXTEXP0001`) is in `Microsoft.Extensions.Http.Resilience`, not Aspire. Unaffected by this upgrade; still in evaluation.

## Test plan

- [x] `dotnet restore Receipts.slnx` clean
- [x] `dotnet build Receipts.slnx` 47 warnings (all pre-existing), 0 errors
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` green
- [x] `dotnet test Receipts.slnx` (full suite incl. integration) green
- [x] Aspire dashboard launches; resources reach Running / healthy
- [x] `vlm-ocr` health check + `vlm-ocr-pull` `WaitForCompletion` wiring intact (RECEIPTS-636)
- [x] Required `vlm-provider` + `anthropic-api-key` Aspire parameters still work (RECEIPTS-652)
- [x] `vlm-eval` parks at startup (`WithExplicitStart` honored)
- [x] No new deprecation warnings introduced
- [x] Release notes scanned for breaking changes affecting us (none)