### PR TITLE
fix(api): make DTO codegen self-heal from stale generated files (RECEIPTS-748)

### DIFF
--- a/src/Presentation/API/API.csproj
+++ b/src/Presentation/API/API.csproj
@@ -46,6 +46,17 @@
     <ProjectReference Include="..\..\Receipts.ServiceDefaults\Receipts.ServiceDefaults.csproj" />
   </ItemGroup>
 
+  <!-- Generated DTOs are produced by the GenerateDtos target below, which re-adds
+       them to <Compile>. Exclude them from the SDK's evaluation-time default glob
+       so a file left over from a previous spec can never enter the compile list as
+       a phantom item (CS2001: source file could not be found) before regeneration
+       cleans the directory. This makes local builds behave like CI, where Generated/
+       starts empty and the target is the single source of these compile items.
+       (RECEIPTS-748) -->
+  <ItemGroup>
+    <Compile Remove="Generated\**\*.cs" />
+  </ItemGroup>
+
   <PropertyGroup>
     <_DtoSplitterProject>$(MSBuildProjectDirectory)\..\..\..\tools\DtoSplitter\DtoSplitter.csproj</_DtoSplitterProject>
     <_DtoSplitterExe>$(MSBuildProjectDirectory)\..\..\..\tools\DtoSplitter\bin\Release\net10.0\DtoSplitter</_DtoSplitterExe>

--- a/tools/DtoSplitter/Program.cs
+++ b/tools/DtoSplitter/Program.cs
@@ -1,8 +1,8 @@
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 if (args.Length < 1)
 {
@@ -46,16 +46,26 @@ static int Check(string[] args)
 		return 1;
 	}
 
-	string? existingHash = ReadHashFromFile(existingFiles[0]);
-
-	if (existingHash == specHash)
+	// Every generated file embeds the spec hash it was produced from. Require
+	// ALL of them to match the current spec — not just the first. A single stale
+	// or orphaned file (a type removed from the spec, or a leftover monolithic
+	// Dtos.g.cs that carries no hash line) forces a full regeneration, which
+	// clears the directory and rewrites the exact current set. Reading only
+	// existingFiles[0] previously let orphaned old-spec files linger and break
+	// local builds (RECEIPTS-748).
+	foreach (string file in existingFiles)
 	{
-		Console.WriteLine("DTOs up-to-date.");
-		return 0;
+		string? fileHash = ReadHashFromFile(file);
+		if (fileHash != specHash)
+		{
+			string name = Path.GetFileName(file);
+			Console.WriteLine($"Generated file '{name}' is stale ({fileHash?[..8] ?? "no-hash"}... -> {specHash[..8]}...). Regeneration needed.");
+			return 1;
+		}
 	}
 
-	Console.WriteLine($"Spec hash changed ({existingHash?[..8] ?? "none"}... -> {specHash[..8]}...). Regeneration needed.");
-	return 1;
+	Console.WriteLine("DTOs up-to-date.");
+	return 0;
 }
 
 static int Split(string[] args)


### PR DESCRIPTION
## Summary
Local builds could break with `CS2001: source file could not be found` after a spec change or branch switch, even though CI stays green (CI always regenerates from an empty `Generated/`). Two independent gaps let stale state survive:

1. **`DtoSplitter check` read the spec-hash from only the first generated file.** A partial/mixed directory (e.g. leftover OCR-era `ProposedReceipt*.g.cs`, `ConfidenceLevel.g.cs`) could pass the freshness gate while orphaned files lingered. Now `check` requires **every** `*.g.cs` to carry the current spec hash; any stale or hashless file (including a leftover monolithic `Dtos.g.cs`) forces a full regen, which clears the dir and rewrites the exact current set.
2. **The SDK's evaluation-time default glob captured `Generated/*.g.cs`,** so a file deleted mid-build (by the split step) could remain a phantom `Compile` item → `CS2001`. `Generated/` is now excluded from the default glob, making the `GenerateDtos` target the single source of those compile items — the same way CI behaves with an empty `Generated/`.

Resolves RECEIPTS-748

## Test plan
Verified locally:
- With an orphaned old-hash `*.g.cs` planted: `dotnet build src/Presentation/API` detects it stale → regenerates → **removes the orphan** → compiles clean (202 types, 0 errors).
- Unchanged rebuild still reports `DTOs up-to-date` and **skips** regen (freshness gate not broken into always-regenerate).
- `DtoSplitter check` returns exit 0 on a clean tree, exit 1 when any file's hash diverges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)