### PR TITLE
feat(client): improve new-receipt line item entry UX

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",

--- a/src/client/src/components/ui/currency-input.tsx
+++ b/src/client/src/components/ui/currency-input.tsx
@@ -38,6 +38,7 @@ export function CurrencyInput({
   value,
   onChange,
   onBlur,
+  onKeyDown,
   symbol = "$",
   className,
   ...props
@@ -135,6 +136,8 @@ export function CurrencyInput({
       }
       commitExpression();
     }
+    // Chain any caller-supplied handler so the value is committed first.
+    onKeyDown?.(e);
   }
 
   function handlePaste(e: React.ClipboardEvent<HTMLInputElement>) {

--- a/src/client/src/components/ui/decimal-input.tsx
+++ b/src/client/src/components/ui/decimal-input.tsx
@@ -1,0 +1,87 @@
+import { useRef, useState, type ComponentProps } from "react";
+import { Input } from "@/components/ui/input";
+
+/** Keep only digits and a single decimal point. */
+function sanitize(raw: string): string {
+  const cleaned = raw.replace(/[^0-9.]/g, "");
+  // Collapse multiple decimal points into the first one.
+  return cleaned.replace(/(\..*)\./g, "$1");
+}
+
+interface DecimalInputProps
+  extends Omit<ComponentProps<"input">, "type" | "value" | "onChange"> {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+/**
+ * Numeric text input that accepts decimals typed with a leading point
+ * (e.g. ".4" → 0.4). Unlike <input type="number">, the browser never
+ * discards a partial value like "." while the user is mid-entry.
+ */
+export function DecimalInput({
+  value,
+  onChange,
+  onFocus,
+  onBlur,
+  ...props
+}: DecimalInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [text, setText] = useState(() => (value ? String(value) : ""));
+  const [focused, setFocused] = useState(false);
+
+  // Track the last value we emitted so we can tell external prop changes
+  // (e.g. form.reset()) apart from echoes of the user's own typing.
+  const [lastEmitted, setLastEmitted] = useState(value);
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
+    if (value !== lastEmitted) {
+      setText(value ? String(value) : "");
+      setLastEmitted(value);
+    }
+  }
+
+  const displayValue = focused ? text : value ? String(value) : "";
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const sanitized = sanitize(e.target.value);
+    setText(sanitized);
+    const num = parseFloat(sanitized);
+    if (!isNaN(num)) {
+      setLastEmitted(num);
+      onChange(num);
+    } else {
+      // "", "." — nothing parseable yet; report 0 so validation can react.
+      setLastEmitted(0);
+      onChange(0);
+    }
+  }
+
+  function handleFocus(e: React.FocusEvent<HTMLInputElement>) {
+    setFocused(true);
+    setText(value ? String(value) : "");
+    setTimeout(() => inputRef.current?.select(), 0);
+    onFocus?.(e);
+  }
+
+  function handleBlur(e: React.FocusEvent<HTMLInputElement>) {
+    setFocused(false);
+    onBlur?.(e);
+  }
+
+  return (
+    <Input
+      ref={inputRef}
+      type="text"
+      inputMode="decimal"
+      autoComplete="off"
+      value={displayValue}
+      placeholder="0"
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      {...props}
+    />
+  );
+}

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/command";
 import { Combobox } from "@/components/ui/combobox";
 import { CurrencyInput } from "@/components/ui/currency-input";
+import { DecimalInput } from "@/components/ui/decimal-input";
 import { Badge } from "@/components/ui/badge";
 import {
   Form,
@@ -80,6 +81,8 @@ interface LineItemsSectionProps {
 export function LineItemsSection({ items, onChange, location }: LineItemsSectionProps) {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const suggestionsListId = "new-receipt-suggestions-list";
+  // Index of the keyboard-highlighted row in the description lookup.
+  const [descriptionActiveIndex, setDescriptionActiveIndex] = useState(0);
   const { data: categories } = useCategories(0, 50, undefined, undefined, true);
 
   const categoryOptions = useMemo(
@@ -111,6 +114,9 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
   // Item code autocomplete
   const [showItemCodeSuggestions, setShowItemCodeSuggestions] = useState(false);
   const itemCodeSuggestionsListId = "new-receipt-item-code-suggestions-list";
+  const itemCodeInputRef = useRef<HTMLInputElement>(null);
+  // Index of the keyboard-highlighted row in the item code lookup.
+  const [itemCodeActiveIndex, setItemCodeActiveIndex] = useState(0);
 
   const { data: itemCodeSuggestions, isFetching: isFetchingItemCodeSuggestions } =
     useReceiptItemSuggestions(itemCode ?? "", location, {
@@ -144,20 +150,40 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     [form],
   );
 
+  // Reset the highlight to the first row whenever the result set changes.
+  useEffect(() => {
+    setItemCodeActiveIndex(0);
+  }, [itemCodeSuggestions]);
+
   const handleItemCodeKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Escape") {
         setShowItemCodeSuggestions(false);
-      } else if (e.key === "ArrowDown" && isItemCodeSuggestionsOpen) {
+        return;
+      }
+      if (!isItemCodeSuggestionsOpen) return;
+      const count = itemCodeSuggestions?.length ?? 0;
+      if (e.key === "ArrowDown") {
         e.preventDefault();
-        const list = document.getElementById(itemCodeSuggestionsListId);
-        const firstItem = list?.querySelector(
-          "[cmdk-item]",
-        ) as HTMLElement | null;
-        firstItem?.focus();
+        setItemCodeActiveIndex((i) => Math.min(i + 1, count - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setItemCodeActiveIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        const suggestion = itemCodeSuggestions?.[itemCodeActiveIndex];
+        if (suggestion) {
+          // Prevent the form from submitting — Enter picks the suggestion.
+          e.preventDefault();
+          applyItemCodeSuggestion(suggestion);
+        }
       }
     },
-    [isItemCodeSuggestionsOpen, itemCodeSuggestionsListId],
+    [
+      isItemCodeSuggestionsOpen,
+      itemCodeSuggestions,
+      itemCodeActiveIndex,
+      applyItemCodeSuggestion,
+    ],
   );
 
   const { data: similarItems, isFetching: isFetchingSimilar } =
@@ -199,6 +225,36 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     [subcategories],
   );
 
+  // Shared subcategory selection: applies the value and creates the
+  // subcategory on the fly when the user enters a name that doesn't exist.
+  const handleSubcategorySelect = useCallback(
+    (
+      next: string,
+      categoryId: string | undefined,
+      existing: { value: string }[],
+      setValue: (v: string) => void,
+    ) => {
+      setValue(next);
+      const isExisting = existing.some((o) => o.value === next);
+      if (
+        !isExisting &&
+        next &&
+        categoryId &&
+        !pendingSubcategories.current.has(next)
+      ) {
+        pendingSubcategories.current.add(next);
+        createSubcategory.mutate(
+          { categoryId, name: next, isActive: true },
+          {
+            onSettled: () => pendingSubcategories.current.delete(next),
+            onError: () => setValue(""),
+          },
+        );
+      }
+    },
+    [createSubcategory],
+  );
+
   const subtotal = useMemo(
     () =>
       items.reduce(
@@ -211,19 +267,9 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
 
   const applySuggestion = useCallback(
     (suggestion: NonNullable<typeof similarItems>[number]) => {
-      form.setValue("description", suggestion.name);
-      if (suggestion.defaultCategory) {
-        form.setValue("category", suggestion.defaultCategory);
-      }
-      if (suggestion.defaultSubcategory) {
-        form.setValue("subcategory", suggestion.defaultSubcategory);
-      }
-      if (suggestion.defaultUnitPrice != null) {
-        form.setValue("unitPrice", Number(suggestion.defaultUnitPrice));
-      }
-      if (suggestion.defaultItemCode) {
-        form.setValue("receiptItemCode", suggestion.defaultItemCode);
-      }
+      // Description lookup only fills the description field — the other
+      // fields are left for the user (or category recommendations) to set.
+      form.setValue("description", suggestion.name, { shouldValidate: true });
       setShowSuggestions(false);
     },
     [form],
@@ -239,20 +285,35 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     [form],
   );
 
+  // Reset the highlight to the first row whenever the result set changes.
+  useEffect(() => {
+    setDescriptionActiveIndex(0);
+  }, [similarItems]);
+
   const handleDescriptionKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Escape") {
         setShowSuggestions(false);
-      } else if (e.key === "ArrowDown" && isSuggestionsOpen) {
+        return;
+      }
+      if (!isSuggestionsOpen) return;
+      const count = similarItems?.length ?? 0;
+      if (e.key === "ArrowDown") {
         e.preventDefault();
-        const list = document.getElementById(suggestionsListId);
-        const firstItem = list?.querySelector(
-          "[cmdk-item]",
-        ) as HTMLElement | null;
-        firstItem?.focus();
+        setDescriptionActiveIndex((i) => Math.min(i + 1, count - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setDescriptionActiveIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        const suggestion = similarItems?.[descriptionActiveIndex];
+        if (suggestion) {
+          // Prevent the form from submitting — Enter picks the suggestion.
+          e.preventDefault();
+          applySuggestion(suggestion);
+        }
       }
     },
-    [isSuggestionsOpen, suggestionsListId],
+    [isSuggestionsOpen, similarItems, descriptionActiveIndex, applySuggestion],
   );
 
   const handleAdd = useCallback(
@@ -273,10 +334,13 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
         description: "",
         quantity: 1,
         unitPrice: 0,
-        category: values.category,
+        category: "",
         subcategory: "",
       });
       setShowSuggestions(false);
+      setShowItemCodeSuggestions(false);
+      // Return focus to the item code field for the next entry.
+      setTimeout(() => itemCodeInputRef.current?.focus(), 0);
     },
     [form, items, onChange],
   );
@@ -293,7 +357,37 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     description: string;
     quantity: number;
     unitPrice: number;
-  }>({ description: "", quantity: 1, unitPrice: 0 });
+    category: string;
+    subcategory: string;
+  }>({
+    description: "",
+    quantity: 1,
+    unitPrice: 0,
+    category: "",
+    subcategory: "",
+  });
+
+  // Subcategory options for the row currently being edited.
+  const editCategoryObj = useMemo(
+    () =>
+      (
+        (categories as { id: string; name: string }[] | undefined) ?? []
+      ).find((c) => c.name === editDraft.category),
+    [categories, editDraft.category],
+  );
+
+  const { data: editSubcategories } = useSubcategoriesByCategoryId(
+    editCategoryObj?.id ?? "",
+    0, 200, undefined, undefined, true,
+  );
+
+  const editSubcategoryOptions = useMemo(
+    () =>
+      (
+        (editSubcategories as { id: string; name: string }[] | undefined) ?? []
+      ).map((s) => ({ value: s.name, label: s.name })),
+    [editSubcategories],
+  );
 
   const startEditing = useCallback((item: ReceiptLineItem) => {
     setEditingItemId(item.id);
@@ -301,6 +395,8 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
       description: item.description,
       quantity: item.quantity,
       unitPrice: item.unitPrice,
+      category: item.category,
+      subcategory: item.subcategory,
     });
   }, []);
 
