### PR TITLE
feat(client): chart text alternatives + aria-labelledby (RECEIPTS-743)

### DIFF
--- a/src/client/src/components/dashboard/SpendingByAccountWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingByAccountWidget.tsx
@@ -34,6 +34,12 @@ export function SpendingByAccountWidget({
     [data?.items],
   );
 
+  const top = chartData[0];
+  const summary =
+    chartData.length === 0
+      ? null
+      : `Top account ${top.name} at ${formatCurrency(top.value)} across ${chartData.length} ${chartData.length === 1 ? "account" : "accounts"}.`;
+
   return (
     <ChartCard
       title="Spending by Account"
@@ -41,11 +47,19 @@ export function SpendingByAccountWidget({
       empty={chartData.length === 0 && !isLoading}
       className={className}
     >
-      <BarChart
-        data={chartData}
-        layout="horizontal"
-        formatValue={formatCurrency}
-      />
+      {(titleId) => (
+        <>
+          {summary && (
+            <p className="sr-only">{summary}</p>
+          )}
+          <BarChart
+            data={chartData}
+            layout="horizontal"
+            formatValue={formatCurrency}
+            aria-labelledby={titleId}
+          />
+        </>
+      )}
     </ChartCard>
   );
 }

--- a/src/client/src/components/dashboard/SpendingByCategoryWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingByCategoryWidget.tsx
@@ -54,6 +54,12 @@ export function SpendingByCategoryWidget({
     [chartData],
   );
 
+  const top = chartData[0];
+  const summary =
+    chartData.length === 0
+      ? null
+      : `Total spending ${formatCurrency(totalSpent)} across ${chartData.length} ${chartData.length === 1 ? "category" : "categories"}. Top: ${top.name} at ${formatCurrency(top.value)}.`;
+
   return (
     <ChartCard
       title="Spending by Category"
@@ -61,11 +67,17 @@ export function SpendingByCategoryWidget({
       empty={chartData.length === 0 && !isLoading}
       className={className}
     >
-      <DonutChart
-        data={chartData}
-        centerLabel={formatCurrency(totalSpent)}
-        formatValue={formatCurrency}
-      />
+      {(titleId) => (
+        <>
+          {summary && <p className="sr-only">{summary}</p>}
+          <DonutChart
+            data={chartData}
+            centerLabel={formatCurrency(totalSpent)}
+            formatValue={formatCurrency}
+            aria-labelledby={titleId}
+          />
+        </>
+      )}
     </ChartCard>
   );
 }

--- a/src/client/src/components/dashboard/SpendingByStoreWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingByStoreWidget.tsx
@@ -44,11 +44,16 @@ export function SpendingByStoreWidget({
       emptyMessage="No store data"
       className={className}
     >
+      {(titleId) => (
       <div className="space-y-4">
+        {/* The table below is a full text alternative; no sr-only
+            summary needed. aria-labelledby ties the chart to the card
+            title so AT users still get a label. */}
         <BarChart
           data={chartData}
           layout="horizontal"
           formatValue={formatCurrency}
+          aria-labelledby={titleId}
         />
         {items.length > 0 && (
           <div className="overflow-x-auto">
@@ -86,6 +91,7 @@ export function SpendingByStoreWidget({
           </div>
         )}
       </div>
+      )}
     </ChartCard>
   );
 }

--- a/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
+++ b/src/client/src/components/dashboard/SpendingOverTimeWidget.tsx
@@ -152,11 +152,28 @@ export function SpendingOverTimeWidget({
         </div>
       }
     >
-      <AreaTimeChart
-        data={chartData}
-        trendlineData={trendlineData}
-        formatValue={formatCurrency}
-      />
+      {(titleId) => {
+        const totals = chartData.reduce((sum, b) => sum + b.amount, 0);
+        const peak = chartData.reduce<typeof chartData[number] | null>(
+          (best, b) => (best == null || b.amount > best.amount ? b : best),
+          null,
+        );
+        const summary =
+          chartData.length === 0
+            ? null
+            : `${chartData.length} ${chartData.length === 1 ? "period" : "periods"}, total ${formatCurrency(totals)}. Peak: ${peak?.period ?? ""} at ${formatCurrency(peak?.amount ?? 0)}.`;
+        return (
+          <>
+            {summary && <p className="sr-only">{summary}</p>}
+            <AreaTimeChart
+              data={chartData}
+              trendlineData={trendlineData}
+              formatValue={formatCurrency}
+              aria-labelledby={titleId}
+            />
+          </>
+        );
+      }}
     </ChartCard>
   );
 }


### PR DESCRIPTION
Closes RECEIPTS-743.

### Icon-only button sweep — clean

Every `.icon-btn`, every shadcn `size=\"icon\"` Button, and every Lucide icon button across the codebase already has either an `aria-label` or an `sr-only` accessible name. No fixes needed.

### Chart text alternatives — gap closed

`ChartCard` already exposes a `titleId` via a render-prop pattern, but the four Dashboard widgets weren't wiring it through to their charts.

- `SpendingByAccountWidget` — sr-only summary (top account + count) + `aria-labelledby`.
- `SpendingByCategoryWidget` — sr-only summary (total + top category) + `aria-labelledby`.
- `SpendingByStoreWidget` — `aria-labelledby` only; the full data table below the chart serves as the text alternative.
- `SpendingOverTimeWidget` — sr-only summary (period count + total + peak) + `aria-labelledby`.

Screen reader users now hear the chart's actual card title (\"Spending by Category\") instead of the generic \"Donut chart\" fallback, and a one-line summary of the chart's shape before they hit the SVG.

### Verification

- 39 dashboard widget tests still passing.
- Full vitest: **2084 passed** (no change).
- `tsc --noEmit` clean. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)