### PR TITLE
fix(infra): reconcile VLM subtotal against item-sum (RECEIPTS-663)

### DIFF
--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -31,6 +31,14 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 	/// </summary>
 	internal const int ExceptionMessageMaxChars = 500;
 
+	/// <summary>
+	/// When the VLM's extracted <c>subtotal</c> disagrees with the sum of <c>items[].totalPrice</c>
+	/// by more than this amount, the subtotal's confidence is downgraded so the wizard renders a
+	/// review badge. The discrepancy is otherwise preserved as-extracted so the user can see both
+	/// values and adjudicate. See RECEIPTS-663.
+	/// </summary>
+	internal const decimal SubtotalReconciliationTolerance = 0.05m;
+
 	private static readonly string[] DateFormats =
 	[
 		"yyyy-MM-dd",
@@ -287,9 +295,7 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 
 		List<ParsedReceiptItem> items = MergeWeightSublines(payload.Items ?? []).Select(MapItem).ToList();
 
-		FieldConfidence<decimal> subtotal = payload.Subtotal is { } s
-			? FieldConfidence<decimal>.High(s)
-			: FieldConfidence<decimal>.None();
+		FieldConfidence<decimal> subtotal = ReconcileSubtotal(payload.Subtotal, items);
 
 		List<ParsedTaxLine> taxLines = (payload.TaxLines ?? []).Select(MapTaxLine).ToList();
 
@@ -397,6 +403,30 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 		return item.LineTotal is null or 0m
 			&& item.Quantity is null or 0m
 			&& item.UnitPrice is null or 0m;
+	}
+
+	/// <summary>
+	/// Cross-checks the VLM's extracted <c>subtotal</c> against the sum of item line totals.
+	/// When the two disagree by more than <see cref="SubtotalReconciliationTolerance"/>, the
+	/// extracted value is preserved (so the user sees what the VLM read) but the confidence is
+	/// downgraded to <see cref="ConfidenceLevel.Low"/> so the wizard surfaces a review badge.
+	/// Without this cross-check the wizard's on-page subtotal and line-item sum could disagree
+	/// silently and break the user's mental balance check. See RECEIPTS-663.
+	/// </summary>
+	internal static FieldConfidence<decimal> ReconcileSubtotal(decimal? extracted, List<ParsedReceiptItem> items)
+	{
+		if (extracted is not { } subtotal)
+		{
+			return FieldConfidence<decimal>.None();
+		}
+
+		decimal itemSum = items
+			.Where(i => i.TotalPrice.IsPresent)
+			.Sum(i => i.TotalPrice.Value);
+		decimal delta = Math.Abs(subtotal - itemSum);
+		return delta <= SubtotalReconciliationTolerance
+			? FieldConfidence<decimal>.High(subtotal)
+			: FieldConfidence<decimal>.Low(subtotal);
 	}
 
 	private static ParsedReceiptItem MapItem(VlmReceiptItem item)

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -35,9 +35,10 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 	/// When the VLM's extracted <c>subtotal</c> disagrees with the sum of <c>items[].totalPrice</c>
 	/// by more than this amount, the subtotal's confidence is downgraded so the wizard renders a
 	/// review badge. The discrepancy is otherwise preserved as-extracted so the user can see both
-	/// values and adjudicate. See RECEIPTS-663.
+	/// values and adjudicate. Public so the VlmEval regression suite can mirror the live threshold
+	/// rather than its own per-fixture money tolerance. See RECEIPTS-663.
 	/// </summary>
