### PR TITLE
fix(infra): tolerate richer Card.CardCode labels when matching VLM lastFour (RECEIPTS-667)

### DIFF
--- a/src/Infrastructure/Services/ProposedTransactionResolver.cs
+++ b/src/Infrastructure/Services/ProposedTransactionResolver.cs
@@ -2,6 +2,7 @@ using Application.Interfaces.Services;
 using Application.Models;
 using Application.Models.Ocr;
 using Domain.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.Services;
 
@@ -14,7 +15,9 @@ namespace Infrastructure.Services;
 /// Users with a different scheme will simply see no auto-match and fall through to the
 /// manual picker, which is the correct degenerate behaviour.
 /// </summary>
-public class ProposedTransactionResolver(ICardService cardService) : IProposedTransactionResolver
+public class ProposedTransactionResolver(
+	ICardService cardService,
+	ILogger<ProposedTransactionResolver> logger) : IProposedTransactionResolver
 {
 	public async Task<List<ProposedTransaction>> ResolveAsync(
 		IReadOnlyList<ParsedPayment> payments,
@@ -51,7 +54,7 @@ public class ProposedTransactionResolver(ICardService cardService) : IProposedTr
 		return result;
 	}
 
-	private static ProposedTransaction ResolveOne(
+	private ProposedTransaction ResolveOne(
 		ParsedPayment payment,
 		IReadOnlyList<Card> activeCards,
 		FieldConfidence<DateOnly?> dateForRow)
@@ -75,11 +78,25 @@ public class ProposedTransactionResolver(ICardService cardService) : IProposedTr
 				MethodSnapshot: methodSnapshot);
 		}
 
-		// Linear scan: cards-per-user is small. Case-insensitive compare so a card stored
-		// as "3409" still matches a VLM-extracted "3409", regardless of how the upstream
-		// canonicalises the string.
+		// Two-pass match (RECEIPTS-667). First try an exact case-insensitive compare so
+		// users with bare last-four CardCodes (e.g. "3409") still get the deterministic
+		// tie-break they used to. Then fall back to a "trailing four digits" comparison
+		// so users whose CardCode embeds the digits in a richer label (e.g. "MC-3409",
+		// "Mastercard ****3409", "Chase Visa 3409") still auto-match. The trailing-four
+		// extraction is also applied to <paramref name="lastFour"/> in case the VLM
+		// emits the four digits with surrounding noise.
 		List<Card> matches = [..
 			activeCards.Where(c => string.Equals(c.CardCode, lastFour, StringComparison.OrdinalIgnoreCase))];
+
+		if (matches.Count == 0)
+		{
+			string? lastFourDigits = ExtractTrailingFourDigits(lastFour);
+			if (!string.IsNullOrEmpty(lastFourDigits))
+			{
+				matches = [..
+					activeCards.Where(c => ExtractTrailingFourDigits(c.CardCode) == lastFourDigits)];
+			}
+		}
 
 		if (matches.Count == 1)
 		{
@@ -108,11 +125,34 @@ public class ProposedTransactionResolver(ICardService cardService) : IProposedTr
 
 		// No matches: this card last-four is new to the user. None confidence means the
 		// chip omits a badge entirely; the wizard simply requires manual selection.
+		// Logged at Information so dropped-prefill regressions are diagnosable without
+		// emitting card PII (only the four digits, which the user already saw on the
+		// receipt photo upload).
+		logger.LogInformation(
+			"No active Card matched VLM lastFour {LastFour} ({ActiveCardCount} active cards scanned)",
+			lastFour, activeCards.Count);
 		return new ProposedTransaction(
 			CardId: FieldConfidence<Guid?>.None(),
 			AccountId: FieldConfidence<Guid?>.None(),
 			Amount: amount,
 			Date: dateForRow,
 			MethodSnapshot: methodSnapshot);
+	}
+
+	/// <summary>
+	/// Extract the last four digits from <paramref name="raw"/>, skipping non-digit
+	/// characters. Returns null when the input has fewer than four digits. Used to
+	/// match a VLM-extracted last-four against a richer Card.CardCode label like
+	/// "MC-3409" or "Mastercard ****3409". See RECEIPTS-667.
+	/// </summary>
+	internal static string? ExtractTrailingFourDigits(string? raw)
+	{
+		if (string.IsNullOrWhiteSpace(raw))
+		{
+			return null;
+		}
+
+		string digits = new([.. raw.Where(char.IsAsciiDigit)]);
+		return digits.Length >= 4 ? digits[^4..] : null;
 	}
 }

