### PR TITLE
feat(api): add YNAB status page with health grid and sync-event log

### DIFF
--- a/docs/migrations/20260701120254_AddYnabSyncEvent.md
+++ b/docs/migrations/20260701120254_AddYnabSyncEvent.md
@@ -1,0 +1,53 @@
+# Migration: AddYnabSyncEvent (RECEIPTS-737)
+
+**Migration id:** `20260701120254_AddYnabSyncEvent`
+**Date:** 2026-07-01
+
+## What it does
+
+Creates the `ynab.YnabSyncEvents` table — an append-only log of YNAB integration attempts
+(pushes and connection validations) backing the `/ynab` status page. One row is written per
+attempt (success or failure). The table lands in the `ynab` bounded-context schema created by
+RECEIPTS-746.
+
+### Columns
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | uuid (PK) | |
+| `UserId` | text, null | Identity user id that triggered the attempt (provenance). |
+| `OccurredAt` | timestamptz | |
+| `EventType` | text | Enum `YnabSyncEventType` (`Push`, `Validate`) stored as string. |
+| `ReceiptId` | uuid, null | Set for push events. |
+| `TransactionId` | uuid, null | Set for push events. |
+| `HttpStatus` | integer, null | YNAB response status when available. |
+| `Success` | boolean | |
+| `ErrorMessage` | text, null | Failure detail. |
+| `RequestId` | text, null | From YNAB `X-Request-Id` when present (opportunistic). |
+
+### Index
+
+`IX_YnabSyncEvents_UserId_OccurredAt` on `(UserId, OccurredAt DESC)` — the acceptance-required
+index. (The status/feed queries are global — YNAB is a single-PAT integration — but the index is
+present as specified and still serves ordered scans.)
+
+## Rollback
+
+`Down` drops `ynab.YnabSyncEvents`. Data-safe in the sense that it only removes the event log;
+no other table references it (no foreign keys in or out). Because the writer hook and the two
+read endpoints live in application code, a rollback should be paired with reverting the
+RECEIPTS-737 code change.
+
+## Related code
+
+- Entity/config: `Infrastructure/Entities/Core/YnabSyncEventEntity.cs`, `Infrastructure/Configurations/YnabSyncEventEntityConfiguration.cs` (excluded from audit generation in `ApplicationDbContext.CollectAuditEntries`).
+- Writer/reader: `Infrastructure/Services/YnabSyncEventService.cs` (`IYnabSyncEventService`).
+- Emission: `PushYnabTransactionsCommandHandler` (push events), `GetYnabConnectionStatusQueryHandler` (validate events).
+- Endpoints: `GET /api/ynab/status`, `GET /api/ynab/events` (`YnabController`).
+
+## Validation
+
+Applied by the Testcontainers integration suite (`tests/Infrastructure.IntegrationTests`,
+`Category=Integration`) which migrates a real PostgreSQL instance to HEAD: 36/37 pass (the one
+failure, `PurgeTrashServiceTests`, is pre-existing and unrelated — RECEIPTS-747). CI does not run
+integration tests, so this is validated locally.

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -4328,6 +4328,70 @@ paths:
               schema:
                 $ref: "#/components/schemas/YnabConnectionStatusResponse"
 
+  /api/ynab/status:
+    get:
+      operationId: GetYnabStatus
+      tags: [YNAB]
+      summary: Get YNAB integration status and sync stats
+      description: Returns an aggregate health snapshot for the YNAB status page — whether YNAB is configured, when it was last validated, last push success/failure timestamps, and push counts by window. Derived from the sync-event log; does not perform a live YNAB call.
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/YnabStatusResponse"
+
+  /api/ynab/events:
+    get:
+      operationId: GetYnabSyncEvents
+      tags: [YNAB]
+      summary: Get recent YNAB sync events with optional filtering
+      description: Paginated, filterable feed of YNAB push and validate attempts, most recent first.
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/SortBy"
+        - $ref: "#/components/parameters/SortDirection"
+        - name: outcome
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [success, failure]
+          description: Filter by outcome (success or failure).
+        - name: dateFrom
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Filter events from this date (inclusive).
+        - name: dateTo
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Filter events up to this date (inclusive, end of day).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/YnabSyncEventListResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
   /api/ynab/budgets:
     get:
       operationId: GetYnabBudgets
@@ -7114,6 +7178,104 @@ components:
             - "null"
           format: date-time
           description: The timestamp of the last successful YNAB sync operation, or null if no syncs have completed.
+
+    YnabStatusResponse:
+      type: object
+      required: [isConfigured, pushCountLast24h, pushCountLast7d, pushCountLast30d, pushSuccessLast30d, pushFailureLast30d]
+      properties:
+        isConfigured:
+          type: boolean
+          description: Whether the YNAB personal access token is set.
+        lastValidatedAt:
+          type:
+            - string
+            - "null"
+          format: date-time
+          description: Timestamp of the last successful connection validation, or null.
+        lastPushSuccessAt:
+          type:
+            - string
+            - "null"
+          format: date-time
+          description: Timestamp of the last successful push, or null.
+        lastPushFailureAt:
+          type:
+            - string
+            - "null"
+          format: date-time
+          description: Timestamp of the last failed push, or null.
+        pushCountLast24h:
+          type: integer
+          format: int32
+        pushCountLast7d:
+          type: integer
+          format: int32
+        pushCountLast30d:
+          type: integer
+          format: int32
+        pushSuccessLast30d:
+          type: integer
+          format: int32
+        pushFailureLast30d:
+          type: integer
+          format: int32
+
+    YnabSyncEventResponse:
+      type: object
+      required: [id, occurredAt, eventType, success]
+      properties:
+        id:
+          type: string
+          format: uuid
+        occurredAt:
+          type: string
+          format: date-time
+        eventType:
+          type: string
+          description: The kind of attempt (Push or Validate).
+        receiptId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        transactionId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        httpStatus:
+          type:
+            - integer
+            - "null"
+          format: int32
+        success:
+          type: boolean
+        errorMessage:
+          type:
+            - string
+            - "null"
+        requestId:
+          type:
+            - string
+            - "null"
+
+    YnabSyncEventListResponse:
+      type: object
+      required: [data, total, offset, limit]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/YnabSyncEventResponse"
+        total:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int32
+        limit:
+          type: integer
+          format: int32
 
     YnabBudgetSettingsResponse:
       type: object

--- a/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
+++ b/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
@@ -5,6 +5,7 @@ using Application.Utilities;
 using Common;
 using Domain.Aggregates;
 using Mediator;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Commands.Ynab.PushTransactions;
 
@@ -18,7 +19,10 @@ public class PushYnabTransactionsCommandHandler(
 	IYnabBudgetSelectionService budgetSelectionService,
 	IYnabSyncRecordService syncRecordService,
 	IYnabApiClient ynabApiClient,
-	IYnabSplitCalculator splitCalculator) : IRequestHandler<PushYnabTransactionsCommand, PushYnabTransactionsResult>
+	IYnabSplitCalculator splitCalculator,
+	IYnabSyncEventService ynabSyncEventService,
+	IYnabResponseContext ynabResponseContext,
+	ILogger<PushYnabTransactionsCommandHandler> logger) : IRequestHandler<PushYnabTransactionsCommand, PushYnabTransactionsResult>
 {
 	public async ValueTask<PushYnabTransactionsResult> Handle(PushYnabTransactionsCommand request, CancellationToken cancellationToken)
 	{
@@ -224,8 +228,11 @@ public class PushYnabTransactionsCommandHandler(
 						txSplit.TotalMilliunits,
 						txSplit.SubTransactions.Count));
 
+					await LogPushEventAsync(request.ReceiptId, localTx.Id, success: true, errorMessage: null, cancellationToken);
 					continue;
 				}
+
+				await LogPushEventAsync(request.ReceiptId, localTx.Id, success: true, errorMessage: null, cancellationToken);
 
 				// Update sync record to Synced — separate error handling (Bug 6)
 				try
@@ -261,11 +268,36 @@ public class PushYnabTransactionsCommandHandler(
 						syncRecord.Id, YnabSyncStatus.Failed, null, ex.Message, cancellationToken);
 				}
 
+				await LogPushEventAsync(request.ReceiptId, localTx.Id, success: false, ex.Message, cancellationToken);
+
 				return new PushYnabTransactionsResult(false, pushedTransactions,
 					Error: $"Failed to push YNAB transaction for local transaction {localTx.Id}: {ex.Message}");
 			}
 		}
 
 		return new PushYnabTransactionsResult(true, pushedTransactions);
+	}
+
+	// RECEIPTS-737: append one YnabSyncEvent per push attempt. Best-effort — a logging failure
+	// must never fail the push itself, so swallow and warn. httpStatus/requestId come from the
+	// transport-layer response context captured on the CreateTransaction call.
+	private async Task LogPushEventAsync(Guid receiptId, Guid transactionId, bool success, string? errorMessage, CancellationToken cancellationToken)
+	{
+		try
+		{
+			await ynabSyncEventService.WriteAsync(
+				YnabSyncEventType.Push,
+				success,
+				receiptId,
+				transactionId,
+				ynabResponseContext.LastStatusCode,
+				errorMessage,
+				ynabResponseContext.LastRequestId,
+				cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(ex, "Failed to write YnabSyncEvent for receipt {ReceiptId} transaction {TransactionId}", receiptId, transactionId);
+		}
 	}
 }

--- a/src/Application/Interfaces/Services/IYnabRateLimitTracker.cs
+++ b/src/Application/Interfaces/Services/IYnabRateLimitTracker.cs
@@ -5,6 +5,14 @@ namespace Application.Interfaces.Services;
 public interface IYnabRateLimitTracker
 {
 	void RecordRequest();
+
+	/// <summary>
+	/// Record YNAB's authoritative rate-limit counts parsed from the <c>X-Rate-Limit</c>
+	/// response header. When a recent server snapshot exists it takes precedence over the
+	/// in-process estimate in <see cref="GetStatus"/>.
+	/// </summary>
+	void RecordServerRateLimit(int used, int limit);
+
 	YnabRateLimitStatus GetStatus();
 	bool CanMakeRequests(int count);
 }

--- a/src/Application/Interfaces/Services/IYnabResponseContext.cs
+++ b/src/Application/Interfaces/Services/IYnabResponseContext.cs
@@ -1,0 +1,13 @@
+namespace Application.Interfaces.Services;
+
+/// <summary>
+/// Scoped holder for transport-level metadata from the most recent YNAB API response
+/// (status code and, when present, a request id). Populated by the YNAB API client after
+/// each call so business-layer handlers can attach it to the <c>YnabSyncEvent</c> they write.
+/// </summary>
+public interface IYnabResponseContext
+{
+	int? LastStatusCode { get; }
+	string? LastRequestId { get; }
+	void Record(int statusCode, string? requestId);
+}

