### PR TITLE
refactor(client): standardize checkbox controls (RECEIPTS-693)

### DIFF
--- a/src/client/src/components/AccountForm.tsx
+++ b/src/client/src/components/AccountForm.tsx
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import {
@@ -90,11 +91,9 @@ export function AccountForm({
             <FormItem>
               <div className="flex items-center gap-2">
                 <FormControl>
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={field.value}
-                    onChange={field.onChange}
-                    className="h-4 w-4 rounded border-gray-300"
+                    onCheckedChange={field.onChange}
                   />
                 </FormControl>
                 <FormLabel>Active</FormLabel>

--- a/src/client/src/components/AdjustmentsCard.tsx
+++ b/src/client/src/components/AdjustmentsCard.tsx
@@ -37,6 +37,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Checkbox } from "@/components/ui/checkbox";
 import { formatCurrency } from "@/lib/format";
 import { Pencil } from "lucide-react";
 
@@ -155,21 +156,19 @@ export function AdjustmentsCard({
                 <TableHeader>
                   <TableRow>
                     <TableHead className="w-12">
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         aria-label="Select all adjustments"
                         checked={
                           selectedAdjs.size === adjustments.length &&
                           adjustments.length > 0
                         }
-                        onChange={() => {
+                        onCheckedChange={() => {
                           if (selectedAdjs.size === adjustments.length) {
                             setSelectedAdjs(new Set());
                           } else {
                             setSelectedAdjs(new Set(adjustments.map((a) => a.id)));
                           }
                         }}
-                        className="h-4 w-4 rounded border-gray-300"
                       />
                     </TableHead>
                     <TableHead>Type</TableHead>
@@ -182,12 +181,10 @@ export function AdjustmentsCard({
                   {adjustments.map((adj) => (
                     <TableRow key={adj.id}>
                       <TableCell>
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           aria-label={`Select ${adj.type} adjustment`}
                           checked={selectedAdjs.has(adj.id)}
-                          onChange={() => toggleSelect(adj.id)}
-                          className="h-4 w-4 rounded border-gray-300"
+                          onCheckedChange={() => toggleSelect(adj.id)}
                         />
                       </TableCell>
                       <TableCell>

--- a/src/client/src/components/CardForm.tsx
+++ b/src/client/src/components/CardForm.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useAccounts } from "@/hooks/useAccounts";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import { Combobox } from "@/components/ui/combobox";
@@ -143,11 +144,9 @@ export function CardForm({
             <FormItem>
               <div className="flex items-center gap-2">
                 <FormControl>
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={field.value}
-                    onChange={field.onChange}
-                    className="h-4 w-4 rounded border-gray-300"
+                    onCheckedChange={field.onChange}
                   />
                 </FormControl>
                 <FormLabel>Active</FormLabel>

--- a/src/client/src/components/CategoryForm.tsx
+++ b/src/client/src/components/CategoryForm.tsx
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import {
@@ -88,11 +89,9 @@ export function CategoryForm({
             <FormItem>
               <div className="flex items-center gap-2">
                 <FormControl>
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={field.value}
-                    onChange={field.onChange}
-                    className="h-4 w-4 rounded border-gray-300"
+                    onCheckedChange={field.onChange}
                   />
                 </FormControl>
                 <FormLabel>Active</FormLabel>

--- a/src/client/src/components/ReceiptItemsCard.tsx
+++ b/src/client/src/components/ReceiptItemsCard.tsx
@@ -36,6 +36,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Checkbox } from "@/components/ui/checkbox";
 import { formatCurrency } from "@/lib/format";
 import { Pencil } from "lucide-react";
 
@@ -178,14 +179,13 @@ export function ReceiptItemsCard({
                 <TableHeader>
                   <TableRow>
                     <TableHead className="w-12">
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         aria-label="Select all items"
                         checked={
                           selectedItems.size === items.length &&
                           items.length > 0
                         }
-                        onChange={() => {
+                        onCheckedChange={() => {
                           if (selectedItems.size === items.length) {
                             setSelectedItems(new Set());
                           } else {
@@ -194,7 +194,6 @@ export function ReceiptItemsCard({
                             );
                           }
                         }}
-                        className="h-4 w-4 rounded border-gray-300"
                       />
                     </TableHead>
                     <TableHead>Code</TableHead>
@@ -211,12 +210,10 @@ export function ReceiptItemsCard({
                   {items.map((item) => (
                     <TableRow key={item.id}>
                       <TableCell>
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           aria-label={`Select ${item.description} item`}
                           checked={selectedItems.has(item.id)}
-                          onChange={() => toggleSelect(item.id)}
-                          className="h-4 w-4 rounded border-gray-300"
+                          onCheckedChange={() => toggleSelect(item.id)}
                         />
                       </TableCell>
                       <TableCell className="font-mono">

--- a/src/client/src/components/ReceiptTransactionsCard.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.tsx
@@ -37,6 +37,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Checkbox } from "@/components/ui/checkbox";
 import { formatCurrency } from "@/lib/format";
 import { Pencil } from "lucide-react";
 
@@ -172,14 +173,13 @@ export function ReceiptTransactionsCard({
                 <TableHeader>
                   <TableRow>
                     <TableHead className="w-12">
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         aria-label="Select all transactions"
                         checked={
                           selectedTxns.size === transactions.length &&
                           transactions.length > 0
                         }
-                        onChange={() => {
+                        onCheckedChange={() => {
                           if (selectedTxns.size === transactions.length) {
                             setSelectedTxns(new Set());
                           } else {
@@ -188,7 +188,6 @@ export function ReceiptTransactionsCard({
                             );
                           }
                         }}
-                        className="h-4 w-4 rounded border-gray-300"
                       />
                     </TableHead>
                     <TableHead className="text-right">Amount</TableHead>
@@ -203,12 +202,10 @@ export function ReceiptTransactionsCard({
                   {transactions.map((ta) => (
                     <TableRow key={ta.transaction.id}>
                       <TableCell>
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           aria-label={`Select ${ta.account.name} transaction`}
                           checked={selectedTxns.has(ta.transaction.id)}
-                          onChange={() => toggleSelect(ta.transaction.id)}
-                          className="h-4 w-4 rounded border-gray-300"
+                          onCheckedChange={() => toggleSelect(ta.transaction.id)}
                         />
                       </TableCell>
                       <TableCell className="text-right">

--- a/src/client/src/components/SubcategoryForm.tsx
+++ b/src/client/src/components/SubcategoryForm.tsx
@@ -6,6 +6,7 @@ import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useFieldHistory } from "@/hooks/useFieldHistory";
 import { useCategories } from "@/hooks/useCategories";
 import { subcategoryNameHistory } from "@/lib/field-history";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Combobox } from "@/components/ui/combobox";
 import { Button } from "@/components/ui/button";
 import { SubmitButton } from "@/components/ui/submit-button";
@@ -144,11 +145,9 @@ export function SubcategoryForm({
             <FormItem>
               <div className="flex items-center gap-2">
                 <FormControl>
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={field.value}
-                    onChange={field.onChange}
-                    className="h-4 w-4 rounded border-gray-300"
+                    onCheckedChange={field.onChange}
                   />
                 </FormControl>
                 <FormLabel>Active</FormLabel>

--- a/src/client/src/components/reports/UncategorizedItems.tsx
+++ b/src/client/src/components/reports/UncategorizedItems.tsx
@@ -17,6 +17,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
 import client from "@/lib/api-client";
@@ -297,12 +298,10 @@ export default function UncategorizedItems() {
         <TableHeader>
           <TableRow>
             <TableHead className="w-10">
-              <input
-                type="checkbox"
+              <Checkbox
                 checked={!!allOnPageSelected}
-                onChange={handleToggleAll}
+                onCheckedChange={handleToggleAll}
                 aria-label="Select all items on this page"
-                className="h-4 w-4 rounded border-gray-300"
               />
             </TableHead>
             <TableHead
@@ -331,12 +330,10 @@ export default function UncategorizedItems() {
           {data.items.map((item) => (
             <TableRow key={item.id}>
               <TableCell>
-                <input
-                  type="checkbox"
+                <Checkbox
                   checked={selectedIds.has(item.id)}
-                  onChange={() => handleToggleItem(item.id)}
+                  onCheckedChange={() => handleToggleItem(item.id)}
                   aria-label={`Select ${item.description}`}
-                  className="h-4 w-4 rounded border-gray-300"
                 />
               </TableCell>
               <TableCell>{item.description}</TableCell>

--- a/src/client/src/components/ui/checkbox.test.tsx
+++ b/src/client/src/components/ui/checkbox.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Checkbox } from "./checkbox";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "./form";
+
+// ---------------------------------------------------------------------------
+// Standalone Checkbox tests
+// ---------------------------------------------------------------------------
+
+describe("Checkbox", () => {
+  it("renders as a button with role=checkbox", () => {
+    render(<Checkbox aria-label="Accept terms" />);
+    expect(screen.getByRole("checkbox", { name: "Accept terms" })).toBeInTheDocument();
+  });
+
+  it("is unchecked by default", () => {
+    render(<Checkbox aria-label="Accept terms" />);
+    const checkbox = screen.getByRole("checkbox", { name: "Accept terms" });
+    expect(checkbox).toHaveAttribute("data-state", "unchecked");
+  });
+
+  it("reflects checked state when controlled", () => {
+    render(<Checkbox aria-label="Accept terms" checked />);
+    const checkbox = screen.getByRole("checkbox", { name: "Accept terms" });
+    expect(checkbox).toHaveAttribute("data-state", "checked");
+  });
+
+  it("calls onCheckedChange when clicked", async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+    render(
+      <Checkbox aria-label="Accept terms" onCheckedChange={onCheckedChange} />,
+    );
+    await user.click(screen.getByRole("checkbox", { name: "Accept terms" }));
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("does not call onCheckedChange when disabled", async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+    render(
+      <Checkbox
+        aria-label="Accept terms"
+        disabled
+        onCheckedChange={onCheckedChange}
+      />,
+    );
+    await user.click(screen.getByRole("checkbox", { name: "Accept terms" }));
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+
+  it("uses border-input token class (no hardcoded border-gray-300)", () => {
+    render(<Checkbox aria-label="Token check" />);
+    const checkbox = screen.getByRole("checkbox", { name: "Token check" });
+    expect(checkbox.className).toContain("border-input");
+    expect(checkbox.className).not.toContain("border-gray-300");
+  });
+
+  it("uses the focus-visible ring class for consistent focus styling", () => {
+    render(<Checkbox aria-label="Focus check" />);
+    const checkbox = screen.getByRole("checkbox", { name: "Focus check" });
+    expect(checkbox.className).toContain("focus-visible:ring-[3px]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Checkbox inside react-hook-form (label association)
+// ---------------------------------------------------------------------------
+
+const schema = z.object({
+  isActive: z.boolean(),
+});
+type TestValues = z.infer<typeof schema>;
+
+function CheckboxForm({
+  onSubmit = () => {},
+  defaultValues = { isActive: false },
+}: {
+  onSubmit?: (values: TestValues) => void;
+  defaultValues?: Partial<TestValues>;
+}) {
+  const form = useForm<TestValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { isActive: false, ...defaultValues },
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          control={form.control}
+          name="isActive"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center gap-2">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+                <FormLabel>Active</FormLabel>
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <button type="submit">Submit</button>
+      </form>
+    </Form>
+  );
+}
+
+describe("Checkbox in Form", () => {
+  it("renders label text", () => {
+    render(<CheckboxForm />);
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("label is programmatically associated with the checkbox via htmlFor/id", () => {
+    render(<CheckboxForm />);
+    // getByLabelText will find the checkbox only if htmlFor matches id
+    const checkbox = screen.getByLabelText("Active");
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toHaveAttribute("role", "checkbox");
+  });
+
+  it("toggles state when clicked", async () => {
+    const user = userEvent.setup();
+    render(<CheckboxForm defaultValues={{ isActive: false }} />);
+    const checkbox = screen.getByLabelText("Active");
+    expect(checkbox).toHaveAttribute("data-state", "unchecked");
+    await user.click(checkbox);
+    expect(checkbox).toHaveAttribute("data-state", "checked");
+  });
+
+  it("submits the correct boolean value", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<CheckboxForm onSubmit={onSubmit} defaultValues={{ isActive: false }} />);
+    await user.click(screen.getByLabelText("Active"));
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+    // react-hook-form handleSubmit passes (values, event) to the onSubmit handler
+    expect(onSubmit).toHaveBeenCalledWith({ isActive: true }, expect.anything());
+  });
+});

--- a/src/client/src/components/ui/checkbox.tsx
+++ b/src/client/src/components/ui/checkbox.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import * as React from "react";
+import { Checkbox as CheckboxPrimitive } from "radix-ui";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer h-4 w-4 shrink-0 rounded border border-input shadow-xs",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary",
+        "aria-invalid:border-destructive",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <Check className="h-3 w-3" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -16,6 +16,7 @@ import { useServerPagination } from "@/hooks/useServerPagination";
 import { useServerSort } from "@/hooks/useServerSort";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Badge } from "@/components/ui/badge";
@@ -58,7 +59,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Label } from "@/components/ui/label";
 import { Pencil } from "lucide-react";
 
 const ROLE_OPTIONS = [
@@ -543,15 +543,12 @@ function AdminUsers() {
                   <FormItem>
                     <div className="flex items-center gap-3">
                       <FormControl>
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           checked={field.value}
-                          onChange={field.onChange}
-                          className="h-4 w-4 rounded border-gray-300"
-                          aria-label="Disable account"
+                          onCheckedChange={field.onChange}
                         />
                       </FormControl>
-                      <Label>Account Disabled</Label>
+                      <FormLabel>Account Disabled</FormLabel>
                     </div>
                     <FormMessage />
                   </FormItem>

--- a/src/client/src/pages/ApiKeys.tsx
+++ b/src/client/src/pages/ApiKeys.tsx
@@ -10,6 +10,7 @@ import client from "@/lib/api-client";
 import { showSuccess, showError } from "@/lib/toast";
 import { capitalize } from "@/lib/format";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Card,
   CardContent,
@@ -314,11 +315,9 @@ function ApiKeys() {
                   render={({ field }) => (
                     <FormItem className="flex items-center gap-2">
                       <FormControl>
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           checked={field.value}
-                          onChange={field.onChange}
-                          className="h-4 w-4 rounded border-input"
+                          onCheckedChange={field.onChange}
                         />
                       </FormControl>
                       <FormLabel className="!mt-0">

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -39,6 +39,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Spinner } from "@/components/ui/spinner";
 import { Pencil } from "lucide-react";
 
@@ -193,15 +194,13 @@ function ItemTemplates() {
               <TableHeader>
                 <TableRow>
                   <TableHead className="w-12">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       aria-label="Select all rows"
                       checked={
                         selected.size === filteredResults.length &&
                         filteredResults.length > 0
                       }
-                      onChange={toggleAll}
-                      className="h-4 w-4 rounded border-gray-300"
+                      onCheckedChange={toggleAll}
                     />
                   </TableHead>
                   <SortableTableHead column="name" label="Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
@@ -231,12 +230,10 @@ function ItemTemplates() {
                       }}
                     >
                       <TableCell>
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           aria-label={`Select ${template.name}`}
                           checked={selected.has(template.id)}
-                          onChange={() => toggleSelect(template.id)}
-                          className="h-4 w-4 rounded border-gray-300"
+                          onCheckedChange={() => toggleSelect(template.id)}
                         />
                       </TableCell>
                       <TableCell>

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -45,6 +45,7 @@ import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Info, Pencil } from "lucide-react";
 import { useReceiptYnabSyncStatuses } from "@/hooks/useYnab";
 import { YnabSyncBadge } from "@/components/YnabSyncBadge";
@@ -282,15 +283,13 @@ function Receipts() {
               <TableHeader>
                 <TableRow>
                   <TableHead className="w-12">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       aria-label="Select all rows"
                       checked={
                         selected.size === filteredResults.length &&
                         filteredResults.length > 0
                       }
-                      onChange={toggleAll}
-                      className="h-4 w-4 rounded border-gray-300"
+                      onCheckedChange={toggleAll}
                     />
                   </TableHead>
                   <SortableTableHead column="location" label="Location" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
@@ -315,12 +314,10 @@ function Receipts() {
                       }}
                     >
                       <TableCell>
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           aria-label={`Select ${receipt.location}`}
                           checked={selected.has(receipt.id)}
-                          onChange={() => toggleSelect(receipt.id)}
-                          className="h-4 w-4 rounded border-gray-300"
+                          onCheckedChange={() => toggleSelect(receipt.id)}
                         />
                       </TableCell>
                       <TableCell>

--- a/src/client/src/test/setup.ts
+++ b/src/client/src/test/setup.ts
@@ -1,6 +1,16 @@
 /// <reference types="vitest/globals" />
 import "@testing-library/jest-dom/vitest";
 
+// Polyfill ResizeObserver for Radix UI primitives (e.g., Checkbox uses @radix-ui/react-use-size)
+if (typeof globalThis.ResizeObserver === "undefined") {
+  class ResizeObserverPolyfill {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = ResizeObserverPolyfill;
+}
+
 // Polyfill matchMedia for jsdom (used by useIsTouchDevice hook)
 if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
   window.matchMedia = (query: string) =>


### PR DESCRIPTION
## Summary

- Create a `Checkbox` design-system primitive (`src/client/src/components/ui/checkbox.tsx`) using Radix `Checkbox.Root` with `border-input` token, a 3px `focus-visible` ring, and proper checked/unchecked state styling.
- Replace all raw `<input type="checkbox" className="border-gray-300">` across 12 components (forms, tables, reports) with the new `Checkbox` primitive.
- Fix missing label association in `AdminUsers` by switching from bare `<Label>` to `<FormLabel>`, which automatically wires `htmlFor`/`id` via react-hook-form context.
- Add `ResizeObserver` polyfill to Vitest setup (required by `@radix-ui/react-use-size` used by the Checkbox primitive).
- Add 11 Vitest tests for the Checkbox component covering token usage, focus styling, label association, and form integration.

Resolves RECEIPTS-693

## Test plan

- All 1904 Vitest tests pass (`npm test -- --run` from `src/client`).
- TypeScript compiles without errors (`npx tsc --noEmit`).
- ESLint produces no new errors (2 pre-existing warnings remain).
- Verify no `border-gray-300` remains in production code: `grep -rn "border-gray-300" src/client/src/ | grep -v test` should be empty.
- Visually verify checkboxes in AccountForm, CardForm, CategoryForm, SubcategoryForm, AdminUsers, ApiKeys, Receipts, ItemTemplates, and the receipt detail cards show consistent styling with the design system focus ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)