### PR TITLE
fix(client): unify currency input focus ring (RECEIPTS-694)

### DIFF
--- a/src/client/src/components/ui/currency-input.test.tsx
+++ b/src/client/src/components/ui/currency-input.test.tsx
@@ -136,6 +136,15 @@ describe("CurrencyInput", () => {
     expect(input).toHaveAttribute("autocomplete", "off");
   });
 
+  it("carries unified focus-ring classes matching the shared Input component", () => {
+    render(<CurrencyInput {...defaultProps} />);
+
+    const input = screen.getByRole("textbox");
+    expect(input.className).toContain("focus-visible:border-ring");
+    expect(input.className).toContain("focus-visible:ring-ring/50");
+    expect(input.className).toContain("focus-visible:ring-[3px]");
+  });
+
   it("keeps text empty (not '0.00') when focusing a zero-value field", async () => {
     const user = userEvent.setup();
 

--- a/src/client/src/components/ui/currency-input.tsx
+++ b/src/client/src/components/ui/currency-input.tsx
@@ -177,7 +177,7 @@ export function CurrencyInput({
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-[color,box-shadow] file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
           "pl-7 text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
           className,
         )}


### PR DESCRIPTION
## Summary
- Replace `focus-visible:ring-1 focus-visible:ring-ring` on `CurrencyInput` with the shared 3px ring treatment (`focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]`) used by `Input`, `PasswordInput`, and `DateInput`
- Also align `shadow-xs` and `transition-[color,box-shadow]` utilities to match `Input` exactly
- Add a Vitest assertion verifying the unified focus classes are present on the rendered element

Resolves RECEIPTS-694

## Test plan
- All 1930 Vitest tests pass, including the new `carries unified focus-ring classes matching the shared Input component` assertion
- Visually: focus a currency field and verify the 3px ring with 50% opacity matches the appearance of other text inputs
- ESLint: no linting issues on changed files