### PR TITLE
feat(client): extract MobileTabbar + useIsMobile hook (RECEIPTS-732)

### DIFF
--- a/src/client/src/components/Layout.test.tsx
+++ b/src/client/src/components/Layout.test.tsx
@@ -195,9 +195,7 @@ describe("Layout", () => {
   it("opens the More sheet from the mobile tabbar", async () => {
     const user = userEvent.setup();
     renderLayout();
-    await user.click(
-      screen.getByRole("button", { name: /more navigation/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /^more$/i }));
     await waitFor(() => {
       const dialog = screen.getByRole("dialog");
       expect(within(dialog).getByText("Workspace")).toBeInTheDocument();

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -14,8 +14,10 @@ import { useSignalR } from "@/hooks/useSignalR";
 import type { SignalRConnectionState } from "@/hooks/useSignalR";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
 import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { ShortcutsHelp } from "@/components/ShortcutsHelp";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { MobileTabbar } from "@/components/MobileTabbar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -98,12 +100,6 @@ const NAV: readonly NavSection[] = [
   },
 ];
 
-const MOBILE_TABS = [
-  { to: "/", label: "Home", icon: Icon.Dashboard },
-  { to: "/receipts", label: "List", icon: Icon.Receipt },
-  { to: "/reports", label: "Reports", icon: Icon.Chart },
-] as const;
-
 const CONNECTION: Record<
   SignalRConnectionState,
   { className: string; label: string }
@@ -129,6 +125,7 @@ export function Layout() {
   const navigation = useNavigation();
   const location = useLocation();
   const { connectionState } = useSignalR(!!user);
+  const isMobile = useIsMobile();
   const [searchOpen, setSearchOpen] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   useGlobalShortcuts();
@@ -213,16 +210,16 @@ export function Layout() {
 
       <div className="main">
         <div className="topbar">
-          <button
-            type="button"
-            className="icon-btn"
-            aria-label="Open navigation menu"
-            onClick={() => setMobileOpen(true)}
-            style={{ display: "none" }}
-            data-mobile-only
-          >
-            <Icon.Sliders />
-          </button>
+          {isMobile && (
+            <button
+              type="button"
+              className="icon-btn"
+              aria-label="Open navigation menu"
+              onClick={() => setMobileOpen(true)}
+            >
+              <Icon.Sliders />
+            </button>
+          )}
           <div className="crumbs">
             <Breadcrumbs />
           </div>
@@ -329,35 +326,7 @@ export function Layout() {
           </div>
         </main>
 
-        <nav className="mobile-tabbar" aria-label="Mobile navigation">
-          {MOBILE_TABS.map((tab) => {
-            const TabIcon = tab.icon;
-            const active =
-              tab.to === "/"
-                ? location.pathname === "/"
-                : location.pathname.startsWith(tab.to);
-            return (
-              <NavLink
-                key={tab.to}
-                to={tab.to}
-                className={cn(active && "on")}
-                aria-current={active ? "page" : undefined}
-                end={tab.to === "/"}
-              >
-                <TabIcon />
-                {tab.label}
-              </NavLink>
-            );
-          })}
-          <button
-            type="button"
-            onClick={() => setMobileOpen(true)}
-            aria-label="More navigation"
-          >
-            <Icon.Sliders />
-            More
-          </button>
-        </nav>
+        <MobileTabbar onOpenMore={() => setMobileOpen(true)} />
       </div>
 
       <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>

--- a/src/client/src/components/MobileTabbar.test.tsx
+++ b/src/client/src/components/MobileTabbar.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { MobileTabbar } from "./MobileTabbar";
+
+describe("MobileTabbar", () => {
+  it("renders all four primary tabs plus a More button", () => {
+    renderWithProviders(<MobileTabbar onOpenMore={() => {}} />);
+
+    // <a> elements: Home, Receipts, New, Reports (Link renders as anchor)
+    expect(screen.getByRole("link", { name: /home/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /^receipts$/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^new$/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /reports/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^more$/i })).toBeInTheDocument();
+  });
+
+  it("marks the Home tab active when the path is '/'", () => {
+    renderWithProviders(<MobileTabbar onOpenMore={() => {}} />, { route: "/" });
+    expect(screen.getByRole("link", { name: /home/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: /^receipts$/i })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("marks the Receipts tab active on /receipts but not on /receipts/new", () => {
+    renderWithProviders(<MobileTabbar onOpenMore={() => {}} />, {
+      route: "/receipts",
+    });
+    expect(screen.getByRole("link", { name: /^receipts$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: /^new$/i })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("marks the New tab active on /receipts/new and not the Receipts tab", () => {
+    renderWithProviders(<MobileTabbar onOpenMore={() => {}} />, {
+      route: "/receipts/new",
+    });
+    expect(screen.getByRole("link", { name: /^new$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: /^receipts$/i })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("marks the Receipts tab active on a receipt detail route", () => {
+    renderWithProviders(<MobileTabbar onOpenMore={() => {}} />, {
+      route: "/receipts/abc-123",
+    });
+    // Detail pages are still part of the receipts list workflow, so the
+    // Receipts tab stays lit — keeps mental model consistent with the desktop sidebar.
+    expect(screen.getByRole("link", { name: /^receipts$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("invokes onOpenMore when the More button is clicked", async () => {
+    const onOpenMore = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(<MobileTabbar onOpenMore={onOpenMore} />);
+
+    await user.click(screen.getByRole("button", { name: /^more$/i }));
+    expect(onOpenMore).toHaveBeenCalledOnce();
+  });
+});

--- a/src/client/src/components/MobileTabbar.tsx
+++ b/src/client/src/components/MobileTabbar.tsx
@@ -1,0 +1,72 @@
+import { Link, useLocation } from "react-router";
+import { Icon } from "@/components/primitives";
+import { cn } from "@/lib/utils";
+
+/**
+ * Bottom-anchored navigation for the mobile shell (≤ 900px). Pairs with the
+ * sidebar-hides rule in `index.css:1499` so JS and CSS stay in lockstep.
+ * Visibility is CSS-driven (`.mobile-tabbar { display: none }` at ≥ 900px),
+ * so the component always renders — that keeps the responsive swap free of
+ * JS layout shift when the breakpoint is crossed.
+ */
+const TABS = [
+  { to: "/", label: "Home", icon: Icon.Dashboard },
+  // Label matches the sidebar entry so screen-reader / voice-control users
+  // hear the same name for the same destination across the two shells
+  // (WCAG 3.2.4 consistent identification).
+  { to: "/receipts", label: "Receipts", icon: Icon.Receipt },
+  { to: "/receipts/new", label: "New", icon: Icon.Plus },
+  { to: "/reports", label: "Reports", icon: Icon.Chart },
+] as const;
+
+interface MobileTabbarProps {
+  onOpenMore: () => void;
+}
+
+function isTabActive(pathname: string, to: string): boolean {
+  if (to === "/") return pathname === "/";
+  if (to === "/receipts") {
+    // /receipts/new owns its own tab, so don't let the List tab claim it.
+    // Detail routes (/receipts/:id) still light up List — keeps the mental
+    // model consistent with the desktop sidebar.
+    if (pathname === "/receipts/new") return false;
+    return pathname === "/receipts" || pathname.startsWith("/receipts/");
+  }
+  if (to === "/receipts/new") return pathname === "/receipts/new";
+  return pathname === to || pathname.startsWith(to + "/");
+}
+
+export function MobileTabbar({ onOpenMore }: MobileTabbarProps) {
+  const location = useLocation();
+
+  return (
+    <nav className="mobile-tabbar" aria-label="Mobile navigation">
+      {TABS.map((tab) => {
+        const TabIcon = tab.icon;
+        const active = isTabActive(location.pathname, tab.to);
+        // Plain Link (not NavLink) — NavLink's own aria-current matching is
+        // too coarse for /receipts vs /receipts/new; we drive the active
+        // state from isTabActive instead.
+        return (
+          <Link
+            key={tab.to}
+            to={tab.to}
+            className={cn(active && "on")}
+            aria-current={active ? "page" : undefined}
+          >
+            <TabIcon />
+            {tab.label}
+          </Link>
+        );
+      })}
+      <button
+        type="button"
+        onClick={onOpenMore}
+        aria-label="More"
+      >
+        <Icon.Sliders />
+        More
+      </button>
+    </nav>
+  );
+}

--- a/src/client/src/hooks/useIsMobile.test.ts
+++ b/src/client/src/hooks/useIsMobile.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useIsMobile } from "./useIsMobile";
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+interface MockMql {
+  matches: boolean;
+  media: string;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  addListener: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  // Test hook to fire a change event from the test side.
+  fire(matches: boolean): void;
+}
+
+function installMatchMedia(initialMatches: boolean): MockMql {
+  const listeners = new Set<Listener>();
+  const mql: MockMql = {
+    matches: initialMatches,
+    media: "(max-width: 900px)",
+    addEventListener: vi.fn((_event: string, l: Listener) => {
+      listeners.add(l);
+    }),
+    removeEventListener: vi.fn((_event: string, l: Listener) => {
+      listeners.delete(l);
+    }),
+    addListener: vi.fn((l: Listener) => listeners.add(l)),
+    removeListener: vi.fn((l: Listener) => listeners.delete(l)),
+    fire(matches: boolean) {
+      mql.matches = matches;
+      const ev = { matches, media: mql.media } as unknown as MediaQueryListEvent;
+      for (const l of listeners) l(ev);
+    },
+  };
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn(() => mql),
+  });
+  return mql;
+}
+
+describe("useIsMobile", () => {
+  let originalMatchMedia: typeof window.matchMedia | undefined;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    } else {
+      // @ts-expect-error - intentional cleanup for tests that mocked it.
+      delete window.matchMedia;
+    }
+  });
+
+  it("returns true when the viewport starts below the breakpoint", () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when the viewport starts above the breakpoint", () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it("updates when the media query change event fires", () => {
+    const mql = installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      mql.fire(true);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      mql.fire(false);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("registers and unregisters the change listener", () => {
+    const mql = installMatchMedia(false);
+    const { unmount } = renderHook(() => useIsMobile());
+    expect(mql.addEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+    unmount();
+    expect(mql.removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+  });
+
+  it("falls back to false when matchMedia is unavailable", () => {
+    // @ts-expect-error - simulating an SSR-like environment.
+    delete window.matchMedia;
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/client/src/hooks/useIsMobile.ts
+++ b/src/client/src/hooks/useIsMobile.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Reactively reports whether the viewport matches the mobile breakpoint
+ * (≤ 900px). Mirrors the CSS breakpoint at `.app { grid-template-columns: 1fr }`
+ * in `index.css` (line 1495) so JS-side gating stays in lockstep with the
+ * sidebar-hides / mobile-tabbar-shows transition.
+ *
+ * SSR-safe: returns `false` before the first client tick when `window` is
+ * undefined.
+ */
+const MOBILE_QUERY = "(max-width: 900px)";
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return false;
+    }
+    return window.matchMedia(MOBILE_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const update = (event: MediaQueryListEvent | MediaQueryList) => {
+      setIsMobile(event.matches);
+    };
+    update(mql);
+    // addEventListener is the modern API; addListener is the deprecated
+    // fallback that Safari < 14 still needs.
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", update);
+      return () => mql.removeEventListener("change", update);
+    }
+    mql.addListener(update);
+    return () => mql.removeListener(update);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
Closes the "Mobile tabbar wiring" deliverable in RECEIPTS-593 and RECEIPTS-597 (Phase 18, post-redesign audit).

### Why

The Layout shell had inline mobile-tabbar markup gated by a CSS `@media` rule, but:

- No JS-side viewport hook → the topbar's mobile menu button was permanently `display: none` with no rule to flip it back.
- Only three tabs (Home / List / Reports) instead of the design bundle's four; "Create receipt" was buried behind the More drawer.
- "List" on mobile vs "Receipts" on the sidebar weakened WCAG 3.2.4 (consistent identification) for screen-reader and voice-control users.

### What

- New `useIsMobile` hook — matchMedia listener for `(max-width: 900px)`, SSR-safe, with `addEventListener` + `addListener` fallback for Safari < 14.
- New `MobileTabbar` component with four tabs: Home → `/`, Receipts → `/receipts`, New → `/receipts/new`, Reports → `/reports`, plus a More button that opens the existing nav drawer.
- `Layout.tsx`:
  - Import the new component; drop the inline tabbar markup.
  - Gate the dead topbar menu button on `useIsMobile()` so it actually shows on mobile.
- Plain `Link` (not `NavLink`) in the tabbar — `NavLink`'s active matching is too coarse to distinguish `/receipts` from `/receipts/new`.

### Verification

- 23 tests across `Layout.test.tsx`, `MobileTabbar.test.tsx`, `useIsMobile.test.ts` — all green.
- Full vitest suite: 2014 passed.
- ESLint clean on touched files.
- Accessibility audit passed (advisories: "List" → "Receipts" rename, More button `aria-label` exact-match → both applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)