@@ -311,6 +407,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
   const saveEditing = useCallback(() => {
     if (!editingItemId) return;
     if (!editDraft.description.trim()) return;
+    if (!editDraft.category.trim()) return;
     if (!Number.isFinite(editDraft.quantity) || editDraft.quantity <= 0) return;
     if (!Number.isFinite(editDraft.unitPrice) || editDraft.unitPrice < 0) return;
 
@@ -322,12 +419,24 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
               description: editDraft.description.trim(),
               quantity: editDraft.quantity,
               unitPrice: editDraft.unitPrice,
+              category: editDraft.category,
+              subcategory: editDraft.subcategory,
             }
           : item,
       ),
     );
     setEditingItemId(null);
   }, [editingItemId, editDraft, items, onChange]);
+
+  const handleEditKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        saveEditing();
+      }
+    },
+    [saveEditing],
+  );
 
   // Clear stale editing state when the edited item is removed externally
   useEffect(() => {
@@ -374,6 +483,17 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                               aria-controls={itemCodeSuggestionsListId}
                               autoComplete="off"
                               {...field}
+                              ref={(el) => {
+                                field.ref(el);
+                                itemCodeInputRef.current = el;
+                              }}
+                              onChange={(e) => {
+                                field.onChange(e);
+                                // Re-open the lookup on every keystroke
+                                // (including backspace) so the search keeps
+                                // firing without needing to blur and refocus.
+                                setShowItemCodeSuggestions(true);
+                              }}
                               onFocus={() => setShowItemCodeSuggestions(true)}
                               onKeyDown={handleItemCodeKeyDown}
                             />
@@ -392,13 +512,20 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                         onOpenAutoFocus={(e) => e.preventDefault()}
                         onInteractOutside={() => setShowItemCodeSuggestions(false)}
                       >
-                        <Command shouldFilter={false}>
+                        <Command
+                          shouldFilter={false}
+                          value={`idx-${itemCodeActiveIndex}`}
+                          onValueChange={(v) => {
+                            const n = Number(v.replace("idx-", ""));
+                            if (!Number.isNaN(n)) setItemCodeActiveIndex(n);
+                          }}
+                        >
                           <CommandList id={itemCodeSuggestionsListId}>
                             <CommandEmpty>No suggestions found</CommandEmpty>
-                            {itemCodeSuggestions?.map((suggestion) => (
+                            {itemCodeSuggestions?.map((suggestion, index) => (
                               <CommandItem
                                 key={`${suggestion.itemCode}-${suggestion.matchType}`}
-                                value={`${suggestion.itemCode} ${suggestion.description}`}
+                                value={`idx-${index}`}
                                 onSelect={() => applyItemCodeSuggestion(suggestion)}
                               >
                                 <div className="flex w-full items-center justify-between">
@@ -458,6 +585,10 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                               aria-controls={suggestionsListId}
                               autoComplete="off"
                               {...field}
+                              onChange={(e) => {
+                                field.onChange(e);
+                                setShowSuggestions(true);
+                              }}
                               onFocus={() => setShowSuggestions(true)}
                               onKeyDown={handleDescriptionKeyDown}
                             />
@@ -476,13 +607,20 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                         onOpenAutoFocus={(e) => e.preventDefault()}
                         onInteractOutside={() => setShowSuggestions(false)}
                       >
-                        <Command shouldFilter={false}>
+                        <Command
+                          shouldFilter={false}
+                          value={`idx-${descriptionActiveIndex}`}
+                          onValueChange={(v) => {
+                            const n = Number(v.replace("idx-", ""));
+                            if (!Number.isNaN(n)) setDescriptionActiveIndex(n);
+                          }}
+                        >
                           <CommandList id={suggestionsListId}>
                             <CommandEmpty>No similar items found</CommandEmpty>
-                            {similarItems?.map((item) => (
+                            {similarItems?.map((item, index) => (
                               <CommandItem
                                 key={`${item.name}-${item.source}`}
-                                value={`${item.name} ${item.source}`}
+                                value={`idx-${index}`}
                                 onSelect={() => applySuggestion(item)}
                               >
                                 <div className="flex w-full items-center justify-between">
@@ -584,35 +722,14 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                       <Combobox
                         options={subcategoryOptions}
                         value={field.value ?? ""}
-                        onValueChange={(v: string) => {
-                          field.onChange(v);
-                          const isExisting = subcategoryOptions.some(
-                            (o) => o.value === v,
-                          );
-                          if (
-                            !isExisting &&
-                            v &&
-                            selectedCategoryObj?.id &&
-                            !pendingSubcategories.current.has(v)
-                          ) {
-                            pendingSubcategories.current.add(v);
-                            createSubcategory.mutate(
-                              {
-                                categoryId: selectedCategoryObj.id,
-                                name: v,
-                                isActive: true,
-                              },
-                              {
-                                onSettled: () => {
-                                  pendingSubcategories.current.delete(v);
-                                },
-                                onError: () => {
-                                  field.onChange("");
-                                },
-                              },
-                            );
-                          }
-                        }}
+                        onValueChange={(v: string) =>
+                          handleSubcategorySelect(
+                            v,
+                            selectedCategoryObj?.id,
+                            subcategoryOptions,
+                            field.onChange,
+                          )
+                        }
                         placeholder="Select subcategory..."
                         searchPlaceholder="Search subcategories..."
                         emptyMessage="No subcategories found."
@@ -632,13 +749,12 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                   <FormItem>
                     <FormLabel required>Qty</FormLabel>
                     <FormControl>
-                      <Input
-                        type="number"
-                        step="any"
-                        min="0.01"
+                      <DecimalInput
                         className="w-20"
-                        {...field}
-                        onChange={(e) => field.onChange(Number(e.target.value))}
+                        name={field.name}
+                        value={field.value}
+                        onChange={field.onChange}
+                        onBlur={field.onBlur}
                       />
                     </FormControl>
                     <FormMessage />
@@ -697,22 +813,18 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                             description: e.target.value,
                           }))
                         }
+                        onKeyDown={handleEditKeyDown}
                         aria-label="Edit description"
                         className="h-8"
                       />
                     </TableCell>
                     <TableCell>
-                      <Input
-                        type="number"
-                        step="any"
-                        min="0.01"
+                      <DecimalInput
                         value={editDraft.quantity}
-                        onChange={(e) =>
-                          setEditDraft((d) => ({
-                            ...d,
-                            quantity: Number(e.target.value),
-                          }))
+                        onChange={(v) =>
+                          setEditDraft((d) => ({ ...d, quantity: v }))
                         }
+                        onKeyDown={handleEditKeyDown}
                         aria-label="Edit quantity"
                         className="h-8 w-20"
                         disabled={item.pricingMode === "flat"}
@@ -724,6 +836,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                         onChange={(v) =>
                           setEditDraft((d) => ({ ...d, unitPrice: v }))
                         }
+                        onKeyDown={handleEditKeyDown}
                         aria-label="Edit unit price"
                         className="h-8"
                       />
@@ -732,8 +845,47 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
                       {formatCurrency(editDraft.quantity * editDraft.unitPrice)}
                     </TableCell>
                     <TableCell>
-                      {item.category}
-                      {item.subcategory ? ` / ${item.subcategory}` : ""}
+                      <div className="flex min-w-[12rem] flex-col gap-1">
+                        <Combobox
+                          options={categoryOptions}
+                          value={editDraft.category}
+                          onValueChange={(v) =>
+                            setEditDraft((d) => ({
+                              ...d,
+                              category: v,
+                              subcategory: "",
+                            }))
+                          }
+                          placeholder="Category..."
+                          searchPlaceholder="Search categories..."
+                          emptyMessage="No categories found."
+                          className="h-8"
+                          aria-label="Edit category"
+                        />
+                        <Combobox
+                          options={editSubcategoryOptions}
+                          value={editDraft.subcategory}
+                          onValueChange={(v) =>
+                            handleSubcategorySelect(
+                              v,
+                              editCategoryObj?.id,
+                              editSubcategoryOptions,
+                              (next) =>
+                                setEditDraft((d) => ({
+                                  ...d,
+                                  subcategory: next,
+                                })),
+                            )
+                          }
+                          placeholder="Subcategory..."
+                          searchPlaceholder="Search subcategories..."
+                          emptyMessage="No subcategories found."
+                          allowCustom
+                          disabled={!editDraft.category}
+                          className="h-8"
+                          aria-label="Edit subcategory"
+                        />
+                      </div>
                     </TableCell>
                     <TableCell>
                       <div className="flex gap-1">


### PR DESCRIPTION
## Summary

Keyboard-driven entry and form-quality fixes for the **Line Items** step of the new-receipt wizard (`src/client/src/pages/new-receipt/LineItemsSection.tsx`).

### RECEIPTS-683 — Line item form UX fixes
- After adding an item, the form **fully resets** and returns focus to the **Item Code** field for the next entry.
- **Item Code lookup re-fires on every keystroke**, including backspace. Previously the lookup gate only flipped back on via focus/blur, so editing in place (especially backspacing) never re-triggered the similarity search.
- **Description lookup fills only the Description field** — it no longer overwrites category, subcategory, unit price, and item code from the matched template.
- New `DecimalInput` component (`ui/decimal-input.tsx`) accepts values typed with a **leading decimal point** (e.g. `.4` → `0.4`). `<input type="number">` discarded partial values like `.`, which caused `.` + `4` to land as `4`. Quantity now uses it in both the add form and the edit row.
- **Category and Subcategory are editable on already-added line items** via inline comboboxes — no more delete + re-enter. Subcategory supports on-the-fly creation, same as the add form.
- **Enter saves** a line item while editing a table row.

### RECEIPTS-684 — Keyboard navigation for lookup dropdowns
- **↑ / ↓** move the highlight through the Item Code and Description suggestion results; focus stays in the input.
- **Enter** selects the highlighted suggestion (and `preventDefault`s so it doesn't also submit the add-item form).
- Mouse hover and keyboard highlight stay in sync; the highlighted row auto-scrolls into view.

### Supporting change
- `CurrencyInput` now *chains* a caller-supplied `onKeyDown` instead of letting it silently override the internal handler — needed for Enter-to-save in the edit row.

## Testing
- `tsc --noEmit` and `eslint` pass clean on the changed files.
- Pre-commit hook (build + full test suite) passed.

Closes RECEIPTS-683
Closes RECEIPTS-684

🤖 Generated with [Claude Code](https://claude.com/claude-code)