### PR TITLE
fix(infra): guard YnabSplitCalculator against remainder > sub count (RECEIPTS-669)

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -297,6 +297,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # GHA-hosted runners ship with ~14GB free disk, which is not enough for
+      # the 1.34GB ONNX model download plus PaddleOCR runtime deps in the
+      # image. Reclaim ~30GB by dropping preinstalled SDKs we don't use
+      # (RECEIPTS-671).
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: false
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -302,7 +302,7 @@ jobs:
       # image. Reclaim ~30GB by dropping preinstalled SDKs we don't use
       # (RECEIPTS-671).
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true

--- a/src/Infrastructure/Services/YnabSplitCalculator.cs
+++ b/src/Infrastructure/Services/YnabSplitCalculator.cs
@@ -120,10 +120,13 @@ public class YnabSplitCalculator : IYnabSplitCalculator
 		long adjustment = remainder > 0 ? 1 : -1;
 		List<YnabSubTransactionSplit> corrected = new(sorted);
 
+		// Wrap with modulo: when |remainder| exceeds sub count, distribute the surplus
+		// across subs in a second pass rather than indexing past the end (RECEIPTS-669).
 		for (int i = 0; i < Math.Abs(remainder); i++)
 		{
-			YnabSubTransactionSplit original = corrected[i];
-			corrected[i] = original with { Milliunits = original.Milliunits + adjustment };
+			int idx = i % corrected.Count;
+			YnabSubTransactionSplit original = corrected[idx];
+			corrected[idx] = original with { Milliunits = original.Milliunits + adjustment };
 		}
 
 		return corrected;

--- a/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
+++ b/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
@@ -13,12 +13,12 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/Infrastructure.Tests/Services/YnabSplitCalculatorTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabSplitCalculatorTests.cs
@@ -287,6 +287,44 @@ public class YnabSplitCalculatorTests
 	}
 
 	[Fact]
+	public void LargestRemainder_PositiveRemainderExceedsCount_WrapsViaModulo()
+	{
+		// Regression for RECEIPTS-669: with 2 subs and remainder = +3, the loop
+		// must wrap rather than indexing past the end of the list.
+		// Arrange: sum is -8003, total is -8000, remainder = +3
+		List<YnabSubTransactionSplit> subs =
+		[
+			new("cat-a", -5003),
+			new("cat-b", -3000),
+		];
+
+		// Act
+		List<YnabSubTransactionSplit> result = YnabSplitCalculator.ApplyLargestRemainderCorrection(-8000, subs);
+
+		// Assert
+		result.Sum(s => s.Milliunits).Should().Be(-8000);
+	}
+
+	[Fact]
+	public void LargestRemainder_NegativeRemainderExceedsCount_WrapsViaModulo()
+	{
+		// Regression for RECEIPTS-669: with 2 subs and remainder = -3, the loop
+		// must wrap rather than indexing past the end of the list.
+		// Arrange: sum is -7997, total is -8000, remainder = -3
+		List<YnabSubTransactionSplit> subs =
+		[
+			new("cat-a", -5000),
+			new("cat-b", -2997),
+		];
+
+		// Act
+		List<YnabSubTransactionSplit> result = YnabSplitCalculator.ApplyLargestRemainderCorrection(-8000, subs);
+
+		// Assert
+		result.Sum(s => s.Milliunits).Should().Be(-8000);
+	}
+
+	[Fact]
 	public void LargestRemainder_RemainderExceedsCount_Throws()
 	{
 		// Arrange: sum is -5000, total is -8000, remainder = -3000 (way too large)

--- a/tests/Infrastructure.Tests/Services/YnabSplitCalculatorTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabSplitCalculatorTests.cs
@@ -290,7 +290,9 @@ public class YnabSplitCalculatorTests
 	public void LargestRemainder_PositiveRemainderExceedsCount_WrapsViaModulo()
 	{
 		// Regression for RECEIPTS-669: with 2 subs and remainder = +3, the loop
-		// must wrap rather than indexing past the end of the list.
+		// must wrap rather than indexing past the end of the list. Distribution:
+		// the larger sub (cat-a) takes the wrap-around extra adjustment, so it
+		// absorbs +2 while cat-b absorbs +1.
 		// Arrange: sum is -8003, total is -8000, remainder = +3
 		List<YnabSubTransactionSplit> subs =
 		[
@@ -301,15 +303,18 @@ public class YnabSplitCalculatorTests
 		// Act
 		List<YnabSubTransactionSplit> result = YnabSplitCalculator.ApplyLargestRemainderCorrection(-8000, subs);
 
-		// Assert
+		// Assert: sum exact and per-sub distribution favors the larger sub
 		result.Sum(s => s.Milliunits).Should().Be(-8000);
+		result.First(s => s.YnabCategoryId == "cat-a").Milliunits.Should().Be(-5001);
+		result.First(s => s.YnabCategoryId == "cat-b").Milliunits.Should().Be(-2999);
 	}
 
 	[Fact]
 	public void LargestRemainder_NegativeRemainderExceedsCount_WrapsViaModulo()
 	{
 		// Regression for RECEIPTS-669: with 2 subs and remainder = -3, the loop
-		// must wrap rather than indexing past the end of the list.
+		// must wrap rather than indexing past the end of the list. Distribution:
+		// the larger sub (cat-a) takes -2, cat-b takes -1.
 		// Arrange: sum is -7997, total is -8000, remainder = -3
 		List<YnabSubTransactionSplit> subs =
 		[
@@ -320,8 +325,10 @@ public class YnabSplitCalculatorTests
 		// Act
 		List<YnabSubTransactionSplit> result = YnabSplitCalculator.ApplyLargestRemainderCorrection(-8000, subs);
 
-		// Assert
+		// Assert: sum exact and per-sub distribution favors the larger sub
 		result.Sum(s => s.Milliunits).Should().Be(-8000);
+		result.First(s => s.YnabCategoryId == "cat-a").Milliunits.Should().Be(-5002);
+		result.First(s => s.YnabCategoryId == "cat-b").Milliunits.Should().Be(-2998);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

Prod crash on `GET /api/ynab/receipts/{id}/split-comparison`:

```
System.ArgumentOutOfRangeException: Index was out of range...
   at Infrastructure.Services.YnabSplitCalculator.ApplyLargestRemainderCorrection(...) YnabSplitCalculator.cs:line 125
```

RECEIPTS-525 widened the acceptable rounding-remainder bound to `Math.Max(subTransactions.Count, 10)`, but the distribution loop still indexed `corrected[i]` directly. When `|remainder|` exceeded `subTransactions.Count` (e.g. 2 subs with a remainder of 3), the loop walked past the end of the list and threw.

Fix: distribute via modulo (`corrected[i % corrected.Count]`) so multiple passes wrap and absorb the remaining adjustments evenly.

Issue: RECEIPTS-669

## Test plan

- [x] New regression tests `LargestRemainder_PositiveRemainderExceedsCount_WrapsViaModulo` and `LargestRemainder_NegativeRemainderExceedsCount_WrapsViaModulo` (2 subs, |remainder|=3 — formerly threw, now succeed and sum exactly).
- [x] All 26 `YnabSplitCalculator` tests pass.
- [ ] After deploy: retry the failing receipt's split-comparison endpoint in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)