### PR TITLE
fix(infra): inherit identity for orphan weight-subline (RECEIPTS-668)

### DIFF
--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -433,15 +433,20 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 	/// <summary>
 	/// True when an orphan weight sub-line should inherit its product identity from the
 	/// previously merged item. Requires the prior to be a real weighted product (has a
-	/// code, description, positive quantity, positive unit price) and the orphan to carry
-	/// a matching unit price — same product sold by weight at the same price-per-unit.
+	/// code, description, fractional positive quantity, positive unit price) and the
+	/// orphan to carry a matching unit price — same product sold by weight at the same
+	/// price-per-unit. The fractional-quantity guard distinguishes weighted produce
+	/// (e.g. 2.46 lb of bananas) from multi-quantity multipack items
+	/// (e.g. 6 cans of soda) whose unit price could coincidentally match the orphan's.
 	/// See RECEIPTS-668.
 	/// </summary>
 	private static bool CanInheritFromPriorWeighted(VlmReceiptItem prior, VlmReceiptItem subline)
 	{
 		return !string.IsNullOrWhiteSpace(prior.Code)
 			&& !string.IsNullOrWhiteSpace(prior.Description)
-			&& prior.Quantity is > 0
+			&& prior.Quantity is { } qty
+			&& qty > 0
+			&& qty != Math.Floor(qty)
 			&& prior.UnitPrice is > 0
 			&& subline.UnitPrice == prior.UnitPrice;
 	}

--- a/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
+++ b/src/Infrastructure/Services/OllamaReceiptExtractionService.cs
@@ -384,6 +384,30 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 					}
 					continue;
 				}
+
+				// RECEIPTS-668: orphan weight-subline. The VLM sometimes emits the parent
+				// header for the first instance of a weighted product but drops it for
+				// subsequent same-product bunches, leaving a sub-line whose previous merged
+				// neighbour is the *first* bunch (fully populated) rather than a matching
+				// parent. When the prior merged item is itself a weighted product carrying
+				// the same unit price, synthesize a sibling line that inherits the prior's
+				// code/description so the wizard renders "BANANAS" rather than the raw
+				// "2.720 lb. @ 1 lb. /0.50" string.
+				if (CanInheritFromPriorWeighted(parent, item))
+				{
+					merged.Add(new VlmReceiptItem
+					{
+						Description = parent.Description,
+						Code = parent.Code,
+						LineTotal = item.LineTotal,
+						Quantity = item.Quantity,
+						UnitPrice = item.UnitPrice,
+						TaxCode = !string.IsNullOrWhiteSpace(item.TaxCode)
+							? item.TaxCode
+							: parent.TaxCode,
+					});
+					continue;
+				}
 			}
 			merged.Add(item);
 		}
@@ -404,6 +428,22 @@ public sealed partial class OllamaReceiptExtractionService : IReceiptExtractionS
 		return item.LineTotal is null or 0m
 			&& item.Quantity is null or 0m
 			&& item.UnitPrice is null or 0m;
