### PR TITLE
feat(client): bulk-actions selection bar on Receipts list (RECEIPTS-735)

### DIFF
--- a/src/client/src/components/BulkActionsBar.test.tsx
+++ b/src/client/src/components/BulkActionsBar.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import { BulkActionsBar } from "./BulkActionsBar";
+
+const defaultProps = {
+  selectedCount: 2,
+  totalCount: 10,
+  itemLabel: "receipt",
+  onClearSelection: () => {},
+  onDelete: () => {},
+};
+
+describe("BulkActionsBar", () => {
+  it("renders nothing when selectedCount is 0", () => {
+    const { container } = renderWithProviders(
+      <BulkActionsBar {...defaultProps} selectedCount={0} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the visible count with a plural noun", () => {
+    renderWithProviders(<BulkActionsBar {...defaultProps} selectedCount={3} />);
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText(/receipts selected/)).toBeInTheDocument();
+  });
+
+  it("uses the singular noun when exactly one item is selected", () => {
+    renderWithProviders(<BulkActionsBar {...defaultProps} selectedCount={1} />);
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText(/receipt selected/)).toBeInTheDocument();
+  });
+
+  it("invokes onClearSelection when Clear is clicked", async () => {
+    const onClearSelection = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <BulkActionsBar {...defaultProps} onClearSelection={onClearSelection} />,
+    );
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onClearSelection).toHaveBeenCalledOnce();
+  });
+
+  it("invokes onDelete when Delete is clicked", async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <BulkActionsBar {...defaultProps} onDelete={onDelete} />,
+    );
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("renders the Push to YNAB button when onPushToYnab is provided", async () => {
+    const onPushToYnab = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <BulkActionsBar {...defaultProps} onPushToYnab={onPushToYnab} />,
+    );
+    await user.click(screen.getByRole("button", { name: /push to ynab/i }));
+    expect(onPushToYnab).toHaveBeenCalledOnce();
+  });
+
+  it("omits the Push to YNAB button when onPushToYnab is not provided", () => {
+    renderWithProviders(<BulkActionsBar {...defaultProps} />);
+    expect(
+      screen.queryByRole("button", { name: /push to ynab/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables the YNAB button and shows a spinner while pushing", () => {
+    renderWithProviders(
+      <BulkActionsBar
+        {...defaultProps}
+        onPushToYnab={() => {}}
+        isPushingToYnab
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /pushing/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("disables the Delete button and swaps to 'Deleting…' while deleting", () => {
+    renderWithProviders(
+      <BulkActionsBar {...defaultProps} isDeleting />,
+    );
+    const btn = screen.getByRole("button", { name: /deleting/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("wraps the bar in an aria-live region for SR announcement", () => {
+    renderWithProviders(<BulkActionsBar {...defaultProps} />);
+    const region = screen.getByRole("region", { name: "Bulk actions" });
+    expect(region).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/src/client/src/components/BulkActionsBar.tsx
+++ b/src/client/src/components/BulkActionsBar.tsx
@@ -1,0 +1,105 @@
+import { Icon } from "@/components/primitives";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+
+interface BulkActionsBarProps {
+  /** Number of currently-selected items. The bar renders nothing when 0. */
+  selectedCount: number;
+  /** Total visible items, for "N of M" disclosure. */
+  totalCount?: number;
+  /** Singular noun for the entity, e.g. "receipt". */
+  itemLabel: string;
+  onClearSelection: () => void;
+  onDelete: () => void;
+  onPushToYnab?: () => void;
+  isPushingToYnab?: boolean;
+  isDeleting?: boolean;
+  className?: string;
+}
+
+/**
+ * Sticky bottom-anchored bar that appears when one or more rows are selected
+ * on a list page. Renders inline (not portaled) so the test wrapper can
+ * find it without extra plumbing; positioning is driven by the .bulk-actions
+ * CSS class in index.css.
+ */
+export function BulkActionsBar({
+  selectedCount,
+  totalCount,
+  itemLabel,
+  onClearSelection,
+  onDelete,
+  onPushToYnab,
+  isPushingToYnab = false,
+  isDeleting = false,
+  className,
+}: BulkActionsBarProps) {
+  if (selectedCount <= 0) return null;
+
+  const noun = selectedCount === 1 ? itemLabel : `${itemLabel}s`;
+  // Show "of N" only when we have a meaningful total — keeps the visible
+  // text the same as the SR-announced text so we don't ship two readings
+  // of the same fact.
+  const ofTotal =
+    totalCount != null && totalCount > 0 ? ` of ${totalCount}` : "";
+
+  return (
+    <div
+      className={cn("bulk-actions", className)}
+      role="region"
+      aria-label="Bulk actions"
+      // aria-live so screen readers announce the selection count as it
+      // changes; polite so it doesn't pre-empt the user mid-task.
+      aria-live="polite"
+    >
+      <div className="bulk-actions-count">
+        <strong>{selectedCount}</strong>
+        {ofTotal} {noun} selected
+      </div>
+      <div className="bulk-actions-spacer" />
+      <button
+        type="button"
+        className="btn xs ghost"
+        onClick={onClearSelection}
+      >
+        Clear
+      </button>
+      {onPushToYnab && (
+        <button
+          type="button"
+          className="btn"
+          onClick={onPushToYnab}
+          disabled={isPushingToYnab}
+        >
+          {isPushingToYnab ? (
+            <>
+              <Spinner className="mr-2 h-3 w-3" />
+              Pushing…
+            </>
+          ) : (
+            <>
+              <Icon.Link /> Push to YNAB
+            </>
+          )}
+        </button>
+      )}
+      <button
+        type="button"
+        className="btn danger"
+        onClick={onDelete}
+        disabled={isDeleting}
+      >
+        {isDeleting ? (
+          <>
+            <Spinner className="mr-2 h-3 w-3" />
+            Deleting…
+          </>
+        ) : (
+          <>
+            <Icon.Trash /> Delete
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -1479,6 +1479,46 @@ body {
   line-height: 1.5;
 }
 
+/* ── Bulk actions bar ───────────────────────────────────────────────── */
+.bulk-actions {
+  position: sticky;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 14px;
+  margin-top: 14px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(8px);
+}
+.bulk-actions-count {
+  font-size: 13px;
+  color: var(--ink);
+}
+.bulk-actions-count strong {
+  color: var(--accent);
+  font-weight: 600;
+  margin-right: 4px;
+}
+.bulk-actions-spacer {
+  flex: 1;
+}
+@media (max-width: 900px) {
+  .bulk-actions {
+    /* Sit above the mobile tabbar (60px tall, fixed at bottom: 0). */
+    bottom: 72px;
+    margin-left: -14px;
+    margin-right: -14px;
+    border-radius: 8px;
+  }
+}
+
 /* ── Mobile tabbar + responsive shell ───────────────────────────────── */
 .mobile-tabbar {
   display: none;

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -15,6 +15,10 @@ vi.mock("@/hooks/useYnab", () => ({
     data: undefined,
     isLoading: false,
   })),
+  useBulkPushYnabTransactions: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
 }));
 
 vi.mock("@/hooks/useReceipts", () => ({
@@ -460,8 +464,12 @@ describe("Receipts", () => {
     renderWithProviders(<Receipts />);
     await user.click(screen.getByLabelText("Select all rows"));
 
+    // Selecting all rows reveals the bulk-actions bar with the count
+    // ("2 receipts selected") and a Delete button.
+    const bar = await screen.findByRole("region", { name: "Bulk actions" });
+    expect(bar).toHaveTextContent(/2.* receipts selected/);
     expect(
-      screen.getByRole("button", { name: /delete \(2\)/i }),
+      screen.getByRole("button", { name: /^delete$/i }),
     ).toBeInTheDocument();
   });
 

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -37,7 +37,11 @@ import { Spinner } from "@/components/ui/spinner";
 import { formatCurrency } from "@/lib/format";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Info } from "lucide-react";
-import { useReceiptYnabSyncStatuses } from "@/hooks/useYnab";
+import {
+  useReceiptYnabSyncStatuses,
+  useBulkPushYnabTransactions,
+} from "@/hooks/useYnab";
+import { BulkActionsBar } from "@/components/BulkActionsBar";
 import {
   Checkbox,
   Icon,
@@ -119,6 +123,7 @@ function Receipts() {
   const createReceipt = useCreateReceipt();
   const updateReceipt = useUpdateReceipt();
   const deleteReceipts = useDeleteReceipts();
+  const bulkPushYnab = useBulkPushYnabTransactions();
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [createOpen, setCreateOpen] = useState(false);
@@ -225,15 +230,6 @@ function Receipts() {
         sub={`${serverTotal} total · ${filteredResults.length} shown`}
         actions={
           <>
-            {selected.size > 0 && (
-              <button
-                type="button"
-                className="btn danger"
-                onClick={() => setDeleteOpen(true)}
-              >
-                <Icon.Trash /> Delete ({selected.size})
-              </button>
-            )}
             <button
               type="button"
               className="btn"
@@ -508,6 +504,20 @@ function Receipts() {
             totalPages={totalPages(serverTotal)}
             onPageChange={(page) => setPage(page, serverTotal)}
             onPageSizeChange={setPageSize}
+          />
+          <BulkActionsBar
+            selectedCount={selected.size}
+            totalCount={filteredResults.length}
+            itemLabel="receipt"
+            onClearSelection={() => setSelected(new Set())}
+            onDelete={() => setDeleteOpen(true)}
+            onPushToYnab={() => {
+              bulkPushYnab.mutate(Array.from(selected), {
+                onSuccess: () => setSelected(new Set()),
+              });
+            }}
+            isPushingToYnab={bulkPushYnab.isPending}
+            isDeleting={deleteReceipts.isPending}
           />
         </>
       )}


### PR DESCRIPTION
Closes RECEIPTS-735.

### Why

The PageHead-Delete-button was cramped: count tucked into the button label, no Push to YNAB, no Clear escape hatch. Swap it for a proper sticky-bottom bar.

### What

#### Component
`BulkActionsBar.tsx` — sticky bottom bar with:
- Selection count (\"N receipts selected\", \"of M\" disclosure)
- Clear button
- Optional Push to YNAB button (only renders if `onPushToYnab` is provided)
- Delete button
- `role=\"region\" aria-label=\"Bulk actions\" aria-live=\"polite\"` so the count is announced
- Both action buttons swap accessible name + spinner while their mutation is pending (Push to YNAB ↔ \"Pushing…\", Delete ↔ \"Deleting…\")

#### CSS
- `.bulk-actions` block in `index.css`, sticky at `bottom: 12px` on desktop; `bottom: 72px` on mobile so it sits above the mobile tabbar.
- Contrast verified per palette: `--accent` on `--surface` = 7.1:1 (Graphite) / 6.1:1 (Paper) → AA passes for 13px bold.

#### Receipts page wiring
- `useBulkPushYnabTransactions` drives Push to YNAB; clears selection on success.
- Inline PageHead Delete button removed.
- Bar appears below the table when selection > 0.

### Categorize action — intentionally omitted

The original 596 brief listed \"Push to YNAB / Categorize / Bulk delete\" as the three actions. Categorize is omitted because receipts don't have a category in the current domain — line items do. Adding a bulk-categorize action would either silently set a non-existent receipt category or trigger an opinionated \"set primary category on all items\" flow that needs a separate design conversation. Filing a follow-up if/when the need surfaces.

### Verification

- 10 unit tests on BulkActionsBar (render, count plural/singular, callbacks, disabled states with name swap, region/aria-live).
- Receipts.test.tsx \"toggles select all checkbox\" updated to assert the new region + count.
- Full vitest: **2051 passed** (was 2041).
- ESLint clean.
- Accessibility audit passed; one advisory applied (Delete button name swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)