### PR TITLE
fix(ci): ignore autorelease: tagged label on conventional-commits check (RECEIPTS-603)

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -73,6 +73,7 @@ jobs:
             Example: "feat(api): add pagination support"
           ignoreLabels: |
             autorelease: pending
+            autorelease: tagged
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

After release-please auto-merges its Release PR, GitHub flips the label from `autorelease: pending` to `autorelease: tagged` and re-runs PR checks. The Conventional Commits action only ignored `autorelease: pending`, so the post-merge re-run validated `chore(main): release X.Y.Z` against our scope list and failed (`main` is not a permitted scope), producing a spurious red check on every release.

Add `autorelease: tagged` to `ignoreLabels`. Regular PRs (which carry neither label) continue to be validated.

Resolves RECEIPTS-603

## Test plan

- [x] Workflow YAML parses (push triggered a CI run; the pr-title job will still pass on this PR since the labels in question only appear on release-please PRs).
- [ ] After next release-please auto-merge: the post-merge re-run of Conventional Commits skips on the `autorelease: tagged` label rather than failing on the `main` scope.
- [x] Regular PRs (no autorelease label) still get the title check enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)