### PR TITLE
fix(api): ConfidenceLevel enum returned as PascalCase (RECEIPTS-660)

### DIFF
--- a/tests/Presentation.API.Tests/Configuration/JsonSerializerEnumCasingTests.cs
+++ b/tests/Presentation.API.Tests/Configuration/JsonSerializerEnumCasingTests.cs
@@ -1,20 +1,29 @@
 using System.Text.Json;
 using API.Configuration;
-using Application.Models.Ocr;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using DomainConfidenceLevel = global::Application.Models.Ocr.ConfidenceLevel;
+using DtoConfidenceLevel = global::API.Generated.Dtos.ConfidenceLevel;
+using ProposedReceiptResponse = global::API.Generated.Dtos.ProposedReceiptResponse;
 
 namespace Presentation.API.Tests.Configuration;
 
 /// <summary>
-/// Regression test for RECEIPTS-534: verifies that the API's configured
-/// JsonSerializerOptions serialize enum values as camelCase. Prior to the fix,
-/// <see cref="ApplicationConfiguration"/> registered <c>JsonStringEnumConverter</c>
-/// without a naming policy, producing PascalCase output that drifted from the
-/// OpenAPI spec.
+/// Regression test for RECEIPTS-534 and RECEIPTS-660: verifies that the API's
+/// configured JsonSerializerOptions serialize enum values as camelCase, both for
+/// domain enums (RECEIPTS-534) and for the NSwag-generated DTO enums (RECEIPTS-660).
+///
+/// RECEIPTS-660 background: NSwag emits a per-property
+/// <c>[JsonConverter(typeof(JsonStringEnumConverter&lt;TEnum&gt;))]</c> attribute on
+/// every enum-typed DTO property. That attribute wins over the global converter
+/// and falls back to C# enum names ("High"/"Low"/"Medium"/"None"), which violates
+/// the OpenAPI contract that declares lowercase enum values. The fix lives in
+/// <c>tools/DtoSplitter</c>: a SyntaxRewriter strips those per-property attributes
+/// from the NSwag output before it is split into individual files. These tests
+/// guard the contract end-to-end.
 /// </summary>
 public class JsonSerializerEnumCasingTests
 {
@@ -28,14 +37,14 @@ public class JsonSerializerEnumCasingTests
 	}
 
 	[Fact]
-	public void JsonStringEnumConverter_SerializesEnumValuesAsCamelCase()
+	public void JsonStringEnumConverter_SerializesDomainEnumValuesAsCamelCase()
 	{
 		JsonSerializerOptions options = GetConfiguredJsonOptions();
 
-		string highJson = JsonSerializer.Serialize(ConfidenceLevel.High, options);
-		string mediumJson = JsonSerializer.Serialize(ConfidenceLevel.Medium, options);
-		string lowJson = JsonSerializer.Serialize(ConfidenceLevel.Low, options);
-		string noneJson = JsonSerializer.Serialize(ConfidenceLevel.None, options);
+		string highJson = JsonSerializer.Serialize(DomainConfidenceLevel.High, options);
+		string mediumJson = JsonSerializer.Serialize(DomainConfidenceLevel.Medium, options);
+		string lowJson = JsonSerializer.Serialize(DomainConfidenceLevel.Low, options);
+		string noneJson = JsonSerializer.Serialize(DomainConfidenceLevel.None, options);
 
 		highJson.Should().Be("\"high\"");
 		mediumJson.Should().Be("\"medium\"");
@@ -44,18 +53,76 @@ public class JsonSerializerEnumCasingTests
 	}
 
 	[Fact]