--- a/src/Application/Interfaces/Services/IYnabSyncEventService.cs
+++ b/src/Application/Interfaces/Services/IYnabSyncEventService.cs
@@ -1,0 +1,35 @@
+using Application.Models;
+using Application.Models.Ynab;
+using Common;
+
+namespace Application.Interfaces.Services;
+
+/// <summary>
+/// Reads and writes the append-only YNAB sync-event log backing the /ynab status page.
+/// </summary>
+public interface IYnabSyncEventService
+{
+	/// <summary>Append one event for a YNAB attempt. User id is resolved from the current request.</summary>
+	Task WriteAsync(
+		YnabSyncEventType eventType,
+		bool success,
+		Guid? receiptId = null,
+		Guid? transactionId = null,
+		int? httpStatus = null,
+		string? errorMessage = null,
+		string? requestId = null,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>Paginated, filterable feed of recent events (most recent first by default).</summary>
+	Task<PagedResult<YnabSyncEventDto>> GetRecentAsync(
+		int offset,
+		int limit,
+		SortParams sort,
+		bool? success = null,
+		DateTimeOffset? dateFrom = null,
+		DateTimeOffset? dateTo = null,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>Aggregate stats (push counts by window, last success/failure/validate timestamps).</summary>
+	Task<YnabStatus> GetStatusAsync(bool isConfigured, CancellationToken cancellationToken = default);
+}

--- a/src/Application/Models/Ynab/YnabStatus.cs
+++ b/src/Application/Models/Ynab/YnabStatus.cs
@@ -1,0 +1,18 @@
+namespace Application.Models.Ynab;
+
+/// <summary>
+/// Aggregate health snapshot for the /ynab status page. Derived from the append-only
+/// YnabSyncEvent log plus the PAT-configured flag — deliberately cheap (no live YNAB call)
+/// so the page can poll it. Connection liveness is validated separately via
+/// <c>/api/ynab/connection-status</c>.
+/// </summary>
+public record YnabStatus(
+	bool IsConfigured,
+	DateTimeOffset? LastValidatedAt,
+	DateTimeOffset? LastPushSuccessAt,
+	DateTimeOffset? LastPushFailureAt,
+	int PushCountLast24h,
+	int PushCountLast7d,
+	int PushCountLast30d,
+	int PushSuccessLast30d,
+	int PushFailureLast30d);

--- a/src/Application/Models/Ynab/YnabSyncEventDto.cs
+++ b/src/Application/Models/Ynab/YnabSyncEventDto.cs
@@ -1,0 +1,12 @@
+namespace Application.Models.Ynab;
+
+public record YnabSyncEventDto(
+	Guid Id,
+	DateTimeOffset OccurredAt,
+	string EventType,
+	Guid? ReceiptId,
+	Guid? TransactionId,
+	int? HttpStatus,
+	bool Success,
+	string? ErrorMessage,
+	string? RequestId);

--- a/src/Application/Queries/Core/Ynab/GetYnabConnectionStatusQueryHandler.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabConnectionStatusQueryHandler.cs
@@ -36,20 +36,28 @@ public class GetYnabConnectionStatusQueryHandler(
 		}
 
 		// RECEIPTS-737: record this live validation so /ynab can show "last validated at".
-		// Best-effort — never fail the status check because event logging failed.
-		try
+		// GetBudgetsAsync can return from the in-memory budget cache without hitting YNAB — those
+		// are not real validations, so only log when an actual call was made (a live success sets
+		// LastStatusCode; any failure is necessarily a live attempt). Otherwise "last validated"
+		// would track poll frequency, not connection health. Best-effort: never fail the status
+		// check because event logging failed.
+		bool wasLiveCall = ynabResponseContext.LastStatusCode.HasValue || validateError is not null;
+		if (wasLiveCall)
 		{
-			await ynabSyncEventService.WriteAsync(
-				YnabSyncEventType.Validate,
-				isConnected,
-				httpStatus: ynabResponseContext.LastStatusCode,
-				errorMessage: validateError,
-				requestId: ynabResponseContext.LastRequestId,
-				cancellationToken: cancellationToken);
-		}
-		catch (Exception ex)
-		{
-			logger.LogWarning(ex, "Failed to write YNAB validate event");
+			try
+			{
+				await ynabSyncEventService.WriteAsync(
+					YnabSyncEventType.Validate,
+					isConnected,
+					httpStatus: ynabResponseContext.LastStatusCode,
+					errorMessage: validateError,
+					requestId: ynabResponseContext.LastRequestId,
+					cancellationToken: cancellationToken);
+			}
+			catch (Exception ex)
+			{
+				logger.LogWarning(ex, "Failed to write YNAB validate event");
+			}
 		}
 
 		DateTimeOffset? lastSync = await syncRecordService.GetLatestSuccessfulSyncTimestampAsync(cancellationToken);

--- a/src/Application/Queries/Core/Ynab/GetYnabConnectionStatusQueryHandler.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabConnectionStatusQueryHandler.cs
@@ -1,12 +1,17 @@
 using Application.Interfaces.Services;
 using Application.Models.Ynab;
+using Common;
 using Mediator;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Queries.Core.Ynab;
 
 public class GetYnabConnectionStatusQueryHandler(
 	IYnabApiClient ynabApiClient,
-	IYnabSyncRecordService syncRecordService) : IRequestHandler<GetYnabConnectionStatusQuery, YnabConnectionStatus>
+	IYnabSyncRecordService syncRecordService,
+	IYnabSyncEventService ynabSyncEventService,
+	IYnabResponseContext ynabResponseContext,
+	ILogger<GetYnabConnectionStatusQueryHandler> logger) : IRequestHandler<GetYnabConnectionStatusQuery, YnabConnectionStatus>
 {
 	public async ValueTask<YnabConnectionStatus> Handle(GetYnabConnectionStatusQuery request, CancellationToken cancellationToken)
 	{
@@ -18,6 +23,7 @@ public class GetYnabConnectionStatusQueryHandler(
 		}
 
 		bool isConnected;
+		string? validateError = null;
 		try
 		{
 			await ynabApiClient.GetBudgetsAsync(cancellationToken);
@@ -26,6 +32,24 @@ public class GetYnabConnectionStatusQueryHandler(
 		catch (Exception ex) when (ex is not OperationCanceledException)
 		{
 			isConnected = false;
+			validateError = ex.Message;
+		}
+
+		// RECEIPTS-737: record this live validation so /ynab can show "last validated at".
+		// Best-effort — never fail the status check because event logging failed.
+		try
+		{
+			await ynabSyncEventService.WriteAsync(
+				YnabSyncEventType.Validate,
+				isConnected,
+				httpStatus: ynabResponseContext.LastStatusCode,
+				errorMessage: validateError,
+				requestId: ynabResponseContext.LastRequestId,
+				cancellationToken: cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(ex, "Failed to write YNAB validate event");
 		}
 
 		DateTimeOffset? lastSync = await syncRecordService.GetLatestSuccessfulSyncTimestampAsync(cancellationToken);

--- a/src/Application/Queries/Core/Ynab/GetYnabStatusQuery.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabStatusQuery.cs
@@ -1,0 +1,6 @@
+using Application.Interfaces;
+using Application.Models.Ynab;
+
+namespace Application.Queries.Core.Ynab;
+
+public record GetYnabStatusQuery : IQuery<YnabStatus>;

--- a/src/Application/Queries/Core/Ynab/GetYnabStatusQueryHandler.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabStatusQueryHandler.cs
@@ -1,0 +1,15 @@
+using Application.Interfaces.Services;
+using Application.Models.Ynab;
+using Mediator;
+
+namespace Application.Queries.Core.Ynab;
+
+public class GetYnabStatusQueryHandler(
+	IYnabApiClient ynabApiClient,
+	IYnabSyncEventService ynabSyncEventService) : IRequestHandler<GetYnabStatusQuery, YnabStatus>
+{
+	public async ValueTask<YnabStatus> Handle(GetYnabStatusQuery request, CancellationToken cancellationToken)
+	{
+		return await ynabSyncEventService.GetStatusAsync(ynabApiClient.IsConfigured, cancellationToken);
+	}
+}

--- a/src/Application/Queries/Core/Ynab/GetYnabSyncEventsQuery.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabSyncEventsQuery.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces;
+using Application.Models;
+using Application.Models.Ynab;
+
+namespace Application.Queries.Core.Ynab;
+
+public record GetYnabSyncEventsQuery(
+	int Offset,
+	int Limit,
+	SortParams Sort,
+	bool? Success,
+	DateTimeOffset? DateFrom,
+	DateTimeOffset? DateTo) : IQuery<PagedResult<YnabSyncEventDto>>;

--- a/src/Application/Queries/Core/Ynab/GetYnabSyncEventsQueryHandler.cs
+++ b/src/Application/Queries/Core/Ynab/GetYnabSyncEventsQueryHandler.cs
@@ -1,0 +1,22 @@
+using Application.Interfaces.Services;
+using Application.Models;
+using Application.Models.Ynab;
+using Mediator;
+
+namespace Application.Queries.Core.Ynab;
+
+public class GetYnabSyncEventsQueryHandler(IYnabSyncEventService ynabSyncEventService)
+	: IRequestHandler<GetYnabSyncEventsQuery, PagedResult<YnabSyncEventDto>>
+{
+	public async ValueTask<PagedResult<YnabSyncEventDto>> Handle(GetYnabSyncEventsQuery request, CancellationToken cancellationToken)
+	{
+		return await ynabSyncEventService.GetRecentAsync(
+			request.Offset,
+			request.Limit,
+			request.Sort,
+			request.Success,
+			request.DateFrom,
+			request.DateTo,
+			cancellationToken);
+	}
+}

--- a/src/Common/GlobalEnums.cs
+++ b/src/Common/GlobalEnums.cs
@@ -43,3 +43,9 @@ public enum YnabSyncStatus
 	Synced,
 	Failed
 }
+
+public enum YnabSyncEventType
+{
+	Push,
+	Validate
+}

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -70,6 +70,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 	public virtual DbSet<YnabAccountMappingEntity> YnabAccountMappings { get; set; } = null!;
 	public virtual DbSet<YnabCategoryMappingEntity> YnabCategoryMappings { get; set; } = null!;
 	public virtual DbSet<YnabServerKnowledgeEntity> YnabServerKnowledge { get; set; } = null!;
+	public virtual DbSet<YnabSyncEventEntity> YnabSyncEvents { get; set; } = null!;
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
@@ -324,7 +325,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
 	private List<AuditEntry> CollectAuditEntries()
 	{
-		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity), typeof(SeedHistoryEntry), typeof(YnabSyncRecordEntity), typeof(YnabSelectedBudgetEntity), typeof(YnabAccountMappingEntity), typeof(YnabCategoryMappingEntity), typeof(YnabServerKnowledgeEntity), typeof(DistinctDescriptionEntity), typeof(ItemSimilarityEdgeEntity)];
+		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity), typeof(SeedHistoryEntry), typeof(YnabSyncRecordEntity), typeof(YnabSelectedBudgetEntity), typeof(YnabAccountMappingEntity), typeof(YnabCategoryMappingEntity), typeof(YnabServerKnowledgeEntity), typeof(YnabSyncEventEntity), typeof(DistinctDescriptionEntity), typeof(ItemSimilarityEdgeEntity)];
 		List<AuditEntry> auditEntries = [];
 		DateTimeOffset now = DateTimeOffset.UtcNow;
 

--- a/src/Infrastructure/Configurations/YnabSyncEventEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/YnabSyncEventEntityConfiguration.cs
@@ -1,0 +1,24 @@
+using Infrastructure.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Configurations;
+
+public class YnabSyncEventEntityConfiguration : IEntityTypeConfiguration<YnabSyncEventEntity>
+{
+	public void Configure(EntityTypeBuilder<YnabSyncEventEntity> builder)
+	{
+		builder.ToTable("YnabSyncEvents", "ynab");
+
+		builder.HasKey(e => e.Id);
+
+		builder.Property(e => e.Id)
+			.IsRequired()
+			.ValueGeneratedOnAdd();
+
+		// Primary access pattern: a user's most-recent events first. Descending on OccurredAt
+		// so the paginated activity feed reads straight off the index.
+		builder.HasIndex(e => new { e.UserId, e.OccurredAt })
+			.IsDescending(false, true);
+	}
+}

--- a/src/Infrastructure/Entities/Core/YnabSyncEventEntity.cs
+++ b/src/Infrastructure/Entities/Core/YnabSyncEventEntity.cs
@@ -1,0 +1,23 @@
+using Common;
+
+namespace Infrastructure.Entities.Core;
+
+/// <summary>
+/// Append-only log of YNAB integration attempts (pushes and connection validations).
+/// One row is written per attempt so the /ynab status page can report health and recent
+/// activity. Not soft-deletable and not audited (excluded in
+/// <see cref="ApplicationDbContext.CollectAuditEntries"/>).
+/// </summary>
+public class YnabSyncEventEntity
+{
+	public Guid Id { get; set; }
+	public string? UserId { get; set; }
+	public DateTimeOffset OccurredAt { get; set; }
+	public YnabSyncEventType EventType { get; set; }
+	public Guid? ReceiptId { get; set; }
+	public Guid? TransactionId { get; set; }
+	public int? HttpStatus { get; set; }
+	public bool Success { get; set; }
+	public string? ErrorMessage { get; set; }
+	public string? RequestId { get; set; }
+}

--- a/src/Infrastructure/Migrations/20260701120254_AddYnabSyncEvent.Designer.cs
+++ b/src/Infrastructure/Migrations/20260701120254_AddYnabSyncEvent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701120254_AddYnabSyncEvent")]
+    partial class AddYnabSyncEvent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260701120254_AddYnabSyncEvent.cs
+++ b/src/Infrastructure/Migrations/20260701120254_AddYnabSyncEvent.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddYnabSyncEvent : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.CreateTable(
+			name: "YnabSyncEvents",
+			schema: "ynab",
+			columns: table => new
+			{
+				Id = table.Column<Guid>(type: "uuid", nullable: false),
+				UserId = table.Column<string>(type: "text", nullable: true),
+				OccurredAt = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false),
+				EventType = table.Column<string>(type: "text", nullable: false),
+				ReceiptId = table.Column<Guid>(type: "uuid", nullable: true),
+				TransactionId = table.Column<Guid>(type: "uuid", nullable: true),
+				HttpStatus = table.Column<int>(type: "integer", nullable: true),
+				Success = table.Column<bool>(type: "boolean", nullable: false),
+				ErrorMessage = table.Column<string>(type: "text", nullable: true),
+				RequestId = table.Column<string>(type: "text", nullable: true)
+			},
+			constraints: table =>
+			{
+				table.PrimaryKey("PK_YnabSyncEvents", x => x.Id);
+			});
+
+		migrationBuilder.CreateIndex(
+			name: "IX_YnabSyncEvents_UserId_OccurredAt",
+			schema: "ynab",
+			table: "YnabSyncEvents",
+			columns: new[] { "UserId", "OccurredAt" },
+			descending: new[] { false, true });
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropTable(
+			name: "YnabSyncEvents",
+			schema: "ynab");
+	}
+}

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -164,7 +164,15 @@ public static class InfrastructureService
 			.AddScoped<IYnabCategoryMappingService, YnabCategoryMappingService>()
 			.AddScoped<IYnabMemoSyncService, YnabMemoSyncService>()
 			.AddScoped<IYnabServerKnowledgeRepository, YnabServerKnowledgeRepository>()
