### PR TITLE
fix(client): give AuditLog combobox filters accessible names (RECEIPTS-698)

### DIFF
--- a/src/client/src/components/ui/combobox.test.tsx
+++ b/src/client/src/components/ui/combobox.test.tsx
@@ -191,6 +191,19 @@ describe("Combobox", () => {
     });
   });
 
+  it("forwards aria-label to the underlying button trigger", () => {
+    render(
+      <Combobox
+        {...defaultProps}
+        aria-label="Filter by entity type"
+      />,
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: "Filter by entity type" }),
+    ).toBeInTheDocument();
+  });
+
   it("filters by sublabel when present", async () => {
     const optionsWithSublabels: ComboboxOption[] = [
       { value: "milk", label: "Milk", sublabel: "Dairy" },

--- a/src/client/src/pages/AuditLog.test.tsx
+++ b/src/client/src/pages/AuditLog.test.tsx
@@ -214,6 +214,20 @@ describe("AuditLog", () => {
     expect(triggers.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("entity type combobox has an explicit accessible name", () => {
+    renderWithProviders(<AuditLog />);
+    expect(
+      screen.getByRole("combobox", { name: /filter by entity type/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("action combobox has an explicit accessible name", () => {
+    renderWithProviders(<AuditLog />);
+    expect(
+      screen.getByRole("combobox", { name: /filter by action/i }),
+    ).toBeInTheDocument();
+  });
+
   it("renders DateRangePicker From and To buttons", () => {
     renderWithProviders(<AuditLog />);
     const buttons = screen.getAllByRole("button");

--- a/src/client/src/pages/AuditLog.tsx
+++ b/src/client/src/pages/AuditLog.tsx
@@ -251,6 +251,7 @@ function AuditLog() {
           placeholder="Entity Type"
           searchPlaceholder="Search types..."
           className="w-[160px]"
+          aria-label="Filter by entity type"
         />
         <Combobox
           options={actionOptions}
@@ -259,6 +260,7 @@ function AuditLog() {
           placeholder="Action"
           searchPlaceholder="Search actions..."
           className="w-[140px]"
+          aria-label="Filter by action"
         />
         <DateRangePicker
           from={dateFrom}


### PR DESCRIPTION
## Summary

- Add `aria-label="Filter by entity type"` and `aria-label="Filter by action"` to the two `Combobox` filters on the Audit Log page
- The `Combobox` component already forwards spread props (`...rest`) to its underlying `<Button>` trigger, so no component changes were needed
- Add Vitest tests asserting both comboboxes have explicit accessible names (WCAG 4.1.2 Name/Role/Value)

Resolves RECEIPTS-698

## Test plan

- [ ] Run `npm test` from `src/client` — all 1962 tests pass including 3 new tests for accessible names
- [ ] New `combobox.test.tsx` test: `"forwards aria-label to the underlying button trigger"`
- [ ] New `AuditLog.test.tsx` tests: `"entity type combobox has an explicit accessible name"` and `"action combobox has an explicit accessible name"`
- [ ] Manual: Open Audit Log page, inspect the combobox buttons with browser devtools or a screen reader — both should announce their labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)