### PR TITLE
feat(client): ynab status page + status/events endpoints (RECEIPTS-737)

### DIFF
--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -4852,6 +4852,51 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/YnabRateLimitStatusResponse"
+  /api/ynab/status:
+    get:
+      operationId: GetYnabStatus
+      tags: [YNAB]
+      summary: Get aggregated YNAB integration status
+      description: >
+        Returns the YNAB integration health snapshot used by the /ynab status
+        page. Aggregates connection state, selected budget, rolling sync
+        counts (24h / 7d / 30d), last success/failure timestamps, and the
+        current rate-limit window.
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Status snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/YnabStatusResponse"
+  /api/ynab/events:
+    get:
+      operationId: GetYnabSyncEvents
+      tags: [YNAB]
+      summary: List YNAB sync events
+      description: >
+        Returns a paginated list of YNAB sync events (one row per push attempt),
+        ordered most-recent-first. Optionally filter by outcome.
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/Limit"
+        - name: outcome
+          in: query
+          required: false
+          description: Filter by sync outcome
+          schema:
+            $ref: "#/components/schemas/YnabSyncEventOutcome"
+      responses:
+        "200":
+          description: Paginated events
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/YnabSyncEventsResponse"
   /api/ynab/receipt-sync-statuses:
     get:
       operationId: GetReceiptYnabSyncStatuses
@@ -7674,6 +7719,110 @@ components:
 
     YnabSyncType:
       enum: [memoUpdate, transactionPush]
+
+    YnabSyncEventOutcome:
+      enum: [pending, synced, failed]
+      description: Outcome of a single YNAB sync attempt.
+
+    YnabSyncEventEventType:
+      enum: [memoUpdate, transactionPush]
+      description: Which YNAB sync operation produced this event.
+
+    YnabSyncEventResponse:
+      type: object
+      required: [id, occurredAt, eventType, outcome]
+      properties:
+        id:
+          type: string
+          format: uuid
+        occurredAt:
+          type: string
+          format: date-time
+        eventType:
+          $ref: "#/components/schemas/YnabSyncEventEventType"
+        outcome:
+          $ref: "#/components/schemas/YnabSyncEventOutcome"
+        localTransactionId:
+          type:
+            - "null"
+            - string
+          format: uuid
+        receiptId:
+          type:
+            - "null"
+            - string
+          format: uuid
+        ynabBudgetId:
+          type:
+            - "null"
+            - string
+        ynabTransactionId:
+          type:
+            - "null"
+            - string
+        errorMessage:
+          type:
+            - "null"
+            - string
+
+    YnabSyncEventsResponse:
+      type: object
+      required: [data, totalCount]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/YnabSyncEventResponse"
+        totalCount:
+          type: integer
+          format: int32
+
+    YnabStatusResponse:
+      type: object
+      required:
+        [
+          isConfigured,
+          isConnected,
+          pushes24h, successes24h, failures24h,
+          pushes7d, successes7d, failures7d,
+          pushes30d, successes30d, failures30d,
+          rateLimit
+        ]
+      properties:
+        isConfigured:
+          type: boolean
+          description: Whether a YNAB personal-access token is configured.
+        isConnected:
+          type: boolean
+          description: Whether the most recent connectivity probe (GetBudgets) succeeded.
+        selectedBudgetId:
+          type:
+            - "null"
+            - string
+          description: Currently selected YNAB budget ID, or null if none selected.
+        lastSuccessUtc:
+          type:
+            - "null"
+            - string
+          format: date-time
+          description: Timestamp of the most recent successful sync event, or null.
+        lastFailureUtc:
+          type:
+            - "null"
+            - string
+          format: date-time
+          description: Timestamp of the most recent failed sync event, or null.
+        pushes24h: { type: integer, format: int32 }
+        successes24h: { type: integer, format: int32 }
+        failures24h: { type: integer, format: int32 }
+        pushes7d: { type: integer, format: int32 }
+        successes7d: { type: integer, format: int32 }
+        failures7d: { type: integer, format: int32 }
+        pushes30d: { type: integer, format: int32 }
+        successes30d: { type: integer, format: int32 }
+        failures30d: { type: integer, format: int32 }
+        rateLimit:
+          $ref: "#/components/schemas/YnabRateLimitStatusResponse"
 
   headers:
     X-Resource-Id:

--- a/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
+++ b/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
@@ -18,7 +18,8 @@ public class PushYnabTransactionsCommandHandler(
 	IYnabBudgetSelectionService budgetSelectionService,
 	IYnabSyncRecordService syncRecordService,
 	IYnabApiClient ynabApiClient,
-	IYnabSplitCalculator splitCalculator) : IRequestHandler<PushYnabTransactionsCommand, PushYnabTransactionsResult>
+	IYnabSplitCalculator splitCalculator,
+	IYnabSyncEventService syncEventService) : IRequestHandler<PushYnabTransactionsCommand, PushYnabTransactionsResult>
 {
 	public async ValueTask<PushYnabTransactionsResult> Handle(PushYnabTransactionsCommand request, CancellationToken cancellationToken)
 	{
@@ -218,6 +219,16 @@ public class PushYnabTransactionsCommandHandler(
 					await syncRecordService.UpdateStatusAsync(
 						syncRecord!.Id, YnabSyncStatus.Synced, recoveredId, null, cancellationToken);
 
+					await syncEventService.RecordAsync(
+						YnabSyncType.TransactionPush,
+						YnabSyncStatus.Synced,
+						localTx.Id,
+						request.ReceiptId,
+						budgetId,
+						recoveredId,
+						errorMessage: null,
+						cancellationToken);
+
 					pushedTransactions.Add(new PushedTransactionInfo(
 						localTx.Id,
 						recoveredId,
@@ -242,9 +253,31 @@ public class PushYnabTransactionsCommandHandler(
 						txSplit.TotalMilliunits,
 						txSplit.SubTransactions.Count));
 
+					// Still record a Synced event — the push itself succeeded against YNAB.
+					// The sync-record write failure is a local bookkeeping miss, not a YNAB-side issue.
+					await syncEventService.RecordAsync(
+						YnabSyncType.TransactionPush,
+						YnabSyncStatus.Synced,
+						localTx.Id,
+						request.ReceiptId,
+						budgetId,
+						ynabResponse.TransactionId,
+						errorMessage: $"Sync record update failed: {statusEx.Message}",
+						cancellationToken);
+
 					return new PushYnabTransactionsResult(true, pushedTransactions,
 						Error: $"YNAB transaction created but sync record update failed for transaction {localTx.Id}: {statusEx.Message}");
 				}
+
+				await syncEventService.RecordAsync(
+					YnabSyncType.TransactionPush,
+					YnabSyncStatus.Synced,
+					localTx.Id,
+					request.ReceiptId,
+					budgetId,
+					ynabResponse.TransactionId,
+					errorMessage: null,
+					cancellationToken);
 
 				pushedTransactions.Add(new PushedTransactionInfo(
 					localTx.Id,
@@ -260,6 +293,16 @@ public class PushYnabTransactionsCommandHandler(
 					await syncRecordService.UpdateStatusAsync(
 						syncRecord.Id, YnabSyncStatus.Failed, null, ex.Message, cancellationToken);
 				}
+
+				await syncEventService.RecordAsync(
+					YnabSyncType.TransactionPush,
+					YnabSyncStatus.Failed,
+					localTx.Id,
+					request.ReceiptId,
+					budgetId,
+					ynabTransactionId: null,
+					errorMessage: ex.Message,
+					cancellationToken);
 
 				return new PushYnabTransactionsResult(false, pushedTransactions,
 					Error: $"Failed to push YNAB transaction for local transaction {localTx.Id}: {ex.Message}");

--- a/src/Application/Interfaces/Services/IYnabSyncEventService.cs
+++ b/src/Application/Interfaces/Services/IYnabSyncEventService.cs
@@ -1,0 +1,23 @@
+using Application.Models.Ynab;
+using Common;
+
+namespace Application.Interfaces.Services;
+
+public interface IYnabSyncEventService
+{
+	Task RecordAsync(
+		YnabSyncType eventType,
+		YnabSyncStatus outcome,
+		Guid? localTransactionId,
+		Guid? receiptId,
+		string? ynabBudgetId,
+		string? ynabTransactionId,
+		string? errorMessage,
+		CancellationToken cancellationToken);
+
+	Task<YnabSyncEventsPage> ListAsync(int offset, int limit, YnabSyncStatus? outcome, CancellationToken cancellationToken);
+
+	Task<DateTimeOffset?> GetLatestOccurrenceAsync(YnabSyncStatus outcome, CancellationToken cancellationToken);
+
+	Task<int> CountSinceAsync(DateTimeOffset since, YnabSyncStatus? outcome, CancellationToken cancellationToken);
+}

--- a/src/Application/Models/Ynab/YnabStatusResult.cs
+++ b/src/Application/Models/Ynab/YnabStatusResult.cs
@@ -1,0 +1,21 @@
+namespace Application.Models.Ynab;
+
+// Aggregated health snapshot for the /ynab status page. Combines signals
+// from YnabSyncEvent (counts) with the already-existing connection and
+// rate-limit surfaces so the frontend can render the health grid in one call.
+public record YnabStatusResult(
+	bool IsConfigured,
+	bool IsConnected,
+	string? SelectedBudgetId,
+	DateTimeOffset? LastSuccessUtc,
+	DateTimeOffset? LastFailureUtc,
+	int Pushes24h,
+	int Successes24h,
+	int Failures24h,
+	int Pushes7d,
+	int Successes7d,
+	int Failures7d,
+	int Pushes30d,
+	int Successes30d,
+	int Failures30d,
+	YnabRateLimitStatus RateLimit);

--- a/src/Application/Models/Ynab/YnabSyncEventDto.cs
+++ b/src/Application/Models/Ynab/YnabSyncEventDto.cs
@@ -1,0 +1,14 @@
+using Common;
+
+namespace Application.Models.Ynab;
+
+public record YnabSyncEventDto(
+	Guid Id,
+	DateTimeOffset OccurredAt,
+	YnabSyncType EventType,
+	YnabSyncStatus Outcome,
+	Guid? LocalTransactionId,
+	Guid? ReceiptId,
+	string? YnabBudgetId,
+	string? YnabTransactionId,
+	string? ErrorMessage);

--- a/src/Application/Models/Ynab/YnabSyncEventsPage.cs
+++ b/src/Application/Models/Ynab/YnabSyncEventsPage.cs
@@ -1,0 +1,3 @@
+namespace Application.Models.Ynab;
+
+public record YnabSyncEventsPage(IReadOnlyList<YnabSyncEventDto> Events, int TotalCount);

--- a/src/Application/Queries/Core/Ynab/GetYnabStatusQuery.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabStatusQuery.cs
@@ -1,0 +1,6 @@
+using Application.Interfaces;
+using Application.Models.Ynab;
+
+namespace Application.Queries.Core.Ynab;
+
+public record GetYnabStatusQuery : IQuery<YnabStatusResult>;

--- a/src/Application/Queries/Core/Ynab/GetYnabStatusQueryHandler.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabStatusQueryHandler.cs
@@ -1,0 +1,81 @@
+using Application.Interfaces.Services;
+using Application.Models.Ynab;
+using Common;
+using Mediator;
+
+namespace Application.Queries.Core.Ynab;
+
+public class GetYnabStatusQueryHandler(
+	IYnabApiClient ynabApiClient,
+	IYnabBudgetSelectionService budgetSelectionService,
+	IYnabSyncEventService syncEventService,
+	IYnabRateLimitTracker rateLimitTracker,
+	TimeProvider timeProvider) : IRequestHandler<GetYnabStatusQuery, YnabStatusResult>
+{
+	public async ValueTask<YnabStatusResult> Handle(GetYnabStatusQuery request, CancellationToken cancellationToken)
+	{
+		bool isConfigured = ynabApiClient.IsConfigured;
+
+		// When YNAB isn't configured we still return a result so the page can render
+		// a "not connected" state; everything zero / null.
+		if (!isConfigured)
+		{
+			return new YnabStatusResult(
+				IsConfigured: false,
+				IsConnected: false,
+				SelectedBudgetId: null,
+				LastSuccessUtc: null,
+				LastFailureUtc: null,
+				Pushes24h: 0, Successes24h: 0, Failures24h: 0,
+				Pushes7d: 0, Successes7d: 0, Failures7d: 0,
+				Pushes30d: 0, Successes30d: 0, Failures30d: 0,
+				RateLimit: rateLimitTracker.GetStatus());
+		}
+
+		bool isConnected;
+		try
+		{
+			await ynabApiClient.GetBudgetsAsync(cancellationToken);
+			isConnected = true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			isConnected = false;
+		}
+
+		string? selectedBudgetId = await budgetSelectionService.GetSelectedBudgetIdAsync(cancellationToken);
+
+		DateTimeOffset? lastSuccess = await syncEventService.GetLatestOccurrenceAsync(YnabSyncStatus.Synced, cancellationToken);
+		DateTimeOffset? lastFailure = await syncEventService.GetLatestOccurrenceAsync(YnabSyncStatus.Failed, cancellationToken);
+
+		DateTimeOffset now = timeProvider.GetUtcNow();
+		DateTimeOffset since24h = now.AddHours(-24);
+		DateTimeOffset since7d = now.AddDays(-7);
+		DateTimeOffset since30d = now.AddDays(-30);
+
+		// Three rolling windows × three buckets each (total / success / failure).
+		// The total bucket is computed by passing outcome=null.
+		int p24 = await syncEventService.CountSinceAsync(since24h, null, cancellationToken);
+		int s24 = await syncEventService.CountSinceAsync(since24h, YnabSyncStatus.Synced, cancellationToken);
+		int f24 = await syncEventService.CountSinceAsync(since24h, YnabSyncStatus.Failed, cancellationToken);
+
+		int p7 = await syncEventService.CountSinceAsync(since7d, null, cancellationToken);
+		int s7 = await syncEventService.CountSinceAsync(since7d, YnabSyncStatus.Synced, cancellationToken);
+		int f7 = await syncEventService.CountSinceAsync(since7d, YnabSyncStatus.Failed, cancellationToken);
+
+		int p30 = await syncEventService.CountSinceAsync(since30d, null, cancellationToken);
+		int s30 = await syncEventService.CountSinceAsync(since30d, YnabSyncStatus.Synced, cancellationToken);
+		int f30 = await syncEventService.CountSinceAsync(since30d, YnabSyncStatus.Failed, cancellationToken);
+
+		return new YnabStatusResult(
+			IsConfigured: true,
+			IsConnected: isConnected,
+			SelectedBudgetId: selectedBudgetId,
+			LastSuccessUtc: lastSuccess,
+			LastFailureUtc: lastFailure,
+			Pushes24h: p24, Successes24h: s24, Failures24h: f24,
+			Pushes7d: p7, Successes7d: s7, Failures7d: f7,
+			Pushes30d: p30, Successes30d: s30, Failures30d: f30,
+			RateLimit: rateLimitTracker.GetStatus());
+	}
+}

--- a/src/Application/Queries/Core/Ynab/GetYnabSyncEventsQuery.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabSyncEventsQuery.cs
@@ -1,0 +1,7 @@
+using Application.Interfaces;
+using Application.Models.Ynab;
+using Common;
+
+namespace Application.Queries.Core.Ynab;
+
+public record GetYnabSyncEventsQuery(int Offset, int Limit, YnabSyncStatus? Outcome) : IQuery<YnabSyncEventsPage>;

--- a/src/Application/Queries/Core/Ynab/GetYnabSyncEventsQueryHandler.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabSyncEventsQueryHandler.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Services;
+using Application.Models.Ynab;
+using Mediator;
+
+namespace Application.Queries.Core.Ynab;
+
+public class GetYnabSyncEventsQueryHandler(IYnabSyncEventService syncEventService) : IRequestHandler<GetYnabSyncEventsQuery, YnabSyncEventsPage>
+{
+	public async ValueTask<YnabSyncEventsPage> Handle(GetYnabSyncEventsQuery request, CancellationToken cancellationToken)
+	{
+		return await syncEventService.ListAsync(request.Offset, request.Limit, request.Outcome, cancellationToken);
+	}
+}

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -69,6 +69,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 	public virtual DbSet<YnabAccountMappingEntity> YnabAccountMappings { get; set; } = null!;
 	public virtual DbSet<YnabCategoryMappingEntity> YnabCategoryMappings { get; set; } = null!;
 	public virtual DbSet<YnabServerKnowledgeEntity> YnabServerKnowledge { get; set; } = null!;
+	public virtual DbSet<YnabSyncEventEntity> YnabSyncEvents { get; set; } = null!;
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{

--- a/src/Infrastructure/Configurations/YnabSyncEventEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/YnabSyncEventEntityConfiguration.cs
@@ -1,0 +1,36 @@
+using Infrastructure.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Configurations;
+
+public class YnabSyncEventEntityConfiguration : IEntityTypeConfiguration<YnabSyncEventEntity>
+{
+	public void Configure(EntityTypeBuilder<YnabSyncEventEntity> builder)
+	{
+		builder.HasKey(e => e.Id);
+
+		builder.Property(e => e.Id)
+			.IsRequired()
+			.ValueGeneratedOnAdd();
+
+		builder.Property(e => e.ErrorMessage)
+			.HasMaxLength(2000);
+
+		builder.Property(e => e.YnabBudgetId)
+			.HasMaxLength(64);
+
+		builder.Property(e => e.YnabTransactionId)
+			.HasMaxLength(64);
+
+		// Activity-log queries always filter or sort by time descending; an
+		// index on OccurredAt (desc) makes the recent-N feed and the
+		// rolling-window status aggregates cheap.
+		builder.HasIndex(e => e.OccurredAt)
+			.IsDescending(true);
+
+		// Drill-down from receipt detail to its event history is a likely
+		// future query; index on ReceiptId keeps that cheap too.
+		builder.HasIndex(e => e.ReceiptId);
+	}
+}

--- a/src/Infrastructure/Entities/Core/YnabSyncEventEntity.cs
+++ b/src/Infrastructure/Entities/Core/YnabSyncEventEntity.cs
@@ -1,0 +1,20 @@
+using Common;
+
+namespace Infrastructure.Entities.Core;
+
+// Append-only activity log of YNAB sync attempts. One row per state transition
+// observed by YnabSyncRecordService.UpdateStatusAsync. Complements
+// YnabSyncRecordEntity (which holds current state; retries upsert that row);
+// this table preserves retry history for the /ynab status page.
+public class YnabSyncEventEntity
+{
+	public Guid Id { get; set; }
+	public DateTimeOffset OccurredAt { get; set; }
+	public YnabSyncType EventType { get; set; }
+	public YnabSyncStatus Outcome { get; set; }
+	public Guid? LocalTransactionId { get; set; }
+	public Guid? ReceiptId { get; set; }
+	public string? YnabBudgetId { get; set; }
+	public string? YnabTransactionId { get; set; }
+	public string? ErrorMessage { get; set; }
+}

--- a/src/Infrastructure/Interfaces/Repositories/IYnabSyncEventRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/IYnabSyncEventRepository.cs
@@ -1,0 +1,19 @@
+using Common;
+using Infrastructure.Entities.Core;
+
+namespace Infrastructure.Interfaces.Repositories;
+
+public interface IYnabSyncEventRepository
+{
+	Task<YnabSyncEventEntity> CreateAsync(YnabSyncEventEntity entity, CancellationToken cancellationToken);
+
+	Task<(IReadOnlyList<YnabSyncEventEntity> Events, int TotalCount)> ListAsync(
+		int offset,
+		int limit,
+		YnabSyncStatus? outcome,
+		CancellationToken cancellationToken);
+
+	Task<DateTimeOffset?> GetLatestOccurrenceAsync(YnabSyncStatus outcome, CancellationToken cancellationToken);
+
+	Task<int> CountSinceAsync(DateTimeOffset since, YnabSyncStatus? outcome, CancellationToken cancellationToken);
+}

--- a/src/Infrastructure/Migrations/20260524101536_AddYnabSyncEventTable.Designer.cs
+++ b/src/Infrastructure/Migrations/20260524101536_AddYnabSyncEventTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524101536_AddYnabSyncEventTable")]
+    partial class AddYnabSyncEventTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260524101536_AddYnabSyncEventTable.cs
+++ b/src/Infrastructure/Migrations/20260524101536_AddYnabSyncEventTable.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddYnabSyncEventTable : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.CreateTable(
+			name: "YnabSyncEvents",
+			columns: table => new
+			{
+				Id = table.Column<Guid>(type: "uuid", nullable: false),
+				OccurredAt = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false),
+				EventType = table.Column<string>(type: "text", nullable: false),
+				Outcome = table.Column<string>(type: "text", nullable: false),
+				LocalTransactionId = table.Column<Guid>(type: "uuid", nullable: true),
+				ReceiptId = table.Column<Guid>(type: "uuid", nullable: true),
+				YnabBudgetId = table.Column<string>(type: "text", maxLength: 64, nullable: true),
+				YnabTransactionId = table.Column<string>(type: "text", maxLength: 64, nullable: true),
+				ErrorMessage = table.Column<string>(type: "text", maxLength: 2000, nullable: true)
+			},
+			constraints: table =>
+			{
+				table.PrimaryKey("PK_YnabSyncEvents", x => x.Id);
+			});
+
+		migrationBuilder.CreateIndex(
+			name: "IX_YnabSyncEvents_OccurredAt",
+			table: "YnabSyncEvents",
+			column: "OccurredAt",
+			descending: new bool[0]);
+
+		migrationBuilder.CreateIndex(
+			name: "IX_YnabSyncEvents_ReceiptId",
+			table: "YnabSyncEvents",
+			column: "ReceiptId");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropTable(
+			name: "YnabSyncEvents");
+	}
+}

--- a/src/Infrastructure/Repositories/YnabSyncEventRepository.cs
+++ b/src/Infrastructure/Repositories/YnabSyncEventRepository.cs
@@ -1,0 +1,67 @@
+using Common;
+using Infrastructure.Entities.Core;
+using Infrastructure.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Repositories;
+
+public class YnabSyncEventRepository(IDbContextFactory<ApplicationDbContext> contextFactory) : IYnabSyncEventRepository
+{
+	public async Task<YnabSyncEventEntity> CreateAsync(YnabSyncEventEntity entity, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		context.YnabSyncEvents.Add(entity);
+		await context.SaveChangesAsync(cancellationToken);
+		return entity;
+	}
+
+	public async Task<(IReadOnlyList<YnabSyncEventEntity> Events, int TotalCount)> ListAsync(
+		int offset,
+		int limit,
+		YnabSyncStatus? outcome,
+		CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		IQueryable<YnabSyncEventEntity> query = context.YnabSyncEvents.AsNoTracking();
+		if (outcome is { } o)
+		{
+			query = query.Where(e => e.Outcome == o);
+		}
+
+		int total = await query.CountAsync(cancellationToken);
+		List<YnabSyncEventEntity> events = await query
+			.OrderByDescending(e => e.OccurredAt)
+			.Skip(offset)
+			.Take(limit)
+			.ToListAsync(cancellationToken);
+
+		return (events, total);
+	}
+
+	public async Task<DateTimeOffset?> GetLatestOccurrenceAsync(YnabSyncStatus outcome, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		return await context.YnabSyncEvents
+			.AsNoTracking()
+			.Where(e => e.Outcome == outcome)
+			.OrderByDescending(e => e.OccurredAt)
+			.Select(e => (DateTimeOffset?)e.OccurredAt)
+			.FirstOrDefaultAsync(cancellationToken);
+	}
+
+	public async Task<int> CountSinceAsync(DateTimeOffset since, YnabSyncStatus? outcome, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+		IQueryable<YnabSyncEventEntity> query = context.YnabSyncEvents
+			.AsNoTracking()
+			.Where(e => e.OccurredAt >= since);
+
+		if (outcome is { } o)
+		{
+			query = query.Where(e => e.Outcome == o);
+		}
+
+		return await query.CountAsync(cancellationToken);
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -164,6 +164,8 @@ public static class InfrastructureService
 			.AddScoped<IYnabCategoryMappingService, YnabCategoryMappingService>()
 			.AddScoped<IYnabMemoSyncService, YnabMemoSyncService>()
 			.AddScoped<IYnabServerKnowledgeRepository, YnabServerKnowledgeRepository>()
+			.AddScoped<IYnabSyncEventRepository, YnabSyncEventRepository>()
+			.AddScoped<IYnabSyncEventService, YnabSyncEventService>()
 			.AddSingleton<IYnabSplitCalculator, YnabSplitCalculator>();
 
 		services.AddMemoryCache();

--- a/src/Infrastructure/Services/YnabSyncEventService.cs
+++ b/src/Infrastructure/Services/YnabSyncEventService.cs
@@ -1,0 +1,60 @@
+using Application.Interfaces.Services;
+using Application.Models.Ynab;
+using Common;
+using Infrastructure.Entities.Core;
+using Infrastructure.Interfaces.Repositories;
+
+namespace Infrastructure.Services;
+
+public class YnabSyncEventService(IYnabSyncEventRepository repository) : IYnabSyncEventService
+{
+	public async Task RecordAsync(
+		YnabSyncType eventType,
+		YnabSyncStatus outcome,
+		Guid? localTransactionId,
+		Guid? receiptId,
+		string? ynabBudgetId,
+		string? ynabTransactionId,
+		string? errorMessage,
+		CancellationToken cancellationToken)
+	{
+		YnabSyncEventEntity entity = new()
+		{
+			Id = Guid.NewGuid(),
+			OccurredAt = DateTimeOffset.UtcNow,
+			EventType = eventType,
+			Outcome = outcome,
+			LocalTransactionId = localTransactionId,
+			ReceiptId = receiptId,
+			YnabBudgetId = ynabBudgetId,
+			YnabTransactionId = ynabTransactionId,
+			ErrorMessage = errorMessage,
+		};
+
+		await repository.CreateAsync(entity, cancellationToken);
+	}
+
+	public async Task<YnabSyncEventsPage> ListAsync(int offset, int limit, YnabSyncStatus? outcome, CancellationToken cancellationToken)
+	{
+		(IReadOnlyList<YnabSyncEventEntity> events, int total) = await repository.ListAsync(offset, limit, outcome, cancellationToken);
+		List<YnabSyncEventDto> dtos = events.Select(ToDto).ToList();
+		return new YnabSyncEventsPage(dtos, total);
+	}
+
+	public Task<DateTimeOffset?> GetLatestOccurrenceAsync(YnabSyncStatus outcome, CancellationToken cancellationToken)
+		=> repository.GetLatestOccurrenceAsync(outcome, cancellationToken);
+
+	public Task<int> CountSinceAsync(DateTimeOffset since, YnabSyncStatus? outcome, CancellationToken cancellationToken)
+		=> repository.CountSinceAsync(since, outcome, cancellationToken);
+
+	private static YnabSyncEventDto ToDto(YnabSyncEventEntity entity) => new(
+		entity.Id,
+		entity.OccurredAt,
+		entity.EventType,
+		entity.Outcome,
+		entity.LocalTransactionId,
+		entity.ReceiptId,
+		entity.YnabBudgetId,
+		entity.YnabTransactionId,
+		entity.ErrorMessage);
+}

--- a/src/Presentation/API/Controllers/YnabController.cs
+++ b/src/Presentation/API/Controllers/YnabController.cs
@@ -450,6 +450,37 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 		return TypedResults.Ok(mapper.ToRateLimitStatusResponse(status));
 	}
 
+	[HttpGet("status")]
+	[EndpointSummary("Get aggregated YNAB integration status")]
+	[EndpointDescription("Returns the health snapshot used by the /ynab status page: connection state, selected budget, rolling sync counts (24h / 7d / 30d), last success/failure timestamps, and the current rate-limit window.")]
+	public async Task<Ok<YnabStatusResponse>> GetStatus(CancellationToken cancellationToken)
+	{
+		YnabStatusResult status = await mediator.Send(new GetYnabStatusQuery(), cancellationToken);
+		return TypedResults.Ok(mapper.ToStatusResponse(status));
+	}
+
+	[HttpGet("events")]
+	[EndpointSummary("List YNAB sync events")]
+	[EndpointDescription("Returns a paginated list of YNAB sync events (one row per push attempt), ordered most-recent-first. Optionally filter by outcome.")]
+	public async Task<Ok<YnabSyncEventsResponse>> GetSyncEvents(
+		[FromQuery] int? offset,
+		[FromQuery] int? limit,
+		[FromQuery] string? outcome,
+		CancellationToken cancellationToken)
+	{
+		// Map the lowercase OpenAPI enum back to the Common enum. Unknown values
+		// fall through as null (no filter) — guards against typos in the query
+		// string. Offset/limit defaults mirror the OpenAPI parameters.
+		YnabSyncStatus? parsedOutcome = outcome is null
+			? null
+			: Enum.TryParse<YnabSyncStatus>(outcome, ignoreCase: true, out YnabSyncStatus parsed) ? parsed : null;
+
+		YnabSyncEventsPage page = await mediator.Send(
+			new GetYnabSyncEventsQuery(offset ?? 0, Math.Clamp(limit ?? 50, 1, 100), parsedOutcome),
+			cancellationToken);
+		return TypedResults.Ok(mapper.ToSyncEventsResponse(page));
+	}
+
 	[HttpGet("receipt-sync-statuses")]
 	[EndpointSummary("Get YNAB sync statuses for receipts")]
 	[EndpointDescription("Returns the aggregate YNAB sync status for each receipt, joining through transactions to sync records.")]

--- a/src/Presentation/API/Mapping/Core/YnabMapper.cs
+++ b/src/Presentation/API/Mapping/Core/YnabMapper.cs
@@ -325,4 +325,57 @@ public partial class YnabMapper
 			OldestRequestAt = source.OldestRequestAt,
 		};
 	}
+
+	[MapperIgnoreTarget(nameof(YnabSyncEventResponse.AdditionalProperties))]
+	public YnabSyncEventResponse ToSyncEventResponse(YnabSyncEventDto source)
+	{
+		return new YnabSyncEventResponse
+		{
+			Id = source.Id,
+			OccurredAt = source.OccurredAt,
+			// Generated enum names follow NSwag's schema-name convention
+			// (YnabSyncEventEventType, YnabSyncEventOutcome) regardless of which
+			// response/request the property belongs to.
+			EventType = Enum.Parse<API.Generated.Dtos.YnabSyncEventEventType>(source.EventType.ToString()),
+			Outcome = Enum.Parse<API.Generated.Dtos.YnabSyncEventOutcome>(source.Outcome.ToString()),
+			LocalTransactionId = source.LocalTransactionId,
+			ReceiptId = source.ReceiptId,
+			YnabBudgetId = source.YnabBudgetId,
+			YnabTransactionId = source.YnabTransactionId,
+			ErrorMessage = source.ErrorMessage,
+		};
+	}
+
+	[MapperIgnoreTarget(nameof(YnabSyncEventsResponse.AdditionalProperties))]
+	public YnabSyncEventsResponse ToSyncEventsResponse(YnabSyncEventsPage source)
+	{
+		return new YnabSyncEventsResponse
+		{
+			Data = source.Events.Select(ToSyncEventResponse).ToList(),
+			TotalCount = source.TotalCount,
+		};
+	}
+
+	[MapperIgnoreTarget(nameof(YnabStatusResponse.AdditionalProperties))]
+	public YnabStatusResponse ToStatusResponse(YnabStatusResult source)
+	{
+		return new YnabStatusResponse
+		{
+			IsConfigured = source.IsConfigured,
+			IsConnected = source.IsConnected,
+			SelectedBudgetId = source.SelectedBudgetId,
+			LastSuccessUtc = source.LastSuccessUtc,
+			LastFailureUtc = source.LastFailureUtc,
+			Pushes24h = source.Pushes24h,
+			Successes24h = source.Successes24h,
+			Failures24h = source.Failures24h,
+			Pushes7d = source.Pushes7d,
+			Successes7d = source.Successes7d,
+			Failures7d = source.Failures7d,
+			Pushes30d = source.Pushes30d,
+			Successes30d = source.Successes30d,
+			Failures30d = source.Failures30d,
+			RateLimit = ToRateLimitStatusResponse(source.RateLimit),
+		};
+	}
 }

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -22,6 +22,7 @@ import RecycleBin from "@/pages/RecycleBin";
 import BackupRestore from "@/pages/BackupRestore";
 import NewReceipt from "@/pages/new-receipt/NewReceiptPage";
 import YnabSettings from "@/pages/settings/YnabSettings";
+import Ynab from "@/pages/Ynab";
 import Settings from "@/pages/Settings";
 import NotFound from "@/pages/NotFound";
 import ServerError from "@/pages/ServerError";
@@ -59,6 +60,7 @@ export const routeConfig = [
           { path: "/security", element: <SecurityLog /> },
           { path: "/settings", element: <Settings /> },
           { path: "/settings/ynab", element: <YnabSettings /> },
+          { path: "/ynab", element: <Ynab /> },
           {
             path: "/audit",
             element: (

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -80,7 +80,8 @@ const NAV: readonly NavSection[] = [
       { to: "/categories", label: "Categories", icon: Icon.Tag },
       { to: "/subcategories", label: "Subcategories", icon: Icon.Tag },
       { to: "/item-templates", label: "Templates", icon: Icon.Sparkle },
-      { to: "/settings/ynab", label: "YNAB", icon: Icon.Link },
+      { to: "/ynab", label: "YNAB status", icon: Icon.Link },
+      { to: "/settings/ynab", label: "YNAB settings", icon: Icon.Settings },
     ],
   },
   {

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -2357,6 +2357,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/ynab/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get aggregated YNAB integration status
+         * @description Returns the YNAB integration health snapshot used by the /ynab status page. Aggregates connection state, selected budget, rolling sync counts (24h / 7d / 30d), last success/failure timestamps, and the current rate-limit window.
+         */
+        get: operations["GetYnabStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ynab/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List YNAB sync events
+         * @description Returns a paginated list of YNAB sync events (one row per push attempt), ordered most-recent-first. Optionally filter by outcome.
+         */
+        get: operations["GetYnabSyncEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/ynab/receipt-sync-statuses": {
         parameters: {
             query?: never;
@@ -3795,6 +3835,73 @@ export interface components {
         YnabMemoSyncOutcome: "synced" | "alreadySynced" | "noMatch" | "ambiguous" | "currencySkipped" | "reconciledSkipped" | "failed";
         /** @enum {unknown} */
         YnabSyncType: "memoUpdate" | "transactionPush";
+        /**
+         * @description Outcome of a single YNAB sync attempt.
+         * @enum {unknown}
+         */
+        YnabSyncEventOutcome: "pending" | "synced" | "failed";
+        /**
+         * @description Which YNAB sync operation produced this event.
+         * @enum {unknown}
+         */
+        YnabSyncEventEventType: "memoUpdate" | "transactionPush";
+        YnabSyncEventResponse: {
+            /** Format: uuid */
+            id: string;
+            /** Format: date-time */
+            occurredAt: string;
+            eventType: components["schemas"]["YnabSyncEventEventType"];
+            outcome: components["schemas"]["YnabSyncEventOutcome"];
+            /** Format: uuid */
+            localTransactionId?: null | string;
+            /** Format: uuid */
+            receiptId?: null | string;
+            ynabBudgetId?: null | string;
+            ynabTransactionId?: null | string;
+            errorMessage?: null | string;
+        };
+        YnabSyncEventsResponse: {
+            data: components["schemas"]["YnabSyncEventResponse"][];
+            /** Format: int32 */
+            totalCount: number;
+        };
+        YnabStatusResponse: {
+            /** @description Whether a YNAB personal-access token is configured. */
+            isConfigured: boolean;
+            /** @description Whether the most recent connectivity probe (GetBudgets) succeeded. */
+            isConnected: boolean;
+            /** @description Currently selected YNAB budget ID, or null if none selected. */
+            selectedBudgetId?: null | string;
+            /**
+             * Format: date-time
+             * @description Timestamp of the most recent successful sync event, or null.
+             */
+            lastSuccessUtc?: null | string;
+            /**
+             * Format: date-time
+             * @description Timestamp of the most recent failed sync event, or null.
+             */
+            lastFailureUtc?: null | string;
+            /** Format: int32 */
+            pushes24h: number;
+            /** Format: int32 */
+            successes24h: number;
+            /** Format: int32 */
+            failures24h: number;
+            /** Format: int32 */
+            pushes7d: number;
+            /** Format: int32 */
+            successes7d: number;
+            /** Format: int32 */
+            failures7d: number;
+            /** Format: int32 */
+            pushes30d: number;
+            /** Format: int32 */
+            successes30d: number;
+            /** Format: int32 */
+            failures30d: number;
+            rateLimit: components["schemas"]["YnabRateLimitStatusResponse"];
+        };
     };
     responses: never;
     parameters: {
@@ -8850,6 +8957,51 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["YnabRateLimitStatusResponse"];
+                };
+            };
+        };
+    };
+    GetYnabStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Status snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["YnabStatusResponse"];
+                };
+            };
+        };
+    };
+    GetYnabSyncEvents: {
+        parameters: {
+            query?: {
+                offset?: components["parameters"]["Offset"];
+                limit?: components["parameters"]["Limit"];
+                /** @description Filter by sync outcome */
+                outcome?: components["schemas"]["YnabSyncEventOutcome"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated events */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["YnabSyncEventsResponse"];
                 };
             };
         };

--- a/src/client/src/hooks/useYnab.ts
+++ b/src/client/src/hooks/useYnab.ts
@@ -803,3 +803,100 @@ export function useYnabRateLimitStatus(enabled = true) {
     [query],
   );
 }
+
+// ── Status page (RECEIPTS-737) ──────────────────────────────────────────
+// Inline shapes mirror api.d.ts; the generated discriminated union is too
+// wide for property access through components["schemas"], same trick as
+// elsewhere in this file.
+
+type YnabSyncEventOutcomeValue = "pending" | "synced" | "failed";
+
+export type YnabSyncEvent = {
+  id: string;
+  occurredAt: string;
+  eventType: "memoUpdate" | "transactionPush";
+  outcome: YnabSyncEventOutcomeValue;
+  localTransactionId?: string | null;
+  receiptId?: string | null;
+  ynabBudgetId?: string | null;
+  ynabTransactionId?: string | null;
+  errorMessage?: string | null;
+};
+
+export type YnabSyncEventsResponse = {
+  data: YnabSyncEvent[];
+  totalCount: number;
+};
+
+export type YnabStatusResponse = {
+  isConfigured: boolean;
+  isConnected: boolean;
+  selectedBudgetId?: string | null;
+  lastSuccessUtc?: string | null;
+  lastFailureUtc?: string | null;
+  pushes24h: number;
+  successes24h: number;
+  failures24h: number;
+  pushes7d: number;
+  successes7d: number;
+  failures7d: number;
+  pushes30d: number;
+  successes30d: number;
+  failures30d: number;
+  rateLimit: YnabRateLimitStatusResponse;
+};
+
+export function useYnabStatus() {
+  const query = useQuery({
+    queryKey: ["ynab", "status"],
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/ynab/status" as never,
+        {} as never,
+      );
+      if (error) throw error;
+      return data as unknown as YnabStatusResponse;
+    },
+    // Health snapshot refetches on a moderate cadence; the rolling-window
+    // counts won't change unless a push happens, and pushes invalidate the
+    // key via the mutation hooks.
+    refetchInterval: 60_000,
+  });
+  return useMemo(
+    () => ({ ...query, status: query.data ?? null }),
+    [query],
+  );
+}
+
+export function useYnabSyncEvents(
+  offset = 0,
+  limit = 25,
+  outcome?: YnabSyncEventOutcomeValue,
+) {
+  const query = useQuery({
+    queryKey: ["ynab", "events", offset, limit, outcome ?? "all"],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      params.set("offset", String(offset));
+      params.set("limit", String(limit));
+      if (outcome) params.set("outcome", outcome);
+      const { data, error } = await client.GET(
+        `/api/ynab/events?${params.toString()}` as never,
+        {} as never,
+      );
+      if (error) throw error;
+      return data as unknown as YnabSyncEventsResponse;
+    },
+    // Keep the previous page visible while paginating to avoid the spinner
+    // flash; the event log doesn't change underneath the user mid-paginate.
+    placeholderData: (prev) => prev,
+  });
+  return useMemo(
+    () => ({
+      ...query,
+      events: query.data?.data ?? [],
+      totalCount: query.data?.totalCount ?? 0,
+    }),
+    [query],
+  );
+}

