### PR TITLE
fix(client): prevent page horizontal scroll on receipt forms (RECEIPTS-682)

### DIFF
--- a/src/client/src/components/ReceiptItemsCard.test.tsx
+++ b/src/client/src/components/ReceiptItemsCard.test.tsx
@@ -417,6 +417,33 @@ describe("ReceiptItemsCard", () => {
     expect(screen.queryByText(/normalized as/i)).not.toBeInTheDocument();
   });
 
+  it("wraps long descriptions so the table cannot force page horizontal scroll (WCAG 1.4.10)", () => {
+    const longDescription = "A".repeat(200);
+    const itemsWithLongDescription = [
+      {
+        id: "item-long-1",
+        receiptItemCode: "ITEM-LONG-1",
+        description: longDescription,
+        quantity: 1,
+        unitPrice: 9.99,
+        category: "Groceries",
+        subcategory: "Produce",
+        pricingMode: "quantity",
+      },
+    ];
+    renderWithQueryClient(
+      <ReceiptItemsCard
+        receiptId="receipt-1"
+        items={itemsWithLongDescription}
+        subtotal={9.99}
+      />,
+    );
+    const cell = screen.getByText(longDescription).closest("td");
+    expect(cell).not.toBeNull();
+    expect(cell).toHaveClass("whitespace-normal");
+    expect(cell).toHaveClass("break-words");
+  });
+
   it("cancels delete dialog without deleting", async () => {
     const { useDeleteReceiptItems } = await import(
       "@/hooks/useReceiptItems"

--- a/src/client/src/components/ReceiptItemsCard.test.tsx
+++ b/src/client/src/components/ReceiptItemsCard.test.tsx
@@ -442,6 +442,7 @@ describe("ReceiptItemsCard", () => {
     expect(cell).not.toBeNull();
     expect(cell).toHaveClass("whitespace-normal");
     expect(cell).toHaveClass("break-words");
+    expect(cell).toHaveClass("max-w-[32ch]");
   });
 
   it("cancels delete dialog without deleting", async () => {

--- a/src/client/src/components/ReceiptItemsCard.tsx
+++ b/src/client/src/components/ReceiptItemsCard.tsx
@@ -198,7 +198,7 @@ export function ReceiptItemsCard({
                       />
                     </TableHead>
                     <TableHead>Code</TableHead>
-                    <TableHead>Description</TableHead>
+                    <TableHead className="min-w-[16ch]">Description</TableHead>
                     <TableHead className="text-right">Qty</TableHead>
                     <TableHead className="text-right">Unit Price</TableHead>
                     <TableHead className="text-right">Total</TableHead>
@@ -222,7 +222,7 @@ export function ReceiptItemsCard({
                       <TableCell className="font-mono">
                         {item.receiptItemCode ?? ""}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="whitespace-normal break-words max-w-[32ch]">
                         <div>{item.description}</div>
                         {item.normalizedDescriptionName &&
                           item.normalizedDescriptionName !==

--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -223,6 +223,7 @@ describe("LineItemsSection", () => {
     expect(cell).not.toBeNull();
     expect(cell).toHaveClass("whitespace-normal");
     expect(cell).toHaveClass("break-words");
+    expect(cell).toHaveClass("max-w-[32ch]");
   });
 
   // --- Inline editing tests ---

--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -202,6 +202,29 @@ describe("LineItemsSection", () => {
     expect(screen.getByText("Household / Cleaning")).toBeInTheDocument();
   });
 
+  it("wraps long descriptions so the table cannot force page horizontal scroll (WCAG 1.4.10)", () => {
+    const longDescription = "A".repeat(200);
+    const items: ReceiptLineItem[] = [
+      {
+        id: "1",
+        receiptItemCode: "",
+        description: longDescription,
+        pricingMode: "quantity",
+        quantity: 1,
+        unitPrice: 2.5,
+        category: "Food",
+        subcategory: "",
+      },
+    ];
+    renderWithProviders(
+      <LineItemsSection {...defaultProps} items={items} />,
+    );
+    const cell = screen.getByText(longDescription).closest("td");
+    expect(cell).not.toBeNull();
+    expect(cell).toHaveClass("whitespace-normal");
+    expect(cell).toHaveClass("break-words");
+  });
+
   // --- Inline editing tests ---
 
   it("shows edit button for each item row", () => {

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -674,7 +674,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Description</TableHead>
+                <TableHead className="min-w-[16ch]">Description</TableHead>
                 <TableHead>Qty</TableHead>
                 <TableHead>Unit Price</TableHead>
                 <TableHead>Line Total</TableHead>
@@ -688,7 +688,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
               {items.map((item) =>
                 editingItemId === item.id ? (
                   <TableRow key={item.id}>
-                    <TableCell>
+                    <TableCell className="max-w-[32ch]">
                       <Input
                         value={editDraft.description}
                         onChange={(e) =>
@@ -758,7 +758,9 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                   </TableRow>
                 ) : (
                   <TableRow key={item.id}>
-                    <TableCell>{item.description}</TableCell>
+                    <TableCell className="whitespace-normal break-words max-w-[32ch]">
+                      {item.description}
+                    </TableCell>
                     <TableCell>{item.quantity}</TableCell>
                     <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
                     <TableCell>

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -143,6 +143,19 @@ describe("NewReceiptPage", () => {
     expect(screen.getAllByTestId("balance-sidebar").length).toBeGreaterThan(0);
   });
 
+  it("gives the 1fr grid column min-w-0 so the items table cannot force page horizontal scroll (WCAG 1.4.10)", () => {
+    // The left form column sits in a `grid-cols-[1fr_280px]` track. Without
+    // `min-w-0` the `1fr` track resolves to its min-content width and a long
+    // line-item description pushes the whole page wide. `min-w-0` lets the
+    // track shrink so the inner table's `overflow-x-auto` engages instead.
+    renderWithProviders(<NewReceiptPage />);
+    const column = screen
+      .getByTestId("line-items-section")
+      .closest("div.min-w-0");
+    expect(column).not.toBeNull();
+    expect(column).toHaveClass("min-w-0");
+  });
+
   it("navigates directly to /receipts when cancel clicked with no data", async () => {
     const user = userEvent.setup();
     renderWithProviders(<NewReceiptPage />);

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -203,7 +203,7 @@ export default function NewReceiptPage({
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_280px]">
         {/* Left column — form sections */}
-        <div className="space-y-6">
+        <div className="space-y-6 min-w-0">
           {/* Receipt Header */}
           <Form {...form}>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">


### PR DESCRIPTION
## Summary

- Fixes a page-level horizontal scroll on `/new-receipt` and `/receipts/:id` caused by long line-item descriptions — a WCAG 2.1 SC 1.4.10 (Reflow, Level AA) failure.
- Root cause: a CSS Grid `1fr` track (`minmax(auto, 1fr)`) refused to shrink below the items table's min-content width, because the Table primitive's default `whitespace-nowrap` cells made that min-content huge. The table wrapper's `overflow-x-auto` never engaged, so the page itself went wide.
- Fix: `min-w-0` on the `1fr` grid column wrapper (`NewReceiptPage`) so the track can shrink, plus per-cell `whitespace-normal break-words max-w-[32ch]` on only the Description column in `LineItemsSection` and `ReceiptItemsCard`. No changes to the shared `Table` primitive — numeric/code cells keep `whitespace-nowrap`.

Resolves RECEIPTS-682

## Test plan

- `npm run test` in `src/client/` — 1844 tests pass, including two new regression tests that mount `LineItemsSection` / `ReceiptItemsCard` with a 200-char description and assert the Description cell carries `whitespace-normal` / `break-words`.
- `npm run build` in `src/client/` passes.
- Manual: open `/new-receipt`, add a line item with a 200-char description, resize to 320 CSS px — no page horizontal scroll, description wraps, sticky balance sidebar stays accessible. Repeat on `/receipts/:id`.

## Review

Per the issue's acceptance criteria, an Opus-model agent review is requested on this PR; the review outcome will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
