### PR TITLE
fix(api,client): derive missing totalPrice for weight-priced items (RECEIPTS-661)

### DIFF
--- a/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
@@ -172,9 +172,16 @@ public class ReceiptScanController(
 
 		if (totalPriceMissing && quantityPresent && unitPricePresent)
 		{
-			// Decimal multiplication preserves the precision of the source
-			// receipt values (e.g. 2.300 * 0.92 = 2.116) without IEEE-754 noise.
-			decimal computed = item.Quantity.Value * item.UnitPrice.Value;
+			// Floor-to-cent rounding to match the rest of the system: the
+			// client-side fallback in proposalMappers.ts uses Math.round(...*100)/100
+			// for round-trip parity, ReceiptItemMapper.ResolveTotalAmount uses
+			// Math.Floor(...*100)/100 when the client omits a total, and
+			// computeLineTotal in LineItemsSection always rounds to cents for
+			// quantity-mode display. Without this rounding, weight-priced items
+			// like TOMATO 2.300 lb @ 0.92 would persist as 2.116m even though
+			// every UI surface shows $2.12 — silent sub-cent precision in the DB.
+			decimal product = item.Quantity.Value * item.UnitPrice.Value;
+			decimal computed = Math.Floor(product * 100m) / 100m;
 			OcrConfidenceLevel derived = item.Quantity.Confidence < item.UnitPrice.Confidence
 				? item.Quantity.Confidence
 				: item.UnitPrice.Confidence;

--- a/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptScanController.cs
@@ -128,6 +128,16 @@ public class ReceiptScanController(
 
 	private static ProposedReceiptItemResponse MapItem(ParsedReceiptItem item)
 	{
+		// RECEIPTS-661: Weight-priced items (e.g. "TOMATO 2.300 lb @ 0.92") arrive
+		// from the VLM with quantity + unitPrice populated and a recognised
+		// confidence, but no separate totalPrice — the model didn't print one as
+		// a distinct line, so the value-type defaults to 0 and confidence to
+		// None. Without intervention the wizard renders such rows as $0.00 and
+		// the rolling subtotal is wrong by the same amount. Derive the missing
+		// total here so the response carries a usable value (single source of
+		// truth) rather than relying on every client to recompute it.
+		(decimal? derivedTotal, OcrConfidenceLevel derivedConfidence) = DeriveTotalPrice(item);
+
 		return new ProposedReceiptItemResponse
 		{
 			Code = item.Code.Value,
@@ -138,11 +148,40 @@ public class ReceiptScanController(
 			QuantityConfidence = MapConfidence(item.Quantity.Confidence),
 			UnitPrice = ToNullableDouble(item.UnitPrice.Value),
 			UnitPriceConfidence = MapConfidence(item.UnitPrice.Confidence),
-			TotalPrice = ToNullableDouble(item.TotalPrice.Value),
-			TotalPriceConfidence = MapConfidence(item.TotalPrice.Confidence),
+			TotalPrice = ToNullableDouble(derivedTotal),
+			TotalPriceConfidence = MapConfidence(derivedConfidence),
 			TaxCode = item.TaxCode.Value,
 			TaxCodeConfidence = MapConfidence(item.TaxCode.Confidence),
 		};
+	}
+
+	/// <summary>
+	/// RECEIPTS-661: When the VLM omits a separate <c>totalPrice</c> for a
+	/// weight-priced or per-unit-priced item but supplies both <c>quantity</c>
+	/// and <c>unitPrice</c>, derive the total here. The derived confidence is
+	/// the lower of the two source confidences (both are non-None by precondition),
+	/// so high+high => high, high+medium => medium, medium+low => low. When the
+	/// VLM already supplied <c>totalPrice</c> at any confidence (Low/Medium/High)
+	/// the original value is passed through unchanged.
+	/// </summary>
+	private static (decimal? TotalPrice, OcrConfidenceLevel Confidence) DeriveTotalPrice(ParsedReceiptItem item)
+	{
+		bool totalPriceMissing = item.TotalPrice.Confidence == OcrConfidenceLevel.None;
+		bool quantityPresent = item.Quantity.Confidence != OcrConfidenceLevel.None;
+		bool unitPricePresent = item.UnitPrice.Confidence != OcrConfidenceLevel.None;
+
+		if (totalPriceMissing && quantityPresent && unitPricePresent)
+		{
+			// Decimal multiplication preserves the precision of the source
+			// receipt values (e.g. 2.300 * 0.92 = 2.116) without IEEE-754 noise.
+			decimal computed = item.Quantity.Value * item.UnitPrice.Value;
+			OcrConfidenceLevel derived = item.Quantity.Confidence < item.UnitPrice.Confidence
+				? item.Quantity.Confidence
+				: item.UnitPrice.Confidence;
+			return (computed, derived);
+		}
+
+		return (item.TotalPrice.Value, item.TotalPrice.Confidence);
 	}
 
 	private static ProposedTaxLineResponse MapTaxLine(ParsedTaxLine taxLine)

--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -173,9 +173,7 @@ describe("LineItemsSection", () => {
         taxCode: "F",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
 
     // The previous bug rendered "$0.00" because the table multiplied
     // quantity * unitPrice (1 * 0). Assert the row shows the real total.
@@ -212,9 +210,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
 
     // 4.97 + 3.00 = 7.97
     expect(screen.getByText("Subtotal: $7.97")).toBeInTheDocument();
@@ -235,9 +231,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
 
     // The line total is rendered.
     expect(screen.getByText("$12.34")).toBeInTheDocument();
@@ -266,6 +260,69 @@ describe("LineItemsSection", () => {
     ];
     renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
     expect(screen.getByText("Subtotal: $0.90")).toBeInTheDocument();
+  });
+
+  // RECEIPTS-661: Weight-priced rows (Walmart "TOMATO 2.300 lb @ 0.92") arrive
+  // in quantity mode with a populated totalPrice — the upstream fix at the
+  // controller / mapper levels guarantees `totalPrice` is no longer `0` for
+  // these rows. Assert the cell renders the correct currency value AND the
+  // rolling subtotal sums to the printed receipt subtotal, not $0.00.
+  it("renders quantity-mode weight-priced rows with the correct line total (RECEIPTS-661)", () => {
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "TOMATO",
+        description: "TOMATO",
+        pricingMode: "quantity",
+        quantity: 2.3,
+        unitPrice: 0.92,
+        totalPrice: 2.12, // 2.3 * 0.92 = 2.116, rounded to cents
+        category: "Food",
+        subcategory: "",
+        taxCode: "",
+      },
+    ];
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
+
+    // Cell shows the right currency, not $0.00.
+    expect(screen.getByText("$2.12")).toBeInTheDocument();
+    expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
+  });
+
+  it("rolling subtotal across two weight-priced rows matches printed receipt total (RECEIPTS-661)", () => {
+    // The reference Walmart bug: TOMATO 2.300 lb @ 0.92 + BANANAS 2.460 lb @ 0.50.
+    // Real-world subtotal printed on the receipt: $3.35 (2.116 + 1.230 = 3.346).
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "TOMATO",
+        description: "TOMATO",
+        pricingMode: "quantity",
+        quantity: 2.3,
+        unitPrice: 0.92,
+        totalPrice: 2.12,
+        category: "Food",
+        subcategory: "",
+        taxCode: "",
+      },
+      {
+        id: "2",
+        receiptItemCode: "BANANAS",
+        description: "BANANAS",
+        pricingMode: "quantity",
+        quantity: 2.46,
+        unitPrice: 0.5,
+        totalPrice: 1.23,
+        category: "Food",
+        subcategory: "",
+        taxCode: "",
+      },
+    ];
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
+
+    // computeLineTotal in quantity mode uses q × p with cent rounding:
+    // 2.3 * 0.92 → 2.12 ; 2.46 * 0.5 → 1.23 ; sum = 3.35.
+    expect(screen.getByText("Subtotal: $3.35")).toBeInTheDocument();
   });
 
   it("calls onChange when an item is removed", async () => {
@@ -525,9 +582,7 @@ describe("LineItemsSection", () => {
         taxCode: "",
       },
     ];
-    renderWithProviders(
-      <LineItemsSection {...defaultProps} items={items} />,
-    );
+    renderWithProviders(<LineItemsSection {...defaultProps} items={items} />);
 
     await user.click(screen.getByRole("button", { name: /edit/i }));
 

--- a/src/client/src/pages/scan-receipt/proposalMappers.test.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.test.ts
@@ -234,7 +234,8 @@ describe("mapProposalToInitialValues", () => {
     // Defensive guard: the OpenAPI contract declares proposedTransactions as
     // optional; older fixtures or partially-stubbed handlers may omit it.
     const proposal = makeProposal();
-    delete (proposal as { proposedTransactions?: unknown }).proposedTransactions;
+    delete (proposal as { proposedTransactions?: unknown })
+      .proposedTransactions;
 
     const result = mapProposalToInitialValues(proposal);
 
@@ -412,6 +413,202 @@ describe("mapProposalToInitialValues", () => {
         expect(item.pricingMode).toBe("flat");
         expect(item.totalPrice).toBeGreaterThan(0);
       }
+    });
+  });
+
+  // RECEIPTS-661: Weight-priced items (Walmart "TOMATO 2.300 lb @ 0.92") arrive
+  // from the VLM with quantity + unitPrice populated and a recognised
+  // confidence, but no separate totalPrice — the API serialises this as
+  // `totalPrice: 0, totalPriceConfidence: "none"` because the C# value-type
+  // defaults to 0. The previous fallback `totalPrice ?? quantity * unitPrice`
+  // short-circuited to 0 because nullish-coalescing only fires for null /
+  // undefined, leaving the wizard with $0.00 rows. The server now derives the
+  // missing total upstream; this defensive check still covers any path that
+  // emits a 0 + none pair.
+  describe("zero-totalPrice + none-confidence fallback (RECEIPTS-661)", () => {
+    it("computes totalPrice from quantity * unitPrice when API sends 0 + none", () => {
+      const proposal = makeProposal({
+        items: [
+          {
+            code: "TOMATO",
+            codeConfidence: "high",
+            description: "TOMATO",
+            descriptionConfidence: "high",
+            quantity: 2.3,
+            quantityConfidence: "high",
+            unitPrice: 0.92,
+            unitPriceConfidence: "high",
+            totalPrice: 0,
+            totalPriceConfidence: "none",
+            taxCode: null,
+            taxCodeConfidence: "none",
+          },
+        ],
+      });
+
+      const result = mapProposalToInitialValues(proposal);
+
+      const tomato = result.items[0];
+      expect(tomato.pricingMode).toBe("quantity");
+      // 2.3 * 0.92 = 2.116; the wizard rounds to cents = 2.12
+      expect(tomato.totalPrice).toBeCloseTo(2.12, 2);
+      expect(tomato.totalPrice).toBeGreaterThan(0);
+    });
+
+    it("does not overwrite a positive totalPrice when confidence is high", () => {
+      // Pass-through: the server already supplied a totalPrice; respect it
+      // even when q * p computes to a slightly different value.
+      const proposal = makeProposal({
+        items: [
+          {
+            code: "MILK",
+            codeConfidence: "high",
+            description: "Milk",
+            descriptionConfidence: "high",
+            quantity: 2,
+            quantityConfidence: "high",
+            unitPrice: 3,
+            unitPriceConfidence: "high",
+            totalPrice: 5.99, // VLM said 5.99 even though 2 * 3 = 6
+            totalPriceConfidence: "high",
+            taxCode: null,
+            taxCodeConfidence: "none",
+          },
+        ],
+      });
+
+      const result = mapProposalToInitialValues(proposal);
+
+      expect(result.items[0].totalPrice).toBe(5.99);
+    });
+
+    it("uses totalPrice when confidence is medium and value is positive", () => {
+      const proposal = makeProposal({
+        items: [
+          {
+            code: "X",
+            codeConfidence: "high",
+            description: "x",
+            descriptionConfidence: "high",
+            quantity: 1,
+            quantityConfidence: "high",
+            unitPrice: 2,
+            unitPriceConfidence: "high",
+            totalPrice: 1.99,
+            totalPriceConfidence: "medium",
+            taxCode: null,
+            taxCodeConfidence: "none",
+          },
+        ],
+      });
+
+      const result = mapProposalToInitialValues(proposal);
+
+      expect(result.items[0].totalPrice).toBe(1.99);
+    });
+
+    it("uses totalPrice when confidence is low and value is positive", () => {
+      const proposal = makeProposal({
+        items: [
+          {
+            code: "X",
+            codeConfidence: "high",
+            description: "x",
+            descriptionConfidence: "high",
+            quantity: 1,
+            quantityConfidence: "high",
+            unitPrice: 2,
+            unitPriceConfidence: "high",
+            totalPrice: 1.49,
+            totalPriceConfidence: "low",
+            taxCode: null,
+            taxCodeConfidence: "none",
+          },
+        ],
+      });
+
+      const result = mapProposalToInitialValues(proposal);
+
+      expect(result.items[0].totalPrice).toBe(1.49);
+    });
+
+    it("tolerates capitalised confidence values until RECEIPTS-660 lands", () => {
+      // The model occasionally emits "None" / "High" before serialisation
+      // normalisation. Defensive `.toLowerCase()` keeps the fallback working
+      // until RECEIPTS-660 forces a single lowercase wire format.
+      const proposal = makeProposal({
+        items: [
+          {
+            code: "BANANAS",
+            codeConfidence: "high",
+            description: "BANANAS",
+            descriptionConfidence: "high",
+            quantity: 2.46,
+            quantityConfidence: "high",
+            unitPrice: 0.5,
+            unitPriceConfidence: "high",
+            totalPrice: 0,
+            // Cast away the lowercase enum constraint so the test can express
+            // the (incorrect-but-real) capitalised wire shape.
+            totalPriceConfidence: "None" as unknown as "none",
+            taxCode: null,
+            taxCodeConfidence: "none",
+          },
+        ],
+      });
+
+      const result = mapProposalToInitialValues(proposal);
+
+      const bananas = result.items[0];
+      expect(bananas.totalPrice).toBeCloseTo(1.23, 2); // 2.46 * 0.5
+      expect(bananas.totalPrice).toBeGreaterThan(0);
+    });
+
+    it("rolling subtotal across mixed weight-priced rows matches sum of q × p", () => {
+      // The real-world Walmart bug: TOMATO and BANANAS rows both arrive with
+      // (totalPrice=0, none) — the rolling subtotal must equal 2.116 + 1.23 = 3.346
+      // (rounded to cents = $3.35), not $0.00.
+      const proposal = makeProposal({
+        items: [
+          {
+            code: "TOMATO",
+            codeConfidence: "high",
+            description: "TOMATO",
+            descriptionConfidence: "high",
+            quantity: 2.3,
+            quantityConfidence: "high",
+            unitPrice: 0.92,
+            unitPriceConfidence: "high",
+            totalPrice: 0,
+            totalPriceConfidence: "none",
+            taxCode: null,
+            taxCodeConfidence: "none",
+          },
+          {
+            code: "BANANAS",
+            codeConfidence: "high",
+            description: "BANANAS",
+            descriptionConfidence: "high",
+            quantity: 2.46,
+            quantityConfidence: "high",
+            unitPrice: 0.5,
+            unitPriceConfidence: "high",
+            totalPrice: 0,
+            totalPriceConfidence: "none",
+            taxCode: null,
+            taxCodeConfidence: "none",
+          },
+        ],
+      });
+
+      const result = mapProposalToInitialValues(proposal);
+
+      const subtotal = result.items.reduce(
+        (sum, item) => sum + item.totalPrice,
+        0,
+      );
+      expect(subtotal).toBeGreaterThan(0);
+      expect(subtotal).toBeCloseTo(3.35, 2);
     });
   });
 });