-	public void JsonStringEnumConverter_DeserializesCamelCaseEnumValues()
+	public void JsonStringEnumConverter_DeserializesCamelCaseDomainEnumValues()
 	{
 		JsonSerializerOptions options = GetConfiguredJsonOptions();
 
-		ConfidenceLevel high = JsonSerializer.Deserialize<ConfidenceLevel>("\"high\"", options);
-		ConfidenceLevel medium = JsonSerializer.Deserialize<ConfidenceLevel>("\"medium\"", options);
-		ConfidenceLevel low = JsonSerializer.Deserialize<ConfidenceLevel>("\"low\"", options);
-		ConfidenceLevel none = JsonSerializer.Deserialize<ConfidenceLevel>("\"none\"", options);
+		DomainConfidenceLevel high = JsonSerializer.Deserialize<DomainConfidenceLevel>("\"high\"", options);
+		DomainConfidenceLevel medium = JsonSerializer.Deserialize<DomainConfidenceLevel>("\"medium\"", options);
+		DomainConfidenceLevel low = JsonSerializer.Deserialize<DomainConfidenceLevel>("\"low\"", options);
+		DomainConfidenceLevel none = JsonSerializer.Deserialize<DomainConfidenceLevel>("\"none\"", options);
 
-		high.Should().Be(ConfidenceLevel.High);
-		medium.Should().Be(ConfidenceLevel.Medium);
-		low.Should().Be(ConfidenceLevel.Low);
-		none.Should().Be(ConfidenceLevel.None);
+		high.Should().Be(DomainConfidenceLevel.High);
+		medium.Should().Be(DomainConfidenceLevel.Medium);
+		low.Should().Be(DomainConfidenceLevel.Low);
+		none.Should().Be(DomainConfidenceLevel.None);
+	}
+
+	[Fact]
+	public void JsonStringEnumConverter_SerializesGeneratedDtoEnumValuesAsCamelCase()
+	{
+		// RECEIPTS-660: the DTO enum lives in API.Generated.Dtos and was previously
+		// shadowed by a per-property [JsonConverter] attribute that produced PascalCase
+		// output. With the DtoSplitter rewriter stripping that override, the global
+		// converter (camelCase) now applies.
+		JsonSerializerOptions options = GetConfiguredJsonOptions();
+
+		string highJson = JsonSerializer.Serialize(DtoConfidenceLevel.High, options);
+		string mediumJson = JsonSerializer.Serialize(DtoConfidenceLevel.Medium, options);
+		string lowJson = JsonSerializer.Serialize(DtoConfidenceLevel.Low, options);
+		string noneJson = JsonSerializer.Serialize(DtoConfidenceLevel.None, options);
+
+		highJson.Should().Be("\"high\"");
+		mediumJson.Should().Be("\"medium\"");
+		lowJson.Should().Be("\"low\"");
+		noneJson.Should().Be("\"none\"");
+	}
+
+	[Fact]
+	public void JsonStringEnumConverter_SerializesProposedReceiptResponse_WithLowercaseConfidence()
+	{
+		// RECEIPTS-660: end-to-end check. Serialize a ProposedReceiptResponse via
+		// the configured options and assert each confidence field is rendered with
+		// the lowercase value declared in openapi/spec.yaml.
+		JsonSerializerOptions options = GetConfiguredJsonOptions();
+
+		ProposedReceiptResponse response = new()
+		{
+			StoreNameConfidence = DtoConfidenceLevel.High,
+			StoreAddressConfidence = DtoConfidenceLevel.Medium,
+			StorePhoneConfidence = DtoConfidenceLevel.Low,
+			DateConfidence = DtoConfidenceLevel.None,
+			SubtotalConfidence = DtoConfidenceLevel.High,
+			TotalConfidence = DtoConfidenceLevel.High,
+			PaymentMethodConfidence = DtoConfidenceLevel.Medium,
+			Items = [],
+			TaxLines = [],
+		};
+
+		string json = JsonSerializer.Serialize(response, options);
+
+		json.Should().Contain("\"storeNameConfidence\":\"high\"");
+		json.Should().Contain("\"storeAddressConfidence\":\"medium\"");
+		json.Should().Contain("\"storePhoneConfidence\":\"low\"");
+		json.Should().Contain("\"dateConfidence\":\"none\"");
+		json.Should().Contain("\"subtotalConfidence\":\"high\"");
+		json.Should().Contain("\"totalConfidence\":\"high\"");
+		json.Should().Contain("\"paymentMethodConfidence\":\"medium\"");
+
+		// And explicitly assert no PascalCase leaks through.
+		json.Should().NotContain("\"High\"");
+		json.Should().NotContain("\"Medium\"");
+		json.Should().NotContain("\"Low\"");
+		json.Should().NotContain("\"None\"");
 	}
 }

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
@@ -2,6 +2,8 @@
 // regression coverage until RECEIPTS-658 deletes the field.
 #pragma warning disable CS0612
 
+using System.Text.Json;
+using API.Configuration;
 using API.Controllers.Core;
 using API.Generated.Dtos;
 using Application.Commands.Receipt.Scan;
@@ -11,7 +13,11 @@ using FluentAssertions;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using DtoConfidenceLevel = global::API.Generated.Dtos.ConfidenceLevel;
 
@@ -474,6 +480,67 @@ public class ReceiptScanControllerTests
 				c.ImageBytes.Length == 512),
 			It.IsAny<CancellationToken>()),
 			Times.Once);
