### PR TITLE
fix(infra,client): invalidate DTO cache on splitter changes (RECEIPTS-665)

### DIFF
--- a/src/client/src/pages/scan-receipt/ConfidenceIndicator.tsx
+++ b/src/client/src/pages/scan-receipt/ConfidenceIndicator.tsx
@@ -56,7 +56,13 @@ export function ConfidenceIndicator({
     return null;
   }
 
+  // Defensive: if the wire format ever drifts from the contract (e.g. a serializer
+  // regression emits PascalCase enum names), fall back to rendering nothing rather
+  // than NRE'ing on an undefined CHIP_CONFIG entry.
   const config = CHIP_CONFIG[confidence];
+  if (!config) {
+    return null;
+  }
 
   return (
     <Tooltip>

--- a/tools/DtoSplitter/Program.cs
+++ b/tools/DtoSplitter/Program.cs
@@ -250,7 +250,11 @@ static string BuildPostamble(List<string> pragmaRestores)
 static string ComputeHash(string filePath)
 {
 	byte[] fileBytes = File.ReadAllBytes(filePath);
-	byte[] hashBytes = SHA256.HashData(fileBytes);
+	byte[] versionBytes = Encoding.UTF8.GetBytes($"\nsplitter-version:{SplitterMetadata.Version}");
+	byte[] combined = new byte[fileBytes.Length + versionBytes.Length];
+	Buffer.BlockCopy(fileBytes, 0, combined, 0, fileBytes.Length);
+	Buffer.BlockCopy(versionBytes, 0, combined, fileBytes.Length, versionBytes.Length);
+	byte[] hashBytes = SHA256.HashData(combined);
 	return Convert.ToHexStringLower(hashBytes);
 }
 
@@ -303,6 +307,18 @@ static int Error(string message)
 {
 	Console.Error.WriteLine(message);
 	return 1;
+}
+
+internal static class SplitterMetadata
+{
+	// Bump when DtoSplitter's generation logic changes (rewriter rules,
+	// preamble/postamble shape, etc.). Folded into the spec hash so a logic
+	// change invalidates existing generated files even when the OpenAPI spec
+	// is unchanged. See RECEIPTS-660 for the regression that motivated this:
+	// the per-property JsonStringEnumConverter rewriter was added but stale
+	// generated files weren't regenerated, so the bug it was supposed to fix
+	// persisted in the wild.
+	public const string Version = "2";
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- `DtoSplitter` freshness check hashed only the OpenAPI spec, so RECEIPTS-660's Roslyn rewriter (which strips per-property `[JsonStringEnumConverter<T>]` from generated DTOs) never re-ran on existing cached files. The bug it was supposed to fix persisted: API kept emitting PascalCase enum values (`"High"`, `"None"`) on the wire and the Scan-Receipt wizard NRE'd on `config.ariaLabel`.
- Added `SplitterMetadata.Version` constant, folded into `ComputeHash` so any future splitter-logic change auto-invalidates the cache. Bumped to "2" to force regeneration of currently-stale files.
- Defensive null-guard in `ConfidenceIndicator.tsx` after the `CHIP_CONFIG[confidence]` lookup — wire format should be lowercase per OpenAPI, but a runtime crash on enum-shape drift is a bad failure mode.

Plane: [RECEIPTS-665](https://plane.wallingford.me/dev/browse/RECEIPTS-665/)

## Test plan

- [x] 22 `JsonSerializerEnumCasingTests` + `ReceiptScanControllerTests` pass
- [x] 13 `ConfidenceIndicator` tests pass
- [x] `dotnet build src/Presentation/API` regenerates DTOs that no longer carry per-property `[JsonStringEnumConverter]`
- [ ] Smoke-test scan flow in Aspire: upload Walmart fixture, verify wizard renders without NRE

🤖 Generated with [Claude Code](https://claude.com/claude-code)