### PR TITLE
fix(client): hide remaining YNAB cards when no PAT is configured (RECEIPTS-731)

### DIFF
--- a/src/client/src/components/YnabMemoSyncCard.test.tsx
+++ b/src/client/src/components/YnabMemoSyncCard.test.tsx
@@ -19,6 +19,11 @@ vi.mock("@/hooks/useYnab", () => ({
     selectedBudgetId: "budget-1",
     isLoading: false,
   })),
+  useYnabConnectionStatus: vi.fn(() => ({
+    isConfigured: true,
+    isConnected: true,
+    isLoading: false,
+  })),
 }));
 
 beforeEach(async () => {
@@ -35,6 +40,11 @@ beforeEach(async () => {
     selectedBudgetId: "budget-1",
     isLoading: false,
   } as ReturnType<typeof ynab.useSelectedYnabBudget>);
+  vi.mocked(ynab.useYnabConnectionStatus).mockReturnValue({
+    isConfigured: true,
+    isConnected: true,
+    isLoading: false,
+  } as ReturnType<typeof ynab.useYnabConnectionStatus>);
 });
 
 describe("YnabMemoSyncCard", () => {
@@ -53,6 +63,34 @@ describe("YnabMemoSyncCard", () => {
     } as ReturnType<typeof ynab.useSelectedYnabBudget>);
 
     const { container } = renderWithProviders(<YnabMemoSyncCard receiptId="r1" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when YNAB is not configured (no PAT) — RECEIPTS-731", async () => {
+    const ynab = await import("@/hooks/useYnab");
+    vi.mocked(ynab.useYnabConnectionStatus).mockReturnValue({
+      isConfigured: false,
+      isConnected: false,
+      isLoading: false,
+    } as ReturnType<typeof ynab.useYnabConnectionStatus>);
+
+    const { container } = renderWithProviders(
+      <YnabMemoSyncCard receiptId="r1" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null while the connection status is still loading", async () => {
+    const ynab = await import("@/hooks/useYnab");
+    vi.mocked(ynab.useYnabConnectionStatus).mockReturnValue({
+      isConfigured: false,
+      isConnected: false,
+      isLoading: true,
+    } as ReturnType<typeof ynab.useYnabConnectionStatus>);
+
+    const { container } = renderWithProviders(
+      <YnabMemoSyncCard receiptId="r1" />,
+    );
     expect(container.firstChild).toBeNull();
   });
 

--- a/src/client/src/components/YnabMemoSyncCard.tsx
+++ b/src/client/src/components/YnabMemoSyncCard.tsx
@@ -3,6 +3,7 @@ import {
   useSyncYnabMemos,
   useResolveYnabMemoSync,
   useMemoSyncSummary,
+  useYnabConnectionStatus,
   type YnabMemoSyncResult,
   type YnabTransactionCandidateDto,
 } from "@/hooks/useYnab";
@@ -87,6 +88,11 @@ function formatMilliunits(amount: number): string {
 }
 
 export function YnabMemoSyncCard({ receiptId }: YnabMemoSyncCardProps) {
+  // YNAB-gated: when YNAB isn't configured this card's actions can't do
+  // anything, so render nothing rather than dead controls. Mirrors
+  // YnabSplitComparisonCard's pattern (RECEIPTS-731).
+  const { isConfigured, isLoading: connectionLoading } =
+    useYnabConnectionStatus();
   const { selectedBudgetId } = useSelectedYnabBudget();
   const syncMemos = useSyncYnabMemos();
   const resolveSync = useResolveYnabMemoSync();
@@ -97,7 +103,8 @@ export function YnabMemoSyncCard({ receiptId }: YnabMemoSyncCardProps) {
   } | null>(null);
   const summary = useMemoSyncSummary(results);
 
-  if (!selectedBudgetId) {
+  // Hooks above run unconditionally to keep order stable; the gate is below.
+  if (connectionLoading || !isConfigured || !selectedBudgetId) {
     return null;
   }
 

--- a/src/client/src/pages/ReceiptDetail.test.tsx
+++ b/src/client/src/pages/ReceiptDetail.test.tsx
@@ -82,6 +82,11 @@ vi.mock("@/hooks/useYnab", () => ({
     statusMap: new Map(),
     isLoading: false,
   })),
+  useYnabConnectionStatus: vi.fn(() => ({
+    isConfigured: true,
+    isConnected: true,
+    isLoading: false,
+  })),
 }));
 
 vi.mock("@/components/YnabPushButton", () => ({
@@ -314,6 +319,64 @@ describe("ReceiptDetail", () => {
     expect(
       screen.getByRole("button", { name: /^edit$/i }),
     ).toBeInTheDocument();
+  });
+
+  it("hides the YNAB push card and PageHead chip when YNAB is unconfigured (RECEIPTS-731)", async () => {
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    vi.mocked(useTripByReceiptId).mockReturnValue(
+      mockQueryResult({
+        data: MOCK_TRIP,
+        isLoading: false,
+        isError: false,
+      }),
+    );
+    const { useYnabConnectionStatus, useReceiptYnabSyncStatuses } =
+      await import("@/hooks/useYnab");
+    vi.mocked(useYnabConnectionStatus).mockReturnValue({
+      isConfigured: false,
+      isConnected: false,
+      isLoading: false,
+    } as ReturnType<typeof useYnabConnectionStatus>);
+    // Force a real sync status so YnabChip would otherwise render — without
+    // this the chip self-renders null on "none" and the assertion below
+    // would be vacuous, hiding any regression to the new gate.
+    vi.mocked(useReceiptYnabSyncStatuses).mockReturnValue({
+      statusMap: new Map([["r1", "Synced"]]),
+      isLoading: false,
+    } as ReturnType<typeof useReceiptYnabSyncStatuses>);
+
+    renderWithRoutes("/receipts/r1");
+    // "YNAB sync" card header should not render
+    expect(screen.queryByText(/^YNAB sync$/)).not.toBeInTheDocument();
+    // Push button is mocked, so verify the mocked test-id is absent
+    expect(screen.queryByTestId("ynab-push-button")).not.toBeInTheDocument();
+    // YnabChip with status="synced" would render aria-label="YNAB: synced".
+    // The gate must prevent it from rendering.
+    expect(screen.queryByLabelText(/YNAB: synced/)).not.toBeInTheDocument();
+  });
+
+  it("renders the YNAB push card when YNAB is configured", async () => {
+    const { useTripByReceiptId } = await import("@/hooks/useTrips");
+    vi.mocked(useTripByReceiptId).mockReturnValue(
+      mockQueryResult({
+        data: MOCK_TRIP,
+        isLoading: false,
+        isError: false,
+      }),
+    );
+    // Reset the connection-status mock — the previous test set it to
+    // isConfigured: false and vi.mock state persists across tests in
+    // this file (no beforeEach reset).
+    const { useYnabConnectionStatus } = await import("@/hooks/useYnab");
+    vi.mocked(useYnabConnectionStatus).mockReturnValue({
+      isConfigured: true,
+      isConnected: true,
+      isLoading: false,
+    } as ReturnType<typeof useYnabConnectionStatus>);
+
+    renderWithRoutes("/receipts/r1");
+    expect(screen.getByText(/^YNAB sync$/)).toBeInTheDocument();
+    expect(screen.getByTestId("ynab-push-button")).toBeInTheDocument();
   });
 
   it("opens edit dialog when edit button is clicked", async () => {

--- a/src/client/src/pages/ReceiptDetail.test.tsx
+++ b/src/client/src/pages/ReceiptDetail.test.tsx
@@ -144,6 +144,24 @@ const MOCK_TRIP = {
 };
 
 describe("ReceiptDetail", () => {
+  // Reset every per-test override on the @/hooks/useYnab module back to its
+  // default before each test. Without this, a test that calls
+  // `vi.mocked(useYnabConnectionStatus).mockReturnValue(...)` leaks that
+  // state into the rest of the file and silently corrupts later assertions.
+  beforeEach(async () => {
+    const { useYnabConnectionStatus, useReceiptYnabSyncStatuses } =
+      await import("@/hooks/useYnab");
+    vi.mocked(useYnabConnectionStatus).mockReturnValue({
+      isConfigured: true,
+      isConnected: true,
+      isLoading: false,
+    } as ReturnType<typeof useYnabConnectionStatus>);
+    vi.mocked(useReceiptYnabSyncStatuses).mockReturnValue({
+      statusMap: new Map(),
+      isLoading: false,
+    } as ReturnType<typeof useReceiptYnabSyncStatuses>);
+  });
+
   it("renders the page heading when id is present", () => {
     renderWithRoutes("/receipts/some-uuid");
     expect(
@@ -364,15 +382,8 @@ describe("ReceiptDetail", () => {
         isError: false,
       }),
     );
-    // Reset the connection-status mock — the previous test set it to
-    // isConfigured: false and vi.mock state persists across tests in
-    // this file (no beforeEach reset).
-    const { useYnabConnectionStatus } = await import("@/hooks/useYnab");
-    vi.mocked(useYnabConnectionStatus).mockReturnValue({
-      isConfigured: true,
-      isConnected: true,
-      isLoading: false,
-    } as ReturnType<typeof useYnabConnectionStatus>);
+    // The describe-level beforeEach already resets useYnabConnectionStatus
+    // to the configured default, so no inline override is needed here.
 
     renderWithRoutes("/receipts/r1");
     expect(screen.getByText(/^YNAB sync$/)).toBeInTheDocument();

--- a/src/client/src/pages/ReceiptDetail.tsx
+++ b/src/client/src/pages/ReceiptDetail.tsx
@@ -3,7 +3,10 @@ import { Link, useParams, Navigate } from "react-router";
 import { useTripByReceiptId } from "@/hooks/useTrips";
 import { useUpdateReceipt } from "@/hooks/useReceipts";
 import { useCreateAdjustment } from "@/hooks/useAdjustments";
-import { useReceiptYnabSyncStatuses } from "@/hooks/useYnab";
+import {
+  useReceiptYnabSyncStatuses,
+  useYnabConnectionStatus,
+} from "@/hooks/useYnab";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import {
   parseProblemDetails,
@@ -50,6 +53,13 @@ function ReceiptDetail() {
     id ? [id] : [],
   );
   const persistedYnabStatus = id ? ynabStatusMap.get(id) : undefined;
+  // YNAB-gated rendering — when no PAT is configured, the YNAB push and chip
+  // surfaces can't do anything useful (RECEIPTS-731). The split-comparison
+  // and memo-sync cards self-gate; the push Card and PageHead chip below
+  // share this signal.
+  const { isConfigured: ynabConfigured, isLoading: ynabConnectionLoading } =
+    useYnabConnectionStatus();
+  const ynabReady = !ynabConnectionLoading && ynabConfigured;
 
   const [editOpen, setEditOpen] = useState(false);
   const [reconcileOpen, setReconcileOpen] = useState(false);
@@ -141,7 +151,7 @@ function ReceiptDetail() {
               >
                 <Icon.Edit /> Edit
               </button>
-              <YnabChip status={yChip} />
+              {ynabReady && <YnabChip status={yChip} />}
             </>
           )
         }
@@ -266,21 +276,24 @@ function ReceiptDetail() {
 
           <YnabMemoSyncCard receiptId={id} />
 
-          <Card>
-            <CardHeader>
-              <CardTitle>YNAB sync</CardTitle>
-              <CardDescription>
-                Push this receipt’s transactions to YNAB with category splits.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <YnabPushButton
-                receiptId={id}
-                hasTransactions={trip.transactions.length > 0}
-                persistedSyncStatus={persistedYnabStatus}
-              />
-            </CardContent>
-          </Card>
+          {ynabReady && (
+            <Card>
+              <CardHeader>
+                <CardTitle>YNAB sync</CardTitle>
+                <CardDescription>
+                  Push this receipt’s transactions to YNAB with category
+                  splits.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <YnabPushButton
+                  receiptId={id}
+                  hasTransactions={trip.transactions.length > 0}
+                  persistedSyncStatus={persistedYnabStatus}
+                />
+              </CardContent>
+            </Card>
+          )}
 
           <YnabSplitComparisonCard receiptId={id} />
 


### PR DESCRIPTION
## Summary

Hides the remaining YNAB surfaces on the receipt detail page when no YNAB PAT is configured — completing the work RECEIPTS-723 started for the split-comparison card.

When YNAB isn't set up, three surfaces still rendered:

- **YnabMemoSyncCard** — showed a "Sync Memos" button that could not function
- **YNAB sync push card** in `ReceiptDetail` — wrapped `YnabPushButton` with no gating
- **YnabChip** in the receipt `PageHead` — rendered a status badge that could never reflect real sync state

All three are now gated on `useYnabConnectionStatus().isConfigured`, mirroring the pattern already used by `YnabSplitComparisonCard`. Render-nothing — not an empty state — per the issue's checklist.

## Changes

- `YnabMemoSyncCard.tsx` — adds `useYnabConnectionStatus()` gate; hooks ordered unconditionally before the conditional return. The existing `selectedBudgetId` check is retained as a secondary gate.
- `ReceiptDetail.tsx` — wraps the inline YNAB sync `<Card>` and the `PageHead` `YnabChip` in the same gate via a shared `ynabReady` flag.
- Test mocks updated for both files; new test cases lock in the null-render path.
- ReceiptDetail chip-hidden assertion uses `"Synced"` sync status so the assertion exercises the new gate rather than coasting on `YnabChip`'s own self-null on `"none"`.

## Other YNAB surfaces audited

- `YnabBulkSyncCard` in `YnabSettings` is already gated on `selectedBudgetId` (a stronger gate — no budget selected implies the PAT path is broken).
- `YnabChip` in the `Receipts` list table self-renders `null` on `"none"` status, which is the default when no statuses are returned.

No other surfaces need changes.

## Verification

- Full vitest suite (2003 tests) green.
- Accessibility audit returned PASS. The diff is a clean visibility gate — no interactive elements made unreachable, no labels orphaned, no heading sequence broken, conditional render is hooks-safe.

Closes RECEIPTS-731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