-	internal const decimal SubtotalReconciliationTolerance = 0.05m;
+	public const decimal SubtotalReconciliationTolerance = 0.05m;
 
 	private static readonly string[] DateFormats =
 	[

--- a/src/Tools/VlmEval/FixtureEvaluator.cs
+++ b/src/Tools/VlmEval/FixtureEvaluator.cs
@@ -53,6 +53,7 @@ public sealed class FixtureEvaluator(
 		diffs.Add(DiffDate(fixture.Expected.Date, parsed.Date));
 		diffs.Add(DiffMoney("subtotal", fixture.Expected.Subtotal, parsed.Subtotal, tolerance));
 		diffs.Add(DiffMoney("total", fixture.Expected.Total, parsed.Total, tolerance));
+		diffs.Add(DiffSubtotalReconciliation(parsed.Subtotal, parsed.Items, tolerance));
 		diffs.Add(DiffTaxLines(fixture.Expected.TaxLines, parsed.TaxLines, tolerance));
 		diffs.Add(DiffPaymentMethod(fixture.Expected.PaymentMethod, parsed.PaymentMethod));
 		diffs.Add(DiffMinItemCount(fixture.Expected.MinItemCount, parsed.Items));
@@ -220,6 +221,42 @@ public sealed class FixtureEvaluator(
 			expected,
 			actual.Value,
 			match ? null : "payment method does not contain expected substring");
+	}
+
+	/// <summary>
+	/// Cross-check that the VLM's extracted <c>subtotal</c> agrees with the sum of
+	/// <c>items[].totalPrice</c> within <paramref name="tolerance"/>. Fires for every fixture
+	/// (no per-sidecar opt-in). Returns <see cref="DiffStatus.NotDeclared"/> when either side
+	/// of the equation is missing — the assertion only makes sense when both are present.
+	/// See RECEIPTS-663.
+	/// </summary>
+	internal static FieldDiff DiffSubtotalReconciliation(FieldConfidence<decimal> subtotal, List<ParsedReceiptItem> items, decimal tolerance = DefaultMoneyTolerance)
+	{
+		if (!subtotal.IsPresent)
+		{
+			return new FieldDiff("subtotalReconciliation", DiffStatus.NotDeclared, null, null, "subtotal not extracted");
+		}
+
+		List<decimal> totals = [.. items
+			.Where(i => i.TotalPrice.IsPresent)
+			.Select(i => i.TotalPrice.Value)];
+
+		if (totals.Count == 0)
+		{
+			return new FieldDiff("subtotalReconciliation", DiffStatus.NotDeclared, null, null, "no item totals extracted");
+		}
+
+		decimal sum = totals.Sum();
+		decimal delta = Math.Abs(subtotal.Value - sum);
+		bool match = delta <= tolerance;
+		string expected = $"|subtotal - sum(items)| <= {tolerance.ToString("0.00", CultureInfo.InvariantCulture)}";
+		string actual = $"subtotal={subtotal.Value.ToString("0.00", CultureInfo.InvariantCulture)}, sum={sum.ToString("0.00", CultureInfo.InvariantCulture)}, delta={delta.ToString("0.00", CultureInfo.InvariantCulture)}";
+		return new FieldDiff(
+			"subtotalReconciliation",
+			match ? DiffStatus.Pass : DiffStatus.Fail,
+			expected,
+			actual,
+			match ? null : $"delta=${delta.ToString("0.00", CultureInfo.InvariantCulture)}");
 	}
 
 	internal static FieldDiff DiffMinItemCount(int? expected, List<ParsedReceiptItem> actual)

--- a/src/Tools/VlmEval/FixtureEvaluator.cs
+++ b/src/Tools/VlmEval/FixtureEvaluator.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using Application.Interfaces.Services;
 using Application.Models.Ocr;
+using Infrastructure.Services;
 using Microsoft.Extensions.Logging;
 
 namespace VlmEval;
@@ -53,7 +54,13 @@ public sealed class FixtureEvaluator(
 		diffs.Add(DiffDate(fixture.Expected.Date, parsed.Date));
 		diffs.Add(DiffMoney("subtotal", fixture.Expected.Subtotal, parsed.Subtotal, tolerance));
 		diffs.Add(DiffMoney("total", fixture.Expected.Total, parsed.Total, tolerance));
-		diffs.Add(DiffSubtotalReconciliation(parsed.Subtotal, parsed.Items, tolerance));
+		// Use the production reconciliation threshold (RECEIPTS-663) rather than the per-fixture
+		// money tolerance: the eval check should mirror the live confidence-downgrade rule, not
+		// the unrelated subtotal/total comparison tolerance.
+		diffs.Add(DiffSubtotalReconciliation(
+			parsed.Subtotal,
+			parsed.Items,
+			OllamaReceiptExtractionService.SubtotalReconciliationTolerance));
 		diffs.Add(DiffTaxLines(fixture.Expected.TaxLines, parsed.TaxLines, tolerance));
 		diffs.Add(DiffPaymentMethod(fixture.Expected.PaymentMethod, parsed.PaymentMethod));
 		diffs.Add(DiffMinItemCount(fixture.Expected.MinItemCount, parsed.Items));

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -491,6 +491,102 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	[Fact]
+	public void ReconcileSubtotal_NoExtractedValue_ReturnsNoneConfidence()
+	{
+		FieldConfidence<decimal> result = OllamaReceiptExtractionService.ReconcileSubtotal(
+			extracted: null,
+			items: [MakeReceiptItem(1.00m)]);
+
+		result.IsPresent.Should().BeFalse();
+		result.Confidence.Should().Be(ConfidenceLevel.None);
+	}
+
+	[Fact]
+	public void ReconcileSubtotal_SubtotalMatchesItemSumExactly_ReturnsHighConfidence()
+	{
+		FieldConfidence<decimal> result = OllamaReceiptExtractionService.ReconcileSubtotal(
+			extracted: 6.00m,
+			items: [MakeReceiptItem(1.00m), MakeReceiptItem(2.00m), MakeReceiptItem(3.00m)]);
+
+		result.Confidence.Should().Be(ConfidenceLevel.High);
+		result.Value.Should().Be(6.00m);
+	}
+
+	[Fact]
+	public void ReconcileSubtotal_DeltaAtToleranceBoundary_ReturnsHighConfidence()
+	{
+		// Inclusive bound: delta exactly equal to tolerance ($0.05) is High confidence.
+		FieldConfidence<decimal> result = OllamaReceiptExtractionService.ReconcileSubtotal(
+			extracted: 10.05m,
+			items: [MakeReceiptItem(10.00m)]);
+
+		result.Confidence.Should().Be(ConfidenceLevel.High);
+	}
+
+	[Fact]
+	public void ReconcileSubtotal_DeltaExceedsTolerance_ReturnsLowConfidencePreservingValue()
+	{
+		// Walmart 2026-01-14 (RECEIPTS-663): subtotal=$69.68, items sum to $69.57, delta=$0.11.
+		FieldConfidence<decimal> result = OllamaReceiptExtractionService.ReconcileSubtotal(
+			extracted: 69.68m,
+			items:
+			[
+				MakeReceiptItem(30.00m),
+				MakeReceiptItem(25.57m),
+				MakeReceiptItem(14.00m),
+			]);
+
+		result.Confidence.Should().Be(ConfidenceLevel.Low);
+		result.Value.Should().Be(69.68m);
+	}
+
+	[Fact]
+	public void ReconcileSubtotal_NoItems_TreatsSumAsZero()
+	{
+		// Defensive: an empty items list shouldn't crash. Sum is 0, so non-zero subtotal
+		// disagrees and ends up Low confidence — exactly the "we missed every item" signal
+		// that motivates the cross-check (Option 1 in RECEIPTS-663).
+		FieldConfidence<decimal> result = OllamaReceiptExtractionService.ReconcileSubtotal(
+			extracted: 5.00m,
+			items: []);
+
+		result.Confidence.Should().Be(ConfidenceLevel.Low);
+		result.Value.Should().Be(5.00m);
+	}
+
+	[Fact]
+	public async Task ExtractAsync_SubtotalDisagreesWithItemSum_DowngradesConfidence()
+	{
+		// End-to-end: Walmart 2026-01-14 shape. Subtotal=$69.68, items sum to $69.57.
+		string innerJson = """
+			{
+			  "schema_version": 1,
+			  "store": { "name": "Walmart" },
+			  "items": [
+			    { "description": "ITEM A", "code": "A", "lineTotal": 30.00 },
+			    { "description": "ITEM B", "code": "B", "lineTotal": 25.57 },
+			    { "description": "ITEM C", "code": "C", "lineTotal": 14.00 }
+			  ],
+			  "subtotal": 69.68,
+			  "total": 70.43
+			}
+			""";
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
+
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
+
+		receipt.Subtotal.Confidence.Should().Be(ConfidenceLevel.Low);
+		receipt.Subtotal.Value.Should().Be(69.68m);
+	}
+
+	private static ParsedReceiptItem MakeReceiptItem(decimal totalPrice) =>
+		new(FieldConfidence<string?>.None(),
+			FieldConfidence<string>.High("X"),
+			FieldConfidence<decimal>.None(),
+			FieldConfidence<decimal>.None(),
+			FieldConfidence<decimal>.High(totalPrice));
+
+	[Fact]
 	public async Task ExtractAsync_PhantomHeaderWithWeightSubline_ProducesSingleItem()
 	{
 		// Arrange — full pipeline reproduction of the Walmart 2026-01-14 shape (RECEIPTS-662).
@@ -1053,7 +1149,8 @@ public class OllamaReceiptExtractionServiceTests
 			  "subtotal": "9.10",
 			  "total": "9.71",
 			  "items": [
-			    { "description": "MILK", "lineTotal": "3.49", "quantity": "1", "unitPrice": "3.49" }
+			    { "description": "MILK", "lineTotal": "3.49", "quantity": "1", "unitPrice": "3.49" },
+			    { "description": "BREAD", "lineTotal": "5.61", "quantity": "1", "unitPrice": "5.61" }
 			  ],
 			  "taxLines": [{ "label": "TAX1", "amount": "0.61" }]
 			}
@@ -1063,17 +1160,19 @@ public class OllamaReceiptExtractionServiceTests
 		// Act
 		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
 
-		// Assert — every numeric-as-string value parsed without loss
+		// Assert — every numeric-as-string value parsed without loss. Two items sum to the
+		// declared subtotal so RECEIPTS-663 reconciliation keeps confidence High.
 		receipt.Subtotal.Value.Should().Be(9.10m);
 		receipt.Subtotal.Confidence.Should().Be(ConfidenceLevel.High);
 		receipt.Total.Value.Should().Be(9.71m);
 		receipt.Total.Confidence.Should().Be(ConfidenceLevel.High);
 		receipt.TaxLines.Should().HaveCount(1);
 		receipt.TaxLines[0].Amount.Value.Should().Be(0.61m);
-		receipt.Items.Should().HaveCount(1);
+		receipt.Items.Should().HaveCount(2);
 		receipt.Items[0].TotalPrice.Value.Should().Be(3.49m);
 		receipt.Items[0].Quantity.Value.Should().Be(1m);
 		receipt.Items[0].UnitPrice.Value.Should().Be(3.49m);
+		receipt.Items[1].TotalPrice.Value.Should().Be(5.61m);
 	}
 
 	[Theory]

--- a/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
+++ b/tests/VlmEval.Tests/FixtureEvaluatorTests.cs
@@ -649,6 +649,87 @@ public class FixtureEvaluatorTests
 
 	#endregion
 
+	#region DiffSubtotalReconciliation
+
+	[Fact]
+	public void DiffSubtotalReconciliation_ExactMatch_ReturnsPass()
+	{
+		List<ParsedReceiptItem> items =
+		[
+			MakeItem("Apple", 1.00m),
+			MakeItem("Bread", 2.00m),
+			MakeItem("Cheese", 3.00m),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffSubtotalReconciliation(FieldConfidence<decimal>.High(6.00m), items);
+
+		diff.Field.Should().Be("subtotalReconciliation");
+		diff.Status.Should().Be(DiffStatus.Pass);
+		diff.Detail.Should().BeNull();
+	}
+
+	[Fact]
+	public void DiffSubtotalReconciliation_DeltaWithinDefaultTolerance_ReturnsPass()
+	{
+		List<ParsedReceiptItem> items = [MakeItem("Apple", 1.00m)];
+
+		// Default tolerance is $0.01 (inclusive). Delta of exactly $0.01 passes.
+		FieldDiff diff = FixtureEvaluator.DiffSubtotalReconciliation(FieldConfidence<decimal>.High(1.01m), items);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffSubtotalReconciliation_DeltaOverTolerance_ReturnsFail()
+	{
+		// Walmart 2026-01-14 (RECEIPTS-663): subtotal=$69.68, items sum to $69.57, delta=$0.11.
+		List<ParsedReceiptItem> items =
+		[
+			MakeItem("Item A", 30.00m),
+			MakeItem("Item B", 25.57m),
+			MakeItem("Item C", 14.00m),
+		];
+
+		FieldDiff diff = FixtureEvaluator.DiffSubtotalReconciliation(FieldConfidence<decimal>.High(69.68m), items, tolerance: 0.05m);
+
+		diff.Status.Should().Be(DiffStatus.Fail);
+		diff.Actual.Should().Contain("delta=0.11");
+		diff.Detail.Should().Contain("0.11");
+	}
+
+	[Fact]
+	public void DiffSubtotalReconciliation_DeltaAtCustomToleranceBoundary_ReturnsPass()
+	{
+		// Inclusive bound: delta == tolerance passes (RECEIPTS-634 convention).
+		List<ParsedReceiptItem> items = [MakeItem("Item", 10.00m)];
+
+		FieldDiff diff = FixtureEvaluator.DiffSubtotalReconciliation(FieldConfidence<decimal>.High(10.05m), items, tolerance: 0.05m);
+
+		diff.Status.Should().Be(DiffStatus.Pass);
+	}
+
+	[Fact]
+	public void DiffSubtotalReconciliation_NoSubtotal_ReturnsNotDeclared()
+	{
+		List<ParsedReceiptItem> items = [MakeItem("Apple", 1.00m)];
+
+		FieldDiff diff = FixtureEvaluator.DiffSubtotalReconciliation(FieldConfidence<decimal>.None(), items);
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+		diff.Detail.Should().Be("subtotal not extracted");
+	}
+
+	[Fact]
+	public void DiffSubtotalReconciliation_NoItems_ReturnsNotDeclared()
+	{
+		FieldDiff diff = FixtureEvaluator.DiffSubtotalReconciliation(FieldConfidence<decimal>.High(10.00m), []);
+
+		diff.Status.Should().Be(DiffStatus.NotDeclared);
+		diff.Detail.Should().Be("no item totals extracted");
+	}
+
+	#endregion
+
 	#region DiffItems
 
 	[Fact]


### PR DESCRIPTION
## Summary
- The VLM extracts `subtotal` independently of `sum(items[].totalPrice)`. On the Walmart 2026-01-14 fixture they disagreed by $0.10 — the wizard rendered both, breaking the user's mental balance check.
- Adds `ReconcileSubtotal` to `MapToParsedReceipt`: when `|subtotal − sum(items)| > $0.05`, preserve the extracted value but downgrade `subtotalConfidence` to `Low` so the wizard surfaces a review badge. Implements Option 1 from the issue (preserves the "did we miss a line item?" cross-check).
- Adds a `subtotalReconciliation` diff to the VlmEval regression suite that fails when the delta exceeds tolerance, catching the same class of regression at eval time.

Resolves RECEIPTS-663

## Test plan
- 6 new unit tests in `OllamaReceiptExtractionServiceTests` covering: no-extracted-value, exact match, boundary delta ($0.05 inclusive), Walmart shape (delta=$0.11 → Low), no items, end-to-end extraction.
- 6 new tests in `FixtureEvaluatorTests` for `DiffSubtotalReconciliation` (exact match, default/custom tolerance, fail case, boundary, missing inputs).
- Existing `ExtractAsync_NumbersAsStrings_ParsedAsDecimals` updated to keep its string-roundtrip intent while staying within reconciliation tolerance.
- All 106 `OllamaReceiptExtractionServiceTests` and 117 `VlmEval.Tests` pass.