--- a/tests/Infrastructure.Tests/Services/ProposedTransactionResolverTests.cs
+++ b/tests/Infrastructure.Tests/Services/ProposedTransactionResolverTests.cs
@@ -4,6 +4,7 @@ using Application.Models.Ocr;
 using Domain.Core;
 using FluentAssertions;
 using Infrastructure.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace Infrastructure.Tests.Services;
@@ -23,7 +24,9 @@ public class ProposedTransactionResolverTests
 
 	public ProposedTransactionResolverTests()
 	{
-		_resolver = new ProposedTransactionResolver(_cardService.Object);
+		_resolver = new ProposedTransactionResolver(
+			_cardService.Object,
+			NullLogger<ProposedTransactionResolver>.Instance);
 	}
 
 	private void StubActiveCards(params Card[] cards)
@@ -356,5 +359,131 @@ public class ProposedTransactionResolverTests
 
 		// Assert
 		await act.Should().ThrowAsync<ArgumentNullException>();
+	}
+
+	[Fact]
+	public async Task ResolveAsync_CardCodeEmbedsLastFour_TrailingDigitFallbackMatches()
+	{
+		// Arrange — RECEIPTS-667: user's CardCode embeds the last four in a richer label
+		// (e.g. "MC-3409" or "Mastercard ****3409"). Exact compare misses; the digit-only
+		// fallback should still find the unambiguous match.
+		Card card = new(VisaCardId, "MC-3409", "MasterCard", VisaAccountId);
+		StubActiveCards(card);
+
+		List<ParsedPayment> payments =
+		[
+			new ParsedPayment(
+				FieldConfidence<string?>.High("MASTERCARD"),
+				FieldConfidence<decimal?>.High(70.43m),
+				FieldConfidence<string?>.High("3409")),
+		];
+
+		// Act
+		List<ProposedTransaction> result = await _resolver.ResolveAsync(
+			payments, ReceiptDateField, CancellationToken.None);
+
+		// Assert
+		result.Should().HaveCount(1);
+		result[0].CardId.Value.Should().Be(VisaCardId);
+		result[0].AccountId.Value.Should().Be(VisaAccountId);
+	}
+
+	[Fact]
+	public async Task ResolveAsync_CardCodeWithSpacesAndAsterisks_TrailingDigitFallbackMatches()
+	{
+		// Arrange — common format: "Mastercard ****3409" with spaces and asterisks
+		// in the user-facing label. Trailing-digit extraction strips them all.
+		Card card = new(VisaCardId, "Mastercard ****3409", "Primary MC", VisaAccountId);
+		StubActiveCards(card);
+
+		List<ParsedPayment> payments =
+		[
+			new ParsedPayment(
+				FieldConfidence<string?>.High("MASTERCARD"),
+				FieldConfidence<decimal?>.High(70.43m),
+				FieldConfidence<string?>.High("3409")),
+		];
+
+		// Act
+		List<ProposedTransaction> result = await _resolver.ResolveAsync(
+			payments, ReceiptDateField, CancellationToken.None);
+
+		// Assert
+		result[0].CardId.Value.Should().Be(VisaCardId);
+	}
+
+	[Fact]
+	public async Task ResolveAsync_ExactMatchWinsOverTrailingDigitMatch()
+	{
+		// Arrange — when both an exact-match Card and a richer-label Card share the
+		// same trailing four digits, the exact-match Card should win (preserving the
+		// pre-RECEIPTS-667 deterministic resolution). The fallback only fires when
+		// the first pass returns zero matches.
+		Card exactCard = new(VisaCardId, "3409", "Bare last-four", VisaAccountId);
+		Card richCard = new(AmexCardId, "MC-3409", "Rich label", AmexAccountId);
+		StubActiveCards(exactCard, richCard);
+
+		List<ParsedPayment> payments =
+		[
+			new ParsedPayment(
+				FieldConfidence<string?>.High("VISA"),
+				FieldConfidence<decimal?>.High(50m),
+				FieldConfidence<string?>.High("3409")),
+		];
+
+		// Act
+		List<ProposedTransaction> result = await _resolver.ResolveAsync(
+			payments, ReceiptDateField, CancellationToken.None);
+
+		// Assert — exact match wins; rich-label card not even considered
+		result[0].CardId.Value.Should().Be(VisaCardId);
+		result[0].AccountId.Value.Should().Be(VisaAccountId);
+	}
+
+	[Fact]
+	public async Task ResolveAsync_TwoCardsBothEmbedSameLastFour_AmbiguousLowConfidence()
+	{
+		// Arrange — two Cards both have the same trailing four digits embedded but
+		// neither matches exactly. The fallback finds two and surfaces ambiguous.
+		Card card1 = new(VisaCardId, "MC-3409", "MasterCard", VisaAccountId);
+		Card card2 = new(AmexCardId, "Visa-3409", "Visa", AmexAccountId);
+		StubActiveCards(card1, card2);
+
+		List<ParsedPayment> payments =
+		[
+			new ParsedPayment(
+				FieldConfidence<string?>.High("CARD"),
+				FieldConfidence<decimal?>.High(50m),
+				FieldConfidence<string?>.High("3409")),
+		];
+
+		// Act
+		List<ProposedTransaction> result = await _resolver.ResolveAsync(
+			payments, ReceiptDateField, CancellationToken.None);
+
+		// Assert — ambiguous: Low confidence on both cardId and accountId
+		result[0].CardId.Confidence.Should().Be(ConfidenceLevel.Low);
+		result[0].CardId.Value.Should().BeNull();
+		result[0].AccountId.Confidence.Should().Be(ConfidenceLevel.Low);
+	}
+
+	[Theory]
+	[InlineData("3409", "3409")]
+	[InlineData("MC-3409", "3409")]
+	[InlineData("Mastercard ****3409", "3409")]
+	[InlineData("Chase Visa 3409", "3409")]
+	[InlineData("12345", "2345")] // takes the trailing four digits, not the leading
+	[InlineData("abc", null)] // fewer than four digits
+	[InlineData("1", null)]
+	[InlineData("", null)]
+	[InlineData(null, null)]
+	[InlineData("   ", null)]
+	public void ExtractTrailingFourDigits_HandlesVariousFormats(string? input, string? expected)
+	{
+		// Arrange/Act
+		string? result = ProposedTransactionResolver.ExtractTrailingFourDigits(input);
+
+		// Assert
+		result.Should().Be(expected);
 	}
 }