--- a/src/client/src/pages/Ynab.test.tsx
+++ b/src/client/src/pages/Ynab.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/test-utils";
+import Ynab from "./Ynab";
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+const useYnabStatusMock = vi.fn();
+const useYnabSyncEventsMock = vi.fn();
+
+vi.mock("@/hooks/useYnab", async () => {
+  // Keep the other hook implementations in case the page ever imports more;
+  // we only stub the two it actually uses today.
+  return {
+    useYnabStatus: () => useYnabStatusMock(),
+    useYnabSyncEvents: (...args: unknown[]) => useYnabSyncEventsMock(...args),
+  };
+});
+
+const STATUS_DEFAULTS = {
+  isConfigured: true,
+  isConnected: true,
+  selectedBudgetId: "budget-abc" as string | null,
+  lastSuccessUtc: new Date(Date.now() - 30 * 60_000).toISOString() as string | null,
+  lastFailureUtc: null as string | null,
+  pushes24h: 5,
+  successes24h: 4,
+  failures24h: 1,
+  pushes7d: 30,
+  successes7d: 28,
+  failures7d: 2,
+  pushes30d: 100,
+  successes30d: 95,
+  failures30d: 5,
+  rateLimit: {
+    remainingRequests: 190,
+    maxRequests: 200,
+    requestsUsed: 10,
+    windowResetAt: null,
+    oldestRequestAt: null,
+  },
+};
+
+function mockStatus(overrides: Partial<typeof STATUS_DEFAULTS> = {}) {
+  useYnabStatusMock.mockReturnValue({
+    status: { ...STATUS_DEFAULTS, ...overrides },
+    isLoading: false,
+  });
+}
+
+function mockEvents(events: object[] = [], totalCount = events.length) {
+  useYnabSyncEventsMock.mockReturnValue({
+    events,
+    totalCount,
+    isLoading: false,
+  });
+}
+
+describe("Ynab status page", () => {
+  beforeEach(() => {
+    useYnabStatusMock.mockReset();
+    useYnabSyncEventsMock.mockReset();
+    mockStatus();
+    mockEvents();
+  });
+
+  it("renders the page heading", () => {
+    renderWithProviders(<Ynab />);
+    expect(
+      screen.getByRole("heading", { name: /ynab status/i, level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the not-configured alert when YNAB has no PAT", () => {
+    mockStatus({ isConfigured: false, isConnected: false, selectedBudgetId: null });
+    renderWithProviders(<Ynab />);
+    expect(screen.getByText(/yna(b)? isn't configured yet/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /connect a personal access token/i }),
+    ).toHaveAttribute("href", "/settings/ynab");
+  });
+
+  it("renders Connected status when configured + connected", () => {
+    renderWithProviders(<Ynab />);
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+  });
+
+  it("renders Disconnected status when configured but probe failed", () => {
+    mockStatus({ isConnected: false });
+    renderWithProviders(<Ynab />);
+    expect(screen.getByText("Disconnected")).toBeInTheDocument();
+  });
+
+  it("renders rolling counts in the activity table", () => {
+    renderWithProviders(<Ynab />);
+    // The 24h row carries 5/4/1; pick a unique number per row to avoid
+    // assertion ambiguity against other "5" / "1" instances on the page.
+    expect(screen.getByRole("row", { name: /last 24h.*5.*4.*1/i })).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: /last 7 days.*30.*28.*2/i })).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: /last 30 days.*100.*95.*5/i })).toBeInTheDocument();
+  });
+
+  it("shows EmptyState when no events", () => {
+    renderWithProviders(<Ynab />);
+    expect(screen.getByText(/no sync events yet/i)).toBeInTheDocument();
+  });
+
+  it("renders a row per event with a link to the receipt when present", () => {
+    const receiptId = "11111111-2222-3333-4444-555555555555";
+    mockEvents(
+      [
+        {
+          id: "ev-1",
+          occurredAt: new Date().toISOString(),
+          eventType: "transactionPush",
+          outcome: "synced",
+          receiptId,
+          errorMessage: null,
+        },
+        {
+          id: "ev-2",
+          occurredAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+          eventType: "transactionPush",
+          outcome: "failed",
+          receiptId: null,
+          errorMessage: "401 Unauthorized",
+        },
+      ],
+      2,
+    );
+
+    renderWithProviders(<Ynab />);
+
+    // Both outcome pills + filter buttons + status tiles can render the
+    // words "Synced"/"Failed". Scope to the recent-activity table so we
+    // only count the pills.
+    const tables = screen.getAllByRole("table");
+    const activityTable = tables[tables.length - 1]!;
+    const scoped = within(activityTable);
+    expect(scoped.getAllByText(/synced/i).length).toBeGreaterThan(0);
+    expect(scoped.getByText(/^failed$/i)).toBeInTheDocument();
+    expect(scoped.getByText(/401 Unauthorized/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /^view$/i }),
+    ).toHaveAttribute("href", `/receipts/${receiptId}`);
+  });
+
+  it("re-queries with the outcome filter when a filter button is pressed", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Ynab />);
+
+    // Initial call: outcome is undefined (the "all" filter).
+    expect(useYnabSyncEventsMock).toHaveBeenLastCalledWith(0, 25, undefined);
+
+    await user.click(screen.getByRole("button", { name: /^failed$/i }));
+    expect(useYnabSyncEventsMock).toHaveBeenLastCalledWith(0, 25, "failed");
+
+    await user.click(screen.getByRole("button", { name: /^synced$/i }));
+    expect(useYnabSyncEventsMock).toHaveBeenLastCalledWith(0, 25, "synced");
+  });
+});