+			.AddScoped<IYnabResponseContext, YnabResponseContext>()
 			.AddSingleton<IYnabSplitCalculator, YnabSplitCalculator>();
+
+		// Append-only YNAB sync-event log (RECEIPTS-737). TimeProvider is optional in DI, so fall
+		// back to the system clock like YnabRateLimitTracker does.
+		services.AddScoped<IYnabSyncEventService>(sp => new YnabSyncEventService(
+			sp.GetRequiredService<IDbContextFactory<ApplicationDbContext>>(),
+			sp.GetRequiredService<ICurrentUserAccessor>(),
+			sp.GetService<TimeProvider>() ?? TimeProvider.System));
 
 		services.AddMemoryCache();
 

--- a/src/Infrastructure/Services/YnabApiClient.cs
+++ b/src/Infrastructure/Services/YnabApiClient.cs
@@ -18,6 +18,7 @@ public class YnabApiClient(
 	IMemoryCache memoryCache,
 	IConfiguration configuration,
 	IYnabRateLimitTracker rateLimitTracker,
+	IYnabResponseContext responseContext,
 	ILogger<YnabApiClient> logger) : IYnabApiClient
 {
 	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
@@ -279,6 +280,7 @@ public class YnabApiClient(
 
 		using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
 		rateLimitTracker.RecordRequest();
+		CaptureResponseMetadata(response);
 		await EnsureSuccessAsync(response, cancellationToken);
 
 		T result = await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken)
@@ -295,6 +297,7 @@ public class YnabApiClient(
 
 		using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
 		rateLimitTracker.RecordRequest();
+		CaptureResponseMetadata(response);
 		await EnsureSuccessAsync(response, cancellationToken);
 
 		TResponse result = await response.Content.ReadFromJsonAsync<TResponse>(JsonOptions, cancellationToken)
@@ -311,7 +314,30 @@ public class YnabApiClient(
 
 		using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
 		rateLimitTracker.RecordRequest();
+		CaptureResponseMetadata(response);
 		await EnsureSuccessAsync(response, cancellationToken);
+	}
+
+	// Parse YNAB's X-Rate-Limit ("used/limit") into the tracker and record status + request id
+	// (when present) for the current request scope, so callers can attach them to a YnabSyncEvent.
+	private void CaptureResponseMetadata(HttpResponseMessage response)
+	{
+		if (response.Headers.TryGetValues("X-Rate-Limit", out IEnumerable<string>? rateLimitValues))
+		{
+			string[]? parts = rateLimitValues.FirstOrDefault()?.Split('/', 2);
+			if (parts is { Length: 2 }
+				&& int.TryParse(parts[0], out int used)
+				&& int.TryParse(parts[1], out int limit))
+			{
+				rateLimitTracker.RecordServerRateLimit(used, limit);
+			}
+		}
+
+		string? requestId = response.Headers.TryGetValues("X-Request-Id", out IEnumerable<string>? requestIdValues)
+			? requestIdValues.FirstOrDefault()
+			: null;
+
+		responseContext.Record((int)response.StatusCode, requestId);
 	}
 
 	private void ApplyAuth(HttpRequestMessage request)

--- a/src/Infrastructure/Services/YnabRateLimitTracker.cs
+++ b/src/Infrastructure/Services/YnabRateLimitTracker.cs
@@ -53,22 +53,7 @@ public class YnabRateLimitTracker : IYnabRateLimitTracker
 		{
 			PruneExpired();
 
-			int max = _options.RateLimitMaxRequests;
-			int requestsUsed = _requestTimestamps.Count;
-
-			// Prefer YNAB's authoritative header counts while the snapshot is still within the
-			// rate-limit window; fall back to the in-process sliding-window estimate otherwise.
-			bool serverFresh = _serverObservedAt is { } observed
-				&& _serverUsed is { } serverUsed
-				&& _serverLimit is { } serverLimit
-				&& observed >= _timeProvider.GetUtcNow().AddSeconds(-_options.RateLimitWindowSeconds);
-
-			if (serverFresh)
-			{
-				max = _serverLimit!.Value;
-				requestsUsed = _serverUsed!.Value;
-			}
-
+			(int requestsUsed, int max) = EffectiveUsage();
 			int remaining = Math.Max(0, max - requestsUsed);
 
 			DateTimeOffset? windowResetAt = null;
@@ -94,9 +79,24 @@ public class YnabRateLimitTracker : IYnabRateLimitTracker
 		lock (_lock)
 		{
 			PruneExpired();
-			int requestsUsed = _requestTimestamps.Count;
-			return requestsUsed + count <= _options.RateLimitMaxRequests;
+			(int requestsUsed, int max) = EffectiveUsage();
+			return requestsUsed + count <= max;
 		}
+	}
+
+	// Effective (used, max): prefers YNAB's authoritative X-Rate-Limit snapshot while it is still
+	// within the rate-limit window, otherwise the in-process sliding-window estimate. So GetStatus
+	// and CanMakeRequests always agree on remaining capacity. Must be called under _lock.
+	private (int Used, int Max) EffectiveUsage()
+	{
+		bool serverFresh = _serverObservedAt is { } observed
+			&& _serverUsed is { } serverUsed
+			&& _serverLimit is { } serverLimit
+			&& observed >= _timeProvider.GetUtcNow().AddSeconds(-_options.RateLimitWindowSeconds);
+
+		return serverFresh
+			? (_serverUsed!.Value, _serverLimit!.Value)
+			: (_requestTimestamps.Count, _options.RateLimitMaxRequests);
 	}
 
 	private void PruneExpired()

--- a/src/Infrastructure/Services/YnabRateLimitTracker.cs
+++ b/src/Infrastructure/Services/YnabRateLimitTracker.cs
@@ -11,6 +11,12 @@ public class YnabRateLimitTracker : IYnabRateLimitTracker
 	private readonly YnabClientOptions _options;
 	private readonly TimeProvider _timeProvider;
 
+	// Latest authoritative counts parsed from YNAB's X-Rate-Limit header. Preferred over the
+	// in-process estimate while still within the rate-limit window.
+	private int? _serverUsed;
+	private int? _serverLimit;
+	private DateTimeOffset? _serverObservedAt;
+
 	public YnabRateLimitTracker(YnabClientOptions options, TimeProvider timeProvider)
 	{
 		_options = options;
@@ -26,14 +32,44 @@ public class YnabRateLimitTracker : IYnabRateLimitTracker
 		}
 	}
 
+	public void RecordServerRateLimit(int used, int limit)
+	{
+		if (limit <= 0)
+		{
+			return;
+		}
+
+		lock (_lock)
+		{
+			_serverUsed = Math.Max(0, used);
+			_serverLimit = limit;
+			_serverObservedAt = _timeProvider.GetUtcNow();
+		}
+	}
+
 	public YnabRateLimitStatus GetStatus()
 	{
 		lock (_lock)
 		{
 			PruneExpired();
 
+			int max = _options.RateLimitMaxRequests;
 			int requestsUsed = _requestTimestamps.Count;
-			int remaining = Math.Max(0, _options.RateLimitMaxRequests - requestsUsed);
+
+			// Prefer YNAB's authoritative header counts while the snapshot is still within the
+			// rate-limit window; fall back to the in-process sliding-window estimate otherwise.
+			bool serverFresh = _serverObservedAt is { } observed
+				&& _serverUsed is { } serverUsed
+				&& _serverLimit is { } serverLimit
+				&& observed >= _timeProvider.GetUtcNow().AddSeconds(-_options.RateLimitWindowSeconds);
+
+			if (serverFresh)
+			{
+				max = _serverLimit!.Value;
+				requestsUsed = _serverUsed!.Value;
+			}
+
+			int remaining = Math.Max(0, max - requestsUsed);
 
 			DateTimeOffset? windowResetAt = null;
 			DateTimeOffset? oldestRequestAt = null;
@@ -46,7 +82,7 @@ public class YnabRateLimitTracker : IYnabRateLimitTracker
 
 			return new YnabRateLimitStatus(
 				remaining,
-				_options.RateLimitMaxRequests,
+				max,
 				requestsUsed,
 				windowResetAt,
 				oldestRequestAt);

--- a/src/Infrastructure/Services/YnabResponseContext.cs
+++ b/src/Infrastructure/Services/YnabResponseContext.cs
@@ -1,0 +1,18 @@
+using Application.Interfaces.Services;
+
+namespace Infrastructure.Services;
+
+/// <summary>
+/// Scoped, per-request holder populated by <see cref="YnabApiClient"/> after each call.
+/// </summary>
+public class YnabResponseContext : IYnabResponseContext
+{
+	public int? LastStatusCode { get; private set; }
+	public string? LastRequestId { get; private set; }
+
+	public void Record(int statusCode, string? requestId)
+	{
+		LastStatusCode = statusCode;
+		LastRequestId = requestId;
+	}
+}

--- a/src/Infrastructure/Services/YnabSyncEventService.cs
+++ b/src/Infrastructure/Services/YnabSyncEventService.cs
@@ -1,0 +1,154 @@
+using System.Linq.Expressions;
+using Application.Interfaces.Services;
+using Application.Models;
+using Application.Models.Ynab;
+using Common;
+using Infrastructure.Entities.Core;
+using Infrastructure.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Services;
+
+public class YnabSyncEventService(
+	IDbContextFactory<ApplicationDbContext> contextFactory,
+	ICurrentUserAccessor currentUserAccessor,
+	TimeProvider timeProvider) : IYnabSyncEventService
+{
+	private static readonly Dictionary<string, Expression<Func<YnabSyncEventEntity, object>>> AllowedSortColumns = new(StringComparer.OrdinalIgnoreCase)
+	{
+		["occurredAt"] = e => e.OccurredAt,
+		["eventType"] = e => e.EventType,
+		["success"] = e => e.Success,
+		["httpStatus"] = e => e.HttpStatus!,
+	};
+
+	private static readonly Expression<Func<YnabSyncEventEntity, object>> DefaultSort = e => e.OccurredAt;
+
+	public async Task WriteAsync(
+		YnabSyncEventType eventType,
+		bool success,
+		Guid? receiptId = null,
+		Guid? transactionId = null,
+		int? httpStatus = null,
+		string? errorMessage = null,
+		string? requestId = null,
+		CancellationToken cancellationToken = default)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+		context.YnabSyncEvents.Add(new YnabSyncEventEntity
+		{
+			Id = Guid.NewGuid(),
+			UserId = currentUserAccessor.UserId,
+			OccurredAt = timeProvider.GetUtcNow(),
+			EventType = eventType,
+			ReceiptId = receiptId,
+			TransactionId = transactionId,
+			HttpStatus = httpStatus,
+			Success = success,
+			ErrorMessage = errorMessage,
+			RequestId = requestId,
+		});
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task<PagedResult<YnabSyncEventDto>> GetRecentAsync(
+		int offset,
+		int limit,
+		SortParams sort,
+		bool? success = null,
+		DateTimeOffset? dateFrom = null,
+		DateTimeOffset? dateTo = null,
+		CancellationToken cancellationToken = default)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		IQueryable<YnabSyncEventEntity> query = context.YnabSyncEvents.AsQueryable();
+
+		if (success.HasValue)
+		{
+			query = query.Where(e => e.Success == success.Value);
+		}
+
+		if (dateFrom.HasValue)
+		{
+			query = query.Where(e => e.OccurredAt >= dateFrom.Value);
+		}
+
+		if (dateTo.HasValue)
+		{
+			// Include the entire end day by moving to the start of the next day.
+			DateTimeOffset endOfDay = new(dateTo.Value.Date.AddDays(1), dateTo.Value.Offset);
+			query = query.Where(e => e.OccurredAt < endOfDay);
+		}
+
+		int total = await query.CountAsync(cancellationToken);
+
+		List<YnabSyncEventDto> data = await query
+			.ApplySort(sort, AllowedSortColumns, DefaultSort, defaultDescending: true)
+			.Skip(offset)
+			.Take(limit)
+			.Select(e => ToDto(e))
+			.ToListAsync(cancellationToken);
+
+		return new PagedResult<YnabSyncEventDto>(data, total, offset, limit);
+	}
+
+	public async Task<YnabStatus> GetStatusAsync(bool isConfigured, CancellationToken cancellationToken = default)
+	{
+		await using ApplicationDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+		DateTimeOffset now = timeProvider.GetUtcNow();
+		DateTimeOffset since24h = now.AddHours(-24);
+		DateTimeOffset since7d = now.AddDays(-7);
+		DateTimeOffset since30d = now.AddDays(-30);
+
+		IQueryable<YnabSyncEventEntity> pushes = context.YnabSyncEvents
+			.Where(e => e.EventType == YnabSyncEventType.Push);
+
+		DateTimeOffset? lastValidatedAt = await context.YnabSyncEvents
+			.Where(e => e.EventType == YnabSyncEventType.Validate && e.Success)
+			.OrderByDescending(e => e.OccurredAt)
+			.Select(e => (DateTimeOffset?)e.OccurredAt)
+			.FirstOrDefaultAsync(cancellationToken);
+
+		DateTimeOffset? lastPushSuccessAt = await pushes
+			.Where(e => e.Success)
+			.OrderByDescending(e => e.OccurredAt)
+			.Select(e => (DateTimeOffset?)e.OccurredAt)
+			.FirstOrDefaultAsync(cancellationToken);
+
+		DateTimeOffset? lastPushFailureAt = await pushes
+			.Where(e => !e.Success)
+			.OrderByDescending(e => e.OccurredAt)
+			.Select(e => (DateTimeOffset?)e.OccurredAt)
+			.FirstOrDefaultAsync(cancellationToken);
+
+		int count24h = await pushes.CountAsync(e => e.OccurredAt >= since24h, cancellationToken);
+		int count7d = await pushes.CountAsync(e => e.OccurredAt >= since7d, cancellationToken);
+		int count30d = await pushes.CountAsync(e => e.OccurredAt >= since30d, cancellationToken);
+		int success30d = await pushes.CountAsync(e => e.OccurredAt >= since30d && e.Success, cancellationToken);
+		int failure30d = count30d - success30d;
+
+		return new YnabStatus(
+			isConfigured,
+			lastValidatedAt,
+			lastPushSuccessAt,
+			lastPushFailureAt,
+			count24h,
+			count7d,
+			count30d,
+			success30d,
+			failure30d);
+	}
+
+	private static YnabSyncEventDto ToDto(YnabSyncEventEntity e) => new(
+		e.Id,
+		e.OccurredAt,
+		e.EventType.ToString(),
+		e.ReceiptId,
+		e.TransactionId,
+		e.HttpStatus,
+		e.Success,
+		e.ErrorMessage,
+		e.RequestId);
+}

--- a/src/Infrastructure/Services/YnabSyncEventService.cs
+++ b/src/Infrastructure/Services/YnabSyncEventService.cs
@@ -127,7 +127,9 @@ public class YnabSyncEventService(
 		int count7d = await pushes.CountAsync(e => e.OccurredAt >= since7d, cancellationToken);
 		int count30d = await pushes.CountAsync(e => e.OccurredAt >= since30d, cancellationToken);
 		int success30d = await pushes.CountAsync(e => e.OccurredAt >= since30d && e.Success, cancellationToken);
-		int failure30d = count30d - success30d;
+		// Two non-atomic counts: a concurrent insert between them could make success30d exceed
+		// count30d. Clamp so the derived failure count can never surface as negative to the client.
+		int failure30d = Math.Max(0, count30d - success30d);
 
 		return new YnabStatus(
 			isConfigured,

--- a/src/Presentation/API/Controllers/YnabController.cs
+++ b/src/Presentation/API/Controllers/YnabController.cs
@@ -9,6 +9,7 @@ using Application.Commands.Ynab.SelectBudget;
 using Application.Commands.Ynab.StaleMappings;
 using Application.Exceptions;
 using Application.Interfaces.Services;
+using Application.Models;
 using Application.Models.Ynab;
 using Application.Queries.Core.Ynab;
 using Asp.Versioning;
@@ -35,6 +36,65 @@ public class YnabController(IMediator mediator, IYnabApiClient ynabClient, IYnab
 	{
 		YnabConnectionStatus status = await mediator.Send(new GetYnabConnectionStatusQuery(), cancellationToken);
 		return TypedResults.Ok(mapper.ToConnectionStatusResponse(status));
+	}
+
+	[HttpGet("status")]
+	[EndpointSummary("Get YNAB integration status and sync stats")]
+	[EndpointDescription("Returns an aggregate health snapshot: configured flag, last validated/push timestamps, and push counts by window. Derived from the sync-event log; performs no live YNAB call.")]
+	public async Task<Ok<YnabStatusResponse>> GetStatus(CancellationToken cancellationToken)
+	{
+		YnabStatus status = await mediator.Send(new GetYnabStatusQuery(), cancellationToken);
+		return TypedResults.Ok(mapper.ToStatusResponse(status));
+	}
+
+	[HttpGet("events")]
+	[EndpointSummary("Get recent YNAB sync events with optional filtering")]
+	[EndpointDescription("Paginated, filterable feed of YNAB push and validate attempts, most recent first.")]
+	public async Task<Results<Ok<YnabSyncEventListResponse>, BadRequest<string>>> GetEvents(
+		[FromQuery] int offset = 0,
+		[FromQuery] int limit = 50,
+		[FromQuery] string? sortBy = null,
+		[FromQuery] string? sortDirection = null,
+		[FromQuery] string? outcome = null,
+		[FromQuery] DateTimeOffset? dateFrom = null,
+		[FromQuery] DateTimeOffset? dateTo = null,
+		CancellationToken cancellationToken = default)
+	{
+		if (offset < 0)
+		{
+			return TypedResults.BadRequest("offset must be non-negative");
+		}
+
+		if (limit <= 0 || limit > 500)
+		{
+			return TypedResults.BadRequest("limit must be between 1 and 500");
+		}
+
+		if (!SortableColumns.IsValidDirection(sortDirection))
+		{
+			return TypedResults.BadRequest($"Invalid sortDirection '{sortDirection}'. Allowed: asc, desc");
+		}
+
+		bool? success;
+		switch (outcome?.ToLowerInvariant())
+		{
+			case null or "":
+				success = null;
+				break;
+			case "success":
+				success = true;
+				break;
+			case "failure":
+				success = false;
+				break;
+			default:
+				return TypedResults.BadRequest("outcome must be 'success' or 'failure'");
+		}
+
+		SortParams sort = new(sortBy, sortDirection);
+		PagedResult<YnabSyncEventDto> result = await mediator.Send(
+			new GetYnabSyncEventsQuery(offset, limit, sort, success, dateFrom, dateTo), cancellationToken);
+		return TypedResults.Ok(mapper.ToSyncEventListResponse(result));
 	}
 
 	[HttpGet("budgets")]

--- a/src/Presentation/API/Mapping/Core/YnabMapper.cs
+++ b/src/Presentation/API/Mapping/Core/YnabMapper.cs
@@ -1,5 +1,6 @@
 using API.Generated.Dtos;
 using Application.Commands.Ynab.PushTransactions;
+using Application.Models;
 using Application.Models.Ynab;
 using Riok.Mapperly.Abstractions;
 using AppYnabMemoSyncOutcome = Application.Models.Ynab.YnabMemoSyncOutcome;
@@ -323,6 +324,52 @@ public partial class YnabMapper
 			RequestsUsed = source.RequestsUsed,
 			WindowResetAt = source.WindowResetAt,
 			OldestRequestAt = source.OldestRequestAt,
+		};
+	}
+
+	[MapperIgnoreTarget(nameof(YnabStatusResponse.AdditionalProperties))]
+	public YnabStatusResponse ToStatusResponse(YnabStatus source)
+	{
+		return new YnabStatusResponse
+		{
+			IsConfigured = source.IsConfigured,
+			LastValidatedAt = source.LastValidatedAt,
+			LastPushSuccessAt = source.LastPushSuccessAt,
+			LastPushFailureAt = source.LastPushFailureAt,
+			PushCountLast24h = source.PushCountLast24h,
+			PushCountLast7d = source.PushCountLast7d,
+			PushCountLast30d = source.PushCountLast30d,
+			PushSuccessLast30d = source.PushSuccessLast30d,
+			PushFailureLast30d = source.PushFailureLast30d,
+		};
+	}
+
+	[MapperIgnoreTarget(nameof(YnabSyncEventResponse.AdditionalProperties))]
+	public YnabSyncEventResponse ToSyncEventResponse(YnabSyncEventDto source)
+	{
+		return new YnabSyncEventResponse
+		{
+			Id = source.Id,
+			OccurredAt = source.OccurredAt,
+			EventType = source.EventType,
+			ReceiptId = source.ReceiptId,
+			TransactionId = source.TransactionId,
+			HttpStatus = source.HttpStatus,
+			Success = source.Success,
+			ErrorMessage = source.ErrorMessage,
+			RequestId = source.RequestId,
+		};
+	}
+
+	[MapperIgnoreTarget(nameof(YnabSyncEventListResponse.AdditionalProperties))]
+	public YnabSyncEventListResponse ToSyncEventListResponse(PagedResult<YnabSyncEventDto> source)
+	{
+		return new YnabSyncEventListResponse
+		{
+			Data = source.Data.Select(ToSyncEventResponse).ToList(),
+			Total = source.Total,
+			Offset = source.Offset,
+			Limit = source.Limit,
 		};
 	}
 }

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -22,6 +22,7 @@ import RecycleBin from "@/pages/RecycleBin";
 import BackupRestore from "@/pages/BackupRestore";
 import NewReceipt from "@/pages/new-receipt/NewReceiptPage";
 import YnabSettings from "@/pages/settings/YnabSettings";
+import Ynab from "@/pages/Ynab";
 import Settings from "@/pages/Settings";
 import NotFound from "@/pages/NotFound";
 import ServerError from "@/pages/ServerError";
@@ -59,6 +60,7 @@ export const routeConfig = [
           { path: "/security", element: <SecurityLog /> },
           { path: "/settings", element: <Settings /> },
           { path: "/settings/ynab", element: <YnabSettings /> },
+          { path: "/ynab", element: <Ynab /> },
           {
             path: "/audit",
             element: (

--- a/src/client/src/components/Layout.tsx
+++ b/src/client/src/components/Layout.tsx
@@ -81,6 +81,7 @@ const NAV: readonly NavSection[] = [
       { to: "/subcategories", label: "Subcategories", icon: Icon.Tag },
       { to: "/item-templates", label: "Templates", icon: Icon.Sparkle },
       { to: "/settings/ynab", label: "YNAB", icon: Icon.Link },
+      { to: "/ynab", label: "YNAB Status", icon: Icon.Chart },
     ],
   },
   {

--- a/src/client/src/components/YnabEventsTable.tsx
+++ b/src/client/src/components/YnabEventsTable.tsx
@@ -1,0 +1,135 @@
+import { Link } from "react-router";
+import { format } from "date-fns";
+import type { YnabSyncEventResponse } from "@/hooks/useYnabEvents";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { SortableTableHead } from "@/components/SortableTableHead";
+
+interface YnabEventsTableProps {
+  events: YnabSyncEventResponse[];
+  isLoading: boolean;
+  sortBy?: string | null;
+  sortDirection?: "asc" | "desc";
+  onToggleSort?: (column: string) => void;
+}
+
+function formatTimestamp(iso: string): string {
+  return format(new Date(iso), "MMM d, HH:mm:ss");
+}
+
+export function YnabEventsTable({
+  events,
+  isLoading,
+  sortBy = null,
+  sortDirection = "desc",
+  onToggleSort,
+}: YnabEventsTableProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="py-12 text-center text-muted-foreground">
+        No YNAB activity yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {onToggleSort ? (
+              <>
+                <SortableTableHead
+                  column="occurredAt"
+                  label="Time"
+                  currentSortBy={sortBy}
+                  currentSortDirection={sortDirection}
+                  onToggleSort={onToggleSort}
+                />
+                <SortableTableHead
+                  column="eventType"
+                  label="Type"
+                  currentSortBy={sortBy}
+                  currentSortDirection={sortDirection}
+                  onToggleSort={onToggleSort}
+                />
+                <SortableTableHead
+                  column="success"
+                  label="Outcome"
+                  currentSortBy={sortBy}
+                  currentSortDirection={sortDirection}
+                  onToggleSort={onToggleSort}
+                />
+              </>
+            ) : (
+              <>
+                <TableHead>Time</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Outcome</TableHead>
+              </>
+            )}
+            <TableHead>HTTP</TableHead>
+            <TableHead>Receipt</TableHead>
+            <TableHead>Detail</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {events.map((e) => (
+            <TableRow key={e.id}>
+              <TableCell className="text-xs whitespace-nowrap">
+                {formatTimestamp(e.occurredAt)}
+              </TableCell>
+              <TableCell>{e.eventType}</TableCell>
+              <TableCell>
+                {e.success ? (
+                  <Badge className="bg-green-100 text-green-800 hover:bg-green-100 border-green-300">
+                    Success
+                  </Badge>
+                ) : (
+                  <Badge variant="destructive">Failure</Badge>
+                )}
+              </TableCell>
+              <TableCell className="text-xs">{e.httpStatus ?? "—"}</TableCell>
+              <TableCell className="text-xs">
+                {e.receiptId ? (
+                  <Link
+                    to={`/receipts/${e.receiptId}`}
+                    className="text-primary hover:underline font-mono"
+                  >
+                    {e.receiptId.slice(0, 8)}
+                  </Link>
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </TableCell>
+              <TableCell
+                className="text-xs text-muted-foreground max-w-md truncate"
+                title={e.errorMessage ?? undefined}
+              >
+                {e.errorMessage ?? "—"}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -1953,6 +1953,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/ynab/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get YNAB integration status and sync stats
+         * @description Returns an aggregate health snapshot for the YNAB status page — whether YNAB is configured, when it was last validated, last push success/failure timestamps, and push counts by window. Derived from the sync-event log; does not perform a live YNAB call.
+         */
+        get: operations["GetYnabStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ynab/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get recent YNAB sync events with optional filtering
+         * @description Paginated, filterable feed of YNAB push and validate attempts, most recent first.
+         */
+        get: operations["GetYnabSyncEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/ynab/budgets": {
         parameters: {
             query?: never;
@@ -3539,6 +3579,61 @@ export interface components {
              * @description The timestamp of the last successful YNAB sync operation, or null if no syncs have completed.
              */
             lastSuccessfulSyncUtc?: string | null;
+        };
+        YnabStatusResponse: {
+            /** @description Whether the YNAB personal access token is set. */
+            isConfigured: boolean;
+            /**
+             * Format: date-time
+             * @description Timestamp of the last successful connection validation, or null.
+             */
+            lastValidatedAt?: string | null;
+            /**
+             * Format: date-time
+             * @description Timestamp of the last successful push, or null.
+             */
+            lastPushSuccessAt?: string | null;
+            /**
+             * Format: date-time
+             * @description Timestamp of the last failed push, or null.
+             */
+            lastPushFailureAt?: string | null;
+            /** Format: int32 */
+            pushCountLast24h: number;
+            /** Format: int32 */
+            pushCountLast7d: number;
+            /** Format: int32 */
+            pushCountLast30d: number;
+            /** Format: int32 */
+            pushSuccessLast30d: number;
+            /** Format: int32 */
+            pushFailureLast30d: number;
+        };
+        YnabSyncEventResponse: {
+            /** Format: uuid */
+            id: string;
+            /** Format: date-time */
+            occurredAt: string;
+            /** @description The kind of attempt (Push or Validate). */
+            eventType: string;
+            /** Format: uuid */
+            receiptId?: string | null;
+            /** Format: uuid */
+            transactionId?: string | null;
+            /** Format: int32 */
+            httpStatus?: number | null;
+            success: boolean;
+            errorMessage?: string | null;
+            requestId?: string | null;
+        };
+        YnabSyncEventListResponse: {
+            data: components["schemas"]["YnabSyncEventResponse"][];
+            /** Format: int32 */
+            total: number;
+            /** Format: int32 */
+            offset: number;
+            /** Format: int32 */
+            limit: number;
         };
         YnabBudgetSettingsResponse: {
             selectedBudgetId?: string | null;
@@ -8185,6 +8280,67 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["YnabConnectionStatusResponse"];
+                };
+            };
+        };
+    };
+    GetYnabStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["YnabStatusResponse"];
+                };
+            };
+        };
+    };
+    GetYnabSyncEvents: {
+        parameters: {
+            query?: {
+                offset?: components["parameters"]["Offset"];
+                limit?: components["parameters"]["Limit"];
+                /** @description Column name to sort by. Allowed values depend on the entity type. */
+                sortBy?: components["parameters"]["SortBy"];
+                sortDirection?: components["parameters"]["SortDirection"];
+                /** @description Filter by outcome (success or failure). */
+                outcome?: "success" | "failure";
+                /** @description Filter events from this date (inclusive). */
+                dateFrom?: string;
+                /** @description Filter events up to this date (inclusive, end of day). */
+                dateTo?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["YnabSyncEventListResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
                 };
             };
         };

--- a/src/client/src/hooks/useYnabEvents.test.ts
+++ b/src/client/src/hooks/useYnabEvents.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+vi.mock("@/lib/api-client", () => ({
+  default: { GET: vi.fn(), POST: vi.fn(), PUT: vi.fn(), DELETE: vi.fn() },
+}));
+
+import client from "@/lib/api-client";
+import { useYnabEvents } from "./useYnabEvents";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useYnabEvents", () => {
+  it("returns paginated data and total, and forwards the outcome filter", async () => {
+    const page = {
+      data: [
+        {
+          id: "1",
+          occurredAt: "2026-06-01T00:00:00Z",
+          eventType: "Push",
+          receiptId: null,
+          transactionId: null,
+          httpStatus: 201,
+          success: true,
+          errorMessage: null,
+          requestId: null,
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    };
+    (client.GET as Mock).mockResolvedValue({ data: page, error: undefined });
+
+    const { result } = renderHook(() => useYnabEvents({ outcome: "success" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.total).toBe(1);
+    expect((client.GET as Mock).mock.calls[0][1].params.query.outcome).toBe("success");
+  });
+
+  it("throws (sets error state) when the API returns an error", async () => {
+    (client.GET as Mock).mockResolvedValue({ data: undefined, error: new Error("boom") });
+
+    const { result } = renderHook(() => useYnabEvents(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/src/client/src/hooks/useYnabEvents.ts
+++ b/src/client/src/hooks/useYnabEvents.ts
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+// Defined inline (matching the generated api.d.ts) — see useYnabStatus for why.
+export type YnabSyncEventResponse = {
+  id: string;
+  occurredAt: string;
+  eventType: string;
+  receiptId?: string | null;
+  transactionId?: string | null;
+  httpStatus?: number | null;
+  success: boolean;
+  errorMessage?: string | null;
+  requestId?: string | null;
+};
+
+type YnabSyncEventListResponse = {
+  data: YnabSyncEventResponse[];
+  total: number;
+  offset: number;
+  limit: number;
+};
+
+export interface YnabEventFilters {
+  offset?: number;
+  limit?: number;
+  sortBy?: string | null;
+  sortDirection?: "asc" | "desc" | null;
+  outcome?: "success" | "failure" | null;
+  dateFrom?: string | null;
+  dateTo?: string | null;
+}
+
+export function useYnabEvents(filters: YnabEventFilters = {}) {
+  const {
+    offset = 0,
+    limit = 50,
+    sortBy,
+    sortDirection,
+    outcome,
+    dateFrom,
+    dateTo,
+  } = filters;
+
+  const query = useQuery({
+    queryKey: [
+      "ynab",
+      "events",
+      offset,
+      limit,
+      sortBy,
+      sortDirection,
+      outcome,
+      dateFrom,
+      dateTo,
+    ],
+    queryFn: async () => {
+      const { data, error } = await client.GET("/api/ynab/events" as never, {
+        params: {
+          query: {
+            offset,
+            limit,
+            sortBy: sortBy ?? undefined,
+            sortDirection: sortDirection ?? undefined,
+            outcome: outcome ?? undefined,
+            dateFrom: dateFrom ?? undefined,
+            dateTo: dateTo ?? undefined,
+          },
+        },
+      } as never);
+      if (error) throw error;
+      return data as unknown as YnabSyncEventListResponse;
+    },
+  });
+
+  return useMemo(
+    () => ({
+      ...query,
+      data: query.data?.data ?? [],
+      total: Number(query.data?.total ?? 0),
+    }),
+    [query],
+  );
+}

--- a/src/client/src/hooks/useYnabStatus.ts
+++ b/src/client/src/hooks/useYnabStatus.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import client from "@/lib/api-client";
+
+// Defined inline (matching the generated api.d.ts) — the YNAB paths exceed
+// TypeScript's type-resolution depth when indexed via the generated `paths` union.
+export type YnabStatusResponse = {
+  isConfigured: boolean;
+  lastValidatedAt?: string | null;
+  lastPushSuccessAt?: string | null;
+  lastPushFailureAt?: string | null;
+  pushCountLast24h: number;
+  pushCountLast7d: number;
+  pushCountLast30d: number;
+  pushSuccessLast30d: number;
+  pushFailureLast30d: number;
+};
+
+export function useYnabStatus() {
+  return useQuery({
+    queryKey: ["ynab", "status"],
+    refetchInterval: 30_000, // live-ish health snapshot; cheap (no live YNAB call server-side)
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/api/ynab/status" as never,
+        {} as never,
+      );
+      if (error) throw error;
+      return data as unknown as YnabStatusResponse;
+    },
+  });
+}

--- a/src/client/src/pages/Ynab.test.tsx
+++ b/src/client/src/pages/Ynab.test.tsx
@@ -1,0 +1,105 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/test-utils";
+import "@/test/setup-combobox-polyfills";
+import Ynab from "./Ynab";
+
+vi.mock("@/hooks/usePageTitle", () => ({ usePageTitle: vi.fn() }));
+
+vi.mock("@/hooks/useYnab", () => ({
+  useYnabConnectionStatus: vi.fn(),
+  useYnabRateLimitStatus: vi.fn(() => ({
+    rateLimitStatus: {
+      requestsUsed: 10,
+      maxRequests: 200,
+      remainingRequests: 190,
+      windowResetAt: null,
+      oldestRequestAt: null,
+    },
+  })),
+}));
+
+vi.mock("@/hooks/useYnabStatus", () => ({
+  useYnabStatus: vi.fn(() => ({
+    data: {
+      isConfigured: true,
+      lastValidatedAt: "2026-06-01T00:00:00Z",
+      lastPushSuccessAt: "2026-06-01T00:00:00Z",
+      lastPushFailureAt: null,
+      pushCountLast24h: 1,
+      pushCountLast7d: 2,
+      pushCountLast30d: 3,
+      pushSuccessLast30d: 3,
+      pushFailureLast30d: 0,
+    },
+  })),
+}));
+
+vi.mock("@/hooks/useYnabEvents", () => ({
+  useYnabEvents: vi.fn(() => ({ data: [], total: 0, isLoading: false })),
+}));
+
+vi.mock("@/hooks/useServerPagination", () => ({
+  useServerPagination: vi.fn(() => ({
+    offset: 0,
+    limit: 50,
+    currentPage: 1,
+    pageSize: 50,
+    totalPages: () => 1,
+    setPage: vi.fn(),
+    setPageSize: vi.fn(),
+    resetPage: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/useServerSort", () => ({
+  useServerSort: vi.fn(() => ({
+    sortBy: "occurredAt",
+    sortDirection: "desc",
+    toggleSort: vi.fn(),
+  })),
+}));
+
+vi.mock("@/components/YnabEventsTable", () => ({
+  YnabEventsTable: () => <div data-testid="ynab-events-table" />,
+}));
+
+vi.mock("@/components/Pagination", () => ({
+  Pagination: () => <div data-testid="pagination" />,
+}));
+
+import { useYnabConnectionStatus } from "@/hooks/useYnab";
+
+const CONFIGURED = {
+  isConfigured: true,
+  isConnected: true,
+  lastSuccessfulSyncUtc: "2026-06-01T00:00:00Z",
+  isLoading: false,
+};
+
+describe("Ynab", () => {
+  it("renders the health grid and activity table when configured", () => {
+    vi.mocked(useYnabConnectionStatus).mockReturnValue(CONFIGURED as never);
+
+    renderWithProviders(<Ynab />);
+
+    expect(screen.getByRole("heading", { name: /ynab status/i })).toBeInTheDocument();
+    expect(screen.getByText(/Connected/i)).toBeInTheDocument();
+    expect(screen.getByTestId("ynab-events-table")).toBeInTheDocument();
+    // Rate-limit progress bar is present and labelled.
+    expect(screen.getByRole("progressbar", { name: /rate limit/i })).toBeInTheDocument();
+  });
+
+  it("shows the not-configured empty state when no PAT is set", () => {
+    vi.mocked(useYnabConnectionStatus).mockReturnValue({
+      isConfigured: false,
+      isConnected: false,
+      lastSuccessfulSyncUtc: null,
+      isLoading: false,
+    } as never);
+
+    renderWithProviders(<Ynab />);
+
+    expect(screen.getByText(/not configured/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("ynab-events-table")).not.toBeInTheDocument();
+  });
+});

--- a/src/client/src/pages/Ynab.tsx
+++ b/src/client/src/pages/Ynab.tsx
@@ -1,0 +1,272 @@
+import { useCallback, useMemo, useState } from "react";
+import { Link } from "react-router";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { useYnabConnectionStatus, useYnabRateLimitStatus } from "@/hooks/useYnab";
+import { useYnabStatus } from "@/hooks/useYnabStatus";
+import { useYnabEvents } from "@/hooks/useYnabEvents";
+import { useServerPagination } from "@/hooks/useServerPagination";
+import { useServerSort } from "@/hooks/useServerSort";
+import { YnabEventsTable } from "@/components/YnabEventsTable";
+import { Pagination } from "@/components/Pagination";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
+import { Combobox } from "@/components/ui/combobox";
+import { EmptyState, Icon, PageHead } from "@/components/primitives";
+
+function formatRelativeTime(dateStr: string): string {
+  const diffMs = Date.now() - new Date(dateStr).getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHrs = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHrs < 24) return `${diffHrs}h ago`;
+  return `${diffDays}d ago`;
+}
+
+const OUTCOME_OPTIONS = [
+  { value: "all", label: "All outcomes" },
+  { value: "success", label: "Success" },
+  { value: "failure", label: "Failure" },
+];
+
+export default function Ynab() {
+  usePageTitle("YNAB Status");
+
+  const {
+    isConfigured,
+    isConnected,
+    lastSuccessfulSyncUtc,
+    isLoading: connectionLoading,
+  } = useYnabConnectionStatus();
+  const { rateLimitStatus } = useYnabRateLimitStatus(isConfigured);
+  const { data: status } = useYnabStatus();
+
+  const [outcome, setOutcome] = useState<"all" | "success" | "failure">("all");
+
+  const { sortBy, sortDirection, toggleSort } = useServerSort({
+    defaultSortBy: "occurredAt",
+    defaultSortDirection: "desc",
+  });
+  const pagination = useServerPagination({ sortBy, sortDirection });
+
+  const handleOutcomeChange = useCallback(
+    (value: string) => {
+      setOutcome(value as "all" | "success" | "failure");
+      pagination.resetPage();
+    },
+    [pagination],
+  );
+
+  const { data: events, total, isLoading } = useYnabEvents({
+    offset: pagination.offset,
+    limit: pagination.limit,
+    sortBy,
+    sortDirection,
+    outcome: outcome !== "all" ? outcome : null,
+  });
+
+  const successRate = useMemo(() => {
+    if (!status || status.pushCountLast30d === 0) return null;
+    return Math.round((status.pushSuccessLast30d / status.pushCountLast30d) * 100);
+  }, [status]);
+
+  if (!connectionLoading && !isConfigured) {
+    return (
+      <>
+        <PageHead title="YNAB status" sub="Integration health and recent sync activity" />
+        <EmptyState
+          icon={Icon.Link}
+          title="YNAB is not configured"
+          body={
+            <>
+              Set the <code>YNAB_PAT</code> environment variable to enable the
+              integration, then choose a budget in{" "}
+              <Link to="/settings/ynab" className="text-primary hover:underline">
+                YNAB settings
+              </Link>
+              .
+            </>
+          }
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <PageHead title="YNAB status" sub="Integration health and recent sync activity" />
+      <div className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-3">
+          {/* Connection */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Connection</CardTitle>
+              <CardDescription>Token status and last sync.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {connectionLoading ? (
+                <div className="flex items-center gap-2">
+                  <Spinner className="h-4 w-4" />
+                  <span className="text-sm text-muted-foreground">
+                    Checking connection...
+                  </span>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {isConnected ? (
+                    <Badge className="bg-green-100 text-green-800 hover:bg-green-100 border-green-300">
+                      Connected
+                    </Badge>
+                  ) : (
+                    <Badge variant="destructive">Disconnected</Badge>
+                  )}
+                  <p className="text-sm text-muted-foreground">
+                    {lastSuccessfulSyncUtc
+                      ? `Last sync ${formatRelativeTime(lastSuccessfulSyncUtc)}`
+                      : "No syncs yet"}
+                  </p>
+                  {status?.lastValidatedAt && (
+                    <p className="text-xs text-muted-foreground">
+                      Validated {formatRelativeTime(status.lastValidatedAt)}
+                    </p>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Sync stats */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Push activity</CardTitle>
+              <CardDescription>Transactions pushed to YNAB.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Last 24h / 7d / 30d</span>
+                  <span className="font-medium">
+                    {status?.pushCountLast24h ?? 0} / {status?.pushCountLast7d ?? 0} /{" "}
+                    {status?.pushCountLast30d ?? 0}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Success rate (30d)</span>
+                  <span className="font-medium">
+                    {successRate === null ? "—" : `${successRate}%`}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>
+                    {status?.lastPushSuccessAt
+                      ? `Last success ${formatRelativeTime(status.lastPushSuccessAt)}`
+                      : "No successful pushes"}
+                  </span>
+                </div>
+                {status?.lastPushFailureAt && (
+                  <div className="text-xs text-destructive">
+                    Last failure {formatRelativeTime(status.lastPushFailureAt)}
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Rate limit */}
+          <Card>
+            <CardHeader>
+              <CardTitle>API rate limit</CardTitle>
+              <CardDescription>YNAB allows 200 requests per hour.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {rateLimitStatus ? (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">
+                      {rateLimitStatus.requestsUsed} / {rateLimitStatus.maxRequests} used
+                    </span>
+                    <span className="font-medium">
+                      {rateLimitStatus.remainingRequests} left
+                    </span>
+                  </div>
+                  <div className="h-2 rounded-full bg-muted overflow-hidden">
+                    <div
+                      role="progressbar"
+                      aria-label="YNAB API rate limit usage"
+                      aria-valuenow={rateLimitStatus.requestsUsed}
+                      aria-valuemin={0}
+                      aria-valuemax={rateLimitStatus.maxRequests}
+                      className={`h-full rounded-full transition-all ${
+                        rateLimitStatus.remainingRequests <= 20
+                          ? "bg-destructive"
+                          : rateLimitStatus.remainingRequests <= 50
+                            ? "bg-amber-500"
+                            : "bg-primary"
+                      }`}
+                      style={{
+                        width: `${(rateLimitStatus.requestsUsed / rateLimitStatus.maxRequests) * 100}%`,
+                      }}
+                    />
+                  </div>
+                  {rateLimitStatus.remainingRequests <= 20 && (
+                    <Alert variant="destructive">
+                      <AlertDescription>
+                        API quota is running low. Pushes may be throttled until the
+                        window resets.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </div>
+              ) : (
+                <span className="text-sm text-muted-foreground">
+                  No rate-limit data yet.
+                </span>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h2 className="text-sm font-medium">Recent activity</h2>
+            <Combobox
+              options={OUTCOME_OPTIONS}
+              value={outcome}
+              onValueChange={handleOutcomeChange}
+              placeholder="Outcome"
+              searchPlaceholder="Filter..."
+              className="w-[160px]"
+              aria-label="Filter by outcome"
+            />
+          </div>
+
+          <YnabEventsTable
+            events={events}
+            isLoading={isLoading}
+            sortBy={sortBy}
+            sortDirection={sortDirection}
+            onToggleSort={toggleSort}
+          />
+
+          <Pagination
+            currentPage={pagination.currentPage}
+            totalItems={total}
+            pageSize={pagination.pageSize}
+            totalPages={pagination.totalPages(total)}
+            onPageChange={(page) => pagination.setPage(page, total)}
+            onPageSizeChange={pagination.setPageSize}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactions409ReconcileTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactions409ReconcileTests.cs
@@ -44,7 +44,10 @@ public class PushYnabTransactions409ReconcileTests
 			_budgetSelectionServiceMock.Object,
 			_syncRecordServiceMock.Object,
 			_ynabApiClientMock.Object,
-			_splitCalculatorMock.Object);
+			_splitCalculatorMock.Object,
+			Mock.Of<Application.Interfaces.Services.IYnabSyncEventService>(),
+			Mock.Of<Application.Interfaces.Services.IYnabResponseContext>(),
+			Mock.Of<Microsoft.Extensions.Logging.ILogger<PushYnabTransactionsCommandHandler>>());
 	}
 
 	private void SetupHappyPath()

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsCommandHandlerTests.cs
@@ -22,6 +22,8 @@ public class PushYnabTransactionsCommandHandlerTests
 	private readonly Mock<IYnabSyncRecordService> _syncRecordServiceMock = new();
 	private readonly Mock<IYnabApiClient> _ynabApiClientMock = new();
 	private readonly Mock<IYnabSplitCalculator> _splitCalculatorMock = new();
+	private readonly Mock<IYnabSyncEventService> _ynabSyncEventServiceMock = new();
+	private readonly Mock<IYnabResponseContext> _ynabResponseContextMock = new();
 	private readonly PushYnabTransactionsCommandHandler _handler;
 
 	private readonly Guid _receiptId = Guid.NewGuid();
@@ -42,7 +44,10 @@ public class PushYnabTransactionsCommandHandlerTests
 			_budgetSelectionServiceMock.Object,
 			_syncRecordServiceMock.Object,
 			_ynabApiClientMock.Object,
-			_splitCalculatorMock.Object);
+			_splitCalculatorMock.Object,
+			_ynabSyncEventServiceMock.Object,
+			_ynabResponseContextMock.Object,
+			Mock.Of<Microsoft.Extensions.Logging.ILogger<PushYnabTransactionsCommandHandler>>());
 	}
 
 	private void SetupHappyPath()
@@ -116,6 +121,44 @@ public class PushYnabTransactionsCommandHandlerTests
 		result.PushedTransactions[0].YnabTransactionId.Should().Be("ynab-tx-1");
 		result.PushedTransactions[0].Milliunits.Should().Be(-11000);
 		result.Error.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Handle_HappyPath_WritesPushSuccessEvent()
+	{
+		SetupHappyPath();
+
+		await _handler.Handle(new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		_ynabSyncEventServiceMock.Verify(s => s.WriteAsync(
+			YnabSyncEventType.Push,
+			true,
+			_receiptId,
+			_transactionId,
+			It.IsAny<int?>(),
+			It.IsAny<string?>(),
+			It.IsAny<string?>(),
+			It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PushFails_WritesPushFailureEvent()
+	{
+		SetupHappyPath();
+		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("boom"));
+
+		await _handler.Handle(new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		_ynabSyncEventServiceMock.Verify(s => s.WriteAsync(
+			YnabSyncEventType.Push,
+			false,
+			_receiptId,
+			_transactionId,
+			It.IsAny<int?>(),
+			It.IsAny<string?>(),
+			It.IsAny<string?>(),
+			It.IsAny<CancellationToken>()), Times.Once);
 	}
 
 	[Fact]

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsFailedRetryTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsFailedRetryTests.cs
@@ -43,7 +43,10 @@ public class PushYnabTransactionsFailedRetryTests
 			_budgetSelectionServiceMock.Object,
 			_syncRecordServiceMock.Object,
 			_ynabApiClientMock.Object,
-			_splitCalculatorMock.Object);
+			_splitCalculatorMock.Object,
+			Mock.Of<Application.Interfaces.Services.IYnabSyncEventService>(),
+			Mock.Of<Application.Interfaces.Services.IYnabResponseContext>(),
+			Mock.Of<Microsoft.Extensions.Logging.ILogger<PushYnabTransactionsCommandHandler>>());
 	}
 
 	private void SetupHappyPathPipeline()

--- a/tests/Application.Tests/Queries/Core/Ynab/GetYnabConnectionStatusQueryHandlerTests.cs
+++ b/tests/Application.Tests/Queries/Core/Ynab/GetYnabConnectionStatusQueryHandlerTests.cs
@@ -16,7 +16,12 @@ public class GetYnabConnectionStatusQueryHandlerTests
 	{
 		_ynabClientMock = new Mock<IYnabApiClient>();
 		_syncRecordServiceMock = new Mock<IYnabSyncRecordService>();
-		_handler = new GetYnabConnectionStatusQueryHandler(_ynabClientMock.Object, _syncRecordServiceMock.Object);
+		_handler = new GetYnabConnectionStatusQueryHandler(
+			_ynabClientMock.Object,
+			_syncRecordServiceMock.Object,
+			Mock.Of<Application.Interfaces.Services.IYnabSyncEventService>(),
+			Mock.Of<Application.Interfaces.Services.IYnabResponseContext>(),
+			Mock.Of<Microsoft.Extensions.Logging.ILogger<GetYnabConnectionStatusQueryHandler>>());
 	}
 
 	[Fact]

--- a/tests/Infrastructure.Tests/Services/YnabApiClientFindByImportIdTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabApiClientFindByImportIdTests.cs
@@ -35,7 +35,7 @@ public class YnabApiClientFindByImportIdTests
 			.Build();
 
 		Mock<ILogger<YnabApiClient>> logger = new();
-		return new YnabApiClient(httpClient, cache, configuration, rateLimitTracker, logger.Object);
+		return new YnabApiClient(httpClient, cache, configuration, rateLimitTracker, new YnabResponseContext(), logger.Object);
 	}
 
 	private static HttpMessageHandler CreateHandler(HttpStatusCode statusCode, string content)

--- a/tests/Infrastructure.Tests/Services/YnabApiClientSubTransactionsTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabApiClientSubTransactionsTests.cs
@@ -25,7 +25,7 @@ public class YnabApiClientSubTransactionsTests
 			.Build();
 
 		Mock<ILogger<YnabApiClient>> logger = new();
-		return new YnabApiClient(httpClient, cache, configuration, rateLimitTracker.Object, logger.Object);
+		return new YnabApiClient(httpClient, cache, configuration, rateLimitTracker.Object, new YnabResponseContext(), logger.Object);
 	}
 
 	private static HttpMessageHandler CreateHandler(string json)

--- a/tests/Infrastructure.Tests/Services/YnabApiClientTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabApiClientTests.cs
@@ -38,7 +38,7 @@ public class YnabApiClientTests
 			.Build();
 
 		Mock<ILogger<YnabApiClient>> logger = new();
-		return new YnabApiClient(httpClient, cache, configuration, rateLimitTracker, logger.Object);
+		return new YnabApiClient(httpClient, cache, configuration, rateLimitTracker, new YnabResponseContext(), logger.Object);
 	}
 
 	private static HttpMessageHandler CreateHandler(HttpStatusCode statusCode, string content)

--- a/tests/Infrastructure.Tests/Services/YnabRateLimitTrackerTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabRateLimitTrackerTests.cs
@@ -232,4 +232,41 @@ public class YnabRateLimitTrackerTests
 		YnabRateLimitStatus status = tracker.GetStatus();
 		status.RequestsUsed.Should().Be(threadCount * requestsPerThread);
 	}
+
+	[Fact]
+	public void RecordServerRateLimit_MakesGetStatusAndCanMakeRequestsUseServerCounts()
+	{
+		// Arrange — in-process sees only 1 request, but YNAB reports 195/200 used
+		// (e.g. another consumer of the same PAT).
+		(YnabRateLimitTracker tracker, _) = CreateTracker();
+		tracker.RecordRequest();
+
+		// Act
+		tracker.RecordServerRateLimit(used: 195, limit: 200);
+		YnabRateLimitStatus status = tracker.GetStatus();
+
+		// Assert — server-authoritative counts win, and CanMakeRequests agrees with GetStatus
+		// (the two were a split-brain before the RECEIPTS-737 fix).
+		status.RequestsUsed.Should().Be(195);
+		status.RemainingRequests.Should().Be(5);
+		tracker.CanMakeRequests(5).Should().BeTrue();
+		tracker.CanMakeRequests(6).Should().BeFalse();
+	}
+
+	[Fact]
+	public void RecordServerRateLimit_StaleSnapshot_FallsBackToInProcessEstimate()
+	{
+		// Arrange
+		(YnabRateLimitTracker tracker, FakeTimeProvider time) = CreateTracker(windowSeconds: 3600);
+		tracker.RecordServerRateLimit(used: 195, limit: 200);
+
+		// Act — advance past the window so the server snapshot is stale.
+		time.Advance(TimeSpan.FromSeconds(3601));
+		YnabRateLimitStatus status = tracker.GetStatus();
+
+		// Assert — falls back to the in-process estimate (no live requests → full quota).
+		status.RequestsUsed.Should().Be(0);
+		status.RemainingRequests.Should().Be(200);
+		tracker.CanMakeRequests(200).Should().BeTrue();
+	}
 }

--- a/tests/Infrastructure.Tests/Services/YnabSyncEventServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/YnabSyncEventServiceTests.cs
@@ -1,0 +1,104 @@
+using Application.Interfaces.Services;
+using Application.Models;
+using Application.Models.Ynab;
+using Common;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Services;
+using Infrastructure.Tests.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Infrastructure.Tests.Services;
+
+public class YnabSyncEventServiceTests
+{
+	private readonly IDbContextFactory<ApplicationDbContext> _factory = DbContextHelpers.CreateInMemoryContextFactory();
+	private readonly Mock<ICurrentUserAccessor> _currentUserMock = new();
+
+	private YnabSyncEventService CreateService(string? userId = "user-1")
+	{
+		_currentUserMock.Setup(a => a.UserId).Returns(userId);
+		return new YnabSyncEventService(_factory, _currentUserMock.Object, TimeProvider.System);
+	}
+
+	private async Task SeedAsync(params YnabSyncEventEntity[] events)
+	{
+		await using ApplicationDbContext context = _factory.CreateDbContext();
+		context.YnabSyncEvents.AddRange(events);
+		await context.SaveChangesAsync();
+	}
+
+	private static YnabSyncEventEntity Event(YnabSyncEventType type, bool success, DateTimeOffset occurredAt) => new()
+	{
+		Id = Guid.NewGuid(),
+		UserId = "user-1",
+		EventType = type,
+		Success = success,
+		OccurredAt = occurredAt,
+	};
+
+	[Fact]
+	public async Task WriteAsync_PersistsEvent_WithCurrentUser()
+	{
+		YnabSyncEventService service = CreateService("user-42");
+		Guid receiptId = Guid.NewGuid();
+
+		await service.WriteAsync(YnabSyncEventType.Push, success: true, receiptId: receiptId, httpStatus: 201, cancellationToken: CancellationToken.None);
+
+		await using ApplicationDbContext context = _factory.CreateDbContext();
+		YnabSyncEventEntity saved = await context.YnabSyncEvents.SingleAsync();
+		saved.UserId.Should().Be("user-42");
+		saved.EventType.Should().Be(YnabSyncEventType.Push);
+		saved.Success.Should().BeTrue();
+		saved.ReceiptId.Should().Be(receiptId);
+		saved.HttpStatus.Should().Be(201);
+	}
+
+	[Fact]
+	public async Task GetRecentAsync_FiltersBySuccess_AndPaginatesMostRecentFirst()
+	{
+		DateTimeOffset now = DateTimeOffset.UtcNow;
+		await SeedAsync(
+			Event(YnabSyncEventType.Push, true, now.AddMinutes(-1)),
+			Event(YnabSyncEventType.Push, false, now.AddMinutes(-2)),
+			Event(YnabSyncEventType.Push, false, now.AddMinutes(-3)));
+
+		YnabSyncEventService service = CreateService();
+
+		PagedResult<YnabSyncEventDto> failures = await service.GetRecentAsync(0, 10, SortParams.Default, success: false);
+		failures.Total.Should().Be(2);
+		failures.Data.Should().OnlyContain(e => !e.Success);
+
+		PagedResult<YnabSyncEventDto> firstPage = await service.GetRecentAsync(0, 1, SortParams.Default);
+		firstPage.Total.Should().Be(3);
+		firstPage.Data.Should().HaveCount(1);
+		firstPage.Data[0].OccurredAt.Should().BeCloseTo(now.AddMinutes(-1), TimeSpan.FromSeconds(2));
+	}
+
+	[Fact]
+	public async Task GetStatusAsync_ComputesWindowCountsAndLastTimestamps()
+	{
+		DateTimeOffset now = DateTimeOffset.UtcNow;
+		await SeedAsync(
+			Event(YnabSyncEventType.Push, true, now.AddHours(-1)),      // 24h, 7d, 30d
+			Event(YnabSyncEventType.Push, false, now.AddDays(-3)),      // 7d, 30d
+			Event(YnabSyncEventType.Push, true, now.AddDays(-20)),      // 30d only
+			Event(YnabSyncEventType.Push, true, now.AddDays(-40)),      // outside all windows
+			Event(YnabSyncEventType.Validate, true, now.AddMinutes(-5)));
+
+		YnabSyncEventService service = CreateService();
+
+		YnabStatus status = await service.GetStatusAsync(isConfigured: true);
+
+		status.IsConfigured.Should().BeTrue();
+		status.PushCountLast24h.Should().Be(1);
+		status.PushCountLast7d.Should().Be(2);
+		status.PushCountLast30d.Should().Be(3);
+		status.PushSuccessLast30d.Should().Be(2);
+		status.PushFailureLast30d.Should().Be(1);
+		status.LastPushSuccessAt.Should().BeCloseTo(now.AddHours(-1), TimeSpan.FromSeconds(2));
+		status.LastPushFailureAt.Should().BeCloseTo(now.AddDays(-3), TimeSpan.FromSeconds(2));
+		status.LastValidatedAt.Should().BeCloseTo(now.AddMinutes(-5), TimeSpan.FromSeconds(2));
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/YnabControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/YnabControllerTests.cs
@@ -8,6 +8,7 @@ using Application.Commands.Ynab.SelectBudget;
 using Application.Commands.Ynab.StaleMappings;
 using Application.Exceptions;
 using Application.Interfaces.Services;
+using Application.Models;
 using Application.Models.Ynab;
 using Application.Queries.Core.Ynab;
 using FluentAssertions;
@@ -64,6 +65,49 @@ public class YnabControllerTests
 		response.IsConfigured.Should().BeTrue();
 		response.IsConnected.Should().BeTrue();
 		response.LastSuccessfulSyncUtc.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task GetStatus_ReturnsMappedStats()
+	{
+		_mediatorMock.Setup(m => m.Send(It.IsAny<GetYnabStatusQuery>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabStatus(true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, 1, 2, 3, 3, 0));
+
+		Ok<YnabStatusResponse> result = await _controller.GetStatus(CancellationToken.None);
+
+		result.Value!.IsConfigured.Should().BeTrue();
+		result.Value.PushCountLast30d.Should().Be(3);
+		result.Value.PushSuccessLast30d.Should().Be(3);
+	}
+
+	[Fact]
+	public async Task GetEvents_ReturnsMappedList()
+	{
+		PagedResult<YnabSyncEventDto> paged = new(
+			[new YnabSyncEventDto(Guid.NewGuid(), DateTimeOffset.UtcNow, "Push", null, null, 201, true, null, null)],
+			1, 0, 50);
+		_mediatorMock.Setup(m => m.Send(It.IsAny<GetYnabSyncEventsQuery>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(paged);
+
+		Results<Ok<YnabSyncEventListResponse>, BadRequest<string>> result =
+			await _controller.GetEvents(cancellationToken: CancellationToken.None);
+
+		Ok<YnabSyncEventListResponse> ok = result.Result.Should().BeOfType<Ok<YnabSyncEventListResponse>>().Subject;
+		ok.Value!.Total.Should().Be(1);
+		ok.Value.Data.Should().HaveCount(1);
+	}
+
+	[Theory]
+	[InlineData(-1, 50, null)]
+	[InlineData(0, 0, null)]
+	[InlineData(0, 501, null)]
+	[InlineData(0, 50, "bogus")]
+	public async Task GetEvents_ReturnsBadRequest_ForInvalidArguments(int offset, int limit, string? outcome)
+	{
+		Results<Ok<YnabSyncEventListResponse>, BadRequest<string>> result =
+			await _controller.GetEvents(offset: offset, limit: limit, outcome: outcome, cancellationToken: CancellationToken.None);
+
+		result.Result.Should().BeOfType<BadRequest<string>>();
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary
Adds a dedicated **`/ynab` status page** — "is the YNAB integration healthy, and what has it done lately?" — plus the persistence and API behind it.

- **New `ynab.YnabSyncEvents` table** (+ migration): append-only log of every YNAB push and connection-validate attempt (userId, occurredAt, eventType, receiptId, transactionId, httpStatus, success, error, requestId). Indexed `(UserId, OccurredAt DESC)`.
- **`IYnabSyncEventService`**: writes events (from the push command handler and the connection-status query handler) and serves paginated/filterable feeds + aggregate stats.
- **`GET /api/ynab/status`** (aggregate stats — cheap, no live YNAB call) and **`GET /api/ynab/events`** (paginated, `outcome`/`dateFrom`/`dateTo` filters). Spec-first via `openapi/spec.yaml`; `check:drift` passes.
- **`YnabApiClient`** now parses YNAB's real **`X-Rate-Limit`** response header into the rate-limit tracker, and captures status/request-id via a scoped `IYnabResponseContext`.
- **Frontend `/ynab` page**: connection, push-activity, and rate-limit cards + a paginated, outcome-filterable activity table (receipt click-through). `useYnabStatus`/`useYnabEvents` hooks; sidebar entry under Library.

Resolves RECEIPTS-737

## Premise corrections (confirmed with the maintainer)
The issue assumed two things the code didn't do; both were decided before implementing:
1. **Rate limit "from response headers we already log"** — the code did *not* read YNAB's `X-Rate-Limit` header (it used an in-process counter). **Decision: add real header parsing** (done in `YnabApiClient`).
2. **"Token last validated at"** wasn't persisted (connection validates live). **Decision: log validate events too**, and derive `lastValidatedAt` from them. `requestId` is captured opportunistically (nullable).

Scope note: `/api/ynab/status` reads cheap DB aggregates (safe to poll at 30s); validate events are logged only by the live connection-status handler (bounded frequency), avoiding a write on every status poll.

## Test plan
- **Backend unit: 2212 pass** (`--filter "Category!=Integration"`), incl. new service (repo-level), controller (status/events + bad-arg 400s), and push-emission tests (asserts one event on success and on failure).
- **Integration (Testcontainers): 36/37 pass** — the new migration applies against real Postgres. The 1 failure (`PurgeTrashServiceTests`) is **pre-existing and unrelated** (RECEIPTS-747).
- **Frontend: 2104 pass**, incl. new `useYnabEvents` hook test and `Ynab` page test (health grid + not-configured empty state).
- `dotnet format --verify-no-changes`, `eslint`, `lint:spec`, `check:drift`, `tsc` all clean.

> ⚠️ CI does not run integration tests (`--filter "Category!=Integration"`), so the migration/table is validated by the local Testcontainers run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)