### PR TITLE
fix(ci): bump GitHub Actions to Node 24 majors (RECEIPTS-673)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,16 +34,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
       #                <image>:sha-<sha>-<arch>, <image>:latest-<arch>
       - name: Extract metadata (platform-specific tags)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Each tag pattern gets the arch suffix appended so tags are unique per platform.
@@ -70,7 +70,7 @@ jobs:
       # The existing GHA cache strategy is preserved per-platform.
       - name: Build and push platform-specific image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -101,20 +101,20 @@ jobs:
 
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Generate the final (arch-neutral) tags that consumers pull.
       # These are the same tags the old workflow published.
       - name: Extract metadata (final manifest tags)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -167,7 +167,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -86,15 +86,15 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
@@ -153,10 +153,10 @@ jobs:
         shard: [1, 2]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-test-shard-${{ matrix.shard }}
           path: src/client/.vitest-reports
@@ -194,10 +194,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -208,7 +208,7 @@ jobs:
         working-directory: src/client
 
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: src/client/.vitest-reports
           pattern: frontend-test-shard-*
@@ -243,15 +243,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
@@ -270,10 +270,10 @@ jobs:
     if: ${{ !cancelled() && (needs.pr-title.result == 'success' || needs.pr-title.result == 'skipped') && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # GHA-hosted runners ship with ~14GB free disk, which is not enough for
       # the 1.34GB ONNX model download plus PaddleOCR runtime deps in the
@@ -313,10 +313,10 @@ jobs:
           swap-storage: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: false
@@ -330,12 +330,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

The v0.4.3 Docker publish run warned that `docker/login-action@v3` and `docker/metadata-action@v5` still target Node 20, which GitHub will remove from runners on Sept 16, 2026 and force-default off on June 2, 2026. An audit found that most other pinned actions also still use Node 20 in their current major version. Bump them all to their already-released Node 24 majors.

**Docker actions:**
- `docker/login-action@v3` → `@v4`
- `docker/metadata-action@v5` → `@v6`
- `docker/setup-buildx-action@v3` → `@v4`
- `docker/setup-qemu-action@v3` → `@v4`
- `docker/build-push-action@v6` → `@v7`

**Core `actions/*` and release-please-action:**
- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`
- `actions/setup-dotnet@v4` → `@v5`
- `actions/cache@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v7`
- `actions/download-artifact@v4` → `@v8`
- `googleapis/release-please-action@v4` → `@v5`

`upload-artifact@v7` and `download-artifact@v8` are the latest matching pair (download's major leads upload's by one in this repo's versioning).

Resolves RECEIPTS-673

## Test plan

- [x] PR's own CI run exercises every bumped action (checkout, setup-dotnet, setup-node, cache, upload-artifact, download-artifact, setup-buildx, build-push, free-disk-space).
- [ ] No `Node.js 20 actions are deprecated` warning in this run.
- [ ] Sharded frontend tests still merge cleanly via `upload-artifact@v7` → `download-artifact@v8` (this is the protocol pair we're most likely to trip on).
- [ ] Docker Build Check still completes within ~10 min on the cached path.
- [ ] Once merged, the next Docker publish on a tag exercises the docker-publish.yml bumps end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)