+	}
+
+	[Fact]
+	public async Task ScanReceipt_ResponseSerializesConfidenceFieldsAsLowercase()
+	{
+		// RECEIPTS-660: confidence fields must serialize as lowercase strings ("high",
+		// "medium", "low", "none") to match the OpenAPI contract. Prior to the
+		// DtoSplitter rewriter, NSwag emitted a per-property [JsonConverter] that
+		// produced PascalCase ("High"/"Medium"/...), tripping OpenAPI response
+		// validation and the wizard's CHIP_CONFIG[confidence] lookup.
+		IFormFile file = CreateMockFormFile("receipt.jpg", "image/jpeg", 1024);
+
+		ParsedReceipt parsedReceipt = new(
+			FieldConfidence<string>.High("WALMART"),
+			FieldConfidence<DateOnly>.Medium(new DateOnly(2026, 3, 15)),
+			[
+				new ParsedReceiptItem(
+					FieldConfidence<string?>.None(),
+					FieldConfidence<string>.High("MILK 2%"),
+					FieldConfidence<decimal>.High(1m),
+					FieldConfidence<decimal>.High(3.49m),
+					FieldConfidence<decimal>.High(3.49m))
+			],
+			FieldConfidence<decimal>.Medium(3.49m),
+			[],
+			FieldConfidence<decimal>.High(3.74m),
+			FieldConfidence<string?>.Low("VISA")
+		);
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<ScanReceiptCommand>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ScanReceiptResult(parsedReceipt));
+
+		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
+
+		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
+
+		// Round-trip through the controller-configured serializer to capture the
+		// exact wire format clients receive.
+		string json = JsonSerializer.Serialize(response, GetConfiguredJsonOptions());
+
+		json.Should().Contain("\"storeNameConfidence\":\"high\"");
+		json.Should().Contain("\"dateConfidence\":\"medium\"");
+		json.Should().Contain("\"subtotalConfidence\":\"medium\"");
+		json.Should().Contain("\"totalConfidence\":\"high\"");
+		json.Should().Contain("\"paymentMethodConfidence\":\"low\"");
+
+		// Hard guard: nothing should escape as PascalCase.
+		json.Should().NotContain("\"High\"");
+		json.Should().NotContain("\"Medium\"");
+		json.Should().NotContain("\"Low\"");
+		json.Should().NotContain("\"None\"");
+	}
+
+	private static JsonSerializerOptions GetConfiguredJsonOptions()
+	{
+		ServiceCollection services = new();
+		services.AddApplicationServices(new ConfigurationBuilder().Build());
+		ServiceProvider provider = services.BuildServiceProvider();
+		JsonOptions mvcJsonOptions = provider.GetRequiredService<IOptions<JsonOptions>>().Value;
+		return mvcJsonOptions.JsonSerializerOptions;
 	}
 
 	private static IFormFile CreateMockFormFile(string fileName, string contentType, int size)

--- a/tools/DtoSplitter/Program.cs
+++ b/tools/DtoSplitter/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Security.Cryptography;
@@ -75,6 +76,19 @@ static int Split(string[] args)
 
 	Microsoft.CodeAnalysis.SyntaxTree tree = CSharpSyntaxTree.ParseText(sourceText);
 	CompilationUnitSyntax root = tree.GetCompilationUnitRoot();
+
+	// AST-rewrite the parsed tree to strip per-property
+	// [JsonConverter(typeof(JsonStringEnumConverter<T>))] attributes that NSwag
+	// emits on every enum-typed property. The global JsonStringEnumConverter
+	// (registered in API/Configuration/ApplicationConfiguration.cs with
+	// JsonNamingPolicy.CamelCase) is the single source of truth for enum wire
+	// format. The per-property attribute, when present, *wins* over the global
+	// converter and falls back to C# enum names ("None"/"Low"/"Medium"/"High"
+	// for ConfidenceLevel) — which violates the OpenAPI contract that declares
+	// lowercase enum values. Stripping the per-property override at codegen time
+	// lets the global converter apply uniformly. See RECEIPTS-660.
+	JsonStringEnumConverterAttributeRemover rewriter = new();
+	root = (CompilationUnitSyntax)rewriter.Visit(root);
 
 	// Find the namespace declaration (block-scoped with braces, as NSwag uses)
 	NamespaceDeclarationSyntax? ns = root.DescendantNodes()
