### PR TITLE
fix(client): redesign confidence chips so they read as ratings, not actions

### DIFF
--- a/src/client/src/pages/new-receipt/HeaderSection.test.tsx
+++ b/src/client/src/pages/new-receipt/HeaderSection.test.tsx
@@ -77,8 +77,10 @@ describe("HeaderSection", () => {
 
   it("displays low-confidence indicator next to location label when confidenceMap.location is low", () => {
     renderWithProviders(<HeaderHost confidenceMap={{ location: "low" }} />);
-    // ConfidenceIndicator renders "Low confidence" text for low-confidence fields.
-    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+    // ConfidenceIndicator renders a chip with an aria-label exposing the rating.
+    expect(
+      screen.getByLabelText("AI confidence rating: low"),
+    ).toBeInTheDocument();
   });
 
   it("validates a missing location on submit", async () => {
@@ -96,9 +98,7 @@ describe("HeaderSection", () => {
     const user = userEvent.setup();
     renderWithProviders(<HeaderHost defaultValues={{ location: "Walmart" }} />);
     await user.click(screen.getByRole("button", { name: /submit/i }));
-    expect(
-      await screen.findByText(/date is required/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/date is required/i)).toBeInTheDocument();
   });
 
   it("rejects an invalid store phone format", async () => {

--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -115,9 +115,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
     expect(screen.getByText("Milk")).toBeInTheDocument();
     expect(screen.getByText("$3.50")).toBeInTheDocument();
     expect(screen.getByText("$7.00")).toBeInTheDocument(); // line total
@@ -149,9 +147,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
     expect(screen.getByText("Subtotal: $11.00")).toBeInTheDocument();
   });
 
@@ -173,9 +169,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
     expect(screen.getByText("Subtotal: $0.90")).toBeInTheDocument();
   });
 
@@ -195,9 +189,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection items={items} onChange={onChange} />,
-    );
+    renderWithProviders(<LineItemsSection items={items} onChange={onChange} />);
 
     await user.click(screen.getByRole("button", { name: /remove/i }));
     expect(onChange).toHaveBeenCalledWith([]);
@@ -217,9 +209,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
     expect(screen.getByText("Household / Cleaning")).toBeInTheDocument();
   });
 
@@ -239,9 +229,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
     expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
   });
 
@@ -260,9 +248,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
 
     await user.click(screen.getByRole("button", { name: /edit/i }));
 
@@ -289,9 +275,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection items={items} onChange={onChange} />,
-    );
+    renderWithProviders(<LineItemsSection items={items} onChange={onChange} />);
 
     await user.click(screen.getByRole("button", { name: /edit/i }));
 
@@ -322,9 +306,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection items={items} onChange={onChange} />,
-    );
+    renderWithProviders(<LineItemsSection items={items} onChange={onChange} />);
 
     await user.click(screen.getByRole("button", { name: /edit/i }));
 
@@ -355,9 +337,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection items={items} onChange={onChange} />,
-    );
+    renderWithProviders(<LineItemsSection items={items} onChange={onChange} />);
 
     await user.click(screen.getByRole("button", { name: /edit/i }));
 
