### PR TITLE
fix(client): paginate category and subcategory pickers to show all options

### DIFF
--- a/src/client/src/components/ItemTemplateForm.test.tsx
+++ b/src/client/src/components/ItemTemplateForm.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({
+  useAllCategories: vi.fn(() => ({
     data: [
       { id: "cat-1", name: "Groceries", isActive: true },
       { id: "cat-2", name: "Electronics", isActive: true },
@@ -32,7 +32,7 @@ vi.mock("@/hooks/useCategories", () => ({
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategoriesByCategoryId: vi.fn(() => ({
+  useAllSubcategoriesByCategoryId: vi.fn(() => ({
     data: [
       { id: "sub-1", name: "Dairy", isActive: true },
       { id: "sub-2", name: "Bakery", isActive: true },

--- a/src/client/src/components/ItemTemplateForm.tsx
+++ b/src/client/src/components/ItemTemplateForm.tsx
@@ -3,8 +3,8 @@ import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
-import { useCategories } from "@/hooks/useCategories";
-import { useSubcategoriesByCategoryId } from "@/hooks/useSubcategories";
+import { useAllCategories } from "@/hooks/useCategories";
+import { useAllSubcategoriesByCategoryId } from "@/hooks/useSubcategories";
 import { Combobox } from "@/components/ui/combobox";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import { Button } from "@/components/ui/button";
@@ -52,7 +52,7 @@ export function ItemTemplateForm({
   const formRef = useRef<HTMLFormElement>(null);
   useFormShortcuts({ formRef });
 
-  const { data: categories } = useCategories(0, 50, undefined, undefined, true);
+  const { data: categories } = useAllCategories(true);
   const categoryOptions =
     (categories as { id: string; name: string; isActive: boolean }[] | undefined)
       ?.map((c) => ({
@@ -83,7 +83,7 @@ export function ItemTemplateForm({
     )?.id ?? null;
 
   const { data: subcategoriesData } =
-    useSubcategoriesByCategoryId(selectedCategoryId, 0, 200, undefined, undefined, true);
+    useAllSubcategoriesByCategoryId(selectedCategoryId, true);
 
   const subcategoryOptions =
     (subcategoriesData as { id: string; name: string; isActive: boolean }[] | undefined)

--- a/src/client/src/components/ReceiptItemForm.test.tsx
+++ b/src/client/src/components/ReceiptItemForm.test.tsx
@@ -18,7 +18,7 @@ vi.mock("@/hooks/useReceipts", () => ({
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({
+  useAllCategories: vi.fn(() => ({
     data: [
       { id: "cat-1", name: "Groceries" },
       { id: "cat-2", name: "Electronics" },
@@ -28,7 +28,7 @@ vi.mock("@/hooks/useCategories", () => ({
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategoriesByCategoryId: vi.fn(() => ({
+  useAllSubcategoriesByCategoryId: vi.fn(() => ({
     data: [
       { id: "sub-1", name: "Dairy" },
       { id: "sub-2", name: "Bakery" },

--- a/src/client/src/components/ReceiptItemForm.tsx
+++ b/src/client/src/components/ReceiptItemForm.tsx
@@ -6,9 +6,9 @@ import Fuse from "fuse.js";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useFieldHistory } from "@/hooks/useFieldHistory";
 import { useReceipts } from "@/hooks/useReceipts";
-import { useCategories } from "@/hooks/useCategories";
+import { useAllCategories } from "@/hooks/useCategories";
 import {
-  useSubcategoriesByCategoryId,
+  useAllSubcategoriesByCategoryId,
   useCreateSubcategory,
 } from "@/hooks/useSubcategories";
 import { useItemTemplates } from "@/hooks/useItemTemplates";
@@ -101,7 +101,7 @@ export function ReceiptItemForm({
     useFieldHistory(itemCodeHistory);
 
   const { data: receipts, isLoading: receiptsLoading } = useReceipts();
-  const { data: categories } = useCategories(0, 50, undefined, undefined, true);
+  const { data: categories } = useAllCategories(true);
   const { data: itemTemplatesData } = useItemTemplates();
   const templates = useMemo(
     () => (itemTemplatesData as ItemTemplate[] | undefined) ?? [],
@@ -175,7 +175,7 @@ export function ReceiptItemForm({
   }, [categories, watchedCategory]);
 
   const { data: subcategoriesData } =
-    useSubcategoriesByCategoryId(selectedCategoryId, 0, 200, undefined, undefined, true);
+    useAllSubcategoriesByCategoryId(selectedCategoryId, true);
   const createSubcategory = useCreateSubcategory();
 
   const subcategoryOptions = useMemo(

--- a/src/client/src/components/ReceiptItemsCard.test.tsx
+++ b/src/client/src/components/ReceiptItemsCard.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/hooks/useReceipts", () => ({
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({
+  useAllCategories: vi.fn(() => ({
     data: [
       { id: "cat-1", name: "Groceries", isActive: true },
       { id: "cat-2", name: "Electronics", isActive: true },
@@ -23,7 +23,7 @@ vi.mock("@/hooks/useCategories", () => ({
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategoriesByCategoryId: vi.fn(() => ({
+  useAllSubcategoriesByCategoryId: vi.fn(() => ({
     data: [
       { id: "sub-1", name: "Dairy", isActive: true },
       { id: "sub-2", name: "Bakery", isActive: true },

--- a/src/client/src/components/SubcategoryForm.test.tsx
+++ b/src/client/src/components/SubcategoryForm.test.tsx
@@ -8,7 +8,7 @@ vi.mock("@/hooks/useFormShortcuts", () => ({
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({
+  useAllCategories: vi.fn(() => ({
     data: [
       { id: "cat-1", name: "Groceries", isActive: true },
       { id: "cat-2", name: "Utilities", isActive: true },

--- a/src/client/src/components/SubcategoryForm.tsx
+++ b/src/client/src/components/SubcategoryForm.tsx
@@ -4,7 +4,7 @@ import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useFieldHistory } from "@/hooks/useFieldHistory";
-import { useCategories } from "@/hooks/useCategories";
+import { useAllCategories } from "@/hooks/useCategories";
 import { subcategoryNameHistory } from "@/lib/field-history";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Combobox } from "@/components/ui/combobox";
@@ -48,7 +48,7 @@ export function SubcategoryForm({
   useFormShortcuts({ formRef });
   const { options: subcategoryNameOptions, add: addSubcategoryName } =
     useFieldHistory(subcategoryNameHistory);
-  const { data: categories } = useCategories();
+  const { data: categories } = useAllCategories();
 
   const categoryOptions = (
     categories as { id: string; name: string; isActive: boolean }[] | undefined

--- a/src/client/src/components/reports/UncategorizedItems.test.tsx
+++ b/src/client/src/components/reports/UncategorizedItems.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/hooks/useUncategorizedItemsReport", () => ({
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn().mockReturnValue({
+  useAllCategories: vi.fn().mockReturnValue({
     data: [
       { id: "cat-1", name: "Groceries" },
       { id: "cat-2", name: "Uncategorized" },
@@ -24,7 +24,7 @@ vi.mock("@/hooks/useCategories", () => ({
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategoriesByCategoryId: vi.fn().mockReturnValue({
+  useAllSubcategoriesByCategoryId: vi.fn().mockReturnValue({
     data: [{ id: "sub-1", name: "Produce" }],
     isLoading: false,
   }),

--- a/src/client/src/components/reports/UncategorizedItems.tsx
+++ b/src/client/src/components/reports/UncategorizedItems.tsx
@@ -5,8 +5,8 @@ import {
   useUncategorizedItemsReport,
   type UncategorizedItemsParams,
 } from "@/hooks/useUncategorizedItemsReport";
-import { useCategories } from "@/hooks/useCategories";
-import { useSubcategoriesByCategoryId } from "@/hooks/useSubcategories";
+import { useAllCategories } from "@/hooks/useCategories";
+import { useAllSubcategoriesByCategoryId } from "@/hooks/useSubcategories";
 import { formatCurrency } from "@/lib/format";
 import {
   Table,
@@ -57,13 +57,7 @@ export default function UncategorizedItems() {
   };
 
   const { data, isLoading, isError } = useUncategorizedItemsReport(params);
-  const { data: categories, isLoading: categoriesLoading } = useCategories(
-    0,
-    200,
-    "name",
-    "asc",
-    true,
-  );
+  const { data: categories, isLoading: categoriesLoading } = useAllCategories(true);
 
   const categoryOptions: ComboboxOption[] = useMemo(
     () =>
@@ -79,7 +73,7 @@ export default function UncategorizedItems() {
   }, [categories, selectedCategory]);
 
   const { data: subcategories, isLoading: subcategoriesLoading } =
-    useSubcategoriesByCategoryId(selectedCategoryId, 0, 200, "name", "asc", true);
+    useAllSubcategoriesByCategoryId(selectedCategoryId, true);
 
   const subcategoryOptions: ComboboxOption[] = useMemo(
     () =>

--- a/src/client/src/hooks/useCategories.test.ts
+++ b/src/client/src/hooks/useCategories.test.ts
@@ -20,6 +20,7 @@ import client from "@/lib/api-client";
 import { toast } from "sonner";
 import {
   useCategories,
+  useAllCategories,
   useCategory,
   useCreateCategory,
   useUpdateCategory,
@@ -79,6 +80,51 @@ describe("useCategories", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(client.GET).toHaveBeenCalledWith("/api/categories", {
       params: { query: { offset: 0, limit: 50 } },
+    });
+  });
+
+  it("useAllCategories returns the full list when it fits in one page", async () => {
+    const categories = [
+      { id: "1", name: "Apparel" },
+      { id: "2", name: "Food" },
+    ];
+    (client.GET as Mock).mockResolvedValue({
+      data: { data: categories, total: 2, offset: 0, limit: 500 },
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useAllCategories(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(categories);
+    expect(client.GET).toHaveBeenCalledTimes(1);
+    expect(client.GET).toHaveBeenCalledWith("/api/categories", {
+      params: { query: { offset: 0, limit: 500, sortBy: "name", sortDirection: "asc" } },
+    });
+  });
+
+  it("useAllCategories auto-paginates across multiple pages", async () => {
+    const pageOne = Array.from({ length: 500 }, (_, i) => ({ id: `${i}`, name: `Cat ${i}` }));
+    const pageTwo = Array.from({ length: 100 }, (_, i) => ({ id: `${500 + i}`, name: `Cat ${500 + i}` }));
+    (client.GET as Mock).mockImplementation((_path, opts) => {
+      const offset = opts.params.query.offset;
+      return Promise.resolve({
+        data: { data: offset === 0 ? pageOne : pageTwo, total: 600, offset, limit: 500 },
+        error: undefined,
+      });
+    });
+
+    const { result } = renderHook(() => useAllCategories(true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(600);
+    expect(client.GET).toHaveBeenCalledTimes(2);
+    expect(client.GET).toHaveBeenLastCalledWith("/api/categories", {
+      params: { query: { offset: 500, limit: 500, sortBy: "name", sortDirection: "asc", isActive: true } },
     });
   });
 

--- a/src/client/src/hooks/useCategories.test.ts
+++ b/src/client/src/hooks/useCategories.test.ts
@@ -102,6 +102,7 @@ describe("useCategories", () => {
     expect(client.GET).toHaveBeenCalledTimes(1);
     expect(client.GET).toHaveBeenCalledWith("/api/categories", {
       params: { query: { offset: 0, limit: 500, sortBy: "name", sortDirection: "asc" } },
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -125,6 +126,7 @@ describe("useCategories", () => {
     expect(client.GET).toHaveBeenCalledTimes(2);
     expect(client.GET).toHaveBeenLastCalledWith("/api/categories", {
       params: { query: { offset: 500, limit: 500, sortBy: "name", sortDirection: "asc", isActive: true } },
+      signal: expect.any(AbortSignal),
     });
   });
 

--- a/src/client/src/hooks/useCategories.ts
+++ b/src/client/src/hooks/useCategories.ts
@@ -29,8 +29,8 @@ export function useCategories(offset = 0, limit = 50, sortBy?: string | null, so
  */
 export function useAllCategories(isActive?: boolean | null) {
   return useQuery({
-    queryKey: ["categories", "all", isActive],
-    queryFn: async () => {
+    queryKey: ["categories", "all", isActive ?? undefined],
+    queryFn: async ({ signal }) => {
       const pageSize = 500;
       const fetchPage = async (offset: number) => {
         const { data, error } = await client.GET("/api/categories", {
@@ -43,6 +43,7 @@ export function useAllCategories(isActive?: boolean | null) {
               isActive: isActive ?? undefined,
             },
           },
+          signal,
         });
         if (error) throw error;
         return data;

--- a/src/client/src/hooks/useCategories.ts
+++ b/src/client/src/hooks/useCategories.ts
@@ -17,6 +17,49 @@ export function useCategories(offset = 0, limit = 50, sortBy?: string | null, so
   return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
 }
 
+/**
+ * Fetches the complete category list by auto-paginating through every page.
+ *
+ * Picker components must show *all* categories, not a single page. The
+ * paginated `useCategories` hook caps at one page (default 50), which silently
+ * truncates dropdowns once the category count exceeds the page size. This hook
+ * loops in 500-row chunks (the API's max `limit`) until `total` is reached.
+ *
+ * Returns the category array directly as `data` (not the paged envelope).
+ */
+export function useAllCategories(isActive?: boolean | null) {
+  return useQuery({
+    queryKey: ["categories", "all", isActive],
+    queryFn: async () => {
+      const pageSize = 500;
+      const fetchPage = async (offset: number) => {
+        const { data, error } = await client.GET("/api/categories", {
+          params: {
+            query: {
+              offset,
+              limit: pageSize,
+              sortBy: "name",
+              sortDirection: "asc",
+              isActive: isActive ?? undefined,
+            },
+          },
+        });
+        if (error) throw error;
+        return data;
+      };
+
+      const first = await fetchPage(0);
+      const all = [...(first?.data ?? [])];
+      const total = Number(first?.total ?? all.length);
+      for (let offset = pageSize; offset < total; offset += pageSize) {
+        const page = await fetchPage(offset);
+        all.push(...(page?.data ?? []));
+      }
+      return all;
+    },
+  });
+}
+
 export function useCategory(id: string | null) {
   return useQuery({
     queryKey: ["categories", id],

--- a/src/client/src/hooks/useSubcategories.test.ts
+++ b/src/client/src/hooks/useSubcategories.test.ts
@@ -196,6 +196,7 @@ describe("useAllSubcategoriesByCategoryId", () => {
       params: {
         query: { categoryId: "cat-1", offset: 0, limit: 500, sortBy: "name", sortDirection: "asc", isActive: true },
       },
+      signal: expect.any(AbortSignal),
     });
   });
 

--- a/src/client/src/hooks/useSubcategories.test.ts
+++ b/src/client/src/hooks/useSubcategories.test.ts
@@ -22,6 +22,7 @@ import {
   useSubcategories,
   useSubcategory,
   useSubcategoriesByCategoryId,
+  useAllSubcategoriesByCategoryId,
   useCreateSubcategory,
   useUpdateSubcategory,
 } from "./useSubcategories";
@@ -161,4 +162,60 @@ describe("useSubcategories", () => {
     expect(toast.success).toHaveBeenCalledWith("Subcategory updated");
   });
 
+});
+
+describe("useAllSubcategoriesByCategoryId", () => {
+  it("is disabled when categoryId is null", () => {
+    const { result } = renderHook(() => useAllSubcategoriesByCategoryId(null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.GET).not.toHaveBeenCalled();
+  });
+
+  it("returns the full list when it fits in one page", async () => {
+    const subcategories = [
+      { id: "1", name: "Bakery", categoryId: "cat-1" },
+      { id: "2", name: "Produce", categoryId: "cat-1" },
+    ];
+    (client.GET as Mock).mockResolvedValue({
+      data: { data: subcategories, total: 2, offset: 0, limit: 500 },
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useAllSubcategoriesByCategoryId("cat-1", true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(subcategories);
+    expect(client.GET).toHaveBeenCalledTimes(1);
+    expect(client.GET).toHaveBeenCalledWith("/api/subcategories", {
+      params: {
+        query: { categoryId: "cat-1", offset: 0, limit: 500, sortBy: "name", sortDirection: "asc", isActive: true },
+      },
+    });
+  });
+
+  it("auto-paginates across multiple pages", async () => {
+    const pageOne = Array.from({ length: 500 }, (_, i) => ({ id: `${i}`, name: `Sub ${i}`, categoryId: "cat-1" }));
+    const pageTwo = Array.from({ length: 50 }, (_, i) => ({ id: `${500 + i}`, name: `Sub ${500 + i}`, categoryId: "cat-1" }));
+    (client.GET as Mock).mockImplementation((_path, opts) => {
+      const offset = opts.params.query.offset;
+      return Promise.resolve({
+        data: { data: offset === 0 ? pageOne : pageTwo, total: 550, offset, limit: 500 },
+        error: undefined,
+      });
+    });
+
+    const { result } = renderHook(() => useAllSubcategoriesByCategoryId("cat-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(550);
+    expect(client.GET).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/client/src/hooks/useSubcategories.ts
+++ b/src/client/src/hooks/useSubcategories.ts
@@ -46,6 +46,50 @@ export function useSubcategoriesByCategoryId(categoryId: string | null, offset =
   return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
 }
 
+/**
+ * Fetches every subcategory for a category by auto-paginating all pages.
+ *
+ * Picker components must show the complete subcategory list. The paginated
+ * `useSubcategoriesByCategoryId` hook caps at one page (default 200), which
+ * silently truncates dropdowns for categories with more subcategories. This
+ * hook loops in 500-row chunks (the API's max `limit`) until `total` is
+ * reached. Returns the subcategory array directly as `data`.
+ */
+export function useAllSubcategoriesByCategoryId(categoryId: string | null, isActive?: boolean | null) {
+  return useQuery({
+    queryKey: ["subcategories", "byCategory", "all", categoryId, isActive],
+    enabled: !!categoryId,
+    queryFn: async () => {
+      const pageSize = 500;
+      const fetchPage = async (offset: number) => {
+        const { data, error } = await client.GET("/api/subcategories", {
+          params: {
+            query: {
+              categoryId: categoryId!,
+              offset,
+              limit: pageSize,
+              sortBy: "name",
+              sortDirection: "asc",
+              isActive: isActive ?? undefined,
+            },
+          },
+        });
+        if (error) throw error;
+        return data;
+      };
+
+      const first = await fetchPage(0);
+      const all = [...(first?.data ?? [])];
+      const total = Number(first?.total ?? all.length);
+      for (let offset = pageSize; offset < total; offset += pageSize) {
+        const page = await fetchPage(offset);
+        all.push(...(page?.data ?? []));
+      }
+      return all;
+    },
+  });
+}
+
 export function useCreateSubcategory() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/client/src/hooks/useSubcategories.ts
+++ b/src/client/src/hooks/useSubcategories.ts
@@ -57,9 +57,9 @@ export function useSubcategoriesByCategoryId(categoryId: string | null, offset =
  */
 export function useAllSubcategoriesByCategoryId(categoryId: string | null, isActive?: boolean | null) {
   return useQuery({
-    queryKey: ["subcategories", "byCategory", "all", categoryId, isActive],
+    queryKey: ["subcategories", "byCategory", "all", categoryId, isActive ?? undefined],
     enabled: !!categoryId,
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const pageSize = 500;
       const fetchPage = async (offset: number) => {
         const { data, error } = await client.GET("/api/subcategories", {
@@ -73,6 +73,7 @@ export function useAllSubcategoriesByCategoryId(categoryId: string | null, isAct
               isActive: isActive ?? undefined,
             },
           },
+          signal,
         });
         if (error) throw error;
         return data;

--- a/src/client/src/pages/ItemTemplates.test.tsx
+++ b/src/client/src/pages/ItemTemplates.test.tsx
@@ -89,11 +89,11 @@ vi.mock("@/hooks/useListKeyboardNav", () => ({
 
 // Mocks needed by ItemTemplateForm (rendered inside dialogs)
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+  useAllCategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategoriesByCategoryId: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+  useAllSubcategoriesByCategoryId: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/usePagination", () => ({

--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -24,7 +24,7 @@ vi.mock("@/hooks/useSubcategories", () => ({
 }));
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+  useAllCategories: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
 }));
 
 vi.mock("@/hooks/useFuzzySearch", () => ({
@@ -131,8 +131,8 @@ async function setupWithData(items = ITEMS, categories = CATEGORIES) {
     }),
   );
 
-  const { useCategories } = await import("@/hooks/useCategories");
-  vi.mocked(useCategories).mockReturnValue(
+  const { useAllCategories } = await import("@/hooks/useCategories");
+  vi.mocked(useAllCategories).mockReturnValue(
     mockQueryResult({
       data: categories,
       total: categories.length,

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/hooks/useSubcategories";
 import type { AffectedReceipt } from "@/hooks/useSubcategories";
 import { usePermission } from "@/hooks/usePermission";
-import { useCategories } from "@/hooks/useCategories";
+import { useAllCategories } from "@/hooks/useCategories";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useEntityLinkParams } from "@/hooks/useEntityLinkParams";
 import { useOpenNewItem } from "@/hooks/useOpenNewItem";
@@ -102,7 +102,7 @@ function Subcategories() {
   const filteredSubcatQuery = useSubcategoriesByCategoryId(linkParams.categoryId ?? null, offset, limit, sortBy, sortDirection, isActiveParam);
   const activeSubcatQuery = linkParams.categoryId ? filteredSubcatQuery : allSubcatQuery;
   const { data: subcategoriesData, total: serverTotal, isLoading: subcategoriesLoading } = activeSubcatQuery;
-  const { data: categoriesData, isLoading: categoriesLoading } = useCategories();
+  const { data: categoriesData, isLoading: categoriesLoading } = useAllCategories();
   const createSubcategory = useCreateSubcategory();
   const updateSubcategory = useUpdateSubcategory();
   const deleteSubcategory = useDeleteSubcategory();

--- a/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.test.tsx
@@ -6,7 +6,7 @@ import "@/test/setup-combobox-polyfills";
 import { LineItemsSection, type ReceiptLineItem } from "./LineItemsSection";
 
 vi.mock("@/hooks/useCategories", () => ({
-  useCategories: vi.fn(() =>
+  useAllCategories: vi.fn(() =>
     mockQueryResult({
       data: [
         { id: "cat-1", name: "Food" },
@@ -19,7 +19,7 @@ vi.mock("@/hooks/useCategories", () => ({
 }));
 
 vi.mock("@/hooks/useSubcategories", () => ({
-  useSubcategoriesByCategoryId: vi.fn(() =>
+  useAllSubcategoriesByCategoryId: vi.fn(() =>
     mockQueryResult({
       data: [],
       isLoading: false,

--- a/src/client/src/pages/new-receipt/LineItemsSection.tsx
+++ b/src/client/src/pages/new-receipt/LineItemsSection.tsx
@@ -3,9 +3,9 @@ import { generateId } from "@/lib/id";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCategories } from "@/hooks/useCategories";
+import { useAllCategories } from "@/hooks/useCategories";
 import {
-  useSubcategoriesByCategoryId,
+  useAllSubcategoriesByCategoryId,
   useCreateSubcategory,
 } from "@/hooks/useSubcategories";
 import {
@@ -82,7 +82,7 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
   const suggestionsListId = "new-receipt-suggestions-list";
   // Index of the keyboard-highlighted row in the description lookup.
   const [descriptionActiveIndex, setDescriptionActiveIndex] = useState(0);
-  const { data: categories } = useCategories(0, 50, undefined, undefined, true);
+  const { data: categories } = useAllCategories(true);
 
   const categoryOptions = useMemo(
     () =>
@@ -209,9 +209,9 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     [categories, selectedCategory],
   );
 
-  const { data: subcategories } = useSubcategoriesByCategoryId(
-    selectedCategoryObj?.id ?? "",
-    0, 200, undefined, undefined, true,
+  const { data: subcategories } = useAllSubcategoriesByCategoryId(
+    selectedCategoryObj?.id ?? null,
+    true,
   );
   const createSubcategory = useCreateSubcategory();
   const pendingSubcategories = useRef(new Set<string>());
@@ -374,9 +374,9 @@ export function LineItemsSection({ items, onChange, location }: LineItemsSection
     [categories, editDraft.category],
   );
 
-  const { data: editSubcategories } = useSubcategoriesByCategoryId(
-    editCategoryObj?.id ?? "",
-    0, 200, undefined, undefined, true,
+  const { data: editSubcategories } = useAllSubcategoriesByCategoryId(
+    editCategoryObj?.id ?? null,
+    true,
   );
 
   const editSubcategoryOptions = useMemo(


### PR DESCRIPTION
## Summary
- Category and subcategory pickers fetched only a single page (50 / 200 rows), silently truncating their option lists once the entity count exceeded the page size — during receipt entry the category picker cut off alphabetically at "R".
- Added `useAllCategories` and `useAllSubcategoriesByCategoryId` hooks that auto-paginate through every page in 500-row chunks (the API's max `limit`).
- Switched all six picker call sites to the new hooks: new-receipt `LineItemsSection`, `ReceiptItemForm`, `ItemTemplateForm`, `SubcategoryForm`, the `Subcategories` page category map, and the `UncategorizedItems` report filter.

Resolves RECEIPTS-712

## Test plan
- New hook tests cover single-page and multi-page (>500 rows) auto-pagination for both hooks, plus the `isActive` filter and the disabled-when-null case.
- Updated the six affected component test mocks to expose the new hook names.
- Full client unit suite passes (2001 tests); lint and `tsc -b` clean.
- Two pre-existing failures in `ItemTemplates.integration.test.tsx` were confirmed present on `main` before this change (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)