### PR TITLE
fix(client): make SortableTableHead keyboard-operable (RECEIPTS-687)

### DIFF
--- a/src/client/src/components/SortableTableHead.test.tsx
+++ b/src/client/src/components/SortableTableHead.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SortableTableHead } from "./SortableTableHead";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+function renderSortableHead(props: {
+  column?: string;
+  label?: string;
+  currentSortBy?: string | null;
+  currentSortDirection?: "asc" | "desc";
+  onToggleSort?: (column: string) => void;
+  className?: string;
+}) {
+  const defaults = {
+    column: "name",
+    label: "Name",
+    currentSortBy: null,
+    currentSortDirection: "asc" as const,
+    onToggleSort: vi.fn(),
+  };
+  const merged = { ...defaults, ...props };
+  return render(
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <SortableTableHead {...merged} />
+        </TableRow>
+      </TableHeader>
+    </Table>,
+  );
+}
+
+describe("SortableTableHead", () => {
+  describe("rendering", () => {
+    it("renders a button with the column label", () => {
+      renderSortableHead({ label: "Name" });
+      const button = screen.getByRole("button", { name: /name/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("renders the button inside a th element", () => {
+      const { container } = renderSortableHead({ label: "Amount" });
+      const th = container.querySelector("th");
+      expect(th).toBeInTheDocument();
+      expect(th!.querySelector("button")).toBeInTheDocument();
+    });
+  });
+
+  describe("aria-sort", () => {
+    it("sets aria-sort to 'none' when column is not the active sort", () => {
+      const { container } = renderSortableHead({
+        column: "name",
+        currentSortBy: "date",
+        currentSortDirection: "asc",
+      });
+      const th = container.querySelector("th");
+      expect(th).toHaveAttribute("aria-sort", "none");
+    });
+
+    it("sets aria-sort to 'ascending' when column is active and direction is asc", () => {
+      const { container } = renderSortableHead({
+        column: "name",
+        currentSortBy: "name",
+        currentSortDirection: "asc",
+      });
+      const th = container.querySelector("th");
+      expect(th).toHaveAttribute("aria-sort", "ascending");
+    });
+
+    it("sets aria-sort to 'descending' when column is active and direction is desc", () => {
+      const { container } = renderSortableHead({
+        column: "name",
+        currentSortBy: "name",
+        currentSortDirection: "desc",
+      });
+      const th = container.querySelector("th");
+      expect(th).toHaveAttribute("aria-sort", "descending");
+    });
+
+    it("sets aria-sort to 'none' when currentSortBy is null", () => {
+      const { container } = renderSortableHead({
+        column: "name",
+        currentSortBy: null,
+      });
+      const th = container.querySelector("th");
+      expect(th).toHaveAttribute("aria-sort", "none");
+    });
+  });
+
+  describe("keyboard activation", () => {
+    it("calls onToggleSort when button is activated with Enter key", async () => {
+      const user = userEvent.setup();
+      const onToggleSort = vi.fn();
+      renderSortableHead({ column: "name", label: "Name", onToggleSort });
+
+      const button = screen.getByRole("button", { name: /name/i });
+      button.focus();
+      await user.keyboard("{Enter}");
+
+      expect(onToggleSort).toHaveBeenCalledWith("name");
+    });
+
+    it("calls onToggleSort when button is activated with Space key", async () => {
+      const user = userEvent.setup();
+      const onToggleSort = vi.fn();
+      renderSortableHead({ column: "amount", label: "Amount", onToggleSort });
+
+      const button = screen.getByRole("button", { name: /amount/i });
+      button.focus();
+      await user.keyboard(" ");
+
+      expect(onToggleSort).toHaveBeenCalledWith("amount");
+    });
+
+    it("calls onToggleSort when button is clicked", async () => {
+      const user = userEvent.setup();
+      const onToggleSort = vi.fn();
+      renderSortableHead({ column: "date", label: "Date", onToggleSort });
+
+      await user.click(screen.getByRole("button", { name: /date/i }));
+
+      expect(onToggleSort).toHaveBeenCalledWith("date");
+    });
+
+    it("button is focusable via tab", async () => {
+      const user = userEvent.setup();
+      renderSortableHead({ label: "Name" });
+
+      await user.tab();
+      const button = screen.getByRole("button", { name: /name/i });
+      expect(button).toHaveFocus();
+    });
+  });
+
+  describe("arrow icon accessibility", () => {
+    it("marks arrow icons as aria-hidden", () => {
+      const { container } = renderSortableHead({
+        column: "name",
+        currentSortBy: "name",
+        currentSortDirection: "asc",
+      });
+      const svgs = container.querySelectorAll("svg");
+      svgs.forEach((svg) => {
+        expect(svg).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+
+    it("marks the neutral sort icon as aria-hidden when column is inactive", () => {
+      const { container } = renderSortableHead({
+        column: "name",
+        currentSortBy: null,
+      });
+      const svgs = container.querySelectorAll("svg");
+      svgs.forEach((svg) => {
+        expect(svg).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+  });
+});

--- a/src/client/src/components/SortableTableHead.tsx
+++ b/src/client/src/components/SortableTableHead.tsx
@@ -20,23 +20,33 @@ export function SortableTableHead({
 }: SortableTableHeadProps) {
   const isActive = currentSortBy === column;
 
+  const ariaSortValue: "ascending" | "descending" | "none" = isActive
+    ? currentSortDirection === "asc"
+      ? "ascending"
+      : "descending"
+    : "none";
+
   return (
     <TableHead
-      className={`cursor-pointer select-none hover:bg-muted/50 ${className ?? ""}`}
-      onClick={() => onToggleSort(column)}
+      aria-sort={ariaSortValue}
+      className={`select-none ${className ?? ""}`}
     >
-      <span className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        className="inline-flex items-center gap-1 cursor-pointer hover:text-foreground w-full"
+        onClick={() => onToggleSort(column)}
+      >
         {label}
         {isActive ? (
           currentSortDirection === "asc" ? (
-            <ArrowUp className="h-3.5 w-3.5" />
+            <ArrowUp aria-hidden className="h-3.5 w-3.5" />
           ) : (
-            <ArrowDown className="h-3.5 w-3.5" />
+            <ArrowDown aria-hidden className="h-3.5 w-3.5" />
           )
         ) : (
-          <ArrowUpDown className="h-3.5 w-3.5 opacity-30" />
+          <ArrowUpDown aria-hidden className="h-3.5 w-3.5 opacity-30" />
         )}
-      </span>
+      </button>
     </TableHead>
   );
 }

--- a/src/client/src/components/SortableTableHead.tsx
+++ b/src/client/src/components/SortableTableHead.tsx
@@ -33,7 +33,7 @@ export function SortableTableHead({
     >
       <button
         type="button"
-        className="inline-flex items-center gap-1 cursor-pointer hover:text-foreground w-full"
+        className="inline-flex items-center gap-1 cursor-pointer hover:text-foreground w-full h-full"
         onClick={() => onToggleSort(column)}
       >
         {label}


### PR DESCRIPTION
## Summary
- Wrap the sort button label in a native `<button type="button">` so keyboard users can reach and activate column sorting via Tab, Enter, and Space (WCAG 2.1.1 Keyboard)
- Set `aria-sort` (`ascending`/`descending`/`none`) on the `<th>` so screen readers announce the sort state for every sortable table (WCAG 4.1.2 Name/Role/Value, 1.3.1)
- Mark the ArrowUp/ArrowDown/ArrowUpDown icons `aria-hidden` since they are decorative and redundant with `aria-sort`
- Add 12 Vitest tests covering rendering, all `aria-sort` states, keyboard activation (Enter, Space, click), tab focusability, and icon accessibility

Resolves RECEIPTS-687

## Test plan
- Tab to any sort header in Receipts, Accounts, Cards, Categories, Subcategories, ItemTemplates, AuditLogTable, or AuthAuditTable and press Enter or Space — sort should toggle
- Inspect the `<th>` element: `aria-sort` should read `ascending`, `descending`, or `none` based on the active column/direction
- Run `npm test` in `src/client` — all 1857 + 12 new tests pass