### PR TITLE
fix(client): announce empty/no-results states (RECEIPTS-696)

### DIFF
--- a/src/client/src/components/NoResults.test.tsx
+++ b/src/client/src/components/NoResults.test.tsx
@@ -92,4 +92,21 @@ describe("NoResults", () => {
     await user.click(screen.getByText("alpha"));
     expect(onSelectSuggestion).toHaveBeenCalledWith("alpha");
   });
+
+  it("has role='status' so screen readers announce the empty state", () => {
+    renderWithProviders(<NoResults {...defaultProps} />);
+    // role="status" is an implicit aria-live="polite" region;
+    // when NoResults mounts, its content is announced to screen readers.
+    const statusRegion = screen.getByRole("status");
+    expect(statusRegion).toBeInTheDocument();
+  });
+
+  it("role='status' region contains the no-results message", () => {
+    renderWithProviders(
+      <NoResults {...defaultProps} searchTerm="hello" entityName="receipts" />,
+    );
+    const statusRegion = screen.getByRole("status");
+    expect(statusRegion).toHaveTextContent(/No receipts match/);
+    expect(statusRegion).toHaveTextContent("hello");
+  });
 });

--- a/src/client/src/components/NoResults.tsx
+++ b/src/client/src/components/NoResults.tsx
@@ -19,7 +19,7 @@ export function NoResults({
   const suggestions = history.filter((h) => h !== searchTerm).slice(0, 5);
 
   return (
-    <div className="flex flex-col items-center py-12 text-center">
+    <div role="status" className="flex flex-col items-center py-12 text-center">
       <Search className="mb-3 h-10 w-10 text-muted-foreground/50" />
       <p className="text-sm text-muted-foreground">
         No {entityName} match &ldquo;

--- a/src/client/src/pages/Accounts.tsx
+++ b/src/client/src/pages/Accounts.tsx
@@ -236,7 +236,7 @@ function Accounts() {
             entityName="accounts"
           />
         ) : (
-          <div className="py-12 text-center text-muted-foreground">
+          <div role="status" className="py-12 text-center text-muted-foreground">
             No accounts yet. Create one to get started.
           </div>
         )

--- a/src/client/src/pages/Cards.tsx
+++ b/src/client/src/pages/Cards.tsx
@@ -236,7 +236,7 @@ function Cards() {
             entityName="cards"
           />
         ) : (
-          <div className="py-12 text-center text-muted-foreground">
+          <div role="status" className="py-12 text-center text-muted-foreground">
             No cards yet. Create one to get started.
           </div>
         )

--- a/src/client/src/pages/Categories.tsx
+++ b/src/client/src/pages/Categories.tsx
@@ -183,7 +183,7 @@ function Categories() {
             entityName="categories"
           />
         ) : (
-          <div className="py-12 text-center text-muted-foreground">
+          <div role="status" className="py-12 text-center text-muted-foreground">
             No categories yet. Create one to get started.
           </div>
         )

--- a/src/client/src/pages/ItemTemplates.tsx
+++ b/src/client/src/pages/ItemTemplates.tsx
@@ -175,7 +175,7 @@ function ItemTemplates() {
             entityName="item templates"
           />
         ) : (
-          <div className="py-12 text-center text-muted-foreground">
+          <div role="status" className="py-12 text-center text-muted-foreground">
             No item templates yet. Create one to get started.
           </div>
         )

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -264,7 +264,7 @@ function Receipts() {
             entityName="receipts"
           />
         ) : (
-          <div className="py-12 text-center text-muted-foreground">
+          <div role="status" className="py-12 text-center text-muted-foreground">
             No receipts yet. Create one to get started.
           </div>
         )

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -327,7 +327,7 @@ function Subcategories() {
             entityName="subcategories"
           />
         ) : (
-          <div className="py-12 text-center text-muted-foreground">
+          <div role="status" className="py-12 text-center text-muted-foreground">
             No subcategories yet. Create one to get started.
           </div>
         )


### PR DESCRIPTION
## Summary
- Added `role=\"status\"` to the `NoResults` component root element so screen readers announce the empty-search state when it mounts (WCAG 4.1.3 Status Messages AA)
- Added `role=\"status\"` to all six \"No X yet\" empty-state divs (Receipts, Accounts, Cards, Categories, Subcategories, ItemTemplates) for the same reason
- Coordinates with `FuzzySearchInput`'s existing `aria-live=\"polite\"` result-count region (RECEIPTS-689): `NoResults` only renders when count is 0, so there is one clear announcement mechanism with no double-announcing

Resolves RECEIPTS-696

## Test plan
- All 1916 existing Vitest tests pass; 2 new tests in `NoResults.test.tsx` verify `role=\"status\"` is present and contains the no-results message
- Manual: type a non-matching search term on any list page — screen reader should announce the no-results message