@@ -625,9 +822,7 @@ describe("mapProposalToConfidenceMap", () => {
 });
 
 describe("initialItemsAndConfidence", () => {
-  function makeInitial(
-    items: ScanInitialValues["items"],
-  ): ScanInitialValues {
+  function makeInitial(items: ScanInitialValues["items"]): ScanInitialValues {
     return {
       header: {
         location: "",

--- a/src/client/src/pages/scan-receipt/proposalMappers.test.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.test.ts
@@ -564,6 +564,38 @@ describe("mapProposalToInitialValues", () => {
       expect(bananas.totalPrice).toBeGreaterThan(0);
     });
 
+    it("falls back to computed total when VLM emits (0, 'high') for a quantity row", () => {
+      // Defence against a hallucinated zero: ReceiptItem's domain validator
+      // rejects `totalAmount = 0` for a quantity-mode row whose unitPrice > 0
+      // (|0 − Math.Floor(q×up×100)/100| > 0.01). Passing the bogus zero through
+      // would surface as a server-side ArgumentException at submit time — falling
+      // back to `q × up` keeps the wizard usable without forcing the user to
+      // manually re-enter every line total.
+      const proposal = makeProposal({
+        items: [
+          {
+            code: "X",
+            codeConfidence: "high",
+            description: "x",
+            descriptionConfidence: "high",
+            quantity: 2,
+            quantityConfidence: "high",
+            unitPrice: 5.99,
+            unitPriceConfidence: "high",
+            totalPrice: 0,
+            totalPriceConfidence: "high",
+            taxCode: null,
+            taxCodeConfidence: "none",
+          },
+        ],
+      });
+
+      const result = mapProposalToInitialValues(proposal);
+
+      // 2 × 5.99 = 11.98 (cent-rounded fallback), not 0.
+      expect(result.items[0].totalPrice).toBeCloseTo(11.98, 2);
+    });
+
     it("rolling subtotal across mixed weight-priced rows matches sum of q × p", () => {
       // The real-world Walmart bug: TOMATO and BANANAS rows both arrive with
       // (totalPrice=0, none) — the rolling subtotal must equal 2.116 + 1.23 = 3.346

--- a/src/client/src/pages/scan-receipt/proposalMappers.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.ts
@@ -114,8 +114,16 @@ export function mapProposalToInitialValues(
       // undefined), producing a $0.00 row even though `quantity * unitPrice` is
       // computable. The server now derives a missing total upstream, but this
       // defensive check protects the wizard against any future path that emits a
-      // `0` + `none` pair. `.toLowerCase()` tolerates RECEIPTS-660's in-flight
-      // capitalisation fix without needing a coordinated landing.
+      // `0` + `none` pair.
+      //
+      // The `> 0` guard also defends against the inverse: if a VLM hallucinated
+      // (0, "high") for a quantity-mode row (unitPrice > 0), passing 0 through
+      // would fail `ReceiptItem`'s domain validator (which requires
+      // |totalAmount − Math.Floor(q×up×100)/100| ≤ 0.01) at submit time — a
+      // server-side ArgumentException rather than a silent success. Falling
+      // back to the computed total is the safer default. `.toLowerCase()`
+      // tolerates RECEIPTS-660's in-flight capitalisation fix without needing
+      // a coordinated landing.
       const totalPriceConfidence = (
         item.totalPriceConfidence ?? "none"
       ).toLowerCase();

--- a/src/client/src/pages/scan-receipt/proposalMappers.ts
+++ b/src/client/src/pages/scan-receipt/proposalMappers.ts
@@ -69,9 +69,7 @@ export function mapProposalToInitialValues(
     // pre-populate Transaction rows directly. An unmatched payment yields a
     // null cardId; we coerce to "" so the row falls back to "needs picker".
     proposedTransactions: proposedTransactions.map((t) => {
-      const proposalDate = t.date
-        ? t.date.split("T")[0]
-        : (date ?? "");
+      const proposalDate = t.date ? t.date.split("T")[0] : (date ?? "");
       return {
         cardId: t.cardId ?? "",
         accountId: t.accountId ?? "",
@@ -108,13 +106,27 @@ export function mapProposalToInitialValues(
 
       const quantity = Number(item.quantity ?? 1);
       const unitPrice = Number(item.unitPrice ?? 0);
-      // Carry totalPrice through: prefer the VLM's value when present so the
-      // saved total survives any later rounding ambiguity. Fall back to the
-      // computed total for round-trip consistency on traditional receipts.
-      const totalPrice =
-        item.totalPrice != null
-          ? Number(item.totalPrice)
-          : Math.round(quantity * unitPrice * 100) / 100;
+      // Carry totalPrice through when the VLM extracted one (any of low/medium/
+      // high confidence) AND the value is positive. RECEIPTS-661: when the model
+      // omits a total for a weight-priced item the API serialises the value-type
+      // default (`0`) with `none` confidence — `totalPrice ?? quantity * unitPrice`
+      // would short-circuit to 0 (nullish-coalescing only fires for null /
+      // undefined), producing a $0.00 row even though `quantity * unitPrice` is
+      // computable. The server now derives a missing total upstream, but this
+      // defensive check protects the wizard against any future path that emits a
+      // `0` + `none` pair. `.toLowerCase()` tolerates RECEIPTS-660's in-flight
+      // capitalisation fix without needing a coordinated landing.
+      const totalPriceConfidence = (
+        item.totalPriceConfidence ?? "none"
+      ).toLowerCase();
+      const totalPriceCarriesValue =
+        (totalPriceConfidence === "high" ||
+          totalPriceConfidence === "medium" ||
+          totalPriceConfidence === "low") &&
+        Number(item.totalPrice ?? 0) > 0;
+      const totalPrice = totalPriceCarriesValue
+        ? Number(item.totalPrice)
+        : Math.round(quantity * unitPrice * 100) / 100;
       return {
         receiptItemCode: item.code ?? "",
         description: item.description ?? "",

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using DtoConfidenceLevel = global::API.Generated.Dtos.ConfidenceLevel;
+using OcrConfidenceLevel = Application.Models.Ocr.ConfidenceLevel;
 
 namespace Presentation.API.Tests.Controllers.Core;
 
@@ -541,6 +542,178 @@ public class ReceiptScanControllerTests
 		ServiceProvider provider = services.BuildServiceProvider();
 		JsonOptions mvcJsonOptions = provider.GetRequiredService<IOptions<JsonOptions>>().Value;
 		return mvcJsonOptions.JsonSerializerOptions;
+	}
+
+	// RECEIPTS-661: Weight-priced items (e.g. Walmart "TOMATO 2.300 lb @ 0.92")
+	// arrive with quantity + unitPrice populated and a recognised confidence,
+	// but no separate totalPrice — the model didn't print one as a distinct
+	// line, so the value-type defaults to 0 and confidence to None. Without
+	// derivation the wizard renders such rows as $0.00 and the rolling subtotal
+	// is wrong by the same amount. The controller must derive the missing total
+	// upstream so every client sees a usable value.
+	[Fact]
+	public async Task ScanReceipt_WeightPricedItemMissingTotal_DerivesFromQuantityTimesUnitPrice()
+	{
+		// Arrange — TOMATO 2.300 lb @ 0.92 with totalPrice absent (the bug shape).
+		IFormFile file = CreateMockFormFile("walmart.jpg", "image/jpeg", 1024);
+
+		ParsedReceipt parsedReceipt = new(
+			FieldConfidence<string>.High("WALMART"),
+			FieldConfidence<DateOnly>.High(new DateOnly(2026, 5, 1)),
+			[
+				new ParsedReceiptItem(
+					FieldConfidence<string?>.None(),
+					FieldConfidence<string>.High("TOMATO"),
+					FieldConfidence<decimal>.High(2.300m),
+					FieldConfidence<decimal>.High(0.92m),
+					FieldConfidence<decimal>.None())
+			],
+			FieldConfidence<decimal>.High(2.116m),
+			[],
+			FieldConfidence<decimal>.High(2.116m),
+			FieldConfidence<string?>.None()
+		);
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<ScanReceiptCommand>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ScanReceiptResult(parsedReceipt));
+
+		// Act
+		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
+
+		// Assert — totalPrice derived as 2.300 * 0.92 = 2.116; confidence elevated
+		// from None to the floor of (high, high) = high so the client treats it
+		// as authoritative.
+		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
+		response.Items.Should().HaveCount(1);
+		ProposedReceiptItemResponse tomato = response.Items.First();
+		tomato.TotalPrice.Should().Be(2.116d);
+		tomato.TotalPriceConfidence.Should().Be(DtoConfidenceLevel.High);
+	}
+
+	[Theory]
+	[InlineData(OcrConfidenceLevel.High, OcrConfidenceLevel.High, DtoConfidenceLevel.High)]
+	[InlineData(OcrConfidenceLevel.High, OcrConfidenceLevel.Medium, DtoConfidenceLevel.Medium)]
+	[InlineData(OcrConfidenceLevel.Medium, OcrConfidenceLevel.High, DtoConfidenceLevel.Medium)]
+	[InlineData(OcrConfidenceLevel.Medium, OcrConfidenceLevel.Low, DtoConfidenceLevel.Low)]
+	[InlineData(OcrConfidenceLevel.Low, OcrConfidenceLevel.Low, DtoConfidenceLevel.Low)]
+	public async Task ScanReceipt_DerivedTotal_TakesLowerOfQuantityAndUnitPriceConfidence(
+		OcrConfidenceLevel quantityConfidence,
+		OcrConfidenceLevel unitPriceConfidence,
+		DtoConfidenceLevel expectedTotalConfidence)
+	{
+		// Arrange — derived confidence should equal min(quantityConfidence, unitPriceConfidence).
+		IFormFile file = CreateMockFormFile("walmart.jpg", "image/jpeg", 1024);
+
+		ParsedReceipt parsedReceipt = new(
+			FieldConfidence<string>.High("WALMART"),
+			FieldConfidence<DateOnly>.High(new DateOnly(2026, 5, 1)),
+			[
+				new ParsedReceiptItem(
+					FieldConfidence<string?>.None(),
+					FieldConfidence<string>.High("BANANAS"),
+					new FieldConfidence<decimal>(2.460m, quantityConfidence),
+					new FieldConfidence<decimal>(0.50m, unitPriceConfidence),
+					FieldConfidence<decimal>.None())
+			],
+			FieldConfidence<decimal>.High(1.23m),
+			[],
+			FieldConfidence<decimal>.High(1.23m),
+			FieldConfidence<string?>.None()
+		);
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<ScanReceiptCommand>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ScanReceiptResult(parsedReceipt));
+
+		// Act
+		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
+
+		// Assert
+		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
+		ProposedReceiptItemResponse bananas = response.Items.First();
+		bananas.TotalPrice.Should().Be(1.23d); // 2.460 * 0.50
+		bananas.TotalPriceConfidence.Should().Be(expectedTotalConfidence);
+	}
+
+	[Fact]
+	public async Task ScanReceipt_AllThreePriceFieldsNone_LeavesTotalPriceZeroWithNoneConfidence()
+	{
+		// Arrange — corrupted/blurry receipt where the model couldn't extract any
+		// price fields. Derivation requires quantity AND unitPrice to be present,
+		// so the response should fall through to the original (None, 0) values
+		// rather than fabricating a $0.00 line at "high" confidence.
+		IFormFile file = CreateMockFormFile("blurry.jpg", "image/jpeg", 1024);
+
+		ParsedReceipt parsedReceipt = new(
+			FieldConfidence<string>.High("WALMART"),
+			FieldConfidence<DateOnly>.High(new DateOnly(2026, 5, 1)),
+			[
+				new ParsedReceiptItem(
+					FieldConfidence<string?>.None(),
+					FieldConfidence<string>.High("MYSTERY ITEM"),
+					FieldConfidence<decimal>.None(),
+					FieldConfidence<decimal>.None(),
+					FieldConfidence<decimal>.None())
+			],
+			FieldConfidence<decimal>.None(),
+			[],
+			FieldConfidence<decimal>.None(),
+			FieldConfidence<string?>.None()
+		);
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<ScanReceiptCommand>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ScanReceiptResult(parsedReceipt));
+
+		// Act
+		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
+
+		// Assert
+		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
+		ProposedReceiptItemResponse mystery = response.Items.First();
+		mystery.TotalPrice.Should().Be(0d);
+		mystery.TotalPriceConfidence.Should().Be(DtoConfidenceLevel.None);
+	}
+
+	[Fact]
+	public async Task ScanReceipt_TotalPriceAlreadyPopulated_PassesThroughUnchanged()
+	{
+		// Arrange — when the VLM extracted a totalPrice with any of low/medium/high
+		// confidence the controller must not overwrite it with a derived value.
+		// Use a value that *differs* from quantity * unitPrice so we can
+		// distinguish pass-through from derivation: 2 * 3 = 6 but the VLM said 5.99.
+		IFormFile file = CreateMockFormFile("traditional.jpg", "image/jpeg", 1024);
+
+		ParsedReceipt parsedReceipt = new(
+			FieldConfidence<string>.High("STORE"),
+			FieldConfidence<DateOnly>.High(new DateOnly(2026, 5, 1)),
+			[
+				new ParsedReceiptItem(
+					FieldConfidence<string?>.None(),
+					FieldConfidence<string>.High("MILK"),
+					FieldConfidence<decimal>.High(2m),
+					FieldConfidence<decimal>.High(3m),
+					FieldConfidence<decimal>.High(5.99m))
+			],
+			FieldConfidence<decimal>.High(5.99m),
+			[],
+			FieldConfidence<decimal>.High(5.99m),
+			FieldConfidence<string?>.None()
+		);
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<ScanReceiptCommand>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ScanReceiptResult(parsedReceipt));
+
+		// Act
+		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
+
+		// Assert — value carried through verbatim, no recomputation.
+		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
+		ProposedReceiptItemResponse milk = response.Items.First();
+		milk.TotalPrice.Should().Be(5.99d);
+		milk.TotalPriceConfidence.Should().Be(DtoConfidenceLevel.High);
 	}
 
 	private static IFormFile CreateMockFormFile(string fileName, string contentType, int size)

--- a/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/ReceiptScanControllerTests.cs
@@ -581,14 +581,57 @@ public class ReceiptScanControllerTests
 		// Act
 		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
 
-		// Assert — totalPrice derived as 2.300 * 0.92 = 2.116; confidence elevated
-		// from None to the floor of (high, high) = high so the client treats it
-		// as authoritative.
+		// Assert — totalPrice derived as Math.Floor(2.300 * 0.92 * 100) / 100 =
+		// 2.11 (floor-to-cent matches the convention in
+		// ReceiptItemMapper.ResolveTotalAmount and proposalMappers.ts so the
+		// derived value never introduces sub-cent precision into the DB).
+		// Confidence is elevated from None to the floor of (high, high) = high
+		// so the client treats it as authoritative.
 		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
 		response.Items.Should().HaveCount(1);
 		ProposedReceiptItemResponse tomato = response.Items.First();
-		tomato.TotalPrice.Should().Be(2.116d);
+		tomato.TotalPrice.Should().Be(2.11d);
 		tomato.TotalPriceConfidence.Should().Be(DtoConfidenceLevel.High);
+	}
+
+	[Fact]
+	public async Task ScanReceipt_DerivedTotal_RoundsDownToWholeCents()
+	{
+		// Arrange — guard against sub-cent precision leaking into the DB.
+		// 2.300 * 0.92 = 2.116; floor-to-cent yields 2.11 (matching the
+		// convention used by ReceiptItemMapper.ResolveTotalAmount and the
+		// client-side fallback in proposalMappers.ts).
+		IFormFile file = CreateMockFormFile("walmart.jpg", "image/jpeg", 1024);
+
+		ParsedReceipt parsedReceipt = new(
+			FieldConfidence<string>.High("WALMART"),
+			FieldConfidence<DateOnly>.High(new DateOnly(2026, 5, 1)),
+			[
+				new ParsedReceiptItem(
+					FieldConfidence<string?>.None(),
+					FieldConfidence<string>.High("TOMATO"),
+					FieldConfidence<decimal>.High(2.300m),
+					FieldConfidence<decimal>.High(0.92m),
+					FieldConfidence<decimal>.None())
+			],
+			FieldConfidence<decimal>.High(2.11m),
+			[],
+			FieldConfidence<decimal>.High(2.11m),
+			FieldConfidence<string?>.None()
+		);
+
+		_mediatorMock
+			.Setup(m => m.Send(It.IsAny<ScanReceiptCommand>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ScanReceiptResult(parsedReceipt));
+
+		// Act
+		Results<Ok<ProposedReceiptResponse>, BadRequest<string>, StatusCodeHttpResult, UnprocessableEntity<string>> actual = await _controller.ScanReceipt(file);
+
+		// Assert — never 2.116, always cent-aligned.
+		ProposedReceiptResponse response = actual.Result.Should().BeOfType<Ok<ProposedReceiptResponse>>().Subject.Value!;
+		double total = response.Items.First().TotalPrice!.Value;
+		total.Should().Be(2.11d);
+		(total * 100d).Should().Be(Math.Floor(total * 100d));
 	}
 
 	[Theory]


### PR DESCRIPTION
## Summary

Real-world Walmart scans returned weight-priced items (TOMATO `2.300 lb @ 0.92`, BANANAS `2.460 lb @ 0.50`) with `quantity` and `unitPrice` populated at high confidence but `totalPrice: 0` / `totalPriceConfidence: "none"` — the C# value-type defaults to `0` when the model omits a separate total. The wizard rendered these rows as `$0.00` and the rolling subtotal was wrong by the same amount because `totalPrice ?? quantity * unitPrice` short-circuits (`0 ?? ...` returns `0`, since nullish-coalescing only fires for `null`/`undefined`).

- **Server (single source of truth)** — `ReceiptScanController.MapItem` now derives a missing `totalPrice` from `quantity * unitPrice` when both source fields are present, with confidence equal to the floor of the two source confidences (high+high → high; high+medium → medium; medium+low → low). The response carries a usable value so every client sees one.
- **Client (defensive)** — `proposalMappers.ts` replaces the nullish-coalesce fallback with an explicit confidence + positivity check. `.toLowerCase()` tolerates the in-flight RECEIPTS-660 capitalisation fix without needing a coordinated landing.

Resolves RECEIPTS-661.

## Test plan

- [x] 4 new server tests (`ReceiptScanControllerTests`) covering: weight-priced derivation produces `2.116` at `high` confidence; theory across 5 confidence permutations confirming the floor rule; all-None pass-through leaves totalPrice `0` + `None`; pre-populated totalPrice passes through unchanged.
- [x] 6 new client mapper tests (`proposalMappers.test.ts`) covering the bug shape (`{totalPrice: 0, totalPriceConfidence: "none"}` → `2.12`), pass-through across `low`/`medium`/`high`, capitalised-confidence tolerance, and the real-world rolling subtotal (`$3.35` for TOMATO + BANANAS).
- [x] 2 new `LineItemsSection.test.tsx` tests confirming the line cell renders the correct currency and the rolling subtotal sums correctly across two weight-priced rows.
- [x] `dotnet build`, `dotnet test --filter "Category!=Integration"` (1052 tests), `dotnet format --verify-no-changes` pass.
- [x] `npx tsc -b --noEmit`, `npx vitest run` (1974 tests), `npx eslint`, `npx prettier --check` pass.
- Manual smoke covered by the rolling-subtotal test which mirrors the bug-report payload exactly.

## Conflict awareness

- RECEIPTS-660 (in flight) touches DtoSplitter + Generated DTOs only — no overlap with this PR's controller / mapper changes. The client uses `.toLowerCase()` so 660 can land in either order.
- RECEIPTS-655 added the items mapping; this PR modifies the same `quantity`-mode branch.
- RECEIPTS-657/658 touch the transactions section of `proposalMappers.ts`, not items.