### PR TITLE
chore(infra): bump vulnerable transitive packages (RECEIPTS-680)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,11 +46,22 @@
     <PackageVersion Include="NSwag.MSBuild" Version="14.6.3" />
     <PackageVersion Include="OpenCvSharp4.Official.runtime.linux-x64" Version="4.11.0.20250507" />
     <PackageVersion Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
-    <!-- Pinned for security: GHSA-g94r-2vxg-569j (RECEIPTS-680) -->
+    <!--
+      OpenTelemetry CPM pins (RECEIPTS-680). The only project that currently references these
+      directly is Receipts.ServiceDefaults, which opts out of CPM (ManagePackageVersionsCentrally=false)
+      and so pins versions inline. These CPM entries are forward-looking guards: if any other
+      project (e.g. a future Worker / Function / tool) starts directly referencing the OTel
+      packages, CPM will force them onto the patched versions instead of the older 1.14.x/1.15.0
+      transitives. Keep these aligned with the inline versions in ServiceDefaults.csproj.
+      Advisories: OpenTelemetry.Api → GHSA-g94r-2vxg-569j;
+      OpenTelemetry.Exporter.OpenTelemetryProtocol → GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p,
+      GHSA-q834-8qmm-v933.
+    -->
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
-    <!-- Pinned for security: GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933 (RECEIPTS-680) -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <!-- Pinned for security: GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf (RECEIPTS-680) -->
+    <!-- Pinned for security: GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf (RECEIPTS-680). Forced
+         into Infrastructure.csproj via a direct PackageReference so CPM resolves the patched
+         transitive. -->
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,6 +46,12 @@
     <PackageVersion Include="NSwag.MSBuild" Version="14.6.3" />
     <PackageVersion Include="OpenCvSharp4.Official.runtime.linux-x64" Version="4.11.0.20250507" />
     <PackageVersion Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
+    <!-- Pinned for security: GHSA-g94r-2vxg-569j (RECEIPTS-680) -->
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <!-- Pinned for security: GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933 (RECEIPTS-680) -->
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <!-- Pinned for security: GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf (RECEIPTS-680) -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -29,6 +29,8 @@
     <PackageReference Include="Microsoft.ML.OnnxRuntime" />
     <PackageReference Include="Microsoft.ML.Tokenizers" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    <!-- Pinned for security: GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf (RECEIPTS-680) -->
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Common\Common.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />

--- a/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
+++ b/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
@@ -13,7 +13,10 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+    <!-- Pinned for security: GHSA-g94r-2vxg-569j (RECEIPTS-680) -->
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <!-- Pinned for security: GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933 (RECEIPTS-680) -->
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />


### PR DESCRIPTION
## Summary

- Pin **OpenTelemetry.Api** `1.15.3` — resolves [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) (moderate).
- Pin **OpenTelemetry.Exporter.OpenTelemetryProtocol** `1.15.3` — resolves [GHSA-4625-4j76-fww9](https://github.com/advisories/GHSA-4625-4j76-fww9), [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p), [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) (moderate). ServiceDefaults uses `ManagePackageVersionsCentrally=false`, so its direct reference is bumped inline.
- Pin **System.Security.Cryptography.Xml** `10.0.6` — resolves [GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx), [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf) (high). Added a direct `PackageReference` in `Infrastructure.csproj` so CPM forces the patched transitive.

Lowest-patched versions chosen per the advisories — no bleeding-edge bumps. The OpenTelemetry instrumentation siblings (AspNetCore/Http/Runtime/EFCore/Hosting) were left at their existing versions because they don't carry advisories; the `OpenTelemetry.Api` 1.15.3 pin satisfies their constraints.

Resolves RECEIPTS-680.

## Test plan

- [x] `dotnet restore Receipts.slnx` — succeeds.
- [x] `dotnet list Receipts.slnx package --vulnerable --include-transitive` — no vulnerable packages reported across all 17 projects.
- [x] `dotnet build Receipts.slnx` — succeeds with no new warnings (only the pre-existing NU1510 on `Presentation.API.Tests`).
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — 2410 unit tests pass.
- [ ] CI "Vulnerability Scan" check passes.
- [ ] Unblocks PR #543 (RECEIPTS-675 spike) rebasing onto develop.