### PR TITLE
chore(infra): bump OpenTelemetry companion packages to 1.15.x stable (RECEIPTS-681)

### DIFF
--- a/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
+++ b/src/Receipts.ServiceDefaults/Receipts.ServiceDefaults.csproj
@@ -17,11 +17,12 @@
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <!-- Pinned for security: GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933 (RECEIPTS-680) -->
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <!-- Latest available is prerelease (1.15.1-beta.1); no 1.15.x stable yet. Re-check on next OTel release. -->
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Follow-up to RECEIPTS-680. The core OTel packages landed at 1.15.3 there; this PR aligns the 5 companion packages in `Receipts.ServiceDefaults.csproj` to their latest stable in the 1.15.x line.

Each companion ships independently from the core, so the version isn't uniform — picked the highest stable for each:

| Package | Was | Now |
|---|---|---|
| `OpenTelemetry.Extensions.Hosting` | 1.14.0 | **1.15.3** |
| `OpenTelemetry.Instrumentation.AspNetCore` | 1.14.0 | **1.15.2** |
| `OpenTelemetry.Instrumentation.Http` | 1.14.0 | **1.15.1** |
| `OpenTelemetry.Instrumentation.Runtime` | 1.14.0 | **1.15.1** |
| `OpenTelemetry.Instrumentation.EntityFrameworkCore` | 1.15.0-beta.1 | **1.15.1-beta.1** (no stable available) |

Resolves RECEIPTS-681.

## Test plan
- [x] `dotnet restore Receipts.slnx` — clean
- [x] `dotnet build Receipts.slnx` — clean (only the pre-existing NU1510 warning)
- [x] `dotnet test Receipts.slnx --filter "Category!=Integration"` — **2392 tests pass**
- [ ] CI: Build & Test, Vulnerability Scan, Code Formatting, Frontend Tests, Docker Build, API Breaking Changes, Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)