@@ -393,9 +373,7 @@ describe("LineItemsSection", () => {
     expect(screen.getByLabelText("Edit description")).toBeInTheDocument();
 
     // Parent removes item-1 from state externally.
-    rerender(
-      <LineItemsSection items={[items[1]]} onChange={onChange} />,
-    );
+    rerender(<LineItemsSection items={[items[1]]} onChange={onChange} />);
 
     // Edit form should no longer be visible because no row matches the stale
     // editingItemId. Bread (item-2) renders in display mode, not edit mode.
@@ -418,9 +396,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
 
     await user.click(screen.getByRole("button", { name: /edit/i }));
 
@@ -430,10 +406,10 @@ describe("LineItemsSection", () => {
   // --- Tax code column tests ---
 
   it("renders the Tax column header in the items table", () => {
-    const items: ReceiptLineItem[] = [makeItem({ id: "1", description: "Milk" })];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    const items: ReceiptLineItem[] = [
+      makeItem({ id: "1", description: "Milk" }),
+    ];
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
     expect(
       screen.getByRole("columnheader", { name: /tax/i }),
     ).toBeInTheDocument();
@@ -443,9 +419,7 @@ describe("LineItemsSection", () => {
     const items: ReceiptLineItem[] = [
       makeItem({ id: "1", description: "Milk", taxCode: "F" }),
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
     expect(screen.getByText("F")).toBeInTheDocument();
   });
 
@@ -453,9 +427,7 @@ describe("LineItemsSection", () => {
     const items: ReceiptLineItem[] = [
       makeItem({ id: "1", description: "Milk", taxCode: "" }),
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
     expect(screen.getByLabelText("No tax code")).toBeInTheDocument();
   });
 
@@ -486,7 +458,9 @@ describe("LineItemsSection", () => {
         itemConfidenceById={itemConfidenceById}
       />,
     );
-    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("AI confidence rating: low"),
+    ).toBeInTheDocument();
   });
 
   it("keeps the confidence indicator paired with the surviving item after a removal", async () => {
@@ -524,7 +498,9 @@ describe("LineItemsSection", () => {
       />,
     );
 
-    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("AI confidence rating: low"),
+    ).toBeInTheDocument();
     // Bread (item-2) is the only row left; the indicator still belongs to it.
     expect(screen.getByText("Bread")).toBeInTheDocument();
   });
@@ -542,9 +518,7 @@ describe("LineItemsSection", () => {
       }),
     ];
 
-    renderWithProviders(
-      <LineItemsSection items={items} onChange={onChange} />,
-    );
+    renderWithProviders(<LineItemsSection items={items} onChange={onChange} />);
 
     await user.click(screen.getByRole("button", { name: /edit/i }));
     await user.click(screen.getByRole("button", { name: /save/i }));
@@ -567,13 +541,13 @@ describe("LineItemsSection", () => {
       }),
     ];
 
-    renderWithProviders(
-      <LineItemsSection items={items} onChange={onChange} />,
-    );
+    renderWithProviders(<LineItemsSection items={items} onChange={onChange} />);
 
     await user.click(screen.getByRole("button", { name: /edit/i }));
 
-    const taxCodeInput = screen.getByLabelText("Edit tax code") as HTMLInputElement;
+    const taxCodeInput = screen.getByLabelText(
+      "Edit tax code",
+    ) as HTMLInputElement;
     await user.type(taxCodeInput, "n");
 
     expect(taxCodeInput.value).toBe("N");

--- a/src/client/src/pages/new-receipt/PaymentsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/PaymentsSection.test.tsx
@@ -5,9 +5,7 @@ import { PaymentsSection, type ReceiptPayment } from "./PaymentsSection";
 
 describe("PaymentsSection", () => {
   it("renders an empty state when there are no payments", () => {
-    renderWithProviders(
-      <PaymentsSection payments={[]} onChange={vi.fn()} />,
-    );
+    renderWithProviders(<PaymentsSection payments={[]} onChange={vi.fn()} />);
     expect(
       screen.getByText("No payments detected on the receipt."),
     ).toBeInTheDocument();
@@ -31,9 +29,7 @@ describe("PaymentsSection", () => {
   it("calls onChange when adding a payment", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    renderWithProviders(
-      <PaymentsSection payments={[]} onChange={onChange} />,
-    );
+    renderWithProviders(<PaymentsSection payments={[]} onChange={onChange} />);
 
     await user.click(screen.getByRole("button", { name: /add payment/i }));
 
@@ -130,8 +126,10 @@ describe("PaymentsSection", () => {
       />,
     );
 
-    // ConfidenceIndicator renders "Low confidence" badge text for low.
-    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+    // ConfidenceIndicator renders a chip with an aria-label exposing the rating.
+    expect(
+      screen.getByLabelText("AI confidence rating: low"),
+    ).toBeInTheDocument();
   });
 
   it("keeps the confidence indicator paired with the surviving payment after a removal", async () => {
@@ -168,7 +166,9 @@ describe("PaymentsSection", () => {
       />,
     );
 
-    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("AI confidence rating: low"),
+    ).toBeInTheDocument();
     expect(screen.getByDisplayValue("VISA")).toBeInTheDocument();
   });
 

--- a/src/client/src/pages/new-receipt/ReceiptDetailsPanel.test.tsx
+++ b/src/client/src/pages/new-receipt/ReceiptDetailsPanel.test.tsx
@@ -76,7 +76,9 @@ describe("ReceiptDetailsPanel", () => {
     await user.click(
       screen.getByRole("button", { name: /expand receipt details/i }),
     );
-    expect(screen.getByText(/low confidence/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("AI confidence rating: low"),
+    ).toBeInTheDocument();
   });
 
   it("renders nothing in the value list when no metadata fields are populated", async () => {

--- a/src/client/src/pages/scan-receipt/ConfidenceIndicator.test.tsx
+++ b/src/client/src/pages/scan-receipt/ConfidenceIndicator.test.tsx
@@ -1,0 +1,118 @@
+import "@/test/setup-combobox-polyfills";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ConfidenceIndicator } from "./ConfidenceIndicator";
+import type { ConfidenceLevel } from "./types";
+
+function renderIndicator(confidence: ConfidenceLevel | undefined) {
+  return render(
+    <TooltipProvider delayDuration={0}>
+      <ConfidenceIndicator confidence={confidence} />
+    </TooltipProvider>,
+  );
+}
+
+describe("ConfidenceIndicator", () => {
+  describe("render-nothing behaviour", () => {
+    it("renders nothing when confidence is undefined", () => {
+      const { container } = renderIndicator(undefined);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when confidence is high", () => {
+      const { container } = renderIndicator("high");
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when confidence is none", () => {
+      const { container } = renderIndicator("none");
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("low confidence", () => {
+    it("renders neutral rating copy 'AI: low' (no verb)", () => {
+      renderIndicator("low");
+      expect(screen.getByText("AI: low")).toBeInTheDocument();
+      // Sanity-check: old verb copy must be gone.
+      expect(screen.queryByText("Low confidence")).not.toBeInTheDocument();
+      expect(screen.queryByText("Review")).not.toBeInTheDocument();
+    });
+
+    it("exposes a rating-shaped aria-label, not a button label", () => {
+      renderIndicator("low");
+      const chip = screen.getByLabelText("AI confidence rating: low");
+      expect(chip).toBeInTheDocument();
+    });
+
+    it("is not focusable and has no button role", () => {
+      renderIndicator("low");
+      const chip = screen.getByLabelText("AI confidence rating: low");
+      expect(chip.getAttribute("tabindex")).toBe("-1");
+      expect(chip.getAttribute("role")).not.toBe("button");
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("uses cursor-default so it does not signal interactivity", () => {
+      renderIndicator("low");
+      const chip = screen.getByLabelText("AI confidence rating: low");
+      expect(chip.className).toContain("cursor-default");
+    });
+
+    it("shows a tooltip with the verify-before-saving guidance on hover", async () => {
+      const user = userEvent.setup();
+      renderIndicator("low");
+      const chip = screen.getByLabelText("AI confidence rating: low");
+
+      await user.hover(chip);
+
+      // Radix renders the tooltip in a portal; the role="tooltip" element
+      // appears asynchronously after hover.
+      const tooltip = await screen.findByRole("tooltip");
+      expect(tooltip).toHaveTextContent(/low confidence/i);
+      expect(tooltip).toHaveTextContent(/verify before saving/i);
+    });
+  });
+
+  describe("medium confidence", () => {
+    it("renders neutral rating copy 'AI: medium' (no 'Review' verb)", () => {
+      renderIndicator("medium");
+      expect(screen.getByText("AI: medium")).toBeInTheDocument();
+      expect(screen.queryByText("Review")).not.toBeInTheDocument();
+    });
+
+    it("exposes a rating-shaped aria-label, not a button label", () => {
+      renderIndicator("medium");
+      const chip = screen.getByLabelText("AI confidence rating: medium");
+      expect(chip).toBeInTheDocument();
+    });
+
+    it("is not focusable and has no button role", () => {
+      renderIndicator("medium");
+      const chip = screen.getByLabelText("AI confidence rating: medium");
+      expect(chip.getAttribute("tabindex")).toBe("-1");
+      expect(chip.getAttribute("role")).not.toBe("button");
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("uses cursor-default so it does not signal interactivity", () => {
+      renderIndicator("medium");
+      const chip = screen.getByLabelText("AI confidence rating: medium");
+      expect(chip.className).toContain("cursor-default");
+    });
+
+    it("shows a tooltip with the quick-glance guidance on hover", async () => {
+      const user = userEvent.setup();
+      renderIndicator("medium");
+      const chip = screen.getByLabelText("AI confidence rating: medium");
+
+      await user.hover(chip);
+
+      const tooltip = await screen.findByRole("tooltip");
+      expect(tooltip).toHaveTextContent(/medium confidence/i);
+      expect(tooltip).toHaveTextContent(/quick glance/i);
+    });
+  });
+});

--- a/src/client/src/pages/scan-receipt/ConfidenceIndicator.tsx
+++ b/src/client/src/pages/scan-receipt/ConfidenceIndicator.tsx
@@ -1,10 +1,50 @@
+import { Sparkles } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { ConfidenceLevel } from "./types";
 
 interface ConfidenceIndicatorProps {
   confidence: ConfidenceLevel | undefined;
   className?: string;
 }
+
+interface ChipConfig {
+  label: string;
+  ariaLabel: string;
+  className: string;
+  tooltip: React.ReactNode;
+}
+
+const CHIP_CONFIG: Record<"low" | "medium", ChipConfig> = {
+  low: {
+    label: "AI: low",
+    ariaLabel: "AI confidence rating: low",
+    className:
+      "border-amber-500 bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-400",
+    tooltip: (
+      <>
+        Claude was <em>low confidence</em> extracting this field. Verify before
+        saving.
+      </>
+    ),
+  },
+  medium: {
+    label: "AI: medium",
+    ariaLabel: "AI confidence rating: medium",
+    className:
+      "border-amber-200 bg-muted text-muted-foreground dark:border-amber-900",
+    tooltip: (
+      <>
+        Claude was <em>medium confidence</em> extracting this field. A quick
+        glance recommended.
+      </>
+    ),
+  },
+};
 
 export function ConfidenceIndicator({
   confidence,
@@ -16,20 +56,22 @@ export function ConfidenceIndicator({
     return null;
   }
 
-  if (confidence === "low") {
-    return (
-      <Badge
-        variant="outline"
-        className={`border-amber-500 bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-400 ${className ?? ""}`}
-      >
-        Low confidence
-      </Badge>
-    );
-  }
+  const config = CHIP_CONFIG[confidence];
 
   return (
-    <Badge variant="secondary" className={className}>
-      Review
-    </Badge>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          variant="outline"
+          aria-label={config.ariaLabel}
+          tabIndex={-1}
+          className={`cursor-default gap-1 ${config.className} ${className ?? ""}`}
+        >
+          <Sparkles className="size-3" aria-hidden="true" />
+          {config.label}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{config.tooltip}</TooltipContent>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces the old `ConfidenceIndicator` chips ("Low confidence" / "Review") with neutral rating language ("AI: low" / "AI: medium") so users no longer mistake them for action targets.
- Wraps the chip in a `<Tooltip>` from `@/components/ui/tooltip` whose body explains what the rating means and what the user should do ("Verify before saving" / "A quick glance recommended").
- Locks the chip out of the interactive surface: `cursor-default`, `tabIndex={-1}`, no `role="button"`, and an `aria-label` shaped as a rating (`"AI confidence rating: low"`) so screen readers convey rating semantics.
- Adds a small `Sparkles` icon from `lucide-react` to reinforce that this is information about an AI extraction.
- Existing render-nothing-for-`high`/`none`/`undefined` behaviour is preserved unchanged.

Resolves RECEIPTS-656.

## Implementation notes

- `src/client/src/pages/scan-receipt/ConfidenceIndicator.tsx` — chip redesign + tooltip + a11y attrs.
- `src/client/src/pages/scan-receipt/ConfidenceIndicator.test.tsx` — new test file: render-nothing for high/none/undefined; correct copy / aria-label / cursor-default / non-focusable / no `role=button` for both `low` and `medium`; tooltip content reachable via `findByRole("tooltip")` after hover.
- Callsite tests (`HeaderSection`, `LineItemsSection`, `PaymentsSection`, `ReceiptDetailsPanel`) updated to query the chip via its new aria-label, which is more semantically meaningful than text-matching.
- Backwards-compatible with the upcoming RECEIPTS-657 deletion of `PaymentsSection.tsx` — the change is component-internal.

## Test plan

- [x] `npx tsc -b --noEmit` (clean)
- [x] `npx eslint src/client/src` (clean — only pre-existing warnings unrelated to this change)
- [x] `npx vitest run` (1945 / 1945 pass, including 13 new tests for `ConfidenceIndicator`)
- [x] `npx vite build` (clean)
- [ ] Manual eyeball: open the wizard, scan a receipt with low/medium-confidence fields, verify chips read as ratings, hover reveals the tooltip, and Tab skips past them.