### PR TITLE
fix(client): forward aria-label through FuzzySearchInput (RECEIPTS-689)

### DIFF
--- a/src/client/src/components/FuzzySearchInput.test.tsx
+++ b/src/client/src/components/FuzzySearchInput.test.tsx
@@ -83,4 +83,54 @@ describe("FuzzySearchInput", () => {
     );
     expect(screen.queryByText("Ctrl+K")).not.toBeInTheDocument();
   });
+
+  it("forwards aria-label to the underlying input element", () => {
+    render(
+      <FuzzySearchInput
+        {...defaultProps}
+        aria-label="Search accounts"
+      />,
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Search accounts" }),
+    ).toBeInTheDocument();
+  });
+
+  it("forwards id to the underlying input element", () => {
+    render(
+      <FuzzySearchInput
+        {...defaultProps}
+        id="accounts-search"
+      />,
+    );
+    expect(document.getElementById("accounts-search")).not.toBeNull();
+  });
+
+  it("announces result count via aria-live region when filtering", () => {
+    render(
+      <FuzzySearchInput
+        {...defaultProps}
+        value="test"
+        resultCount={3}
+        totalCount={57}
+      />,
+    );
+    // The live region should contain the announcement text
+    const liveRegion = document.querySelector("[aria-live='polite']");
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion?.textContent).toBe("3 of 57 results");
+  });
+
+  it("clears aria-live region when search value is empty", () => {
+    render(
+      <FuzzySearchInput
+        {...defaultProps}
+        value=""
+        resultCount={3}
+        totalCount={57}
+      />,
+    );
+    const liveRegion = document.querySelector("[aria-live='polite']");
+    expect(liveRegion?.textContent).toBe("");
+  });
 });

--- a/src/client/src/components/FuzzySearchInput.tsx
+++ b/src/client/src/components/FuzzySearchInput.tsx
@@ -11,6 +11,8 @@ interface FuzzySearchInputProps {
   totalCount?: number;
   className?: string;
   showShortcutHint?: boolean;
+  "aria-label"?: string;
+  id?: string;
 }
 
 export function FuzzySearchInput({
@@ -21,19 +23,34 @@ export function FuzzySearchInput({
   totalCount,
   className,
   showShortcutHint = false,
+  "aria-label": ariaLabel,
+  id,
 }: FuzzySearchInputProps) {
+  const showCount =
+    value && resultCount !== undefined && totalCount !== undefined;
+
   return (
     <div className={cn("relative", className)}>
       <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
       <Input
+        id={id}
+        aria-label={ariaLabel}
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="pl-9 pr-24"
       />
+      {/* Visually hidden live region announces result count changes to screen readers */}
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {showCount ? `${resultCount} of ${totalCount} results` : ""}
+      </span>
       <div className="absolute right-3 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
-        {value && resultCount !== undefined && totalCount !== undefined && (
-          <Badge variant="secondary" className="text-xs">
+        {showCount && (
+          <Badge variant="secondary" className="text-xs" aria-hidden="true">
             {resultCount}/{totalCount}
           </Badge>
         )}


### PR DESCRIPTION
## Summary

- `FuzzySearchInputProps` did not declare `aria-label` or `id`, so every caller's `aria-label` was silently dropped — all list-page search boxes were unlabeled text inputs (WCAG 4.1.2 Name/Role/Value)
- Added `aria-label` and `id` to the props interface and forwarded both to the inner `<Input>` element
- Added a visually-hidden `aria-live="polite"` region that announces "{resultCount} of {totalCount} results" when filter results change, giving screen readers audible feedback (WCAG 4.1.3 Status Messages); the visible `<Badge>` gets `aria-hidden="true"` to avoid duplicate announcement

Resolves RECEIPTS-689

## Test plan

- [ ] Run `npm test -- --run src/components/FuzzySearchInput.test.tsx` — all 12 tests pass
- [ ] Verify `getByRole('textbox', { name: 'Search accounts' })` resolves correctly (new test)
- [ ] Verify `aria-live` region text is "3 of 57 results" when filtering (new test)
- [ ] Verify `aria-live` region is empty when search is cleared (new test)
- [ ] Manual: open any list page, inspect the search input — confirm `aria-label` attribute is present
- [ ] Manual: use a screen reader on a list page and filter — confirm result count is announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)