### PR TITLE
test(client): fix ReceiptTransactionsCard reflow regression test target (RECEIPTS-704)

### DIFF
--- a/src/client/src/components/ReceiptTransactionsCard.test.tsx
+++ b/src/client/src/components/ReceiptTransactionsCard.test.tsx
@@ -441,7 +441,12 @@ describe("ReceiptTransactionsCard", () => {
       />,
     );
     const table = screen.getByRole("table");
-    const wrapper = table.closest("div");
+    // Use .rounded-md to reach the outer wrapper div
+    // ("overflow-x-auto rounded-md border") rather than the Table
+    // component's internal container div (data-slot="table-container",
+    // "relative w-full overflow-x-auto"), which always carries
+    // overflow-x-auto regardless of whether the outer wrapper does.
+    const wrapper = table.closest(".rounded-md");
     expect(wrapper).not.toBeNull();
     expect(wrapper).toHaveClass("overflow-x-auto");
   });


### PR DESCRIPTION
## Summary

- The regression test added in RECEIPTS-702 used `table.closest('div')` which found the `Table` component's internal `data-slot="table-container"` div (which always has `overflow-x-auto`), making the test a false-positive that passed even before the overflow fix was present.
- Replaced with `table.closest('.rounded-md')` to target the actual outer wrapper `<div className="overflow-x-auto rounded-md border">` — the element that RECEIPTS-702 actually added `overflow-x-auto` to.
- Verified the test now genuinely fails when `overflow-x-auto` is removed from the outer wrapper.

Resolves RECEIPTS-704

## Test plan

- `npm test` in `src/client` — all 1997 tests pass
- To confirm the test is meaningful: temporarily remove `overflow-x-auto` from `ReceiptTransactionsCard.tsx` line 171 → the "table wrapper has overflow-x-auto" test fails with `Expected element to have class: overflow-x-auto, Received: rounded-md border`