### PR TITLE
chore(infra): explicit MidpointRounding on money sites (RECEIPTS-672)

### DIFF
--- a/src/Domain/Money.cs
+++ b/src/Domain/Money.cs
@@ -25,6 +25,7 @@ public record Money(decimal Amount, Currency Currency)
 
 	public static Money operator /(Money a, Money b)
 	{
-		return new Money(Math.Round(a.Amount / b.Amount, 2), a.Currency);
+		// Half-up to match the cash-register convention used for line-item totals (RECEIPTS-670).
+		return new Money(Math.Round(a.Amount / b.Amount, 2, MidpointRounding.AwayFromZero), a.Currency);
 	}
 }

--- a/src/Infrastructure/Services/DashboardService.cs
+++ b/src/Infrastructure/Services/DashboardService.cs
@@ -31,7 +31,7 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 			.Where(t => receiptIds.Contains(t.ReceiptId))
 			.SumAsync(t => t.Amount, cancellationToken);
 
-		decimal averageTripAmount = totalReceipts > 0 ? Math.Round(totalSpent / totalReceipts, 2) : 0;
+		decimal averageTripAmount = totalReceipts > 0 ? Math.Round(totalSpent / totalReceipts, 2, MidpointRounding.AwayFromZero) : 0;
 
 		// Most-used account = account with the most transactions in range
 		// Single query: EF Core translates Account!.Name to a SQL JOIN, eliminating a second round-trip.
@@ -163,7 +163,7 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 			.Select(c => new SpendingCategoryItemResult(
 				c.Category,
 				c.Amount,
-				total > 0 ? Math.Round(c.Amount / total * 100, 2) : 0))
+				total > 0 ? Math.Round(c.Amount / total * 100, 2, MidpointRounding.AwayFromZero) : 0))
 			.ToList();
 
 		return new SpendingByCategoryResult(items);
@@ -203,7 +203,7 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 				a.AccountId,
 				accountNames.GetValueOrDefault(a.AccountId, "Unknown"),
 				a.Amount,
-				total > 0 ? Math.Round(a.Amount / total * 100, 2) : 0))
+				total > 0 ? Math.Round(a.Amount / total * 100, 2, MidpointRounding.AwayFromZero) : 0))
 			.ToList();
 
 		return new SpendingByAccountResult(items);
@@ -236,7 +236,7 @@ public class DashboardService(IDbContextFactory<ApplicationDbContext> contextFac
 			{
 				int visitCount = g.Count();
 				decimal totalAmount = g.Sum(r => r.TransactionTotal);
-				decimal averagePerVisit = visitCount > 0 ? Math.Round(totalAmount / visitCount, 2) : 0;
+				decimal averagePerVisit = visitCount > 0 ? Math.Round(totalAmount / visitCount, 2, MidpointRounding.AwayFromZero) : 0;
 				return new SpendingByStoreItemResult(g.Key, visitCount, totalAmount, averagePerVisit);
 			})
 			.OrderByDescending(i => i.TotalAmount)

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -141,7 +141,7 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 				x.Location,
 				x.Visits,
 				x.Total,
-				x.Visits > 0 ? Math.Round(x.Total / x.Visits, 2) : 0m))
+				x.Visits > 0 ? Math.Round(x.Total / x.Visits, 2, MidpointRounding.AwayFromZero) : 0m))
 			.ToList();
 
 		return new SpendingByLocationResult(pagedItems, totalCount, grandTotal);

--- a/tests/Domain.Tests/MoneyTests.cs
+++ b/tests/Domain.Tests/MoneyTests.cs
@@ -83,4 +83,15 @@ public class MoneyTests
 		Money result = money1 / money2;
 		Assert.Equal(new Money(100.50m), result);
 	}
+
+	[Fact]
+	public void Money_Division_RoundsHalfAwayFromZero()
+	{
+		// Regression for RECEIPTS-672: division should round half-up to match
+		// the cash-register convention adopted in RECEIPTS-670, not banker's
+		// rounding (which is what Math.Round(x, 2) defaults to).
+		// 1.005 / 1 = 1.005 → half-up = 1.01, banker's = 1.00.
+		Money result = new Money(1.005m) / new Money(1m);
+		Assert.Equal(new Money(1.01m), result);
+	}
 }


### PR DESCRIPTION
## Summary

Follow-up from the RECEIPTS-670 review. Six 2-arg `Math.Round` call sites silently defaulted to `MidpointRounding.ToEven` (banker's rounding). For money-shaped values, this disagreed with the cash-register convention RECEIPTS-670 standardized on for line items.

Make every 2-decimal Round site explicit and align all monetary call sites to `MidpointRounding.AwayFromZero`:

- `src/Domain/Money.cs` — division operator (covered by a new regression test).
- `src/Infrastructure/Services/DashboardService.cs` — average trip amount, category percentage, account percentage, average per visit.
- `src/Infrastructure/Services/ReportService.cs` — average per visit (the Plane issue missed this one; folded in for consistency).

Resolves RECEIPTS-672

## Test plan

- [x] `Money_Division_RoundsHalfAwayFromZero`: `1.005 / 1.00 = 1.01` (banker's would produce `1.00`).
- [x] Existing `Domain.Tests` filtered to `Money`: 11 pass.
- [x] `Infrastructure.Tests` filtered to `DashboardService`: 14 pass (no expectations were tied to the prior rounding mode).
- [x] `Application.Tests` Dashboard + SpendingByLocation: 23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)