--- a/src/client/src/pages/Ynab.tsx
+++ b/src/client/src/pages/Ynab.tsx
@@ -1,0 +1,392 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import {
+  useYnabStatus,
+  useYnabSyncEvents,
+  type YnabSyncEvent,
+} from "@/hooks/useYnab";
+import { PageHead, Icon, EmptyState } from "@/components/primitives";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+const PAGE_SIZE = 25;
+
+type OutcomeFilter = "all" | "synced" | "failed";
+
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return "never";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHrs = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+  if (diffMs < 60_000) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHrs < 24) return `${diffHrs}h ago`;
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+function formatAbsolute(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString();
+}
+
+function StatusDot({ tone }: { tone: "pos" | "neg" | "warn" | "mute" }) {
+  // Per design system: status colors live in CSS tokens. The dot is purely
+  // decorative — the text label conveys the same meaning to screen readers.
+  return <span className={`dot ${tone}`} aria-hidden="true" />;
+}
+
+function OutcomePill({ outcome }: { outcome: YnabSyncEvent["outcome"] }) {
+  const label = outcome === "synced" ? "Synced" : outcome === "failed" ? "Failed" : "Pending";
+  const tone = outcome === "synced" ? "pos" : outcome === "failed" ? "neg" : "warn";
+  return (
+    <span className={`chip ${tone}`}>
+      <StatusDot tone={tone} />
+      {label}
+    </span>
+  );
+}
+
+export default function Ynab() {
+  usePageTitle("YNAB status");
+  const { status, isLoading: statusLoading } = useYnabStatus();
+  const [outcomeFilter, setOutcomeFilter] = useState<OutcomeFilter>("all");
+  const [page, setPage] = useState(0);
+  const offset = page * PAGE_SIZE;
+  const { events, totalCount, isLoading: eventsLoading } = useYnabSyncEvents(
+    offset,
+    PAGE_SIZE,
+    outcomeFilter === "all" ? undefined : outcomeFilter,
+  );
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+  const isConfigured = status?.isConfigured ?? false;
+  const isConnected = status?.isConnected ?? false;
+
+  return (
+    <>
+      <PageHead
+        title="YNAB status"
+        sub="Is anything stuck? Connection health, sync log."
+      />
+
+      {!statusLoading && !isConfigured && (
+        <Alert>
+          <AlertDescription>
+            YNAB isn't configured yet.{" "}
+            <Link to="/settings/ynab" className="underline">
+              Connect a personal access token
+            </Link>{" "}
+            to start syncing.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Health grid: four tiles, one row at desktop, stacks at mobile */}
+      <section
+        aria-labelledby="health-heading"
+        style={{ marginTop: 16 }}
+      >
+        <h2
+          id="health-heading"
+          className="sr-only"
+        >
+          Health summary
+        </h2>
+        <div
+          className="grid"
+          style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}
+        >
+          {/* Connection */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm font-medium">Connection</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {statusLoading ? (
+                <Skeleton className="h-6 w-24" />
+              ) : (
+                <div className="flex items-center gap-2">
+                  <StatusDot tone={!isConfigured ? "mute" : isConnected ? "pos" : "neg"} />
+                  <span className="text-base font-semibold">
+                    {!isConfigured ? "Not configured" : isConnected ? "Connected" : "Disconnected"}
+                  </span>
+                </div>
+              )}
+              {isConfigured && status?.selectedBudgetId && (
+                <p className="text-xs text-muted-foreground" style={{ marginTop: 4 }}>
+                  Budget · {status.selectedBudgetId}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Last sync */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm font-medium">Last successful sync</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {statusLoading ? (
+                <Skeleton className="h-6 w-24" />
+              ) : (
+                <>
+                  <p className="text-base font-semibold">
+                    {formatRelative(status?.lastSuccessUtc)}
+                  </p>
+                  {status?.lastSuccessUtc && (
+                    <p className="text-xs text-muted-foreground" style={{ marginTop: 4 }}>
+                      {formatAbsolute(status.lastSuccessUtc)}
+                    </p>
+                  )}
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Last failure */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm font-medium">Last failure</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {statusLoading ? (
+                <Skeleton className="h-6 w-24" />
+              ) : status?.lastFailureUtc ? (
+                <>
+                  <p className="text-base font-semibold">
+                    {formatRelative(status.lastFailureUtc)}
+                  </p>
+                  <p className="text-xs text-muted-foreground" style={{ marginTop: 4 }}>
+                    {formatAbsolute(status.lastFailureUtc)}
+                  </p>
+                </>
+              ) : (
+                <p className="text-base font-semibold text-muted-foreground">none</p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Rate limit */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm font-medium">Rate limit</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {statusLoading ? (
+                <Skeleton className="h-6 w-24" />
+              ) : (
+                <>
+                  <p className="text-base font-semibold">
+                    {status?.rateLimit.remainingRequests ?? 0}{" "}
+                    <span className="text-xs font-normal text-muted-foreground">
+                      / {status?.rateLimit.maxRequests ?? 200} remaining
+                    </span>
+                  </p>
+                  {status?.rateLimit.windowResetAt && (
+                    <p className="text-xs text-muted-foreground" style={{ marginTop: 4 }}>
+                      resets {formatRelative(status.rateLimit.windowResetAt)}
+                    </p>
+                  )}
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* Rolling counts: three windows × three buckets */}
+      <section aria-labelledby="counts-heading" style={{ marginTop: 24 }}>
+        <h2 id="counts-heading" className="sr-only">
+          Sync counts by window
+        </h2>
+        <Card>
+          <CardHeader>
+            <CardTitle>Sync activity</CardTitle>
+            <CardDescription>
+              Push attempts by rolling window. Counts include both successful
+              and failed attempts.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <table className="w-full text-sm" style={{ borderCollapse: "collapse" }}>
+              <caption className="sr-only">YNAB sync attempt counts grouped by 24-hour, 7-day, and 30-day rolling windows.</caption>
+              <thead>
+                <tr style={{ borderBottom: "1px solid var(--line)", textAlign: "left" }}>
+                  <th scope="col" style={{ padding: "8px 4px" }}>Window</th>
+                  <th scope="col" style={{ padding: "8px 4px", textAlign: "right" }}>Total</th>
+                  <th scope="col" style={{ padding: "8px 4px", textAlign: "right" }}>Success</th>
+                  <th scope="col" style={{ padding: "8px 4px", textAlign: "right" }}>Failed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {statusLoading ? (
+                  <tr>
+                    <td colSpan={4} style={{ padding: 12 }}>
+                      <Skeleton className="h-4 w-full" />
+                    </td>
+                  </tr>
+                ) : (
+                  <>
+                    <tr style={{ borderBottom: "1px solid var(--line)" }}>
+                      <th scope="row" style={{ padding: "8px 4px", fontWeight: 500 }}>Last 24h</th>
+                      <td style={{ padding: "8px 4px", textAlign: "right" }}>{status?.pushes24h ?? 0}</td>
+                      <td style={{ padding: "8px 4px", textAlign: "right" }}>{status?.successes24h ?? 0}</td>
+                      <td style={{ padding: "8px 4px", textAlign: "right" }}>{status?.failures24h ?? 0}</td>
+                    </tr>
+                    <tr style={{ borderBottom: "1px solid var(--line)" }}>
+                      <th scope="row" style={{ padding: "8px 4px", fontWeight: 500 }}>Last 7 days</th>
+                      <td style={{ padding: "8px 4px", textAlign: "right" }}>{status?.pushes7d ?? 0}</td>
+                      <td style={{ padding: "8px 4px", textAlign: "right" }}>{status?.successes7d ?? 0}</td>
+                      <td style={{ padding: "8px 4px", textAlign: "right" }}>{status?.failures7d ?? 0}</td>
+                    </tr>
+                    <tr>
+                      <th scope="row" style={{ padding: "8px 4px", fontWeight: 500 }}>Last 30 days</th>
+                      <td style={{ padding: "8px 4px", textAlign: "right" }}>{status?.pushes30d ?? 0}</td>
+                      <td style={{ padding: "8px 4px", textAlign: "right" }}>{status?.successes30d ?? 0}</td>
+                      <td style={{ padding: "8px 4px", textAlign: "right" }}>{status?.failures30d ?? 0}</td>
+                    </tr>
+                  </>
+                )}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      </section>
+
+      {/* Recent activity */}
+      <section aria-labelledby="activity-heading" style={{ marginTop: 24 }}>
+        <Card>
+          <CardHeader>
+            <CardTitle id="activity-heading">Recent activity</CardTitle>
+            <CardDescription>
+              One row per sync attempt. Most recent first.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center gap-2" style={{ marginBottom: 12 }}>
+              {(["all", "synced", "failed"] as const).map((opt) => (
+                <button
+                  key={opt}
+                  type="button"
+                  className={`btn xs ${outcomeFilter === opt ? "primary" : ""}`}
+                  aria-pressed={outcomeFilter === opt}
+                  onClick={() => {
+                    setOutcomeFilter(opt);
+                    setPage(0);
+                  }}
+                >
+                  {opt[0].toUpperCase() + opt.slice(1)}
+                </button>
+              ))}
+            </div>
+
+            {eventsLoading ? (
+              <div role="status" aria-live="polite">
+                <span className="sr-only">Loading sync events…</span>
+                {[0, 1, 2].map((i) => (
+                  <Skeleton key={i} className="h-6 w-full" style={{ marginBottom: 6 }} />
+                ))}
+              </div>
+            ) : events.length === 0 ? (
+              <EmptyState
+                icon={Icon.Link}
+                title="No sync events yet"
+                body={
+                  isConfigured
+                    ? "Push a receipt to YNAB and it'll show up here."
+                    : "Connect YNAB to start syncing."
+                }
+              />
+            ) : (
+              <>
+                <table className="w-full text-sm" style={{ borderCollapse: "collapse" }}>
+                  <caption className="sr-only">
+                    YNAB sync attempts, most-recent first. {totalCount} total
+                    {outcomeFilter !== "all" ? ` ${outcomeFilter}` : ""}.
+                  </caption>
+                  <thead>
+                    <tr style={{ borderBottom: "1px solid var(--line)", textAlign: "left" }}>
+                      <th scope="col" style={{ padding: "8px 4px" }}>When</th>
+                      <th scope="col" style={{ padding: "8px 4px" }}>Outcome</th>
+                      <th scope="col" style={{ padding: "8px 4px" }}>Receipt</th>
+                      <th scope="col" style={{ padding: "8px 4px" }}>Error</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {events.map((ev) => (
+                      <tr key={ev.id} style={{ borderBottom: "1px solid var(--line)" }}>
+                        <td style={{ padding: "8px 4px" }} title={formatAbsolute(ev.occurredAt)}>
+                          {formatRelative(ev.occurredAt)}
+                        </td>
+                        <td style={{ padding: "8px 4px" }}>
+                          <OutcomePill outcome={ev.outcome} />
+                        </td>
+                        <td style={{ padding: "8px 4px" }}>
+                          {ev.receiptId ? (
+                            <Link to={`/receipts/${ev.receiptId}`} className="underline">
+                              View
+                            </Link>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                        <td style={{ padding: "8px 4px", maxWidth: 320, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={ev.errorMessage ?? undefined}>
+                          {ev.errorMessage ?? <span className="text-muted-foreground">—</span>}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+
+                {totalPages > 1 && (
+                  <nav
+                    aria-label="Sync events pagination"
+                    className="flex items-center justify-between"
+                    style={{ marginTop: 12 }}
+                  >
+                    <span className="text-xs text-muted-foreground">
+                      Page {page + 1} of {totalPages} · {totalCount.toLocaleString()} total
+                    </span>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={page === 0}
+                        onClick={() => setPage((p) => Math.max(0, p - 1))}
+                      >
+                        Previous
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={page + 1 >= totalPages}
+                        onClick={() => setPage((p) => p + 1)}
+                      >
+                        Next
+                      </Button>
+                    </div>
+                  </nav>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+    </>
+  );
+}

--- a/tests/Application.Tests/Application.Tests.csproj
+++ b/tests/Application.Tests/Application.Tests.csproj
@@ -25,6 +25,7 @@
     </PackageReference>
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactions409ReconcileTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactions409ReconcileTests.cs
@@ -23,6 +23,7 @@ public class PushYnabTransactions409ReconcileTests
 	private readonly Mock<IYnabSyncRecordService> _syncRecordServiceMock = new();
 	private readonly Mock<IYnabApiClient> _ynabApiClientMock = new();
 	private readonly Mock<IYnabSplitCalculator> _splitCalculatorMock = new();
+	private readonly Mock<IYnabSyncEventService> _syncEventServiceMock = new();
 	private readonly PushYnabTransactionsCommandHandler _handler;
 
 	private readonly Guid _receiptId = Guid.NewGuid();
@@ -44,7 +45,8 @@ public class PushYnabTransactions409ReconcileTests
 			_budgetSelectionServiceMock.Object,
 			_syncRecordServiceMock.Object,
 			_ynabApiClientMock.Object,
-			_splitCalculatorMock.Object);
+			_splitCalculatorMock.Object,
+			_syncEventServiceMock.Object);
 	}
 
 	private void SetupHappyPath()

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
@@ -22,6 +22,7 @@ public class PushYnabTransactionsCommandHandlerTests
 	private readonly Mock<IYnabSyncRecordService> _syncRecordServiceMock = new();
 	private readonly Mock<IYnabApiClient> _ynabApiClientMock = new();
 	private readonly Mock<IYnabSplitCalculator> _splitCalculatorMock = new();
+	private readonly Mock<IYnabSyncEventService> _syncEventServiceMock = new();
 	private readonly PushYnabTransactionsCommandHandler _handler;
 
 	private readonly Guid _receiptId = Guid.NewGuid();
@@ -42,7 +43,8 @@ public class PushYnabTransactionsCommandHandlerTests
 			_budgetSelectionServiceMock.Object,
 			_syncRecordServiceMock.Object,
 			_ynabApiClientMock.Object,
-			_splitCalculatorMock.Object);
+			_splitCalculatorMock.Object,
+			_syncEventServiceMock.Object);
 	}
 
 	private void SetupHappyPath()

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsFailedRetryTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsFailedRetryTests.cs
@@ -22,6 +22,7 @@ public class PushYnabTransactionsFailedRetryTests
 	private readonly Mock<IYnabSyncRecordService> _syncRecordServiceMock = new();
 	private readonly Mock<IYnabApiClient> _ynabApiClientMock = new();
 	private readonly Mock<IYnabSplitCalculator> _splitCalculatorMock = new();
+	private readonly Mock<IYnabSyncEventService> _syncEventServiceMock = new();
 	private readonly PushYnabTransactionsCommandHandler _handler;
 
 	private readonly Guid _receiptId = Guid.NewGuid();
@@ -43,7 +44,8 @@ public class PushYnabTransactionsFailedRetryTests
 			_budgetSelectionServiceMock.Object,
 			_syncRecordServiceMock.Object,
 			_ynabApiClientMock.Object,
-			_splitCalculatorMock.Object);
+			_splitCalculatorMock.Object,
+			_syncEventServiceMock.Object);
 	}
 
 	private void SetupHappyPathPipeline()

--- a/tests/Application.Tests/Queries/Core/Ynab/GetYnabStatusQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Core/Ynab/GetYnabStatusQueryHandlerTests.cs
@@ -1,0 +1,112 @@
+using Application.Interfaces.Services;
+using Application.Models.Ynab;
+using Application.Queries.Core.Ynab;
+using Common;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+
+namespace Application.Tests.Queries.Core.Ynab;
+
+public class GetYnabStatusQueryHandlerTests
+{
+	private readonly Mock<IYnabApiClient> _ynabClientMock = new();
+	private readonly Mock<IYnabBudgetSelectionService> _budgetSelectionMock = new();
+	private readonly Mock<IYnabSyncEventService> _syncEventMock = new();
+	private readonly Mock<IYnabRateLimitTracker> _rateLimitMock = new();
+	private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 5, 24, 12, 0, 0, TimeSpan.Zero));
+	private readonly GetYnabStatusQueryHandler _handler;
+
+	public GetYnabStatusQueryHandlerTests()
+	{
+		// Default the rate-limit tracker so handlers don't NRE when YNAB isn't configured.
+		_rateLimitMock.Setup(r => r.GetStatus())
+			.Returns(new YnabRateLimitStatus(200, 200, 0, null, null));
+		_handler = new GetYnabStatusQueryHandler(
+			_ynabClientMock.Object,
+			_budgetSelectionMock.Object,
+			_syncEventMock.Object,
+			_rateLimitMock.Object,
+			_timeProvider);
+	}
+
+	[Fact]
+	public async Task Handle_NotConfigured_ReturnsAllZeroAndDisconnected()
+	{
+		_ynabClientMock.Setup(c => c.IsConfigured).Returns(false);
+
+		YnabStatusResult result = await _handler.Handle(new GetYnabStatusQuery(), CancellationToken.None);
+
+		result.IsConfigured.Should().BeFalse();
+		result.IsConnected.Should().BeFalse();
+		result.SelectedBudgetId.Should().BeNull();
+		result.LastSuccessUtc.Should().BeNull();
+		result.LastFailureUtc.Should().BeNull();
+		result.Pushes24h.Should().Be(0);
+		result.Pushes7d.Should().Be(0);
+		result.Pushes30d.Should().Be(0);
+		// Sync-event service should not be queried when not configured.
+		_syncEventMock.VerifyNoOtherCalls();
+	}
+
+	[Fact]
+	public async Task Handle_Configured_AggregatesRollingWindows()
+	{
+		// Arrange
+		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+		_ynabClientMock.Setup(c => c.GetBudgetsAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync([new YnabBudget("b1", "Budget 1")]);
+		_budgetSelectionMock.Setup(b => b.GetSelectedBudgetIdAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync("b1");
+
+		DateTimeOffset lastSuccess = _timeProvider.GetUtcNow().AddMinutes(-30);
+		DateTimeOffset lastFailure = _timeProvider.GetUtcNow().AddHours(-3);
+		_syncEventMock.Setup(s => s.GetLatestOccurrenceAsync(YnabSyncStatus.Synced, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(lastSuccess);
+		_syncEventMock.Setup(s => s.GetLatestOccurrenceAsync(YnabSyncStatus.Failed, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(lastFailure);
+
+		// 24h window: 10 total, 8 success, 2 failure
+		_syncEventMock.Setup(s => s.CountSinceAsync(It.Is<DateTimeOffset>(d => d == _timeProvider.GetUtcNow().AddHours(-24)), null, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(10);
+		_syncEventMock.Setup(s => s.CountSinceAsync(It.Is<DateTimeOffset>(d => d == _timeProvider.GetUtcNow().AddHours(-24)), YnabSyncStatus.Synced, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(8);
+		_syncEventMock.Setup(s => s.CountSinceAsync(It.Is<DateTimeOffset>(d => d == _timeProvider.GetUtcNow().AddHours(-24)), YnabSyncStatus.Failed, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(2);
+
+		_syncEventMock.Setup(s => s.CountSinceAsync(It.Is<DateTimeOffset>(d => d == _timeProvider.GetUtcNow().AddDays(-7)), null, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(50);
+		_syncEventMock.Setup(s => s.CountSinceAsync(It.Is<DateTimeOffset>(d => d == _timeProvider.GetUtcNow().AddDays(-30)), null, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(120);
+
+		// Act
+		YnabStatusResult result = await _handler.Handle(new GetYnabStatusQuery(), CancellationToken.None);
+
+		// Assert
+		result.IsConfigured.Should().BeTrue();
+		result.IsConnected.Should().BeTrue();
+		result.SelectedBudgetId.Should().Be("b1");
+		result.LastSuccessUtc.Should().Be(lastSuccess);
+		result.LastFailureUtc.Should().Be(lastFailure);
+		result.Pushes24h.Should().Be(10);
+		result.Successes24h.Should().Be(8);
+		result.Failures24h.Should().Be(2);
+		result.Pushes7d.Should().Be(50);
+		result.Pushes30d.Should().Be(120);
+	}
+
+	[Fact]
+	public async Task Handle_ConfiguredButBudgetsCallThrows_ReturnsDisconnectedButStillAggregates()
+	{
+		_ynabClientMock.Setup(c => c.IsConfigured).Returns(true);
+		_ynabClientMock.Setup(c => c.GetBudgetsAsync(It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("YNAB unreachable"));
+
+		YnabStatusResult result = await _handler.Handle(new GetYnabStatusQuery(), CancellationToken.None);
+
+		result.IsConfigured.Should().BeTrue();
+		result.IsConnected.Should().BeFalse();
+		// Event counts still queried — the rolling history is independent of live connectivity.
+		_syncEventMock.Verify(s => s.CountSinceAsync(It.IsAny<DateTimeOffset>(), It.IsAny<YnabSyncStatus?>(), It.IsAny<CancellationToken>()), Times.AtLeast(3));
+	}
+}

--- a/tests/Infrastructure.Tests/Services/YnabSyncEventServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabSyncEventServiceTests.cs
@@ -1,0 +1,147 @@
+using Application.Models.Ynab;
+using Common;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Interfaces.Repositories;
+using Infrastructure.Services;
+using Moq;
+
+namespace Infrastructure.Tests.Services;
+
+public class YnabSyncEventServiceTests
+{
+	private readonly Mock<IYnabSyncEventRepository> _repositoryMock = new();
+	private readonly YnabSyncEventService _service;
+
+	public YnabSyncEventServiceTests()
+	{
+		_service = new YnabSyncEventService(_repositoryMock.Object);
+	}
+
+	[Fact]
+	public async Task RecordAsync_WritesEntityWithAllFieldsAndGeneratesId()
+	{
+		// Arrange
+		Guid txId = Guid.NewGuid();
+		Guid receiptId = Guid.NewGuid();
+		YnabSyncEventEntity? captured = null;
+
+		_repositoryMock.Setup(r => r.CreateAsync(It.IsAny<YnabSyncEventEntity>(), It.IsAny<CancellationToken>()))
+			.Callback<YnabSyncEventEntity, CancellationToken>((e, _) => captured = e)
+			.ReturnsAsync((YnabSyncEventEntity e, CancellationToken _) => e);
+
+		// Act
+		await _service.RecordAsync(
+			YnabSyncType.TransactionPush,
+			YnabSyncStatus.Synced,
+			txId,
+			receiptId,
+			"budget-123",
+			"ynab-tx-456",
+			errorMessage: null,
+			CancellationToken.None);
+
+		// Assert
+		captured.Should().NotBeNull();
+		captured!.Id.Should().NotBe(Guid.Empty);
+		captured.EventType.Should().Be(YnabSyncType.TransactionPush);
+		captured.Outcome.Should().Be(YnabSyncStatus.Synced);
+		captured.LocalTransactionId.Should().Be(txId);
+		captured.ReceiptId.Should().Be(receiptId);
+		captured.YnabBudgetId.Should().Be("budget-123");
+		captured.YnabTransactionId.Should().Be("ynab-tx-456");
+		captured.ErrorMessage.Should().BeNull();
+		captured.OccurredAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+	}
+
+	[Fact]
+	public async Task RecordAsync_WithFailure_PreservesErrorMessage()
+	{
+		YnabSyncEventEntity? captured = null;
+		_repositoryMock.Setup(r => r.CreateAsync(It.IsAny<YnabSyncEventEntity>(), It.IsAny<CancellationToken>()))
+			.Callback<YnabSyncEventEntity, CancellationToken>((e, _) => captured = e)
+			.ReturnsAsync((YnabSyncEventEntity e, CancellationToken _) => e);
+
+		await _service.RecordAsync(
+			YnabSyncType.TransactionPush,
+			YnabSyncStatus.Failed,
+			localTransactionId: Guid.NewGuid(),
+			receiptId: Guid.NewGuid(),
+			ynabBudgetId: null,
+			ynabTransactionId: null,
+			errorMessage: "401 Unauthorized",
+			CancellationToken.None);
+
+		captured!.Outcome.Should().Be(YnabSyncStatus.Failed);
+		captured.ErrorMessage.Should().Be("401 Unauthorized");
+	}
+
+	[Fact]
+	public async Task ListAsync_ProjectsEntitiesToDtosAndPreservesTotalCount()
+	{
+		// Arrange
+		YnabSyncEventEntity entity = new()
+		{
+			Id = Guid.NewGuid(),
+			OccurredAt = DateTimeOffset.UtcNow,
+			EventType = YnabSyncType.TransactionPush,
+			Outcome = YnabSyncStatus.Synced,
+			LocalTransactionId = Guid.NewGuid(),
+			ReceiptId = Guid.NewGuid(),
+			YnabBudgetId = "b1",
+			YnabTransactionId = "ynab-1",
+			ErrorMessage = null,
+		};
+
+		_repositoryMock.Setup(r => r.ListAsync(0, 50, null, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(((IReadOnlyList<YnabSyncEventEntity>)[entity], 42));
+
+		// Act
+		YnabSyncEventsPage page = await _service.ListAsync(0, 50, null, CancellationToken.None);
+
+		// Assert
+		page.TotalCount.Should().Be(42);
+		page.Events.Should().HaveCount(1);
+		YnabSyncEventDto dto = page.Events[0];
+		dto.Id.Should().Be(entity.Id);
+		dto.EventType.Should().Be(YnabSyncType.TransactionPush);
+		dto.Outcome.Should().Be(YnabSyncStatus.Synced);
+		dto.YnabBudgetId.Should().Be("b1");
+		dto.YnabTransactionId.Should().Be("ynab-1");
+	}
+
+	[Fact]
+	public async Task ListAsync_PassesOutcomeFilterThrough()
+	{
+		_repositoryMock.Setup(r => r.ListAsync(10, 25, YnabSyncStatus.Failed, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(((IReadOnlyList<YnabSyncEventEntity>)[], 0));
+
+		await _service.ListAsync(10, 25, YnabSyncStatus.Failed, CancellationToken.None);
+
+		_repositoryMock.Verify(r => r.ListAsync(10, 25, YnabSyncStatus.Failed, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task GetLatestOccurrenceAsync_DelegatesToRepository()
+	{
+		DateTimeOffset expected = DateTimeOffset.UtcNow.AddHours(-2);
+		_repositoryMock.Setup(r => r.GetLatestOccurrenceAsync(YnabSyncStatus.Synced, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		DateTimeOffset? actual = await _service.GetLatestOccurrenceAsync(YnabSyncStatus.Synced, CancellationToken.None);
+
+		actual.Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task CountSinceAsync_DelegatesToRepository()
+	{
+		DateTimeOffset since = DateTimeOffset.UtcNow.AddDays(-7);
+		_repositoryMock.Setup(r => r.CountSinceAsync(since, YnabSyncStatus.Failed, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(13);
+
+		int count = await _service.CountSinceAsync(since, YnabSyncStatus.Failed, CancellationToken.None);
+
+		count.Should().Be(13);
+	}
+}


### PR DESCRIPTION
Closes RECEIPTS-737.

## Summary

Adds a dedicated `/ynab` status page that answers "is YNAB healthy and what has it done lately?" — distinct from `/settings/ynab` (configuration).

## What ships

### Backend
- **New `YnabSyncEvent` table** (append-only activity log; complements the existing `YnabSyncRecord` which holds current state). Indexed on `OccurredAt desc` and `ReceiptId`.
- **Writer hook** in `PushYnabTransactionsCommandHandler` — every push attempt (success, conflict-recovered, failure) records one event. Preserves retry history.
- **`GET /api/ynab/status`** — single-call health snapshot: connection state, selected budget, rolling counts (24h / 7d / 30d × total/success/failure), last success/failure timestamps, rate-limit window.
- **`GET /api/ynab/events`** — paginated event feed (default 25, max 100), filterable by outcome (`synced` / `failed`).
- Migration `20260524101536_AddYnabSyncEventTable`.

### Frontend
- **`/ynab` route** inside the authenticated layout.
- **Sidebar nav**: existing "YNAB" entry split into "YNAB status" (→ `/ynab`) and "YNAB settings" (→ `/settings/ynab`).
- **`useYnabStatus` + `useYnabSyncEvents` hooks** with 60s refetch interval on status.
- **`Ynab.tsx`**: PageHead, four health tiles, rolling-counts table, outcome filter, paginated activity log with click-through to receipt detail.

### Tests
- 3 new Application.Tests on `GetYnabStatusQueryHandler` (FakeTimeProvider).
- 6 new Infrastructure.Tests on `YnabSyncEventService`.
- 8 new frontend tests on `Ynab.tsx` (heading, not-configured alert, status states, rolling counts, EmptyState, event rows, filter wiring).

## Decisions

- **New table, not reuse audit log**: per the user's confirmation. Different access pattern (high-frequency write, scoped read by time desc), wouldn't fit cleanly in the audit log.
- **Database-schema reorganization** (move `dbo.*` into bounded contexts like `ynab`, `identity`, `receipts`) tracked as RECEIPTS-746 follow-up.
- **Memo sync events deferred**: only `TransactionPush` events emitted today. Adding memo sync events would just inject the same `IYnabSyncEventService` call into `YnabMemoSyncService` — straightforward follow-up if/when needed.

## Out of scope (intentionally deferred)

- Retry/replay UI for failed events
- Reverse sync (YNAB → Receipts)
- Webhook ingestion (YNAB doesn't offer webhooks)
- Retention/archival of old events (>90d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)