### PR TITLE
fix(client): reflow ReceiptTransactionsCard table at narrow viewports (RECEIPTS-702)

### DIFF
--- a/src/client/src/components/ReceiptTransactionsCard.test.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.test.tsx
@@ -398,4 +398,44 @@ describe("ReceiptTransactionsCard", () => {
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(mockDeleteMutate).not.toHaveBeenCalled();
   });
+
+  it("wraps long account names so the table cannot force page horizontal scroll (WCAG 1.4.10)", () => {
+    const longAccountName = "A".repeat(200);
+    const transactionsWithLongName = [
+      {
+        transaction: { id: "txn-long-1", amount: 50.0, date: "2024-01-15", cardId: null },
+        account: {
+          id: "acc-long-1",
+          name: longAccountName,
+          isActive: true,
+        },
+      },
+    ];
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={transactionsWithLongName}
+        transactionsTotal={50.0}
+      />,
+    );
+    const cell = screen.getByText(longAccountName).closest("td");
+    expect(cell).not.toBeNull();
+    expect(cell).toHaveClass("whitespace-normal");
+    expect(cell).toHaveClass("break-words");
+    expect(cell).toHaveClass("max-w-[32ch]");
+  });
+
+  it("table wrapper has overflow-x-auto to contain horizontal overflow within the widget (WCAG 1.4.10)", () => {
+    renderWithQueryClient(
+      <ReceiptTransactionsCard
+        receiptId="receipt-1"
+        transactions={mockTransactions}
+        transactionsTotal={75.5}
+      />,
+    );
+    const table = screen.getByRole("table");
+    const wrapper = table.closest("div");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toHaveClass("overflow-x-auto");
+  });
 });

--- a/src/client/src/components/ReceiptTransactionsCard.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.tsx
@@ -168,7 +168,7 @@ export function ReceiptTransactionsCard({
               No transactions for this receipt.
             </p>
           ) : (
-            <div className="rounded-md border">
+            <div className="overflow-x-auto rounded-md border">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -193,7 +193,7 @@ export function ReceiptTransactionsCard({
                     <TableHead className="text-right">Amount</TableHead>
                     <TableHead>Date</TableHead>
                     <TableHead>Card</TableHead>
-                    <TableHead>Account</TableHead>
+                    <TableHead className="min-w-[16ch]">Account</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead className="w-24">Actions</TableHead>
                   </TableRow>
@@ -217,7 +217,9 @@ export function ReceiptTransactionsCard({
                           ? (cardNameMap.get(ta.transaction.cardId) ?? "")
                           : ""}
                       </TableCell>
-                      <TableCell>{ta.account.name}</TableCell>
+                      <TableCell className="whitespace-normal break-words max-w-[32ch]">
+                        {ta.account.name}
+                      </TableCell>
                       <TableCell>
                         <Badge
                           variant={


### PR DESCRIPTION
## Summary

- Long account names in the transactions table could overflow the widget and push the page into horizontal scroll at narrow viewports, violating WCAG 2.1 SC 1.4.10 (Reflow, AA).
- Mirrors the RECEIPTS-682 treatment from `ReceiptItemsCard`: add `overflow-x-auto` to the table wrapper div, allow the Account column to wrap (`whitespace-normal break-words max-w-[32ch]`), and add a `min-w-[16ch]` header minimum.
- Adds two regression tests: one asserting the Account cell carries the wrap classes, one asserting the wrapper carries `overflow-x-auto`.

Resolves RECEIPTS-702

## Test plan

- [ ] All 20 `ReceiptTransactionsCard` tests pass (including 2 new regression tests)
- [ ] Full Vitest suite (1961 tests) passes with no failures
- [ ] At 320px viewport, the transactions table does not push the page into horizontal scroll
- [ ] At wider viewports, layout is unchanged