### PR TITLE
fix(client): make ReceiptTransactionsCard account column width cap effective (RECEIPTS-705)

### DIFF
--- a/src/client/src/components/ReceiptTransactionsCard.test.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.test.tsx
@@ -399,7 +399,9 @@ describe("ReceiptTransactionsCard", () => {
     expect(mockDeleteMutate).not.toHaveBeenCalled();
   });
 
-  it("wraps long account names so the table cannot force page horizontal scroll (WCAG 1.4.10)", () => {
+  it("account name is wrapped in a block span with max-w-[32ch] so the cap is effective (CSS §17.5.2)", () => {
+    // max-width on a <td> is inert under table-layout:auto — the constraint must be
+    // on a block-level child element where max-width actually applies.
     const longAccountName = "A".repeat(200);
     const transactionsWithLongName = [
       {
@@ -418,11 +420,16 @@ describe("ReceiptTransactionsCard", () => {
         transactionsTotal={50.0}
       />,
     );
-    const cell = screen.getByText(longAccountName).closest("td");
+    // The text node must be inside a <span> (not a bare <td>) so max-w applies.
+    const nameEl = screen.getByText(longAccountName);
+    expect(nameEl.tagName.toLowerCase()).toBe("span");
+    expect(nameEl).toHaveClass("block");
+    expect(nameEl).toHaveClass("max-w-[32ch]");
+    expect(nameEl).toHaveClass("break-words");
+    expect(nameEl).toHaveClass("whitespace-normal");
+    // The parent must still be a table cell — structural check.
+    const cell = nameEl.closest("td");
     expect(cell).not.toBeNull();
-    expect(cell).toHaveClass("whitespace-normal");
-    expect(cell).toHaveClass("break-words");
-    expect(cell).toHaveClass("max-w-[32ch]");
   });
 
   it("table wrapper has overflow-x-auto to contain horizontal overflow within the widget (WCAG 1.4.10)", () => {

--- a/src/client/src/components/ReceiptTransactionsCard.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.tsx
@@ -217,8 +217,10 @@ export function ReceiptTransactionsCard({
                           ? (cardNameMap.get(ta.transaction.cardId) ?? "")
                           : ""}
                       </TableCell>
-                      <TableCell className="whitespace-normal break-words max-w-[32ch]">
-                        {ta.account.name}
+                      <TableCell>
+                        <span className="block max-w-[32ch] break-words whitespace-normal">
+                          {ta.account.name}
+                        </span>
                       </TableCell>
                       <TableCell>
                         <Badge


### PR DESCRIPTION
## Summary

- `max-width` on a `<td>` is inert under CSS `table-layout: auto` (spec §17.5.2) — the 32ch cap added in RECEIPTS-702 never took effect
- Wraps the account name text in `<span className="block max-w-[32ch] break-words whitespace-normal">` so the constraint applies to a block-level element where `max-width` is effective
- The `overflow-x-auto` outer wrapper from RECEIPTS-702 is retained and still satisfies WCAG 1.4.10 reflow

Resolves RECEIPTS-705

## Test plan

- Updated Vitest test now verifies that the `max-w-[32ch]` class is on the `<span>` element (not the `<td>`), ensuring the constraint is structurally effective
- All 1997 existing tests pass
- Visual: render a transaction with a long account name — it should wrap near 32 characters rather than expanding the column indefinitely