### PR TITLE
feat(client): add text alternatives for charts (RECEIPTS-688)

### DIFF
--- a/src/client/src/components/charts/AreaTimeChart.test.tsx
+++ b/src/client/src/components/charts/AreaTimeChart.test.tsx
@@ -82,4 +82,52 @@ describe("AreaTimeChart", () => {
     render(<AreaTimeChart data={mockData} trendlineData={[]} />);
     expect(screen.queryByTestId("trendline-area")).not.toBeInTheDocument();
   });
+
+  // Accessibility tests
+  it("renders a visually-hidden data table with period and amount columns", () => {
+    render(<AreaTimeChart data={mockData} />);
+    const table = document.querySelector("table.sr-only");
+    expect(table).toBeInTheDocument();
+    expect(screen.getByText("Jan")).toBeInTheDocument();
+    expect(screen.getByText("Feb")).toBeInTheDocument();
+    expect(screen.getByText("Mar")).toBeInTheDocument();
+  });
+
+  it("renders chart container with role=img and accessible name", () => {
+    render(<AreaTimeChart data={mockData} aria-label="Monthly spending" />);
+    expect(screen.getByRole("img", { name: "Monthly spending" })).toBeInTheDocument();
+  });
+
+  it("uses aria-labelledby when provided", () => {
+    render(
+      <div>
+        <h2 id="area-title">Spending over time</h2>
+        <AreaTimeChart data={mockData} aria-labelledby="area-title" />
+      </div>,
+    );
+    const img = document.querySelector("[role='img']");
+    expect(img).toHaveAttribute("aria-labelledby", "area-title");
+    expect(img).not.toHaveAttribute("aria-label");
+  });
+
+  it("falls back to a default aria-label when neither aria-label nor aria-labelledby is provided", () => {
+    render(<AreaTimeChart data={mockData} />);
+    expect(screen.getByRole("img", { name: "Area time chart" })).toBeInTheDocument();
+  });
+
+  it("includes a Rolling Average column in the table when trendline data is provided", () => {
+    render(<AreaTimeChart data={mockData} trendlineData={mockTrendline} />);
+    const table = document.querySelector("table.sr-only");
+    const headers = table?.querySelectorAll("th");
+    const headerTexts = Array.from(headers ?? []).map((h) => h.textContent);
+    expect(headerTexts).toContain("Rolling Average");
+  });
+
+  it("does not include Rolling Average column when trendline data is absent", () => {
+    render(<AreaTimeChart data={mockData} />);
+    const table = document.querySelector("table.sr-only");
+    const headers = table?.querySelectorAll("th");
+    const headerTexts = Array.from(headers ?? []).map((h) => h.textContent);
+    expect(headerTexts).not.toContain("Rolling Average");
+  });
 });

--- a/src/client/src/components/charts/AreaTimeChart.tsx
+++ b/src/client/src/components/charts/AreaTimeChart.tsx
@@ -22,6 +22,10 @@ interface AreaTimeChartProps {
   color?: string;
   trendlineColor?: string;
   formatValue?: (value: number) => string;
+  /** ARIA label used as the chart's accessible name when no labelledby id is available. */
+  "aria-label"?: string;
+  /** ID of an element that labels this chart (e.g. ChartCard's title id). */
+  "aria-labelledby"?: string;
 }
 
 export function AreaTimeChart({
@@ -31,6 +35,8 @@ export function AreaTimeChart({
   color = CHART_COLORS[0],
   trendlineColor = CHART_COLORS[1],
   formatValue = (v) => v.toLocaleString(),
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
 }: AreaTimeChartProps) {
   const gradientId = useId();
 
@@ -42,62 +48,100 @@ export function AreaTimeChart({
     }));
   }, [data, trendlineData]);
 