@@ -289,4 +303,93 @@ static int Error(string message)
 {
 	Console.Error.WriteLine(message);
 	return 1;
+}
+
+/// <summary>
+/// Removes per-property <c>[JsonConverter(typeof(JsonStringEnumConverter&lt;T&gt;))]</c>
+/// attributes from the NSwag-generated source so the globally-registered
+/// <c>JsonStringEnumConverter(JsonNamingPolicy.CamelCase)</c> applies uniformly.
+/// See RECEIPTS-660 for why this matters.
+/// </summary>
+internal sealed class JsonStringEnumConverterAttributeRemover : CSharpSyntaxRewriter
+{
+	public override SyntaxNode? VisitAttributeList(AttributeListSyntax node)
+	{
+		// First recurse into children so any nested transformations (none today,
+		// but future-proof) are applied before we evaluate the resulting list.
+		AttributeListSyntax? visited = (AttributeListSyntax?)base.VisitAttributeList(node);
+		if (visited is null)
+		{
+			return null;
+		}
+
+		SeparatedSyntaxList<AttributeSyntax> kept = SyntaxFactory.SeparatedList<AttributeSyntax>();
+		foreach (AttributeSyntax attr in visited.Attributes)
+		{
+			if (!IsJsonStringEnumConverterAttribute(attr))
+			{
+				kept = kept.Add(attr);
+			}
+		}
+
+		if (kept.Count == 0)
+		{
+			// All attributes in this list were stripped — drop the empty list
+			// entirely (an empty `[]` would not parse). Preserve the leading
+			// trivia (indentation, comments) so downstream nodes keep formatting.
+			return null;
+		}
+
+		if (kept.Count == visited.Attributes.Count)
+		{
+			return visited;
+		}
+
+		return visited.WithAttributes(kept);
+	}
+
+	private static bool IsJsonStringEnumConverterAttribute(AttributeSyntax attr)
+	{
+		// The attribute name as NSwag emits it: System.Text.Json.Serialization.JsonConverter.
+		// Strip "Attribute" suffix if present and compare the trailing identifier.
+		string name = attr.Name.ToString();
+		string lastSegment = name.Split('.').Last();
+		if (lastSegment != "JsonConverter" && lastSegment != "JsonConverterAttribute")
+		{
+			return false;
+		}
+
+		AttributeArgumentListSyntax? argList = attr.ArgumentList;
+		if (argList is null || argList.Arguments.Count == 0)
+		{
+			return false;
+		}
+
+		// We expect a single typeof(...) argument referencing
+		// JsonStringEnumConverter<TEnum>.
+		AttributeArgumentSyntax firstArg = argList.Arguments[0];
+		if (firstArg.Expression is not TypeOfExpressionSyntax typeOfExpr)
+		{
+			return false;
+		}
+
+		// Drill into the typeof's type argument and look for a generic name
+		// "JsonStringEnumConverter" (with one or more type parameters). The
+		// type can be qualified (System.Text.Json.Serialization.JsonStringEnumConverter<T>)
+		// or bare (JsonStringEnumConverter<T>) depending on the emitted form.
+		TypeSyntax inner = typeOfExpr.Type;
+		GenericNameSyntax? generic = inner switch
+		{
+			GenericNameSyntax g => g,
+			QualifiedNameSyntax q when q.Right is GenericNameSyntax g => g,
+			_ => null,
+		};
+
+		if (generic is null)
+		{
+			return false;
+		}
+
+		return generic.Identifier.Text == "JsonStringEnumConverter";
+	}
 }


### PR DESCRIPTION
## Summary

- NSwag-generated DTOs carry a per-property `[JsonConverter(typeof(JsonStringEnumConverter<TEnum>))]` attribute that wins over the global camelCase converter and falls back to C# enum names (`None`/`Low`/`Medium`/`High`), violating the `enum: [none, low, medium, high]` contract in `openapi/spec.yaml`. In production this floods OpenAPI response validation with `NotInEnumeration` errors and crashes the wizard's `CHIP_CONFIG[confidence]` lookup with `Cannot read properties of undefined (reading 'ariaLabel')`.
- DtoSplitter now AST-rewrites NSwag output via a Roslyn `CSharpSyntaxRewriter` that strips the offending per-property attributes. The global `JsonStringEnumConverter(JsonNamingPolicy.CamelCase)` registered in `API/Configuration/ApplicationConfiguration.cs` is now the single source of truth for enum wire format. The `ConfidenceLevel.g.cs` enum DEFINITION is unchanged; only the per-property usage on DTOs is cleaned up.
- Regression coverage in `JsonSerializerEnumCasingTests` (DTO-enum + end-to-end `ProposedReceiptResponse` serialization) and `ReceiptScanControllerTests` (focused JSON-shape assertion through the configured serializer) guards the contract.

Resolves RECEIPTS-660

## Test plan

- [x] `dotnet build Receipts.slnx` clean
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2,635 unit tests pass
- [x] `dotnet format Receipts.slnx --verify-no-changes` clean
- [x] `npx tsc -b --noEmit` clean
- [x] `npx vitest run` — 1,966 client tests pass
- [x] Verified `src/Presentation/API/Generated/*.g.cs` no longer contains `JsonStringEnumConverter<...>` per-property attributes (10 affected DTOs cleaned)
- [x] Verified `ConfidenceLevel.g.cs` enum file is unchanged