### PR TITLE
fix(infrastructure): symmetric schema teardown in OrganizeTablesIntoSchemas Down (RECEIPTS-749)

### DIFF
--- a/docs/migrations/20260701091936_OrganizeTablesIntoSchemas.md
+++ b/docs/migrations/20260701091936_OrganizeTablesIntoSchemas.md
@@ -56,8 +56,18 @@ Notes:
 
 ## Rollback notes
 
-`Down` moves every table back to `public` via the reverse `ALTER TABLE … SET SCHEMA public`. It
-is symmetric and data-safe.
+`Down` is symmetric and data-safe. For every table it emits the reverse
+`ALTER TABLE "<schema>"."<table>" SET SCHEMA public`, then drops the six now-empty
+bounded-context schemas (`DROP SCHEMA <name>`), returning the database to its exact
+pre-migration state. `Up`'s `EnsureSchema` keeps re-application idempotent.
+
+> **RECEIPTS-749:** the symmetric teardown was completed here. As originally scaffolded, the
+> `Down` `RenameTable` operations specified no `newSchema`, so they generated no SQL — the tables
+> were never moved back to `public` and the schemas were left in place. `Down` now sets
+> `newSchema: "public"` on each move and drops the emptied schemas. `MigrationSafetyTests` rolls
+> the database back past this migration, so it verifies the teardown succeeds; its
+> null-`CardId` assertion queries the row with unqualified raw SQL because, mid-rollback, the
+> tables legitimately live in `public` rather than their `receipts`/etc. schemas.
 
 **Important:** the schema-qualification of the runtime raw SQL lives in application code, not in
 the migration. Rolling the database back with `Down` alone is not sufficient — you must also revert
@@ -69,9 +79,9 @@ those tables. Roll back code and database together.
 - Applied by the Testcontainers integration suite
   (`tests/Infrastructure.IntegrationTests`, `Category=Integration`), which migrates a real
   PostgreSQL instance to HEAD and exercises repositories, Identity, and the similarity/embedding
-  raw SQL against the reorganized schema: **36 of 37 pass**. The one failure,
-  `PurgeTrashServiceTests`, is pre-existing and unrelated (confirmed on `main`) — tracked in
-  RECEIPTS-747.
+  raw SQL against the reorganized schema: **37 of 37 pass** (including `MigrationSafetyTests`,
+  which exercises the symmetric `Down`). The previously-failing `PurgeTrashServiceTests` was a
+  pre-existing, unrelated FK-seed bug, fixed under RECEIPTS-747.
 - CI does **not** run integration tests (`dotnet test --filter "Category!=Integration"`), so this
   migration's schema move is validated by the local Testcontainers run above, not by CI.
 - Test fixture `PostgresFixture` sets a `search_path` spanning all schemas (with `public` first) so

--- a/src/Infrastructure/Migrations/20260701091936_OrganizeTablesIntoSchemas.cs
+++ b/src/Infrastructure/Migrations/20260701091936_OrganizeTablesIntoSchemas.cs
@@ -180,152 +180,185 @@ public partial class OrganizeTablesIntoSchemas : Migration
 		migrationBuilder.RenameTable(
 			name: "YnabSyncRecords",
 			schema: "ynab",
-			newName: "YnabSyncRecords");
+			newName: "YnabSyncRecords",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "YnabServerKnowledge",
 			schema: "ynab",
-			newName: "YnabServerKnowledge");
+			newName: "YnabServerKnowledge",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "YnabSelectedBudgets",
 			schema: "ynab",
-			newName: "YnabSelectedBudgets");
+			newName: "YnabSelectedBudgets",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "YnabCategoryMappings",
 			schema: "ynab",
-			newName: "YnabCategoryMappings");
+			newName: "YnabCategoryMappings",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "YnabAccountMappings",
 			schema: "ynab",
-			newName: "YnabAccountMappings");
+			newName: "YnabAccountMappings",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "Transactions",
 			schema: "receipts",
-			newName: "Transactions");
+			newName: "Transactions",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "Subcategories",
 			schema: "library",
