### PR TITLE
feat(client): last-route persistence + palette navigation test (RECEIPTS-733)

### DIFF
--- a/src/client/src/components/CommandPalette.test.tsx
+++ b/src/client/src/components/CommandPalette.test.tsx
@@ -153,6 +153,28 @@ describe("CommandPalette", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  // Closes the RECEIPTS-593 DoD item: "open palette, type 'new receipt',
+  // press Enter — lands on /receipts/new". This exercises the full keyboard
+  // path (typing + Enter) rather than clicking, since that's what the user
+  // contract specifies.
+  it("typing 'new receipt' and pressing Enter navigates to /receipts/new", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderWithQueryClient(
+      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+    );
+
+    const input = screen.getByPlaceholderText(/type a command or search/i);
+    await user.type(input, "new receipt");
+
+    // cmdk highlights the first matching row by default; pressing Enter
+    // activates it.
+    await user.keyboard("{Enter}");
+
+    expect(navigateMock).toHaveBeenCalledWith("/receipts/new");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it("does not render entity groups when query is empty", async () => {
     const { useAccounts } = await import("@/hooks/useAccounts");
     vi.mocked(useAccounts).mockReturnValue(

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -15,6 +15,7 @@ import type { SignalRConnectionState } from "@/hooks/useSignalR";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
 import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useLastRoutePersistence } from "@/hooks/useLastRoutePersistence";
 import { ShortcutsHelp } from "@/components/ShortcutsHelp";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { MobileTabbar } from "@/components/MobileTabbar";
@@ -126,6 +127,7 @@ export function Layout() {
   const location = useLocation();
   const { connectionState } = useSignalR(!!user);
   const isMobile = useIsMobile();
+  useLastRoutePersistence();
   const [searchOpen, setSearchOpen] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   useGlobalShortcuts();

--- a/src/client/src/hooks/useLastRoutePersistence.test.tsx
+++ b/src/client/src/hooks/useLastRoutePersistence.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router";
+import {
+  useLastRoutePersistence,
+  isTrackableRoute,
+} from "./useLastRoutePersistence";
+
+const STORAGE_KEY = "receipts:last-route";
+
+function Probe() {
+  useLastRoutePersistence();
+  const location = useLocation();
+  return <div data-testid="path">{location.pathname + (location.search ?? "")}</div>;
+}
+
+function harness(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/" element={<Probe />} />
+        <Route path="/receipts" element={<Probe />} />
+        <Route path="/receipts/abc-123" element={<Probe />} />
+        <Route path="/cards" element={<Probe />} />
+        <Route path="/login" element={<Probe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("isTrackableRoute", () => {
+  it.each([
+    ["/", false],
+    ["/login", false],
+    ["/login/forgot", false],
+    ["/change-password", false],
+    ["/onboarding", false],
+    ["/onboarding/step-2", false],
+    ["/receipts", true],
+    ["/receipts/abc-123", true],
+    ["/cards", true],
+    ["/reports", true],
+  ])("returns %s → %s", (path, expected) => {
+    expect(isTrackableRoute(path)).toBe(expected);
+  });
+});
+
+describe("useLastRoutePersistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("writes the current pathname to localStorage when on a trackable route", () => {
+    harness("/cards");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("/cards");
+  });
+
+  it("preserves the search string", () => {
+    harness("/receipts?filter=open");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("/receipts?filter=open");
+  });
+
+  it("does not write when on an untrackable route", () => {
+    harness("/login");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not write when on root", () => {
+    harness("/");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("redirects from / to the stored route on first mount", () => {
+    window.localStorage.setItem(STORAGE_KEY, "/cards");
+    harness("/");
+    expect(screen.getByTestId("path")).toHaveTextContent("/cards");
+  });
+
+  it("does not redirect when stored route is untrackable", () => {
+    window.localStorage.setItem(STORAGE_KEY, "/login");
+    harness("/");
+    expect(screen.getByTestId("path")).toHaveTextContent("/");
+  });
+
+  it("does not redirect when stored value looks like an external URL", () => {
+    window.localStorage.setItem(STORAGE_KEY, "//evil.example.com/path");
+    harness("/");
+    expect(screen.getByTestId("path")).toHaveTextContent("/");
+  });
+
+  it("does not redirect when no stored route exists", () => {
+    harness("/");
+    expect(screen.getByTestId("path")).toHaveTextContent("/");
+  });
+
+  it("does not redirect when the current path is not exactly /", () => {
+    window.localStorage.setItem(STORAGE_KEY, "/cards");
+    harness("/receipts");
+    expect(screen.getByTestId("path")).toHaveTextContent("/receipts");
+  });
+
+  it("ignores localStorage read errors", () => {
+    const spy = vi
+      .spyOn(window.localStorage.__proto__, "getItem")
+      .mockImplementation(() => {
+        throw new Error("denied");
+      });
+    expect(() => harness("/")).not.toThrow();
+    spy.mockRestore();
+  });
+});

--- a/src/client/src/hooks/useLastRoutePersistence.ts
+++ b/src/client/src/hooks/useLastRoutePersistence.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+/**
+ * Persists the user's current route so a cold-open to "/" lands back where
+ * they were last working. Closes the last DoD item in RECEIPTS-593.
+ *
+ * Behavior:
+ * - On every authenticated location change, writes the pathname (with search)
+ *   to localStorage — unless it's a route we don't want to be the landing
+ *   target (root, auth flows).
+ * - On the first mount only, if the current path is exactly "/" and a stored
+ *   route exists and is still considered trackable, redirect to it.
+ *
+ * The hook is intended to mount inside `Layout`, which already lives behind
+ * `ProtectedRoute` — so we don't second-guess auth state here.
+ */
+const STORAGE_KEY = "receipts:last-route";
+
+const UNTRACKABLE_PREFIXES = [
+  "/", // exact match check below; we don't store root
+  "/login",
+  "/change-password",
+  "/onboarding",
+];
+
+export function isTrackableRoute(pathname: string): boolean {
+  if (pathname === "/") return false;
+  return !UNTRACKABLE_PREFIXES.some(
+    (p) => p !== "/" && (pathname === p || pathname.startsWith(p + "/")),
+  );
+}
+
+function readStoredRoute(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    if (!v) return null;
+    // Cheap sanity check — must start with `/`, no protocol, no opaque host.
+    if (!v.startsWith("/") || v.startsWith("//")) return null;
+    return v;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredRoute(value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // localStorage may throw in privacy mode; failing closed is fine here.
+  }
+}
+
+export function useLastRoutePersistence(): void {
+  const location = useLocation();
+  const navigate = useNavigate();
+  // Only redirect on the very first mount of this hook in the session — we
+  // never want to re-redirect mid-session if the user lands on / by clicking
+  // the brand link.
+  const didInitialRedirect = useRef(false);
+
+  useEffect(() => {
+    if (didInitialRedirect.current) return;
+    didInitialRedirect.current = true;
+    if (location.pathname !== "/") return;
+    const stored = readStoredRoute();
+    if (!stored) return;
+    if (!isTrackableRoute(stored)) return;
+    // `replace` so the redirect doesn't clutter the back-stack with `/`.
+    navigate(stored, { replace: true });
+    // We intentionally run only on first mount — listing `location.pathname`
+    // / `navigate` would cause re-entry on every nav.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!isTrackableRoute(location.pathname)) return;
+    const path = location.pathname + (location.search ?? "");
+    writeStoredRoute(path);
+  }, [location.pathname, location.search]);
+}


### PR DESCRIPTION
Closes the last two DoD items in RECEIPTS-593:

- Last-route persistence across reloads.
- E2E-ish test for the palette path \"type 'new receipt' → Enter → /receipts/new\".

### Why

After RECEIPTS-732 landed the MobileTabbar, the only open items on the App Shell epic were a fresh-tab persistence hook and a missing keyboard-path test on the palette. Both are small and natural to ship together.

### What

#### `useLastRoutePersistence`
- New hook in `src/client/src/hooks/useLastRoutePersistence.ts`, mounted in `Layout` (already behind `ProtectedRoute`).
- Writes the current pathname + search to localStorage on every location change, **iff** the route is trackable. Untrackable routes (root, `/login`, `/change-password`, `/onboarding`) are excluded so they can never become landing targets.
- On first mount only, if the current path is exactly `/` and a valid stored route exists, navigates to it with `replace: true` so the back-stack stays clean. The first-mount-only guard means clicking the brand link mid-session does NOT re-redirect — root stays root once you've gone there deliberately.
- Defensive against `localStorage` exceptions (privacy mode) and against protocol-relative URLs (`//evil.example.com/...`).

#### Palette navigation test
- Adds the missing keyboard-path coverage to `CommandPalette.test.tsx`:
  type \"new receipt\" → press Enter → asserts `navigate(\"/receipts/new\")`.
- Closes the DoD bullet \"E2E: open palette, type 'new receipt', press Enter — lands on detail-edit\".

### Verification

- 20 new tests for the hook (trackable-route enumeration, write-skip cases, redirect cases, search preservation, localStorage error handling, protocol-relative guard).
- 1 new palette keyboard test (sibling to the existing click-driven test).
- Full vitest suite: **2035 passed** (was 2014 before this PR; 21 net new tests = 20 hook + 1 palette).
- ESLint clean.
- Closes RECEIPTS-593 DoD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)