### PR TITLE
feat(client): add X and / list shortcuts (RECEIPTS-734)

### DIFF
--- a/src/client/src/hooks/useListKeyboardNav.test.ts
+++ b/src/client/src/hooks/useListKeyboardNav.test.ts
@@ -448,6 +448,102 @@ describe("useListKeyboardNav", () => {
     });
   });
 
+  describe("x hotkey (Gmail-style select toggle)", () => {
+    it("calls onToggleSelect with the focused item", () => {
+      const onToggleSelect = vi.fn();
+
+      const { result } = renderHook(() =>
+        useListKeyboardNav({
+          items,
+          getId: (item) => item.id,
+          onToggleSelect,
+        }),
+      );
+
+      act(() => {
+        result.current.setFocusedIndex(1);
+      });
+
+      act(() => {
+        hotkeysMap.get("x")?.();
+      });
+
+      expect(onToggleSelect).toHaveBeenCalledWith(items[1]);
+    });
+
+    it("is not registered when focusedIndex is -1", () => {
+      const onToggleSelect = vi.fn();
+      renderHook(() =>
+        useListKeyboardNav({
+          items,
+          getId: (item) => item.id,
+          onToggleSelect,
+        }),
+      );
+      expect(hotkeysMap.has("x")).toBe(false);
+    });
+
+    it("is not registered when onToggleSelect is not provided", () => {
+      const { result } = renderHook(() =>
+        useListKeyboardNav({
+          items,
+          getId: (item) => item.id,
+        }),
+      );
+      act(() => {
+        result.current.setFocusedIndex(0);
+      });
+      expect(hotkeysMap.has("x")).toBe(false);
+    });
+  });
+
+  describe("/ hotkey (focus search)", () => {
+    it("calls onFocusSearch", () => {
+      const onFocusSearch = vi.fn();
+
+      renderHook(() =>
+        useListKeyboardNav({
+          items,
+          getId: (item) => item.id,
+          onFocusSearch,
+        }),
+      );
+
+      act(() => {
+        hotkeysMap.get("/")?.();
+      });
+
+      expect(onFocusSearch).toHaveBeenCalledOnce();
+    });
+
+    it("is not registered when onFocusSearch is not provided", () => {
+      renderHook(() =>
+        useListKeyboardNav({
+          items,
+          getId: (item) => item.id,
+        }),
+      );
+      expect(hotkeysMap.has("/")).toBe(false);
+    });
+
+    it("does not depend on focusedIndex", () => {
+      // / focuses the search bar regardless of whether a row is focused.
+      const onFocusSearch = vi.fn();
+      renderHook(() =>
+        useListKeyboardNav({
+          items,
+          getId: (item) => item.id,
+          onFocusSearch,
+        }),
+      );
+      // No setFocusedIndex call — focus is still -1.
+      act(() => {
+        hotkeysMap.get("/")?.();
+      });
+      expect(onFocusSearch).toHaveBeenCalledOnce();
+    });
+  });
+
   describe("Delete hotkey", () => {
     it("calls onDelete when items are selected", () => {
       const onDelete = vi.fn();

--- a/src/client/src/hooks/useListKeyboardNav.ts
+++ b/src/client/src/hooks/useListKeyboardNav.ts
@@ -12,6 +12,12 @@ export interface UseListKeyboardNavOptions<T> {
   onSelectAll?: () => void;
   onDeselectAll?: () => void;
   onToggleSelect?: (item: T) => void;
+  /**
+   * Called when the user presses `/` (Vim/Gmail-style search activation).
+   * The page is responsible for focusing whatever input it considers
+   * the list's search field.
+   */
+  onFocusSearch?: () => void;
   selected?: Set<string>;
 }
 
@@ -25,6 +31,7 @@ export function useListKeyboardNav<T>({
   onSelectAll,
   onDeselectAll,
   onToggleSelect,
+  onFocusSearch,
   selected,
 }: UseListKeyboardNavOptions<T>) {
   const [focusedIndex, setFocusedIndex] = useState(-1);
@@ -89,7 +96,7 @@ export function useListKeyboardNav<T>({
     [focusedIndex, items, onOpen],
   );
 
-  // Space — toggle selection on focused item
+  // Space — toggle selection on focused item (standard a11y idiom).
   useHotkeys(
     "Space",
     () => {
@@ -103,6 +110,40 @@ export function useListKeyboardNav<T>({
       preventDefault: true,
     },
     [focusedIndex, items, onToggleSelect],
+  );
+
+  // x — toggle selection on focused item (Gmail/Vim "select message" idiom).
+  // Registered as a separate hotkey from Space so tests that target one or
+  // the other key can interrogate them independently.
+  useHotkeys(
+    "x",
+    () => {
+      if (focusedIndex >= 0 && focusedIndex < items.length && onToggleSelect) {
+        onToggleSelect(items[focusedIndex]);
+      }
+    },
+    {
+      enabled: enabled && !!onToggleSelect && focusedIndex >= 0,
+      enableOnFormTags: false,
+      preventDefault: true,
+    },
+    [focusedIndex, items, onToggleSelect],
+  );
+
+  // / — focus the list's search input (Vim/Gmail idiom). The page wires
+  // the actual focus call via onFocusSearch since useListKeyboardNav does
+  // not know about page-specific search components.
+  useHotkeys(
+    "/",
+    () => {
+      onFocusSearch?.();
+    },
+    {
+      enabled: enabled && !!onFocusSearch,
+      enableOnFormTags: false,
+      preventDefault: true,
+    },
+    [onFocusSearch],
   );
 
   // Delete — trigger delete action

--- a/src/client/src/lib/shortcut-registry.ts
+++ b/src/client/src/lib/shortcut-registry.ts
@@ -28,7 +28,16 @@ export const shortcuts: ShortcutDefinition[] = [
     label: "Open / edit focused item",
     category: "List Navigation",
   },
-  { keys: "Space", label: "Toggle selection", category: "List Navigation" },
+  {
+    keys: "Space / x",
+    label: "Toggle selection on focused row",
+    category: "List Navigation",
+  },
+  {
+    keys: "/",
+    label: "Focus the search field",
+    category: "List Navigation",
+  },
   {
     keys: "Delete",
     label: "Delete selected items",

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -205,6 +205,16 @@ function Receipts() {
         setSelected(new Set(filteredResults.map((r) => r.id))),
       onDeselectAll: () => setSelected(new Set()),
       onToggleSelect: (r) => toggleSelect(r.id),
+      onFocusSearch: () => {
+        // Search lives outside useListKeyboardNav's scope — focus it by id.
+        // Using getElementById (vs. a ref) keeps the hook agnostic about
+        // the input component and lets it work with any input on the page.
+        const input = document.getElementById("receipts-search");
+        if (input instanceof HTMLInputElement) {
+          input.focus();
+          input.select();
+        }
+      },
       selected,
     });
 
@@ -241,6 +251,7 @@ function Receipts() {
       <div className="filter-strip">
         <div style={{ flex: 1, minWidth: 240 }}>
           <FuzzySearchInput
+            id="receipts-search"
             aria-label="Search receipts"
             value={search}
             onChange={setSearch}


### PR DESCRIPTION
Closes RECEIPTS-734. The Receipts list already had J/K/Enter/Space/Delete/Ctrl+A via `useListKeyboardNav`; this fills in the two remaining keys from the RECEIPTS-594 keyboard contract.

### What

- **`x`** — toggle selection on the focused row (Gmail/Vim idiom, alongside the existing Space binding for the same action).
- **`/`** — focus the list's search input (Vim/Gmail idiom). Implemented via an optional `onFocusSearch` callback so `useListKeyboardNav` stays agnostic about which input belongs to the page; `Receipts.tsx` wires it through a `getElementById` on a new `id="receipts-search"` on the `FuzzySearchInput`.

### Registry

ShortcutsHelp picks both up via the registry — `shortcut-registry.ts` updated:
- Space label changed to `"Space / x"`.
- New `/` row: "Focus the search field".

### Verification

- New unit tests for X (focused-item toggle, unregistered when no focus or no callback) and `/` (calls callback, doesn't depend on focused index, unregistered when callback absent).
- Existing Space/Enter/Delete/mod+a tests unchanged and still passing.
- Full vitest suite: **2041 passed** (was 2035; 6 net new tests).
- ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)