-			newName: "Subcategories");
+			newName: "Subcategories",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "Receipts",
 			schema: "receipts",
-			newName: "Receipts");
+			newName: "Receipts",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "ReceiptItems",
 			schema: "receipts",
-			newName: "ReceiptItems");
+			newName: "ReceiptItems",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "NormalizedDescriptionSettings",
 			schema: "matching",
-			newName: "NormalizedDescriptionSettings");
+			newName: "NormalizedDescriptionSettings",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "NormalizedDescriptions",
 			schema: "matching",
-			newName: "NormalizedDescriptions");
+			newName: "NormalizedDescriptions",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "ItemTemplates",
 			schema: "library",
-			newName: "ItemTemplates");
+			newName: "ItemTemplates",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "ItemSimilarityEdges",
 			schema: "matching",
-			newName: "ItemSimilarityEdges");
+			newName: "ItemSimilarityEdges",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "ItemEmbeddings",
 			schema: "matching",
-			newName: "ItemEmbeddings");
+			newName: "ItemEmbeddings",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "DistinctDescriptions",
 			schema: "matching",
-			newName: "DistinctDescriptions");
+			newName: "DistinctDescriptions",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "Categories",
 			schema: "library",
-			newName: "Categories");
+			newName: "Categories",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "Cards",
 			schema: "library",
-			newName: "Cards");
+			newName: "Cards",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "AuthAuditLogs",
 			schema: "audit",
-			newName: "AuthAuditLogs");
+			newName: "AuthAuditLogs",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "AuditLogs",
 			schema: "audit",
-			newName: "AuditLogs");
+			newName: "AuditLogs",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "AspNetUserTokens",
 			schema: "identity",
-			newName: "AspNetUserTokens");
+			newName: "AspNetUserTokens",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "AspNetUsers",
 			schema: "identity",
-			newName: "AspNetUsers");
+			newName: "AspNetUsers",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "AspNetUserRoles",
 			schema: "identity",
-			newName: "AspNetUserRoles");
+			newName: "AspNetUserRoles",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "AspNetUserLogins",
 			schema: "identity",
-			newName: "AspNetUserLogins");
+			newName: "AspNetUserLogins",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "AspNetUserClaims",
 			schema: "identity",
-			newName: "AspNetUserClaims");
+			newName: "AspNetUserClaims",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "AspNetRoles",
 			schema: "identity",
-			newName: "AspNetRoles");
+			newName: "AspNetRoles",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "AspNetRoleClaims",
 			schema: "identity",
-			newName: "AspNetRoleClaims");
+			newName: "AspNetRoleClaims",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "ApiKeys",
 			schema: "identity",
-			newName: "ApiKeys");
+			newName: "ApiKeys",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "Adjustments",
 			schema: "receipts",
-			newName: "Adjustments");
+			newName: "Adjustments",
+			newSchema: "public");
 
 		migrationBuilder.RenameTable(
 			name: "Accounts",
 			schema: "library",
-			newName: "Accounts");
+			newName: "Accounts",
+			newSchema: "public");
 
-		// The six schemas created by Up() are intentionally left in place. Dropping them
-		// here fails during the partial rollback/replay that MigrationSafetyTests exercise
-		// (DROP SCHEMA ... RESTRICT reports lingering dependents mid-rollback), and the
-		// schemas are harmless when empty — Up()'s EnsureSchema keeps re-apply idempotent.
-		// Symmetric teardown is tracked separately (RECEIPTS-749).
+		// Every table has been moved back to public above, so the six bounded-context
+		// schemas Up() created are now empty and can be dropped — restoring the exact
+		// pre-migration state (symmetric teardown, RECEIPTS-749).
+		migrationBuilder.DropSchema(name: "ynab");
+		migrationBuilder.DropSchema(name: "matching");
+		migrationBuilder.DropSchema(name: "audit");
+		migrationBuilder.DropSchema(name: "identity");
+		migrationBuilder.DropSchema(name: "receipts");
+		migrationBuilder.DropSchema(name: "library");
 	}
 }