+	}
+
+	/// <summary>
+	/// True when an orphan weight sub-line should inherit its product identity from the
+	/// previously merged item. Requires the prior to be a real weighted product (has a
+	/// code, description, positive quantity, positive unit price) and the orphan to carry
+	/// a matching unit price — same product sold by weight at the same price-per-unit.
+	/// See RECEIPTS-668.
+	/// </summary>
+	private static bool CanInheritFromPriorWeighted(VlmReceiptItem prior, VlmReceiptItem subline)
+	{
+		return !string.IsNullOrWhiteSpace(prior.Code)
+			&& !string.IsNullOrWhiteSpace(prior.Description)
+			&& prior.Quantity is > 0
+			&& prior.UnitPrice is > 0
+			&& subline.UnitPrice == prior.UnitPrice;
 	}
 
 	/// <summary>

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -491,6 +491,131 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	[Fact]
+	public void MergeWeightSublines_OrphanSublineInheritsPriorWeightedIdentity()
+	{
+		// Arrange — RECEIPTS-668: real Walmart 2026-01-14 shape. Two BANANAS bunches at
+		// the same $0.50/lb. The VLM merged the first (parent+subline → one row) but
+		// emitted only the sub-line for the second bunch. The orphan sub-line should
+		// inherit "BANANAS" identity from the prior merged item.
+		List<VlmReceiptItem> items =
+		[
+			new() { Description = "BANANAS", Code = "0000000401100", LineTotal = 1.23m, Quantity = 2.46m, UnitPrice = 0.50m, TaxCode = "N" },
+			new() { Description = "2.720 lb. @ 1 lb. /0.50", Code = null, LineTotal = 1.36m, Quantity = 2.72m, UnitPrice = 0.50m, TaxCode = "N" },
+		];
+
+		// Act
+		List<VlmReceiptItem> merged = OllamaReceiptExtractionService.MergeWeightSublines(items);
+
+		// Assert — both rows render as BANANAS with their own weights; first row untouched
+		merged.Should().HaveCount(2);
+		merged[0].Description.Should().Be("BANANAS");
+		merged[0].Code.Should().Be("0000000401100");
+		merged[0].Quantity.Should().Be(2.46m);
+		merged[0].LineTotal.Should().Be(1.23m);
+		merged[1].Description.Should().Be("BANANAS");
+		merged[1].Code.Should().Be("0000000401100");
+		merged[1].Quantity.Should().Be(2.72m);
+		merged[1].UnitPrice.Should().Be(0.50m);
+		merged[1].LineTotal.Should().Be(1.36m);
+		merged[1].TaxCode.Should().Be("N");
+	}
+
+	[Fact]
+	public void MergeWeightSublines_OrphanSublineDifferentUnitPrice_PreservedAsIs()
+	{
+		// Arrange — defensive: if the orphan sub-line's unitPrice differs from the prior
+		// merged item, they're not the same product. Don't inherit identity; preserve
+		// the orphan as a separate item rather than mislabeling it.
+		List<VlmReceiptItem> items =
+		[
+			new() { Description = "BANANAS", Code = "0000000401100", LineTotal = 1.23m, Quantity = 2.46m, UnitPrice = 0.50m, TaxCode = "N" },
+			new() { Description = "1.500 lb. @ 1 lb. /1.99", Code = null, LineTotal = 2.99m, Quantity = 1.50m, UnitPrice = 1.99m, TaxCode = "N" },
+		];
+
+		// Act
+		List<VlmReceiptItem> merged = OllamaReceiptExtractionService.MergeWeightSublines(items);
+
+		// Assert — orphan kept as-is, no identity inherited
+		merged.Should().HaveCount(2);
+		merged[1].Description.Should().Be("1.500 lb. @ 1 lb. /1.99");
+		merged[1].Code.Should().BeNull();
+	}
+
+	[Fact]
+	public void MergeWeightSublines_OrphanSublinePriorNotWeighted_PreservedAsIs()
+	{
+		// Arrange — defensive: prior merged item is a flat-priced item (qty=null,
+		// unitPrice=null, only lineTotal). Don't inherit identity from it; the prior
+		// is not a weighted product so the orphan can't be a sibling bunch.
+		List<VlmReceiptItem> items =
+		[
+			new() { Description = "BREAD", Code = "0072250049190", LineTotal = 3.76m, Quantity = null, UnitPrice = null, TaxCode = "F" },
+			new() { Description = "2.720 lb. @ 1 lb. /0.50", Code = null, LineTotal = 1.36m, Quantity = 2.72m, UnitPrice = 0.50m, TaxCode = "N" },
+		];
+
+		// Act
+		List<VlmReceiptItem> merged = OllamaReceiptExtractionService.MergeWeightSublines(items);
+
+		// Assert — orphan preserved; BREAD untouched
+		merged.Should().HaveCount(2);
+		merged[0].Description.Should().Be("BREAD");
+		merged[1].Description.Should().Be("2.720 lb. @ 1 lb. /0.50");
+		merged[1].Code.Should().BeNull();
+	}
+
+	[Fact]
+	public void MergeWeightSublines_OrphanSublinePriorMissingCode_PreservedAsIs()
+	{
+		// Arrange — defensive: prior weighted item has no code (e.g. unknown PLU). The
+		// inheritance is conservative: without a code we don't propagate identity.
+		List<VlmReceiptItem> items =
+		[
+			new() { Description = "BANANAS", Code = null, LineTotal = 1.23m, Quantity = 2.46m, UnitPrice = 0.50m, TaxCode = "N" },
+			new() { Description = "2.720 lb. @ 1 lb. /0.50", Code = null, LineTotal = 1.36m, Quantity = 2.72m, UnitPrice = 0.50m, TaxCode = "N" },
+		];
+
+		// Act
+		List<VlmReceiptItem> merged = OllamaReceiptExtractionService.MergeWeightSublines(items);
+
+		// Assert — orphan preserved
+		merged.Should().HaveCount(2);
+		merged[1].Description.Should().Be("2.720 lb. @ 1 lb. /0.50");
+	}
+
+	[Fact]
+	public async Task ExtractAsync_OrphanWeightSubline_RendersBothBunchesAsBananas()
+	{
+		// Arrange — full-pipeline reproduction of the Walmart 2026-01-14 shape (RECEIPTS-668).
+		string innerJson = """
+			{
+			  "schema_version": 1,
+			  "store": { "name": "Walmart" },
+			  "items": [
+			    { "description": "BANANAS", "code": "0000000401100", "lineTotal": 1.23,
+			      "quantity": 2.46, "unitPrice": 0.50, "taxCode": "N" },
+			    { "description": "2.720 lb. @ 1 lb. /0.50", "code": null, "lineTotal": 1.36,
+			      "quantity": 2.72, "unitPrice": 0.50, "taxCode": "N" }
+			  ],
+			  "subtotal": 2.59,
+			  "total": 2.59
+			}
+			""";
+		OllamaReceiptExtractionService service = CreateService(CreateHandler(WrapInOllamaEnvelope(innerJson)));
+
+		// Act
+		ParsedReceipt receipt = await service.ExtractAsync(FakeImage, CancellationToken.None);
+
+		// Assert — both bunches render as BANANAS; orphan sub-line description is gone
+		receipt.Items.Should().HaveCount(2);
+		receipt.Items[0].Description.Value.Should().Be("BANANAS");
+		receipt.Items[0].Quantity.Value.Should().Be(2.46m);
+		receipt.Items[1].Description.Value.Should().Be("BANANAS");
+		receipt.Items[1].Code.Value.Should().Be("0000000401100");
+		receipt.Items[1].Quantity.Value.Should().Be(2.72m);
+		receipt.Items[1].TotalPrice.Value.Should().Be(1.36m);
+	}
+
+	[Fact]
 	public void ReconcileSubtotal_NoExtractedValue_ReturnsNoneConfidence()
 	{
 		FieldConfidence<decimal> result = OllamaReceiptExtractionService.ReconcileSubtotal(

--- a/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/OllamaReceiptExtractionServiceTests.cs
@@ -564,6 +564,28 @@ public class OllamaReceiptExtractionServiceTests
 	}
 
 	[Fact]
+	public void MergeWeightSublines_OrphanSublinePriorMultiQuantityIntegerCount_PreservedAsIs()
+	{
+		// Arrange — defensive: prior is a multi-quantity multipack (e.g. 6-pack of soda)
+		// whose per-unit price coincidentally equals the orphan sub-line's per-pound rate.
+		// Without the fractional-quantity guard, the orphan would be mislabeled as SPRITE.
+		List<VlmReceiptItem> items =
+		[
+			new() { Description = "SPRITE", Code = "0012345000010", LineTotal = 4.98m, Quantity = 6m, UnitPrice = 0.83m, TaxCode = "X" },
+			new() { Description = "0.500 lb. @ 1 lb. /0.83", Code = null, LineTotal = 0.42m, Quantity = 0.5m, UnitPrice = 0.83m, TaxCode = "N" },
+		];
+
+		// Act
+		List<VlmReceiptItem> merged = OllamaReceiptExtractionService.MergeWeightSublines(items);
+
+		// Assert — orphan preserved, NOT mislabeled as SPRITE
+		merged.Should().HaveCount(2);
+		merged[0].Description.Should().Be("SPRITE");
+		merged[1].Description.Should().Be("0.500 lb. @ 1 lb. /0.83");
+		merged[1].Code.Should().BeNull();
+	}
+
+	[Fact]
 	public void MergeWeightSublines_OrphanSublinePriorMissingCode_PreservedAsIs()
 	{
 		// Arrange — defensive: prior weighted item has no code (e.g. unknown PLU). The


### PR DESCRIPTION
## Summary
- The VLM sometimes emits the parent header for the first bunch of a weighted product (e.g. BANANAS) but drops it for subsequent bunches, leaving an orphan sub-line whose previous neighbour is the *first* bunch (already populated), not a matching parent. Confirmed against the Walmart 2026-01-14 payload.
- Existing case-(a) exact-`LineTotal` merge and case-(b) phantom-parent merge both miss this shape, so the wizard rendered raw `"2.720 lb. @ 1 lb. /0.50"` as a separate line.
- Adds a third merge case: when the prior merged item is itself a weighted product (has code, description, qty > 0, unit price > 0) and the orphan shares the same unit price, synthesize a sibling line inheriting the prior's code/description. Same-unit-price is the heuristic — same product sold by weight at the same price-per-unit.
- Falls back to preserving the orphan as-is when prior isn't weighted, lacks a code, or has a different unit price.

Resolves RECEIPTS-668

## Test plan
- 5 new tests in `OllamaReceiptExtractionServiceTests`:
  - `MergeWeightSublines_OrphanSublineInheritsPriorWeightedIdentity` — Walmart 2026-01-14 shape
  - `MergeWeightSublines_OrphanSublineDifferentUnitPrice_PreservedAsIs` — different product
  - `MergeWeightSublines_OrphanSublinePriorNotWeighted_PreservedAsIs` — flat-priced prior
  - `MergeWeightSublines_OrphanSublinePriorMissingCode_PreservedAsIs` — null code
  - `ExtractAsync_OrphanWeightSubline_RendersBothBunchesAsBananas` — full pipeline
- All 111 `OllamaReceiptExtractionService` tests pass.
- Existing parent+subline and phantom-parent cases unchanged.