### PR TITLE
feat(client): dedicated 500 + 401 pages + API interceptor (RECEIPTS-740)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -23,6 +23,8 @@ import BackupRestore from "@/pages/BackupRestore";
 import NewReceipt from "@/pages/new-receipt/NewReceiptPage";
 import YnabSettings from "@/pages/settings/YnabSettings";
 import NotFound from "@/pages/NotFound";
+import ServerError from "@/pages/ServerError";
+import Unauthorized from "@/pages/Unauthorized";
 
 export const routeConfig = [
   {
@@ -89,6 +91,12 @@ export const routeConfig = [
           },
         ],
       },
+      // Error routes live outside the authenticated Layout so the page
+      // shell isn't required for them to render. NotFound stays as the
+      // catch-all; 500 and 401 are reachable directly via /error/500 and
+      // /unauthorized.
+      { path: "/error/500", element: <ServerError /> },
+      { path: "/unauthorized", element: <Unauthorized /> },
       { path: "*", element: <NotFound /> },
     ],
   },

--- a/src/client/src/components/RootLayout.test.tsx
+++ b/src/client/src/components/RootLayout.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { RootLayout } from "./RootLayout";
+import { notifyServerError } from "@/lib/server-error-bus";
 
 vi.mock("@/components/ui/sonner", () => ({
   Toaster: () => <div data-testid="toaster">Toaster</div>,
@@ -13,7 +14,27 @@ vi.mock("@/components/ErrorBoundary", () => ({
   ),
 }));
 
+const navigateMock = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useNavigate: vi.fn(() => navigateMock),
+  };
+});
+
+const toastErrorMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (m: string) => toastErrorMock(m) },
+}));
+
 describe("RootLayout", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+    toastErrorMock.mockClear();
+    window.sessionStorage.clear();
+  });
+
   it("renders the ErrorBoundary wrapper", () => {
     renderWithProviders(<RootLayout />);
     expect(screen.getByTestId("error-boundary")).toBeInTheDocument();
@@ -31,9 +52,34 @@ describe("RootLayout", () => {
     expect(errorBoundary).toContainElement(toaster);
   });
 
-  it("renders children via Outlet within ErrorBoundary", () => {
-    renderWithProviders(<RootLayout />);
-    const errorBoundary = screen.getByTestId("error-boundary");
-    expect(errorBoundary).toBeInTheDocument();
+  describe("ServerErrorBridge (RECEIPTS-740)", () => {
+    it("navigates to /error/500 on the first 5xx of the session", () => {
+      renderWithProviders(<RootLayout />);
+      act(() => {
+        notifyServerError(500);
+      });
+      expect(navigateMock).toHaveBeenCalledWith("/error/500");
+      expect(toastErrorMock).not.toHaveBeenCalled();
+    });
+
+    it("toasts subsequent 5xx after the first has shown the page", () => {
+      window.sessionStorage.setItem("receipts:server-error-shown", "1");
+      renderWithProviders(<RootLayout />);
+      act(() => {
+        notifyServerError(503);
+      });
+      expect(navigateMock).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "A server error occurred. Please try again.",
+      );
+    });
+
+    it("does not bounce back to /error/500 if already there", () => {
+      renderWithProviders(<RootLayout />, { route: "/error/500" });
+      act(() => {
+        notifyServerError(500);
+      });
+      expect(navigateMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/client/src/components/RootLayout.tsx
+++ b/src/client/src/components/RootLayout.tsx
@@ -1,10 +1,47 @@
-import { Outlet } from "react-router";
+import { useEffect } from "react";
+import { Outlet, useLocation, useNavigate } from "react-router";
+import { toast } from "sonner";
 import { Toaster } from "@/components/ui/sonner";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import {
+  addServerErrorListener,
+  hasShownServerErrorPage,
+  markServerErrorPageShown,
+} from "@/lib/server-error-bus";
+
+/**
+ * On the first 5xx in a tab session we navigate to /error/500 for the full
+ * editorial treatment; subsequent 5xx land as toasts so we don't yank the
+ * user out of whatever they were doing repeatedly (RECEIPTS-740).
+ *
+ * Listener registered here so it survives across page transitions — placing
+ * it lower in the tree would unmount whenever the user navigates.
+ */
+function ServerErrorBridge() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const unsubscribe = addServerErrorListener(() => {
+      // Already on the error page — don't bounce back to it.
+      if (location.pathname === "/error/500") return;
+      if (hasShownServerErrorPage()) {
+        toast.error("A server error occurred. Please try again.");
+        return;
+      }
+      markServerErrorPageShown();
+      navigate("/error/500");
+    });
+    return unsubscribe;
+  }, [navigate, location.pathname]);
+
+  return null;
+}
 
 export function RootLayout() {
   return (
     <ErrorBoundary>
+      <ServerErrorBridge />
       <Outlet />
       <Toaster />
     </ErrorBoundary>

--- a/src/client/src/lib/api-client.ts
+++ b/src/client/src/lib/api-client.ts
@@ -10,6 +10,10 @@ import {
   notifyPasswordChangeRequired,
 } from "@/lib/auth";
 import { getConnectionId } from "@/lib/signalr-connection";
+import {
+  notifyServerError,
+  setLoginFlash,
+} from "@/lib/server-error-bus";
 
 const baseUrl = import.meta.env.VITE_API_URL ?? "";
 const API_TIMEOUT_MS = 30_000;
@@ -95,6 +99,9 @@ const authMiddleware: Middleware = {
     const refreshed = await refreshPromise;
     if (!refreshed) {
       clearTokens();
+      // Surface a session-scoped flash on /login so the user sees *why*
+      // they're back there rather than wondering. RECEIPTS-740.
+      setLoginFlash("Your session expired. Please sign in again.");
       window.location.href = "/login";
       return response;
     }
@@ -125,7 +132,21 @@ const signalRConnectionMiddleware: Middleware = {
   },
 };
 
+// Surfaces 5xx responses to the React shell so it can navigate to the
+// dedicated /error/500 page on the first occurrence of a session, then
+// fall back to toasts (RECEIPTS-740). The "first vs subsequent" decision
+// lives in the subscriber (RootLayout) — this middleware only publishes.
+const serverErrorMiddleware: Middleware = {
+  async onResponse({ response }) {
+    if (response.status >= 500 && response.status < 600) {
+      notifyServerError(response.status);
+    }
+    return response;
+  },
+};
+
 client.use(authMiddleware);
 client.use(signalRConnectionMiddleware);
+client.use(serverErrorMiddleware);
 
 export default client;

--- a/src/client/src/lib/server-error-bus.test.ts
+++ b/src/client/src/lib/server-error-bus.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  addServerErrorListener,
+  notifyServerError,
+  hasShownServerErrorPage,
+  markServerErrorPageShown,
+  clearServerErrorPageFlag,
+  setLoginFlash,
+  consumeLoginFlash,
+} from "./server-error-bus";
+
+describe("server-error-bus", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  describe("listener pub/sub", () => {
+    it("delivers the status code to subscribers", () => {
+      const listener = vi.fn();
+      const unsubscribe = addServerErrorListener(listener);
+      notifyServerError(503);
+      expect(listener).toHaveBeenCalledWith(503);
+      unsubscribe();
+    });
+
+    it("does not notify after unsubscribe", () => {
+      const listener = vi.fn();
+      const unsubscribe = addServerErrorListener(listener);
+      unsubscribe();
+      notifyServerError(500);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("supports multiple subscribers independently", () => {
+      const a = vi.fn();
+      const b = vi.fn();
+      const offA = addServerErrorListener(a);
+      const offB = addServerErrorListener(b);
+      notifyServerError(502);
+      expect(a).toHaveBeenCalledOnce();
+      expect(b).toHaveBeenCalledOnce();
+      offA();
+      notifyServerError(500);
+      expect(a).toHaveBeenCalledOnce();
+      expect(b).toHaveBeenCalledTimes(2);
+      offB();
+    });
+  });
+
+  describe("session flag", () => {
+    it("returns false when nothing has been marked", () => {
+      expect(hasShownServerErrorPage()).toBe(false);
+    });
+
+    it("returns true after markServerErrorPageShown", () => {
+      markServerErrorPageShown();
+      expect(hasShownServerErrorPage()).toBe(true);
+    });
+
+    it("clears the flag on demand", () => {
+      markServerErrorPageShown();
+      clearServerErrorPageFlag();
+      expect(hasShownServerErrorPage()).toBe(false);
+    });
+  });
+
+  describe("login flash", () => {
+    it("returns null when nothing is set", () => {
+      expect(consumeLoginFlash()).toBeNull();
+    });
+
+    it("reads back what was set", () => {
+      setLoginFlash("session-expired");
+      expect(consumeLoginFlash()).toBe("session-expired");
+    });
+
+    it("consume-on-read clears the value", () => {
+      setLoginFlash("once");
+      consumeLoginFlash();
+      expect(consumeLoginFlash()).toBeNull();
+    });
+  });
+
+  describe("storage failures", () => {
+    it("tolerates getItem throwing", () => {
+      const spy = vi
+        .spyOn(window.sessionStorage.__proto__, "getItem")
+        .mockImplementation(() => {
+          throw new Error("denied");
+        });
+      expect(hasShownServerErrorPage()).toBe(false);
+      expect(consumeLoginFlash()).toBeNull();
+      spy.mockRestore();
+    });
+
+    it("tolerates setItem throwing", () => {
+      const spy = vi
+        .spyOn(window.sessionStorage.__proto__, "setItem")
+        .mockImplementation(() => {
+          throw new Error("denied");
+        });
+      expect(() => markServerErrorPageShown()).not.toThrow();
+      expect(() => setLoginFlash("x")).not.toThrow();
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/client/src/lib/server-error-bus.ts
+++ b/src/client/src/lib/server-error-bus.ts
@@ -1,0 +1,77 @@
+/**
+ * Decouples the API client (which can't call React Router's `navigate`) from
+ * the React shell (which can). The middleware fires `notifyServerError()` on
+ * a 5xx response; a subscriber inside the shell decides whether to navigate
+ * to /error/500 or show a toast.
+ *
+ * Listed in lib/ rather than hooks/ because the publisher is non-React.
+ */
+type ServerErrorListener = (status: number) => void;
+const serverErrorListeners = new Set<ServerErrorListener>();
+
+export function addServerErrorListener(cb: ServerErrorListener): () => void {
+  serverErrorListeners.add(cb);
+  return () => serverErrorListeners.delete(cb);
+}
+
+export function notifyServerError(status: number): void {
+  serverErrorListeners.forEach((cb) => cb(status));
+}
+
+/**
+ * Session-scoped flag: have we already navigated to the dedicated 500 page
+ * during this tab session? If so, subsequent 5xx responses are toasted
+ * instead of navigating again. sessionStorage clears with the tab so a
+ * fresh tab gets the full editorial treatment again.
+ */
+const SESSION_KEY = "receipts:server-error-shown";
+
+export function hasShownServerErrorPage(): boolean {
+  try {
+    return window.sessionStorage.getItem(SESSION_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function markServerErrorPageShown(): void {
+  try {
+    window.sessionStorage.setItem(SESSION_KEY, "1");
+  } catch {
+    // Private mode / disabled storage — degrade silently. We'll just keep
+    // navigating to the page; users in private mode have bigger problems.
+  }
+}
+
+export function clearServerErrorPageFlag(): void {
+  try {
+    window.sessionStorage.removeItem(SESSION_KEY);
+  } catch {
+    /* see above */
+  }
+}
+
+/**
+ * sessionStorage-backed flash message shown on the Login page after a 401
+ * triggers an automatic redirect. Set by the api-client middleware right
+ * before navigating to /login; consumed and cleared by the Login page.
+ */
+const LOGIN_FLASH_KEY = "receipts:login-flash";
+
+export function setLoginFlash(message: string): void {
+  try {
+    window.sessionStorage.setItem(LOGIN_FLASH_KEY, message);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function consumeLoginFlash(): string | null {
+  try {
+    const v = window.sessionStorage.getItem(LOGIN_FLASH_KEY);
+    if (v) window.sessionStorage.removeItem(LOGIN_FLASH_KEY);
+    return v;
+  } catch {
+    return null;
+  }
+}

--- a/src/client/src/pages/Login.test.tsx
+++ b/src/client/src/pages/Login.test.tsx
@@ -159,4 +159,17 @@ describe("Login", () => {
 
     expect(await screen.findByText(/unable to reach the server/i)).toBeInTheDocument();
   });
+
+  it("surfaces a login-flash message from sessionStorage (RECEIPTS-740)", () => {
+    window.sessionStorage.setItem(
+      "receipts:login-flash",
+      "Your session expired. Please sign in again.",
+    );
+    renderWithProviders(<Login />);
+    expect(
+      screen.getByText(/your session expired/i),
+    ).toBeInTheDocument();
+    // Flash should be consumed on read so reload doesn't re-show it.
+    expect(window.sessionStorage.getItem("receipts:login-flash")).toBeNull();
+  });
 });

--- a/src/client/src/pages/Login.tsx
+++ b/src/client/src/pages/Login.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { isTimeoutError, isNetworkError } from "@/lib/api-client";
+import { consumeLoginFlash } from "@/lib/server-error-bus";
 import { SubmitButton } from "@/components/ui/submit-button";
 import {
   Form,
@@ -30,6 +31,13 @@ function Login() {
   usePageTitle("Sign In");
   const { user, mustResetPassword, login } = useAuth();
   const [error, setError] = useState<string | null>(null);
+  // Session-scoped notice surfaced when the api-client middleware bounces
+  // the user here after a failed token refresh (RECEIPTS-740). Lazy
+  // initializer so the consume-on-read happens exactly once on mount;
+  // putting it in useEffect would re-render and re-consume (and the
+  // consume side-effect inside useState is fine because StrictMode runs
+  // the initializer once per state slot in production).
+  const [flash] = useState<string | null>(() => consumeLoginFlash());
 
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
@@ -63,6 +71,11 @@ function Login() {
     <div className="auth-card">
       <h1 className="auth-title">Sign in</h1>
       <p className="auth-sub">Welcome back</p>
+      {flash && !error && (
+        <Alert className="mb-4">
+          <AlertDescription>{flash}</AlertDescription>
+        </Alert>
+      )}
       {error && (
         <Alert variant="destructive" className="mb-4">
           <AlertDescription>{error}</AlertDescription>

--- a/src/client/src/pages/ServerError.test.tsx
+++ b/src/client/src/pages/ServerError.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import ServerError from "./ServerError";
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+const navigateMock = vi.fn();
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useNavigate: vi.fn(() => navigateMock),
+  };
+});
+
+describe("ServerError", () => {
+  it("renders the 500 code", () => {
+    renderWithProviders(<ServerError />);
+    expect(screen.getByText("500")).toBeInTheDocument();
+  });
+
+  it("uses the editorial heading from the design bundle", () => {
+    renderWithProviders(<ServerError />);
+    expect(screen.getByText(/the kitchen is closed/i)).toBeInTheDocument();
+  });
+
+  it("provides a Try again button that navigates back", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ServerError />);
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+    expect(navigateMock).toHaveBeenCalledWith(-1);
+  });
+
+  it("provides a Dashboard link", () => {
+    renderWithProviders(<ServerError />);
+    const link = screen.getByRole("link", { name: /dashboard/i });
+    expect(link).toHaveAttribute("href", "/");
+  });
+});

--- a/src/client/src/pages/ServerError.tsx
+++ b/src/client/src/pages/ServerError.tsx
@@ -1,0 +1,46 @@
+import { Link, useNavigate } from "react-router";
+import { usePageTitle } from "@/hooks/usePageTitle";
+
+/**
+ * Editorial 500 page (RECEIPTS-740). Reachable on the first 5xx response in
+ * a tab session — subsequent 5xx surface as toasts only. Reuses the
+ * `.err-shell` block from the design system that NotFound already uses.
+ */
+function ServerError() {
+  usePageTitle("Something broke");
+  const navigate = useNavigate();
+
+  return (
+    <div className="page">
+      <div className="err-shell">
+        <div>
+          <div className="err-code" aria-hidden="true">
+            500
+          </div>
+          <div className="err-ti">The kitchen is closed</div>
+          <div className="err-sub">
+            Something on our side caught fire. We logged it; if you saw
+            unsaved work disappear, that’s the explanation. Try the page
+            again, or head back to the dashboard.
+          </div>
+          <div
+            style={{ display: "flex", gap: 8, justifyContent: "center" }}
+          >
+            <button
+              type="button"
+              className="btn"
+              onClick={() => navigate(-1)}
+            >
+              ← Try again
+            </button>
+            <Link to="/" className="btn primary">
+              Dashboard
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ServerError;

--- a/src/client/src/pages/Unauthorized.test.tsx
+++ b/src/client/src/pages/Unauthorized.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/test-utils";
+import Unauthorized from "./Unauthorized";
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+describe("Unauthorized", () => {
+  it("renders the 401 code", () => {
+    renderWithProviders(<Unauthorized />);
+    expect(screen.getByText("401")).toBeInTheDocument();
+  });
+
+  it("uses the editorial heading from the design bundle", () => {
+    renderWithProviders(<Unauthorized />);
+    expect(screen.getByText(/you need to sign in/i)).toBeInTheDocument();
+  });
+
+  it("provides a Sign in link that points at /login", () => {
+    renderWithProviders(<Unauthorized />);
+    const link = screen.getByRole("link", { name: /sign in/i });
+    expect(link).toHaveAttribute("href", "/login");
+  });
+});

--- a/src/client/src/pages/Unauthorized.tsx
+++ b/src/client/src/pages/Unauthorized.tsx
@@ -1,0 +1,40 @@
+import { Link } from "react-router";
+import { usePageTitle } from "@/hooks/usePageTitle";
+
+/**
+ * Editorial 401 page (RECEIPTS-740). Note that most 401 cases route through
+ * `/login` directly (via `setLoginFlash` in the api-client). This route is
+ * reachable for the explicit case where a user navigates to a protected URL
+ * without an authenticated session and the app chooses to land them here
+ * instead of `/login` — e.g. a deep-link they followed from email.
+ */
+function Unauthorized() {
+  usePageTitle("Sign in required");
+
+  return (
+    <div className="page">
+      <div className="err-shell">
+        <div>
+          <div className="err-code" aria-hidden="true">
+            401
+          </div>
+          <div className="err-ti">You need to sign in</div>
+          <div className="err-sub">
+            This page is only available to signed-in members of the
+            household. Sign in to keep going — we’ll send you back to where
+            you were trying to go.
+          </div>
+          <div
+            style={{ display: "flex", gap: 8, justifyContent: "center" }}
+          >
+            <Link to="/login" className="btn primary">
+              Sign in
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Unauthorized;


### PR DESCRIPTION
Closes RECEIPTS-740. The 500 / 401 / 404 trio from RECEIPTS-597 was partial — 404 was covered by NotFound, but 500 and 401 had no editorial treatment and 401 silently bounced to /login without explanation.

### Pages

- `ServerError.tsx` at `/error/500` — \"The kitchen is closed\" + Try again / Dashboard CTAs.
- `Unauthorized.tsx` at `/unauthorized` — \"You need to sign in\" + Sign in CTA. Reachable for deep-link scenarios where the app prefers a soft landing over an immediate `/login` redirect.

Both reuse the `.err-shell` design-system block that `NotFound` already uses.

### Pub/sub bus

`lib/server-error-bus.ts` decouples the non-React API client from the React shell (same pattern as `notifyTokenRefresh` in `lib/auth.ts`):

- Listener-set publisher for 5xx events.
- sessionStorage-backed \"page-shown\" flag for first-vs-subsequent logic.
- Login-flash setter / consume-on-read pair.

### API client middleware

- `serverErrorMiddleware` publishes every 5xx response to the bus.
- Existing 401 → token-refresh → fallback to /login now also writes \"Your session expired. Please sign in again.\" to the login flash.

### React shell

- `RootLayout` mounts a `ServerErrorBridge` that subscribes to the bus. First 5xx in the tab session: navigate to `/error/500`. Subsequent: toast. Already on `/error/500`: no-op (no bounce-back loop).
- `Login` reads + consumes the flash via a lazy `useState` initializer and renders it in a non-destructive Alert above the form.

### Verification

- 11 unit tests on the bus (pub/sub, flag lifecycle, flash consume, storage-failure tolerance).
- 4 unit tests on ServerError, 3 on Unauthorized.
- 3 new RootLayout tests for the ServerErrorBridge (first 5xx navigates, subsequent toasts, no bounce-back on /error/500).
- 1 new Login test for the flash surfacing + consume-on-read.
- Full vitest: **2082 passed** (+21 net new).
- `tsc --noEmit` clean. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)