--- a/tests/Infrastructure.IntegrationTests/MigrationSafetyTests.cs
+++ b/tests/Infrastructure.IntegrationTests/MigrationSafetyTests.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using FluentAssertions;
 using Infrastructure.IntegrationTests.Fixtures;
 using Microsoft.EntityFrameworkCore;
@@ -52,11 +53,29 @@ public class MigrationSafetyTests(PostgresFixture fixture)
 			.Subject.First();
 		ex.MessageText.Should().Contain("cannot promote Transactions.CardId to NOT NULL");
 
-		// The row should still exist in its original nullable state.
-		long nullCardIdCount = await context.Transactions
-			.IgnoreQueryFilters()
-			.LongCountAsync(t => t.Id == txId);
-		nullCardIdCount.Should().Be(1);
+		// The row should still exist in its original nullable state. Query with raw
+		// SQL against the unqualified table name (resolved via search_path to public):
+		// the forward migration aborted at the 574 guard, before RECEIPTS-746 re-applied,
+		// so the tables are still in `public` — not the `receipts` schema the EF model
+		// maps `context.Transactions` to. (RECEIPTS-746's Down now correctly returns the
+		// tables to public, which is what makes the schema-qualified query miss them here.)
+		await context.Database.OpenConnectionAsync();
+		try
+		{
+			await using DbCommand countCmd = context.Database.GetDbConnection().CreateCommand();
+			countCmd.CommandText = """SELECT COUNT(*) FROM "Transactions" WHERE "Id" = @id""";
+			DbParameter idParam = countCmd.CreateParameter();
+			idParam.ParameterName = "id";
+			idParam.Value = txId;
+			countCmd.Parameters.Add(idParam);
+
+			long nullCardIdCount = (long)(await countCmd.ExecuteScalarAsync())!;
+			nullCardIdCount.Should().Be(1);
+		}
+		finally
+		{
+			await context.Database.CloseConnectionAsync();
+		}
 
 		// Clean up: delete the offending row so later tests (which share the fixture)
 		// are not blocked, then reapply the migration to leave the fixture in its


### PR DESCRIPTION
## Summary
The 746 migration's `Down` left the six bounded-context schemas (`identity`, `receipts`, `library`, `ynab`, `audit`, `matching`) behind after a rollback. A naive `DropSchema` had previously regressed `MigrationSafetyTests` with `2BP01: cannot drop schema … because other objects depend on it`.

**Root cause:** the scaffolded `Down` `RenameTable` operations specified no `newSchema`, so EF generated **no SQL** for them — the tables were never actually moved back to `public`. `DROP SCHEMA` then hit non-empty schemas (the `ynab` tables were still in `ynab`; confirmed via `Include Error Detail`).

**Fix:** set `newSchema: "public"` on each `Down` move so it emits `ALTER TABLE "<schema>"."<table>" SET SCHEMA public`, then drop the now-empty schemas. `Down` is now truly symmetric and restores the exact pre-746 state.

**Test adjustment:** `MigrationSafetyTests.PromoteTransactionCardIdNotNull` verified the null-`CardId` row via `context.Transactions`, which the EF model pins to the `receipts` schema. Now that `Down` correctly returns tables to `public`, that row is (correctly) in `public` when the forward migration aborts at the 574 guard *before* 746 re-applies. Switched that one assertion to schema-agnostic raw SQL (unqualified name, resolved via `search_path`).

Resolves RECEIPTS-749

## Test plan
Verified locally against Testcontainers PostgreSQL (Docker):
- `MigrationSafetyTests` — **2/2 pass** (both roll the DB back past 746, exercising the symmetric `Down`).
- Full `Infrastructure.IntegrationTests` suite — **37/37 pass**.
- Regenerated `dotnet ef migrations script OrganizeTablesIntoSchemas RemovePricingMode` confirms the `Down` now emits 29 `SET SCHEMA public` moves followed by 6 `DROP SCHEMA`.

Note: CI does **not** run integration tests (`--filter "Category!=Integration"`), so this rollback path is validated by the local run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)