### PR TITLE
fix(client): align BalanceSidebar subtotal with line items (RECEIPTS-664)

### DIFF
--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -13,6 +13,7 @@ import {
   useCategoryRecommendations,
 } from "@/hooks/useSimilarItems";
 import { useReceiptItemSuggestions } from "@/hooks/useReceiptItemSuggestions";
+import { computeLineTotal } from "./computeLineTotal";
 import { formatCurrency } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -112,24 +113,6 @@ export interface ReceiptLineItem {
   category: string;
   subcategory: string;
   taxCode: string;
-}
-
-/**
- * Compute the per-row line total, picking the source-of-truth field based on
- * pricingMode. For "quantity" rows this honors the quantity x unit-price math
- * (with cent rounding to dodge IEEE-754 noise); for "flat" rows it returns
- * the receipt-printed total verbatim.
- */
-function computeLineTotal(item: {
-  pricingMode: "quantity" | "flat";
-  quantity: number;
-  unitPrice: number;
-  totalPrice: number;
-}): number {
-  if (item.pricingMode === "flat") {
-    return item.totalPrice;
-  }
-  return Math.round(item.quantity * item.unitPrice * 100) / 100;
 }
 
 interface LineItemsSectionProps {

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -7,6 +7,7 @@ import { useLocationHistory } from "@/hooks/useLocationHistory";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { TransactionsSection } from "./TransactionsSection";
 import { LineItemsSection } from "./LineItemsSection";
+import { computeLineTotal } from "./computeLineTotal";
 import { BalanceSidebar } from "./BalanceSidebar";
 import { HeaderSection } from "./HeaderSection";
 import { headerSchema, type HeaderFormValues } from "./headerSchema";
@@ -96,13 +97,12 @@ export default function NewReceiptPage({
     locationRef.current?.focus();
   }, []);
 
+  // Must mirror LineItemsSection's per-row total (which branches on pricingMode):
+  // flat-priced rows store the receipt-printed total in `totalPrice` and have
+  // quantity=1, unitPrice=0, so a naïve `q × p` would silently drop them and
+  // surface a sidebar subtotal that disagrees with the table's footer.
   const subtotal = useMemo(
-    () =>
-      items.reduce(
-        (sum, item) =>
-          sum + Math.round(item.quantity * item.unitPrice * 100) / 100,
-        0,
-      ),
+    () => items.reduce((sum, item) => sum + computeLineTotal(item), 0),
     [items],
   );
 

--- a/src/client/src/pages/new-receipt/computeLineTotal.ts
+++ b/src/client/src/pages/new-receipt/computeLineTotal.ts
@@ -1,0 +1,18 @@
+/**
+ * Single source of truth for an item's line total. Both the LineItemsSection
+ * footer and the NewReceiptPage BalanceSidebar consume this so the two
+ * subtotals can never disagree (RECEIPTS-655 / RECEIPTS-661): for "flat" rows
+ * the receipt-printed `totalPrice` is authoritative; for "quantity" rows the
+ * total is `q × p` rounded to cents to dodge IEEE-754 noise.
+ */
+export function computeLineTotal(item: {
+  pricingMode: "quantity" | "flat";
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+}): number {
+  if (item.pricingMode === "flat") {
+    return item.totalPrice;
+  }
+  return Math.round(item.quantity * item.unitPrice * 100) / 100;
+}


### PR DESCRIPTION
## Summary

- `NewReceiptPage.tsx` computed the subtotal it passed to `BalanceSidebar` with a naïve `quantity × unitPrice` reducer. Flat-priced rows (RECEIPTS-655) carry `quantity=1, unitPrice=0, totalPrice=X` — so they contributed 0. `LineItemsSection`'s footer already used the correct `computeLineTotal()` that branches on `pricingMode`, so the two on-screen subtotals diverged whenever any flat-priced rows were present.
- Symptom (Walmart 2026-01-14 scan, mostly flat-priced): Line Items footer showed `$69.58`, Balance sidebar showed `$4.71` (only the three weight-priced rows: 2.116 + 1.23 + 1.36).
- Extracted `computeLineTotal()` to `src/pages/new-receipt/computeLineTotal.ts` so both consumers share one source of truth and can never drift again.

Plane: [RECEIPTS-664](https://plane.wallingford.me/dev/browse/RECEIPTS-664/)

## Test plan

- [x] 68 tests across `NewReceiptPage` / `LineItemsSection` / `BalanceSidebar` pass
- [x] `tsc --noEmit` clean
- [ ] Smoke-test scan flow: scan Walmart fixture, verify Line Items subtotal matches Balance sidebar subtotal

🤖 Generated with [Claude Code](https://claude.com/claude-code)