+  const hasTrendline = trendlineData && trendlineData.length > 0;
+
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <AreaChart
-        data={mergedData}
-        margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
+    <div>
+      {/* Visually-hidden data table — provides a text alternative (WCAG 1.1.1)
+          and resolves the color-only series identification concern (WCAG 1.4.1) */}
+      <table className="sr-only">
+        <caption>{ariaLabel ?? "Area time chart data"}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Period</th>
+            <th scope="col">Amount</th>
+            {hasTrendline && <th scope="col">Rolling Average</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {mergedData.map((row) => (
+            <tr key={row.period}>
+              <td>{row.period}</td>
+              <td>{formatValue(row.amount)}</td>
+              {hasTrendline && (
+                <td>
+                  {(row as unknown as { trendline?: number }).trendline !== undefined
+                    ? formatValue((row as unknown as { trendline: number }).trendline)
+                    : ""}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div
+        role="img"
+        aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Area time chart")}
+        aria-labelledby={ariaLabelledBy}
       >
-        <defs>
-          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor={color} stopOpacity={0.3} />
-            <stop offset="95%" stopColor={color} stopOpacity={0} />
-          </linearGradient>
-        </defs>
-        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-        <XAxis
-          dataKey="period"
-          tick={{ fontSize: 12 }}
-          className="fill-muted-foreground"
-        />
-        <YAxis
-          tick={{ fontSize: 12 }}
-          className="fill-muted-foreground"
-          tickFormatter={formatValue}
-        />
-        <Tooltip
-          formatter={(value, name) => [
-            formatValue(Number(value)),
-            name === "trendline" ? "Rolling Avg" : "Amount",
-          ]}
-          contentStyle={{
-            backgroundColor: "hsl(var(--popover))",
-            border: "1px solid hsl(var(--border))",
-            borderRadius: "var(--radius)",
-            color: "hsl(var(--popover-foreground))",
-          }}
-        />
-        <Area
-          type="monotone"
-          dataKey="amount"
-          stroke={color}
-          fill={`url(#${gradientId})`}
-          strokeWidth={2}
-        />
-        {trendlineData && trendlineData.length > 0 && (
-          <Area
-            type="monotone"
-            dataKey="trendline"
-            stroke={trendlineColor}
-            fill="none"
-            strokeWidth={2}
-            strokeDasharray="5 5"
-            strokeOpacity={0.7}
-            dot={false}
-            name="trendline"
-          />
-        )}
-      </AreaChart>
-    </ResponsiveContainer>
+        <ResponsiveContainer width="100%" height={height}>
+          <AreaChart
+            data={mergedData}
+            margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
+          >
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={color} stopOpacity={0.3} />
+                <stop offset="95%" stopColor={color} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis
+              dataKey="period"
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+            />
+            <YAxis
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+              tickFormatter={formatValue}
+            />
+            <Tooltip
+              formatter={(value, name) => [
+                formatValue(Number(value)),
+                name === "trendline" ? "Rolling Avg" : "Amount",
+              ]}
+              contentStyle={{
+                backgroundColor: "hsl(var(--popover))",
+                border: "1px solid hsl(var(--border))",
+                borderRadius: "var(--radius)",
+                color: "hsl(var(--popover-foreground))",
+              }}
+            />
+            <Area
+              type="monotone"
+              dataKey="amount"
+              stroke={color}
+              fill={`url(#${gradientId})`}
+              strokeWidth={2}
+            />
+            {hasTrendline && (
+              <Area
+                type="monotone"
+                dataKey="trendline"
+                stroke={trendlineColor}
+                fill="none"
+                strokeWidth={2}
+                strokeDasharray="5 5"
+                strokeOpacity={0.7}
+                dot={false}
+                name="trendline"
+              />
+            )}
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
   );
 }

--- a/src/client/src/components/charts/BarChart.test.tsx
+++ b/src/client/src/components/charts/BarChart.test.tsx
@@ -67,4 +67,46 @@ describe("BarChart", () => {
     render(<BarChart data={[]} />);
     expect(screen.getByTestId("bar-chart")).toHaveAttribute("data-count", "0");
   });
+
+  // Accessibility tests
+  it("renders a visually-hidden data table with all data rows", () => {
+    render(<BarChart data={mockData} />);
+    const table = document.querySelector("table.sr-only");
+    expect(table).toBeInTheDocument();
+    expect(screen.getByText("Account A")).toBeInTheDocument();
+    expect(screen.getByText("Account B")).toBeInTheDocument();
+  });
+
+  it("renders chart container with role=img", () => {
+    render(<BarChart data={mockData} aria-label="Spending by account" />);
+    expect(screen.getByRole("img", { name: "Spending by account" })).toBeInTheDocument();
+  });
+
+  it("uses aria-labelledby when provided", () => {
+    render(
+      <div>
+        <h2 id="chart-title">Accounts</h2>
+        <BarChart data={mockData} aria-labelledby="chart-title" />
+      </div>,
+    );
+    const img = document.querySelector("[role='img']");
+    expect(img).toHaveAttribute("aria-labelledby", "chart-title");
+    expect(img).not.toHaveAttribute("aria-label");
+  });
+
+  it("falls back to a default aria-label when neither aria-label nor aria-labelledby is provided", () => {
+    render(<BarChart data={mockData} />);
+    expect(screen.getByRole("img", { name: "Bar chart" })).toBeInTheDocument();
+  });
+
+  it("renders formatted values in the data table", () => {
+    render(
+      <BarChart
+        data={mockData}
+        formatValue={(v) => `$${v.toFixed(2)}`}
+      />,
+    );
+    expect(screen.getByText("$500.00")).toBeInTheDocument();
+    expect(screen.getByText("$300.00")).toBeInTheDocument();
+  });
 });

--- a/src/client/src/components/charts/BarChart.tsx
+++ b/src/client/src/components/charts/BarChart.tsx
@@ -15,6 +15,10 @@ interface BarChartProps {
   color?: string;
   layout?: "horizontal" | "vertical";
   formatValue?: (value: number) => string;
+  /** ARIA label used as the chart's accessible name when no labelledby id is available. */
+  "aria-label"?: string;
+  /** ID of an element that labels this chart (e.g. ChartCard's title id). */
+  "aria-labelledby"?: string;
 }
 
 export function BarChart({
@@ -23,58 +27,89 @@ export function BarChart({
   color = CHART_COLORS[0],
   layout = "vertical",
   formatValue = (v) => v.toLocaleString(),
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
 }: BarChartProps) {
   const isHorizontal = layout === "horizontal";
 
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <RechartsBarChart
-        data={data}
-        layout={isHorizontal ? "vertical" : "horizontal"}
-        margin={{ top: 5, right: 20, bottom: 5, left: isHorizontal ? 80 : 0 }}
+    <div>
+      {/* Visually-hidden data table — provides a text alternative (WCAG 1.1.1)
+          and resolves the color-only concern (WCAG 1.4.1) */}
+      <table className="sr-only">
+        <caption>{ariaLabel ?? "Bar chart data"}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row) => (
+            <tr key={row.name}>
+              <td>{row.name}</td>
+              <td>{formatValue(row.value)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div
+        role="img"
+        aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Bar chart")}
+        aria-labelledby={ariaLabelledBy}
+        aria-hidden={false}
       >
-        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-        {isHorizontal ? (
-          <>
-            <XAxis
-              type="number"
-              tick={{ fontSize: 12 }}
-              className="fill-muted-foreground"
-              tickFormatter={formatValue}
+        <ResponsiveContainer width="100%" height={height}>
+          <RechartsBarChart
+            data={data}
+            layout={isHorizontal ? "vertical" : "horizontal"}
+            margin={{ top: 5, right: 20, bottom: 5, left: isHorizontal ? 80 : 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            {isHorizontal ? (
+              <>
+                <XAxis
+                  type="number"
+                  tick={{ fontSize: 12 }}
+                  className="fill-muted-foreground"
+                  tickFormatter={formatValue}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="name"
+                  tick={{ fontSize: 12 }}
+                  className="fill-muted-foreground"
+                  width={75}
+                />
+              </>
+            ) : (
+              <>
+                <XAxis
+                  dataKey="name"
+                  tick={{ fontSize: 12 }}
+                  className="fill-muted-foreground"
+                />
+                <YAxis
+                  tick={{ fontSize: 12 }}
+                  className="fill-muted-foreground"
+                  tickFormatter={formatValue}
+                />
+              </>
+            )}
+            <Tooltip
+              formatter={(value) => [formatValue(Number(value)), "Amount"]}
+              contentStyle={{
+                backgroundColor: "hsl(var(--popover))",
+                border: "1px solid hsl(var(--border))",
+                borderRadius: "var(--radius)",
+                color: "hsl(var(--popover-foreground))",
+              }}
             />
-            <YAxis
-              type="category"
-              dataKey="name"
-              tick={{ fontSize: 12 }}
-              className="fill-muted-foreground"
-              width={75}
-            />
-          </>
-        ) : (
-          <>
-            <XAxis
-              dataKey="name"
-              tick={{ fontSize: 12 }}
-              className="fill-muted-foreground"
-            />
-            <YAxis
-              tick={{ fontSize: 12 }}
-              className="fill-muted-foreground"
-              tickFormatter={formatValue}
-            />
-          </>
-        )}
-        <Tooltip
-          formatter={(value) => [formatValue(Number(value)), "Amount"]}
-          contentStyle={{
-            backgroundColor: "hsl(var(--popover))",
-            border: "1px solid hsl(var(--border))",
-            borderRadius: "var(--radius)",
-            color: "hsl(var(--popover-foreground))",
-          }}
-        />
-        <Bar dataKey="value" fill={color} radius={isHorizontal ? [0, 4, 4, 0] : [4, 4, 0, 0]} />
-      </RechartsBarChart>
-    </ResponsiveContainer>
+            <Bar dataKey="value" fill={color} radius={isHorizontal ? [0, 4, 4, 0] : [4, 4, 0, 0]} />
+          </RechartsBarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
   );
 }

--- a/src/client/src/components/charts/BarChart.tsx
+++ b/src/client/src/components/charts/BarChart.tsx
@@ -58,7 +58,6 @@ export function BarChart({
         role="img"
         aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Bar chart")}
         aria-labelledby={ariaLabelledBy}
-        aria-hidden={false}
       >
         <ResponsiveContainer width="100%" height={height}>
           <RechartsBarChart

--- a/src/client/src/components/charts/ChartCard.test.tsx
+++ b/src/client/src/components/charts/ChartCard.test.tsx
@@ -61,4 +61,41 @@ describe("ChartCard", () => {
       screen.getByRole("button", { name: "Action" }),
     ).toBeInTheDocument();
   });
+
+  // Accessibility tests
+  it("assigns an id to the CardTitle element", () => {
+    renderWithProviders(
+      <ChartCard title="Spending Overview">
+        <div>Chart content</div>
+      </ChartCard>,
+    );
+    // The title should have an id so chart children can reference it via aria-labelledby
+    const titleEl = screen.getByText("Spending Overview");
+    expect(titleEl).toHaveAttribute("id");
+    expect(titleEl.getAttribute("id")).not.toBe("");
+  });
+
+  it("passes titleId to render-prop children", () => {
+    let capturedId = "";
+    renderWithProviders(
+      <ChartCard title="My Chart">
+        {(titleId) => {
+          capturedId = titleId;
+          return <div aria-labelledby={titleId}>chart</div>;
+        }}
+      </ChartCard>,
+    );
+    expect(capturedId).not.toBe("");
+    const titleEl = screen.getByText("My Chart");
+    expect(titleEl).toHaveAttribute("id", capturedId);
+  });
+
+  it("renders regular ReactNode children without render-prop pattern", () => {
+    renderWithProviders(
+      <ChartCard title="Title">
+        <span data-testid="plain-child">plain</span>
+      </ChartCard>,
+    );
+    expect(screen.getByTestId("plain-child")).toBeInTheDocument();
+  });
 });

--- a/src/client/src/components/charts/ChartCard.tsx
+++ b/src/client/src/components/charts/ChartCard.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import {
   Card,
   CardContent,
@@ -17,7 +18,7 @@ interface ChartCardProps {
   empty?: boolean;
   emptyMessage?: string;
   action?: ReactNode;
-  children: ReactNode;
+  children: ReactNode | ((titleId: string) => ReactNode);
   className?: string;
 }
 
@@ -31,11 +32,13 @@ export function ChartCard({
   children,
   className,
 }: ChartCardProps) {
+  const titleId = useId();
+
   return (
     <Card className={cn("flex flex-col", className)}>
       <CardHeader>
         <div>
-          <CardTitle>{title}</CardTitle>
+          <CardTitle id={titleId}>{title}</CardTitle>
           {subtitle && <CardDescription>{subtitle}</CardDescription>}
         </div>
         {action && <CardAction>{action}</CardAction>}
@@ -51,6 +54,8 @@ export function ChartCard({
           <div className="flex items-center justify-center h-32 text-muted-foreground text-sm">
             {emptyMessage}
           </div>
+        ) : typeof children === "function" ? (
+          children(titleId)
         ) : (
           children
         )}

--- a/src/client/src/components/charts/DonutChart.test.tsx
+++ b/src/client/src/components/charts/DonutChart.test.tsx
@@ -54,4 +54,56 @@ describe("DonutChart", () => {
     render(<DonutChart data={[]} />);
     expect(screen.getByTestId("pie")).toHaveAttribute("data-count", "0");
   });
+
+  // Accessibility tests
+  it("renders a visually-hidden data table with all category rows", () => {
+    render(<DonutChart data={mockData} />);
+    const table = document.querySelector("table.sr-only");
+    expect(table).toBeInTheDocument();
+    expect(screen.getByText("Food")).toBeInTheDocument();
+    expect(screen.getByText("Transport")).toBeInTheDocument();
+    expect(screen.getByText("Entertainment")).toBeInTheDocument();
+  });
+
+  it("renders chart container with role=img and accessible name", () => {
+    render(<DonutChart data={mockData} aria-label="Spending by category" />);
+    expect(screen.getByRole("img", { name: "Spending by category" })).toBeInTheDocument();
+  });
+
+  it("uses aria-labelledby when provided", () => {
+    render(
+      <div>
+        <h2 id="donut-title">Categories</h2>
+        <DonutChart data={mockData} aria-labelledby="donut-title" />
+      </div>,
+    );
+    const img = document.querySelector("[role='img']");
+    expect(img).toHaveAttribute("aria-labelledby", "donut-title");
+    expect(img).not.toHaveAttribute("aria-label");
+  });
+
+  it("falls back to a default aria-label when neither aria-label nor aria-labelledby is provided", () => {
+    render(<DonutChart data={mockData} />);
+    expect(screen.getByRole("img", { name: "Donut chart" })).toBeInTheDocument();
+  });
+
+  it("renders formatted values in the data table", () => {
+    render(
+      <DonutChart
+        data={mockData}
+        formatValue={(v) => `$${v.toFixed(2)}`}
+      />,
+    );
+    expect(screen.getByText("$300.00")).toBeInTheDocument();
+    expect(screen.getByText("$200.00")).toBeInTheDocument();
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
+  });
+
+  it("data table identifies each category by name, not color alone", () => {
+    render(<DonutChart data={mockData} />);
+    const table = document.querySelector("table.sr-only");
+    const headers = table?.querySelectorAll("th");
+    expect(headers?.[0]?.textContent).toBe("Category");
+    expect(headers?.[1]?.textContent).toBe("Value");
+  });
 });

--- a/src/client/src/components/charts/DonutChart.tsx
+++ b/src/client/src/components/charts/DonutChart.tsx
@@ -18,6 +18,10 @@ interface DonutChartProps {
   height?: number;
   centerLabel?: string;
   formatValue?: (value: number) => string;
+  /** ARIA label used as the chart's accessible name when no labelledby id is available. */
+  "aria-label"?: string;
+  /** ID of an element that labels this chart (e.g. ChartCard's title id). */
+  "aria-labelledby"?: string;
 }
 
 export function DonutChart({
@@ -25,55 +29,85 @@ export function DonutChart({
   height = 300,
   centerLabel,
   formatValue = (v) => v.toLocaleString(),
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
 }: DonutChartProps) {
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <PieChart>
-        <Pie
-          data={data}
-          cx="50%"
-          cy="50%"
-          innerRadius="55%"
-          outerRadius="80%"
-          paddingAngle={2}
-          dataKey="value"
-          nameKey="name"
-          label={false}
-        >
-          {data.map((_entry, index) => (
-            <Cell
-              key={`cell-${index}`}
-              fill={CHART_COLORS[index % CHART_COLORS.length]}
-            />
+    <div>
+      {/* Visually-hidden data table — provides a text alternative (WCAG 1.1.1)
+          and resolves the color-only slice identification concern (WCAG 1.4.1) */}
+      <table className="sr-only">
+        <caption>{ariaLabel ?? "Donut chart data"}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Category</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((item) => (
+            <tr key={item.name}>
+              <td>{item.name}</td>
+              <td>{formatValue(item.value)}</td>
+            </tr>
           ))}
-        </Pie>
-        {centerLabel && (
-          <text
-            x="50%"
-            y="50%"
-            textAnchor="middle"
-            dominantBaseline="middle"
-            className="fill-foreground text-lg font-semibold"
-          >
-            {centerLabel}
-          </text>
-        )}
-        <Tooltip
-          formatter={(value) => [formatValue(Number(value))]}
-          contentStyle={{
-            backgroundColor: "hsl(var(--popover))",
-            border: "1px solid hsl(var(--border))",
-            borderRadius: "var(--radius)",
-            color: "hsl(var(--popover-foreground))",
-          }}
-        />
-        <Legend
-          verticalAlign="bottom"
-          iconType="circle"
-          iconSize={8}
-          wrapperStyle={{ fontSize: "12px" }}
-        />
-      </PieChart>
-    </ResponsiveContainer>
+        </tbody>
+      </table>
+
+      <div
+        role="img"
+        aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Donut chart")}
+        aria-labelledby={ariaLabelledBy}
+      >
+        <ResponsiveContainer width="100%" height={height}>
+          <PieChart>
+            <Pie
+              data={data}
+              cx="50%"
+              cy="50%"
+              innerRadius="55%"
+              outerRadius="80%"
+              paddingAngle={2}
+              dataKey="value"
+              nameKey="name"
+              label={false}
+            >
+              {data.map((_entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={CHART_COLORS[index % CHART_COLORS.length]}
+                />
+              ))}
+            </Pie>
+            {centerLabel && (
+              <text
+                x="50%"
+                y="50%"
+                textAnchor="middle"
+                dominantBaseline="middle"
+                className="fill-foreground text-lg font-semibold"
+              >
+                {centerLabel}
+              </text>
+            )}
+            <Tooltip
+              formatter={(value) => [formatValue(Number(value))]}
+              contentStyle={{
+                backgroundColor: "hsl(var(--popover))",
+                border: "1px solid hsl(var(--border))",
+                borderRadius: "var(--radius)",
+                color: "hsl(var(--popover-foreground))",
+              }}
+            />
+            <Legend
+              verticalAlign="bottom"
+              iconType="circle"
+              iconSize={8}
+              wrapperStyle={{ fontSize: "12px" }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
   );
 }

--- a/src/client/src/components/charts/StackedAreaChart.test.tsx
+++ b/src/client/src/components/charts/StackedAreaChart.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+import { StackedAreaChart } from "./StackedAreaChart";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  AreaChart: ({
+    children,
+    data,
+  }: {
+    children: React.ReactNode;
+    data: unknown[];
+  }) => (
+    <div data-testid="area-chart" data-count={data.length}>
+      {children}
+    </div>
+  ),
+  Area: ({ dataKey }: { dataKey: string }) => (
+    <div data-testid="area" data-key={dataKey} />
+  ),
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+const mockCategories = ["Food", "Transport", "Entertainment"];
+const mockBuckets = [
+  { period: "Jan", amounts: [100, 50, 30] },
+  { period: "Feb", amounts: [120, 60, 40] },
+  { period: "Mar", amounts: [90, 45, 25] },
+];
+
+describe("StackedAreaChart", () => {
+  it("renders the chart with data", () => {
+    render(<StackedAreaChart categories={mockCategories} buckets={mockBuckets} />);
+    expect(screen.getByTestId("responsive-container")).toBeInTheDocument();
+    expect(screen.getByTestId("area-chart")).toHaveAttribute("data-count", "3");
+  });
+
+  it("renders one Area element per category", () => {
+    render(<StackedAreaChart categories={mockCategories} buckets={mockBuckets} />);
+    expect(screen.getAllByTestId("area")).toHaveLength(3);
+  });
+
+  it("renders axis, grid, legend, and tooltip elements", () => {
+    render(<StackedAreaChart categories={mockCategories} buckets={mockBuckets} />);
+    expect(screen.getByTestId("x-axis")).toBeInTheDocument();
+    expect(screen.getByTestId("y-axis")).toBeInTheDocument();
+    expect(screen.getByTestId("cartesian-grid")).toBeInTheDocument();
+    expect(screen.getByTestId("legend")).toBeInTheDocument();
+    expect(screen.getByTestId("tooltip")).toBeInTheDocument();
+  });
+
+  it("renders with empty categories and buckets", () => {
+    render(<StackedAreaChart categories={[]} buckets={[]} />);
+    expect(screen.getByTestId("area-chart")).toHaveAttribute("data-count", "0");
+    expect(screen.queryAllByTestId("area")).toHaveLength(0);
+  });
+
+  // Accessibility tests
+  it("renders a visually-hidden data table with period and category columns", () => {
+    render(<StackedAreaChart categories={mockCategories} buckets={mockBuckets} />);
+    const table = document.querySelector("table.sr-only");
+    expect(table).toBeInTheDocument();
+    expect(screen.getByText("Jan")).toBeInTheDocument();
+    expect(screen.getByText("Feb")).toBeInTheDocument();
+    expect(screen.getByText("Mar")).toBeInTheDocument();
+  });
+
+  it("renders category names as column headers in the data table", () => {
+    render(<StackedAreaChart categories={mockCategories} buckets={mockBuckets} />);
+    const table = document.querySelector("table.sr-only");
+    const headers = table?.querySelectorAll("th");
+    const headerTexts = Array.from(headers ?? []).map((h) => h.textContent);
+    expect(headerTexts).toContain("Food");
+    expect(headerTexts).toContain("Transport");
+    expect(headerTexts).toContain("Entertainment");
+  });
+
+  it("renders chart container with role=img and accessible name", () => {
+    render(
+      <StackedAreaChart
+        categories={mockCategories}
+        buckets={mockBuckets}
+        aria-label="Category spending trends"
+      />,
+    );
+    expect(screen.getByRole("img", { name: "Category spending trends" })).toBeInTheDocument();
+  });
+
+  it("uses aria-labelledby when provided", () => {
+    render(
+      <div>
+        <h2 id="stacked-title">Spending by Category</h2>
+        <StackedAreaChart
+          categories={mockCategories}
+          buckets={mockBuckets}
+          aria-labelledby="stacked-title"
+        />
+      </div>,
+    );
+    const img = document.querySelector("[role='img']");
+    expect(img).toHaveAttribute("aria-labelledby", "stacked-title");
+    expect(img).not.toHaveAttribute("aria-label");
+  });
+
+  it("falls back to a default aria-label when neither aria-label nor aria-labelledby is provided", () => {
+    render(<StackedAreaChart categories={mockCategories} buckets={mockBuckets} />);
+    expect(screen.getByRole("img", { name: "Stacked area chart" })).toBeInTheDocument();
+  });
+
+  it("renders formatted values in the data table for each category", () => {
+    render(
+      <StackedAreaChart
+        categories={mockCategories}
+        buckets={mockBuckets}
+        formatValue={(v) => `$${v}`}
+      />,
+    );
+    expect(screen.getByText("$100")).toBeInTheDocument();
+    expect(screen.getByText("$50")).toBeInTheDocument();
+    expect(screen.getByText("$30")).toBeInTheDocument();
+  });
+
+  it("data table identifies each series by name, not color alone", () => {
+    render(<StackedAreaChart categories={mockCategories} buckets={mockBuckets} />);
+    const table = document.querySelector("table.sr-only");
+    const headers = table?.querySelectorAll("th");
+    // First column is Period, rest are category names
+    expect(headers?.[0]?.textContent).toBe("Period");
+    expect(headers?.[1]?.textContent).toBe("Food");
+  });
+});

--- a/src/client/src/components/charts/StackedAreaChart.tsx
+++ b/src/client/src/components/charts/StackedAreaChart.tsx
@@ -16,6 +16,10 @@ interface StackedAreaChartProps {
   buckets: Array<{ period: string; amounts: number[] }>;
   height?: number;
   formatValue?: (value: number) => string;
+  /** ARIA label used as the chart's accessible name when no labelledby id is available. */
+  "aria-label"?: string;
+  /** ID of an element that labels this chart (e.g. ChartCard's title id). */
+  "aria-labelledby"?: string;
 }
 
 export function StackedAreaChart({
@@ -23,6 +27,8 @@ export function StackedAreaChart({
   buckets,
   height = 350,
   formatValue = (v) => v.toLocaleString(),
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
 }: StackedAreaChartProps) {
   const baseId = useId();
 
@@ -41,78 +47,112 @@ export function StackedAreaChart({
   );
 
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <AreaChart
-        data={chartData}
-        margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
-      >
-        <defs>
-          {categories.map((cat, i) => (
-            <linearGradient
-              key={cat}
-              id={`${baseId}-gradient-${i}`}
-              x1="0"
-              y1="0"
-              x2="0"
-              y2="1"
-            >
-              <stop
-                offset="5%"
-                stopColor={CHART_COLORS[i % CHART_COLORS.length]}
-                stopOpacity={0.4}
-              />
-              <stop
-                offset="95%"
-                stopColor={CHART_COLORS[i % CHART_COLORS.length]}
-                stopOpacity={0.05}
-              />
-            </linearGradient>
+    <div>
+      {/* Visually-hidden data table — provides a text alternative (WCAG 1.1.1)
+          and resolves the color-only series identification concern (WCAG 1.4.1) */}
+      <table className="sr-only">
+        <caption>{ariaLabel ?? "Stacked area chart data"}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Period</th>
+            {categories.map((cat) => (
+              <th key={cat} scope="col">
+                {cat}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {buckets.map((bucket) => (
+            <tr key={bucket.period}>
+              <td>{bucket.period}</td>
+              {categories.map((cat, i) => (
+                <td key={cat}>{formatValue(bucket.amounts[i] ?? 0)}</td>
+              ))}
+            </tr>
           ))}
-        </defs>
-        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-        <XAxis
-          dataKey="period"
-          type="category"
-          tick={{ fontSize: 12 }}
-          className="fill-muted-foreground"
-        />
-        <YAxis
-          tick={{ fontSize: 12 }}
-          className="fill-muted-foreground"
-          tickFormatter={formatValue}
-        />
-        <Tooltip
-          formatter={(value, name) => [
-            formatValue(Number(value)),
-            String(name),
-          ]}
-          contentStyle={{
-            backgroundColor: "hsl(var(--popover))",
-            border: "1px solid hsl(var(--border))",
-            borderRadius: "var(--radius)",
-            color: "hsl(var(--popover-foreground))",
-          }}
-        />
-        <Legend
-          verticalAlign="bottom"
-          iconType="circle"
-          iconSize={8}
-          wrapperStyle={{ fontSize: "12px" }}
-        />
-        {categories.map((cat, i) => (
-          <Area
-            key={cat}
-            type="monotone"
-            dataKey={cat}
-            stackId="1"
-            stroke={CHART_COLORS[i % CHART_COLORS.length]}
-            fill={`url(#${baseId}-gradient-${i})`}
-            fillOpacity={0.3}
-            strokeWidth={2}
-            strokeOpacity={0.8}
-          />
-        ))}
-      </AreaChart>
-    </ResponsiveContainer>
+        </tbody>
+      </table>
+
+      <div
+        role="img"
+        aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Stacked area chart")}
+        aria-labelledby={ariaLabelledBy}
+      >
+        <ResponsiveContainer width="100%" height={height}>
+          <AreaChart
+            data={chartData}
+            margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
+          >
+            <defs>
+              {categories.map((cat, i) => (
+                <linearGradient
+                  key={cat}
+                  id={`${baseId}-gradient-${i}`}
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop
+                    offset="5%"
+                    stopColor={CHART_COLORS[i % CHART_COLORS.length]}
+                    stopOpacity={0.4}
+                  />
+                  <stop
+                    offset="95%"
+                    stopColor={CHART_COLORS[i % CHART_COLORS.length]}
+                    stopOpacity={0.05}
+                  />
+                </linearGradient>
+              ))}
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis
+              dataKey="period"
+              type="category"
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+            />
+            <YAxis
+              tick={{ fontSize: 12 }}
+              className="fill-muted-foreground"
+              tickFormatter={formatValue}
+            />
+            <Tooltip
+              formatter={(value, name) => [
+                formatValue(Number(value)),
+                String(name),
+              ]}
+              contentStyle={{
+                backgroundColor: "hsl(var(--popover))",
+                border: "1px solid hsl(var(--border))",
+                borderRadius: "var(--radius)",
+                color: "hsl(var(--popover-foreground))",
+              }}
+            />
+            <Legend
+              verticalAlign="bottom"
+              iconType="circle"
+              iconSize={8}
+              wrapperStyle={{ fontSize: "12px" }}
+            />
+            {categories.map((cat, i) => (
+              <Area
+                key={cat}
+                type="monotone"
+                dataKey={cat}
+                stackId="1"
+                stroke={CHART_COLORS[i % CHART_COLORS.length]}
+                fill={`url(#${baseId}-gradient-${i})`}
+                fillOpacity={0.3}
+                strokeWidth={2}
+                strokeOpacity={0.8}
+              />
+            ))}
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
   );
 }

--- a/src/client/src/components/dashboard/SpendingByStoreWidget.test.tsx
+++ b/src/client/src/components/dashboard/SpendingByStoreWidget.test.tsx
@@ -39,8 +39,9 @@ describe("SpendingByStoreWidget", () => {
 
     renderWithQueryClient(<SpendingByStoreWidget dateRange={dateRange} />);
     expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
-    expect(screen.getByText("Walmart")).toBeInTheDocument();
-    expect(screen.getByText("Target")).toBeInTheDocument();
+    // Location names appear in both the sr-only chart data table and the visible summary table
+    expect(screen.getAllByText("Walmart").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Target").length).toBeGreaterThan(0);
   });
 
   it("shows loading state", () => {


### PR DESCRIPTION
## Summary

- Add `role="img"` container with `aria-label`/`aria-labelledby` to BarChart, DonutChart, AreaTimeChart, and StackedAreaChart (WCAG 1.1.1 Non-text Content)
- Add visually-hidden `<table class="sr-only">` to each chart, mirroring all series and values — resolves both the missing text alternative (1.1.1) and color-only series identification (1.4.1 Use of Color)
- Extend `ChartCard` to accept a render-prop children signature so consumers can access the card's `titleId` for `aria-labelledby` wiring; plain ReactNode children continue to work unchanged
- Add accessibility tests to all four existing chart test files; add new `StackedAreaChart.test.tsx`
- Fix `SpendingByStoreWidget.test.tsx` to handle duplicate text nodes introduced by the sr-only table

Resolves RECEIPTS-688

## Assumptions

- Used the `sr-only` Tailwind utility class for the visually-hidden table (matches existing usage in codebase)
- ChartCard render-prop is opt-in; existing callers using plain JSX children are unaffected
- The `Legend` component in DonutChart and StackedAreaChart already provides text labels next to color swatches — the sr-only table is the definitive color-independent alternative

## Test plan

- All 1881 Vitest tests pass
- New accessibility tests verify: `role="img"` presence, `aria-labelledby`/`aria-label` wiring, sr-only table with correct headers and data, formatted values in the table, and color-only concerns addressed
- Manual: open a chart page in Chrome with NVDA/JAWS — the sr-only table should be announced before the SVG, and the chart container should announce its label