### PR TITLE
fix(client): normalize new-receipt metadata and transaction layout (RECEIPTS-713)

### DIFF
--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -215,17 +215,17 @@ export default function NewReceiptPage() {
       </div>
 
       {/* Upper container: receipt metadata + transactions (left), balance panel (right) */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_minmax(300px,360px)]">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(300px,360px)]">
         {/* Upper-left — receipt metadata and transactions */}
         <div className="space-y-6 min-w-0">
           {/* Receipt Header */}
           <Form {...form}>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="flex flex-wrap gap-4">
               <FormField
                 control={form.control}
                 name="location"
                 render={({ field }) => (
-                  <FormItem>
+                  <FormItem className="min-w-[220px] flex-1">
                     <FormLabel required>Location</FormLabel>
                     <FormControl>
                       <Combobox
@@ -249,7 +249,7 @@ export default function NewReceiptPage() {
                 control={form.control}
                 name="date"
                 render={({ field }) => (
-                  <FormItem>
+                  <FormItem className="min-w-[170px] flex-1">
                     <FormLabel required>Date</FormLabel>
                     <FormControl>
                       <DateInput
@@ -267,7 +267,7 @@ export default function NewReceiptPage() {
                 control={form.control}
                 name="taxAmount"
                 render={({ field }) => (
-                  <FormItem>
+                  <FormItem className="min-w-[150px] flex-1">
                     <FormLabel>Tax Amount</FormLabel>
                     <FormControl>
                       <CurrencyInput {...field} />

--- a/src/client/src/pages/new-receipt/TransactionsSection.tsx
+++ b/src/client/src/pages/new-receipt/TransactionsSection.tsx
@@ -176,13 +176,13 @@ export function TransactionsSection({
           <form
             ref={formRef}
             onSubmit={form.handleSubmit(handleAdd)}
-            className="grid grid-cols-1 gap-4 sm:grid-cols-[1fr_1fr_auto_auto_auto] sm:items-end"
+            className="flex flex-wrap items-end gap-4"
           >
             <FormField
               control={form.control}
               name="cardId"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="min-w-[160px] flex-1">
                   <FormLabel required>Card</FormLabel>
                   <FormControl>
                     <Combobox
@@ -205,7 +205,7 @@ export function TransactionsSection({
               control={form.control}
               name="accountId"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="min-w-[160px] flex-1">
                   <FormLabel required>Account</FormLabel>
                   <FormControl>
                     <Combobox
@@ -227,7 +227,7 @@ export function TransactionsSection({
               control={form.control}
               name="amount"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="min-w-[120px] flex-1">
                   <FormLabel required>Amount</FormLabel>
                   <FormControl>
                     <CurrencyInput {...field} />
@@ -241,7 +241,7 @@ export function TransactionsSection({
               control={form.control}
               name="date"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="min-w-[160px] flex-1">
                   <FormLabel required>Date</FormLabel>
                   <FormControl>
                     <DateInput aria-required="true" {...field} />
@@ -251,7 +251,7 @@ export function TransactionsSection({
               )}
             />
 
-            <Button type="submit" variant="secondary" size="sm" className="sm:mb-0.5">
+            <Button type="submit" variant="secondary" size="sm" className="mb-0.5 shrink-0">
               <Plus className="mr-1 h-4 w-4" />
               Add
             </Button>


### PR DESCRIPTION
## Summary

Follow-up to RECEIPTS-711. The reworked new-receipt layout left the **Location** and **Date** metadata fields overlapping, and the transaction entry form collapsed **Amount**/**Date** to unusable widths.

## Changes

- **Upper grid track**: `1fr` → `minmax(0,1fr)` so the left column can shrink past its content min-width instead of overflowing into the balance sidebar (root cause of the Location/Date overlap).
- **Metadata fields**: rigid `sm:grid-cols-3` → `flex flex-wrap` with per-field `flex-1` and `min-w` floors (Location 220px, Date 170px, Tax 150px).
- **Transaction form**: `sm:grid-cols-[1fr_1fr_auto_auto_auto]` → `flex flex-wrap`. The `auto` tracks had collapsed the `w-full` inputs to near-zero width. Each field now has `flex-1` and a `min-w` floor; the Add button is `shrink-0`.

Fields reflow to new rows at narrow widths rather than overlapping or collapsing.

## Testing

- `tsc --noEmit` clean, ESLint clean
- All 50 new-receipt tests pass; full client suite (1966 tests) passes via pre-commit hook

Resolves RECEIPTS-713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)