### PR TITLE
refactor(client): stabilize list-hook returns and filter callbacks (RECEIPTS-750)

### DIFF
--- a/src/client/src/hooks/useAccounts.ts
+++ b/src/client/src/hooks/useAccounts.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -14,7 +15,8 @@ export function useAccounts(offset = 0, limit = 50, sortBy?: string | null, sort
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useAccount(id: string | null) {

--- a/src/client/src/hooks/useAdjustments.ts
+++ b/src/client/src/hooks/useAdjustments.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -14,7 +15,8 @@ export function useAdjustments(offset = 0, limit = 50, sortBy?: string | null, s
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: query.data?.total ?? 0 }), [base, query.data]);
 }
 
 export function useAdjustment(id: string | null) {
@@ -43,7 +45,8 @@ export function useAdjustmentsByReceiptId(receiptId: string | null, offset = 0, 
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: query.data?.total ?? 0 }), [base, query.data]);
 }
 
 export function useCreateAdjustment() {
@@ -160,7 +163,8 @@ export function useDeletedAdjustments(offset = 0, limit = 50, sortBy?: string | 
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: query.data?.total ?? 0 }), [base, query.data]);
 }
 
 export function useRestoreAdjustment() {

--- a/src/client/src/hooks/useAudit.ts
+++ b/src/client/src/hooks/useAudit.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 
@@ -30,7 +31,8 @@ export function useEntityAuditHistory(
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export interface AuditLogFilters {
@@ -95,5 +97,6 @@ export function useRecentAuditLogs(filters: AuditLogFilters = {}) {
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }

--- a/src/client/src/hooks/useAuthAudit.ts
+++ b/src/client/src/hooks/useAuthAudit.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 
@@ -25,7 +26,8 @@ export function useMyAuthAuditLog(
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useRecentAuthAuditLogs(
@@ -51,7 +53,8 @@ export function useRecentAuthAuditLogs(
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useFailedAuthAttempts(
@@ -77,5 +80,6 @@ export function useFailedAuthAttempts(
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }

--- a/src/client/src/hooks/useCards.ts
+++ b/src/client/src/hooks/useCards.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -16,7 +17,8 @@ export function useCards(offset = 0, limit = 50, sortBy?: string | null, sortDir
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useCard(id: string | null) {

--- a/src/client/src/hooks/useCategories.ts
+++ b/src/client/src/hooks/useCategories.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -14,7 +15,8 @@ export function useCategories(offset = 0, limit = 50, sortBy?: string | null, so
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 /**
@@ -169,7 +171,8 @@ export function useDeletedCategories(offset = 0, limit = 50, sortBy?: string | n
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useRestoreCategory() {

--- a/src/client/src/hooks/useItemTemplates.ts
+++ b/src/client/src/hooks/useItemTemplates.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -14,7 +15,8 @@ export function useItemTemplates(offset = 0, limit = 50, sortBy?: string | null,
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useItemTemplate(id: string | null) {
@@ -175,7 +177,8 @@ export function useDeletedItemTemplates(offset = 0, limit = 50, sortBy?: string 
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useRestoreItemTemplate() {

--- a/src/client/src/hooks/useReceiptItems.ts
+++ b/src/client/src/hooks/useReceiptItems.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -15,7 +16,8 @@ export function useReceiptItems(offset = 0, limit = 50, sortBy?: string | null, 
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: query.data?.total ?? 0 }), [base, query.data]);
 }
 
 export function useReceiptItem(id: string | null) {
@@ -44,7 +46,8 @@ export function useReceiptItemsByReceiptId(receiptId: string | null, offset = 0,
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: query.data?.total ?? 0 }), [base, query.data]);
 }
 
 export function useCreateReceiptItem() {
@@ -194,7 +197,8 @@ export function useDeletedReceiptItems(offset = 0, limit = 50, sortBy?: string |
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: query.data?.total ?? 0 }), [base, query.data]);
 }
 
 export function useRestoreReceiptItem() {

--- a/src/client/src/hooks/useReceipts.ts
+++ b/src/client/src/hooks/useReceipts.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -33,7 +34,8 @@ export function useReceipts(
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useReceipt(id: string | null) {
@@ -146,7 +148,8 @@ export function useDeletedReceipts(offset = 0, limit = 50, sortBy?: string | nul
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useCreateCompleteReceipt() {

--- a/src/client/src/hooks/useStableQuery.test.ts
+++ b/src/client/src/hooks/useStableQuery.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { useStableQuery } from "./useStableQuery";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe("useStableQuery", () => {
+  it("returns a referentially stable object across renders when query state is unchanged", async () => {
+    const { result, rerender } = renderHook(
+      () => {
+        const query = useQuery({
+          queryKey: ["stable-query-test"],
+          queryFn: async () => ({ value: 42 }),
+        });
+        return useStableQuery(query);
+      },
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const first = result.current;
+    rerender();
+
+    // Same reference: unlike a `[query]` dependency (which recomputes every
+    // render because TanStack returns a fresh result object each time), the
+    // field-level deps keep the projection stable when nothing changed.
+    expect(result.current).toBe(first);
+    expect(result.current.data).toEqual({ value: 42 });
+  });
+
+  it("exposes the standard query state fields", async () => {
+    const { result } = renderHook(
+      () => {
+        const query = useQuery({
+          queryKey: ["stable-query-fields"],
+          queryFn: async () => ({ value: 1 }),
+        });
+        return useStableQuery(query);
+      },
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current).toMatchObject({
+      isLoading: false,
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      isFetching: false,
+      status: "success",
+      fetchStatus: "idle",
+    });
+    expect(typeof result.current.refetch).toBe("function");
+  });
+});

--- a/src/client/src/hooks/useStableQuery.ts
+++ b/src/client/src/hooks/useStableQuery.ts
@@ -1,0 +1,47 @@
+import { useMemo } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+
+/**
+ * Projects a TanStack Query result into a referentially-stable object.
+ *
+ * Spreading `...query` into a memo makes eslint-plugin-react-hooks (v7) infer
+ * the whole, per-render-fresh `query` object as the dependency, so the memo
+ * recomputes every render and provides no referential stability. Listing the
+ * specific fields lets the returned identity stay stable across renders while
+ * still satisfying `react-hooks/preserve-manual-memoization`.
+ *
+ * List hooks wrap this and add their own derived fields (e.g. `data`/`total`),
+ * depending on `[base, query.data]` so the derived object is stable too.
+ */
+export function useStableQuery<TData, TError>(
+  query: UseQueryResult<TData, TError>,
+) {
+  return useMemo(
+    () => ({
+      data: query.data,
+      error: query.error,
+      status: query.status,
+      fetchStatus: query.fetchStatus,
+      isLoading: query.isLoading,
+      isPending: query.isPending,
+      isError: query.isError,
+      isSuccess: query.isSuccess,
+      isFetching: query.isFetching,
+      isRefetching: query.isRefetching,
+      refetch: query.refetch,
+    }),
+    [
+      query.data,
+      query.error,
+      query.status,
+      query.fetchStatus,
+      query.isLoading,
+      query.isPending,
+      query.isError,
+      query.isSuccess,
+      query.isFetching,
+      query.isRefetching,
+      query.refetch,
+    ],
+  );
+}

--- a/src/client/src/hooks/useSubcategories.ts
+++ b/src/client/src/hooks/useSubcategories.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -14,7 +15,8 @@ export function useSubcategories(offset = 0, limit = 50, sortBy?: string | null,
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useSubcategory(id: string | null) {
@@ -43,7 +45,8 @@ export function useSubcategoriesByCategoryId(categoryId: string | null, offset =
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 /**
@@ -202,7 +205,8 @@ export function useDeletedSubcategories(offset = 0, limit = 50, sortBy?: string 
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useRestoreSubcategory() {

--- a/src/client/src/hooks/useTransactions.ts
+++ b/src/client/src/hooks/useTransactions.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -14,7 +15,8 @@ export function useTransactions(offset = 0, limit = 50, sortBy?: string | null, 
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: query.data?.total ?? 0 }), [base, query.data]);
 }
 
 export function useTransaction(id: string | null) {
@@ -43,7 +45,8 @@ export function useTransactionsByReceiptId(receiptId: string | null, offset = 0,
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: query.data?.total ?? 0 }), [base, query.data]);
 }
 
 export function useCreateTransaction() {
@@ -174,7 +177,8 @@ export function useDeletedTransactions(offset = 0, limit = 50, sortBy?: string |
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: query.data?.total ?? 0 }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: query.data?.total ?? 0 }), [base, query.data]);
 }
 
 export function useRestoreTransaction() {

--- a/src/client/src/hooks/useUsers.ts
+++ b/src/client/src/hooks/useUsers.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import {
   useQuery,
   useMutation,
@@ -26,7 +27,8 @@ export function useUsers(
       return data;
     },
   });
-  return useMemo(() => ({ ...query, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [query]);
+  const base = useStableQuery(query);
+  return useMemo(() => ({ ...base, data: query.data?.data, total: Number(query.data?.total ?? 0) }), [base, query.data]);
 }
 
 export function useUser(userId: string | null) {

--- a/src/client/src/hooks/useYnab.ts
+++ b/src/client/src/hooks/useYnab.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
@@ -31,14 +32,15 @@ export function useYnabConnectionStatus() {
       return data as unknown as YnabConnectionStatusResponse;
     },
   });
+  const base = useStableQuery(query);
   return useMemo(
     () => ({
-      ...query,
+      ...base,
       isConfigured: query.data?.isConfigured ?? false,
       isConnected: query.data?.isConnected ?? false,
       lastSuccessfulSyncUtc: query.data?.lastSuccessfulSyncUtc ?? null,
     }),
-    [query],
+    [base, query.data],
   );
 }
 
@@ -52,9 +54,10 @@ export function useYnabBudgets() {
     },
     retry: false,
   });
+  const base = useStableQuery(query);
   return useMemo(
-    () => ({ ...query, budgets: query.data?.data ?? [] }),
-    [query],
+    () => ({ ...base, budgets: query.data?.data ?? [] }),
+    [base, query.data],
   );
 }
 
@@ -67,12 +70,13 @@ export function useSelectedYnabBudget() {
       return data;
     },
   });
+  const base = useStableQuery(query);
   return useMemo(
     () => ({
-      ...query,
+      ...base,
       selectedBudgetId: query.data?.selectedBudgetId ?? null,
     }),
-    [query],
+    [base, query.data],
   );
 }
 
@@ -106,9 +110,10 @@ export function useYnabAccounts(enabled = true) {
     retry: false,
     enabled,
   });
+  const base = useStableQuery(query);
   return useMemo(
-    () => ({ ...query, accounts: query.data?.data ?? [] }),
-    [query],
+    () => ({ ...base, accounts: query.data?.data ?? [] }),
+    [base, query.data],
   );
 }
 
@@ -122,9 +127,10 @@ export function useYnabAccountMappings(enabled = true) {
     },
     enabled,
   });
+  const base = useStableQuery(query);
   return useMemo(
-    () => ({ ...query, mappings: query.data?.data ?? [] }),
-    [query],
+    () => ({ ...base, mappings: query.data?.data ?? [] }),
+    [base, query.data],
   );
 }
 
@@ -219,9 +225,10 @@ export function useYnabCategories(enabled = true) {
     retry: false,
     enabled,
   });
+  const base = useStableQuery(query);
   return useMemo(
-    () => ({ ...query, categories: query.data?.data ?? [] }),
-    [query],
+    () => ({ ...base, categories: query.data?.data ?? [] }),
+    [base, query.data],
   );
 }
 
@@ -237,9 +244,10 @@ export function useDistinctReceiptItemCategories(enabled = true) {
     },
     enabled,
   });
+  const base = useStableQuery(query);
   return useMemo(
-    () => ({ ...query, categories: query.data?.categories ?? [] }),
-    [query],
+    () => ({ ...base, categories: query.data?.categories ?? [] }),
+    [base, query.data],
   );
 }
 
@@ -255,9 +263,10 @@ export function useYnabCategoryMappings(enabled = true) {
     },
     enabled,
   });
+  const base = useStableQuery(query);
   return useMemo(
-    () => ({ ...query, mappings: query.data?.data ?? [] }),
-    [query],
+    () => ({ ...base, mappings: query.data?.data ?? [] }),
+    [base, query.data],
   );
 }
 
@@ -273,12 +282,13 @@ export function useUnmappedCategories(enabled = true) {
     },
     enabled,
   });
+  const base = useStableQuery(query);
   return useMemo(
     () => ({
-      ...query,
+      ...base,
       unmappedCategories: query.data?.unmappedCategories ?? [],
     }),
-    [query],
+    [base, query.data],
   );
 }
 
@@ -351,16 +361,17 @@ export function useStaleMappings(enabled = true) {
     },
     enabled,
   });
+  const base = useStableQuery(query);
   return useMemo(
     () => ({
-      ...query,
+      ...base,
       staleAccountMappingCount: query.data?.staleAccountMappingCount ?? 0,
       staleCategoryMappingCount: query.data?.staleCategoryMappingCount ?? 0,
       hasStaleMappings:
         (query.data?.staleAccountMappingCount ?? 0) > 0 ||
         (query.data?.staleCategoryMappingCount ?? 0) > 0,
     }),
-    [query],
+    [base, query.data],
   );
 }
 
@@ -703,14 +714,15 @@ export function useAllReceiptIds(enabled = true) {
     queryFn: fetchAllReceiptIds,
     enabled,
   });
+  const base = useStableQuery(query);
   return useMemo(
     () => ({
-      ...query,
+      ...base,
       receiptIds: query.data?.ids ?? [],
       totalReceipts: query.data?.total ?? 0,
       isTruncated: (query.data?.total ?? 0) > (query.data?.ids.length ?? 0),
     }),
-    [query],
+    [base, query.data],
   );
 }
 
@@ -743,13 +755,14 @@ export function useReceiptYnabSyncStatuses(receiptIds: string[]) {
     retry: false,
     staleTime: 30_000,
   });
+  const base = useStableQuery(query);
   return useMemo(() => {
     const statusMap = new Map<string, ReceiptYnabSyncStatusValue>();
     for (const item of query.data?.data ?? []) {
       statusMap.set(item.receiptId, item.syncStatus);
     }
-    return { ...query, statusMap };
-  }, [query]);
+    return { ...base, statusMap };
+  }, [base, query.data]);
 }
 
 export function useYnabSyncStatus(transactionId: string | null) {
@@ -795,11 +808,12 @@ export function useYnabRateLimitStatus(enabled = true) {
     enabled,
     refetchInterval: 30_000,
   });
+  const base = useStableQuery(query);
   return useMemo(
     () => ({
-      ...query,
+      ...base,
       rateLimitStatus: query.data ?? null,
     }),
-    [query],
+    [base, query.data],
   );
 }

--- a/src/client/src/hooks/useYnabEvents.ts
+++ b/src/client/src/hooks/useYnabEvents.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
 import { useQuery } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 
@@ -74,12 +75,13 @@ export function useYnabEvents(filters: YnabEventFilters = {}) {
     },
   });
 
+  const base = useStableQuery(query);
   return useMemo(
     () => ({
-      ...query,
+      ...base,
       data: query.data?.data ?? [],
       total: Number(query.data?.total ?? 0),
     }),
-    [query],
+    [base, query.data],
   );
 }

--- a/src/client/src/pages/AuditLog.tsx
+++ b/src/client/src/pages/AuditLog.tsx
@@ -154,38 +154,41 @@ function AuditLog() {
     defaultSortDirection: "desc",
   });
   const pagination = useServerPagination({ sortBy, sortDirection });
+  // `resetPage` is stable (useServerPagination memoizes it); depend on it
+  // directly so these handlers don't churn when other pagination state changes.
+  const { resetPage } = pagination;
 
   // Reset pagination when filters change
   const handleEntityTypeChange = useCallback(
     (value: string) => {
       setEntityTypeFilter(value);
-      pagination.resetPage();
+      resetPage();
     },
-    [pagination],
+    [resetPage],
   );
 
   const handleActionChange = useCallback(
     (value: string) => {
       setActionFilter(value);
-      pagination.resetPage();
+      resetPage();
     },
-    [pagination],
+    [resetPage],
   );
 
   const handleDateFromChange = useCallback(
     (d: Date | undefined) => {
       setDateFrom(d);
-      pagination.resetPage();
+      resetPage();
     },
-    [pagination],
+    [resetPage],
   );
 
   const handleDateToChange = useCallback(
     (d: Date | undefined) => {
       setDateTo(d);
-      pagination.resetPage();
+      resetPage();
     },
-    [pagination],
+    [resetPage],
   );
 
   const entityTypeOptions = useMemo(
@@ -257,7 +260,7 @@ function AuditLog() {
           value={search}
           onChange={(e) => {
             setSearch(e.target.value);
-            pagination.resetPage();
+            resetPage();
           }}
           className="max-w-xs"
         />

--- a/src/client/src/pages/Ynab.tsx
+++ b/src/client/src/pages/Ynab.tsx
@@ -57,13 +57,16 @@ export default function Ynab() {
     defaultSortDirection: "desc",
   });
   const pagination = useServerPagination({ sortBy, sortDirection });
+  // `resetPage` is stable (useServerPagination memoizes it); depend on it
+  // directly so this handler doesn't churn when other pagination state changes.
+  const { resetPage } = pagination;
 
   const handleOutcomeChange = useCallback(
     (value: string) => {
       setOutcome(value as "all" | "success" | "failure");
-      pagination.resetPage();
+      resetPage();
     },
-    [pagination],
+    [resetPage],
   );
 
   const { data: events, total, isLoading } = useYnabEvents({


### PR DESCRIPTION
## Summary
The list hooks wrapped their return in `useMemo(() => ({ ...query, data, total }), [query])`. Because TanStack returns a fresh result object every render, `[query]` changed each render and the memo provided **no referential stability** — harmless while consumers read primitives, but it would cause a render loop the moment a consumer put the return value in a dependency array.

**The ticket's suggested fix (field-level deps) does not work in this repo.** `eslint-plugin-react-hooks` v7's `preserve-manual-memoization` rule infers the whole `query` object as the dependency of a `...query` spread (and the base object of a `pagination.resetPage()` call), so `[query.data, …]` / `[pagination.resetPage]` are rejected as **errors**. The only lint-clean way to get stability is to stop spreading the whole object:

- New **`useStableQuery`** helper projects a TanStack result into an explicit, field-memoized object (mirrors the existing `useServerPagination` idiom). All 14 list hooks now return `{ ...base, <derived> }` memoized on `[base, query.data]`, so the returned identity is stable across renders when nothing changed.
- Filter-change callbacks in `AuditLog`/`Ynab` now destructure the stable `resetPage` and depend on `[resetPage]` instead of the whole `[pagination]` object.

Resolves RECEIPTS-750

## Test plan
- `eslint` — 0 errors across all changed files (previous `preserve-manual-memoization` errors from the naive fix are gone).
- `tsc -b` — 0 errors: no consumer or test read a field dropped from the `...query` spread.
- `vitest run` — full suite **2104 tests green**.
- New `useStableQuery.test.ts` asserts the referential-stability guarantee (the returned object keeps the same reference across an unrelated re-render) — this test **fails on the old `[query]` form**, so it guards the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)