### PR DESCRIPTION
## Summary
- The single-pass exact case-insensitive compare in `ProposedTransactionResolver` only matched when `Card.CardCode` equaled the VLM-extracted `lastFour` exactly (e.g. CardCode = "3409"). Users whose CardCode embeds the digits in a richer label (`"MC-3409"`, `"Mastercard ****3409"`, `"Chase Visa 3409"`) saw the wizard land with empty Card/Account dropdowns on every scan.
- Adds a digit-only fallback: extract the trailing four digits from both sides and compare. Exact case-insensitive match still runs first so existing bare-last-four CardCodes win deterministically when both shapes coexist.
- Adds `ILogger` injection and emits a single `Information` log when no card matches a non-null lastFour, so future drop-prefill regressions are diagnosable from telemetry without needing card PII (only the four digits, which the user already saw on the receipt photo upload).

Resolves RECEIPTS-667

## Test plan
- 11 new tests in `ProposedTransactionResolverTests`:
  - Trailing-digit fallback matches `"MC-3409"`, `"Mastercard ****3409"`
  - Exact match wins when both an exact-match Card and a richer-label Card share the same trailing four
  - Two-richer-label Cards with the same trailing four → ambiguous Low confidence (unchanged behavior)
  - `ExtractTrailingFourDigits` theory: bare digits, mixed strings, fewer-than-four, null/empty
- All 26 `ProposedTransactionResolverTests` pass.
- All existing exact-match cases still pass (no regression).