### PR TITLE
test(infrastructure): seed Card so PurgeTrash transactions satisfy Cards FK (RECEIPTS-747)

### DIFF
--- a/tests/Infrastructure.IntegrationTests/PurgeTrashServiceTests.cs
+++ b/tests/Infrastructure.IntegrationTests/PurgeTrashServiceTests.cs
@@ -23,6 +23,14 @@ public class PurgeTrashServiceTests(PostgresFixture fixture)
 
 		// Parents (needed for FK-valid child inserts)
 		AccountEntity account = AccountEntityGenerator.Generate();
+		// Transactions default their CardId to the Account's Id
+		// (TransactionEntityGenerator sets CardId = accountId when no explicit
+		// cardId is given). Since RECEIPTS-574 enforced FK_Transactions_Cards_CardId,
+		// that Card must exist — seed one whose Id mirrors the 1:1 Account:Card
+		// backfill so the transaction inserts below satisfy the FK.
+		CardEntity card = CardEntityGenerator.Generate();
+		card.Id = account.Id;
+		card.AccountId = account.Id;
 		ReceiptEntity activeReceipt = ReceiptEntityGenerator.Generate();
 		ReceiptEntity deletedReceipt = ReceiptEntityGenerator.Generate();
 		deletedReceipt.DeletedAt = deletedAt;
@@ -69,6 +77,7 @@ public class PurgeTrashServiceTests(PostgresFixture fixture)
 		await using (ApplicationDbContext setup = fixture.CreateDbContext())
 		{
 			setup.Accounts.Add(account);
+			setup.Cards.Add(card);
 			setup.Receipts.AddRange(activeReceipt, deletedReceipt);
 			setup.Categories.AddRange(activeCategory, deletedCategory);
 			await setup.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- `PurgeTrashServiceTests` seeds transactions via `TransactionEntityGenerator`, which defaults `CardId` to the Account's Id. Since RECEIPTS-574 enforced `FK_Transactions_Cards_CardId`, that Card must exist — but the test inserted only an Account, so setup failed with Postgres 23503 (FK violation).
- Seed a `Card` whose `Id` mirrors the Account's Id (the 1:1 Account:Card backfill pattern) in the first save batch so the transaction inserts satisfy the FK.

The failure was invisible in CI because integration tests are excluded (`--filter "Category!=Integration"`); it only runs locally against Testcontainers Postgres.

Resolves RECEIPTS-747

## Test plan
- `dotnet test tests/Infrastructure.IntegrationTests --filter "FullyQualifiedName~PurgeTrashServiceTests"` (Docker running) — now **Passed: 1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)