### PR TITLE
fix(api): require admin authorization on audit and trash-purge endpoints

### DIFF
--- a/src/Presentation/API/Controllers/AuditController.cs
+++ b/src/Presentation/API/Controllers/AuditController.cs
@@ -12,7 +12,7 @@ namespace API.Controllers;
 [ApiController]
 [Route("api/audit")]
 [Produces("application/json")]
-[Authorize]
+[Authorize(Policy = "RequireAdmin")]
 public class AuditController(IAuditService auditService) : ControllerBase
 {
 	[HttpGet("")]

--- a/src/Presentation/API/Controllers/AuthAuditController.cs
+++ b/src/Presentation/API/Controllers/AuthAuditController.cs
@@ -56,6 +56,7 @@ public class AuthAuditController(IAuthAuditService authAuditService) : Controlle
 	}
 
 	[HttpGet("recent")]
+	[Authorize(Policy = "RequireAdmin")]
 	public async Task<Results<Ok<GeneratedDtos.AuthAuditListResponse>, BadRequest<string>>> GetRecent(
 		[FromQuery] int offset = 0,
 		[FromQuery] int limit = 50,
@@ -89,6 +90,7 @@ public class AuthAuditController(IAuthAuditService authAuditService) : Controlle
 	}
 
 	[HttpGet("failed")]
+	[Authorize(Policy = "RequireAdmin")]
 	public async Task<Results<Ok<GeneratedDtos.AuthAuditListResponse>, BadRequest<string>>> GetFailed(
 		[FromQuery] int offset = 0,
 		[FromQuery] int limit = 50,

--- a/src/Presentation/API/Controllers/Core/TrashController.cs
+++ b/src/Presentation/API/Controllers/Core/TrashController.cs
@@ -17,6 +17,7 @@ public class TrashController(IMediator mediator, ILogger<TrashController> logger
 {
 	[HttpPost("purge")]
 	[EndpointSummary("Permanently delete all soft-deleted items")]
+	[Authorize(Policy = "RequireAdmin")]
 	public async Task<NoContent> PurgeTrash(CancellationToken cancellationToken = default)
 	{
 		logger.LogWarning("PurgeTrash called — permanently deleting all soft-deleted items");

--- a/tests/Presentation.API.Tests/Controllers/AdminAuthorizationAttributeTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AdminAuthorizationAttributeTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using API.Controllers;
+using API.Controllers.Core;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Presentation.API.Tests.Controllers;
+
+/// <summary>
+/// Reflection-based regression tests that lock in the admin-only authorization on
+/// the audit and trash-purge endpoints (RECEIPTS-759, RECEIPTS-758, RECEIPTS-775).
+/// These assert the presence (and, for the self-service endpoint, the absence) of an
+/// <see cref="AuthorizeAttribute"/> carrying the <c>RequireAdmin</c> policy so a future
+/// change that drops the policy fails the build instead of silently reopening the hole.
+/// </summary>
+public class AdminAuthorizationAttributeTests
+{
+	private const string RequireAdminPolicy = "RequireAdmin";
+
+	private static bool HasRequireAdmin(IEnumerable<AuthorizeAttribute> attributes) =>
+		attributes.Any(a => a.Policy == RequireAdminPolicy);
+
+	private static MethodInfo GetAction(Type controllerType, string methodName)
+	{
+		MethodInfo? method = controllerType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+		method.Should().NotBeNull($"{controllerType.Name}.{methodName} should exist");
+		return method!;
+	}
+
+	[Fact]
+	public void PurgeTrash_RequiresAdminPolicy()
+	{
+		MethodInfo action = GetAction(typeof(TrashController), nameof(TrashController.PurgeTrash));
+
+		HasRequireAdmin(action.GetCustomAttributes<AuthorizeAttribute>())
+			.Should().BeTrue("POST /api/trash/purge permanently deletes all soft-deleted data and must be admin-only");
+	}
+
+	[Fact]
+	public void AuditController_RequiresAdminPolicy_AtClassLevel()
+	{
+		HasRequireAdmin(typeof(AuditController).GetCustomAttributes<AuthorizeAttribute>())
+			.Should().BeTrue("AuditController exposes cross-user change-history and must be admin-only for every action");
+	}
+
+	[Fact]
+	public void AuthAuditGetRecent_RequiresAdminPolicy()
+	{
+		MethodInfo action = GetAction(typeof(AuthAuditController), nameof(AuthAuditController.GetRecent));
+
+		HasRequireAdmin(action.GetCustomAttributes<AuthorizeAttribute>())
+			.Should().BeTrue("GET /api/auth/audit/recent returns every user's sign-in events and must be admin-only");
+	}
+
+	[Fact]
+	public void AuthAuditGetFailed_RequiresAdminPolicy()
+	{
+		MethodInfo action = GetAction(typeof(AuthAuditController), nameof(AuthAuditController.GetFailed));
+
+		HasRequireAdmin(action.GetCustomAttributes<AuthorizeAttribute>())
+			.Should().BeTrue("GET /api/auth/audit/failed returns every user's failed-login attempts and must be admin-only");
+	}
+
+	[Fact]
+	public void AuthAuditGetMyAuditLog_DoesNotRequireAdminPolicy()
+	{
+		MethodInfo action = GetAction(typeof(AuthAuditController), nameof(AuthAuditController.GetMyAuditLog));
+
+		HasRequireAdmin(action.GetCustomAttributes<AuthorizeAttribute>())
+			.Should().BeFalse("GET /api/auth/audit/me self-filters to the caller's own userId and must stay reachable by any authenticated user");
+	}
+}


### PR DESCRIPTION
## Summary
- Three endpoints carried bare `[Authorize]` with no admin policy, making them reachable by any authenticated user instead of admins only.
- `TrashController.PurgeTrash` — permanent, unrecoverable delete of all soft-deleted data. Added `[Authorize(Policy = "RequireAdmin")]` to the action.
- `AuthAuditController.GetRecent` / `GetFailed` — expose every user's sign-in events, emails, IPs, and failed-login attempts. Added `[Authorize(Policy = "RequireAdmin")]` to both actions. `GetMyAuditLog` (`/me`) is left untouched — it already self-filters to the caller's own userId and must stay accessible to any authenticated user.
- `AuditController` — both actions (`GetAuditLogs`, `GetRecent`) expose cross-user change-history (`ChangesJson`, `ChangedByUserId`, `IpAddress`), none of which are self-service. Added `[Authorize(Policy = "RequireAdmin")]` at the class level (replacing the bare `[Authorize]`).

Closes RECEIPTS-759, RECEIPTS-758, RECEIPTS-775

## Validation
- `dotnet build Receipts.slnx` — succeeded, 0 errors, only pre-existing NuGet advisory warnings (unrelated packages), no new warnings introduced.
- `dotnet test tests/Presentation.API.Tests --filter "Category!=Integration"` — 995 passed, 0 failed, 0 skipped.
- No existing test asserted the old (buggy) non-admin-reachable behavior, so no test needed updating. The controller unit tests instantiate controllers directly and call action methods, bypassing the ASP.NET Core authorization filter pipeline entirely — so `[Authorize]` attribute changes are invisible to them by design.
- Did not add new HTTP-level authorization tests: the only existing integration-style pattern in this test project (`RateLimitBypassIntegrationTests`, `Category=Integration`) spins up a bare `TestServer` with minimal endpoints to test the auth/rate-limit *middleware* pipeline — it does not host real MVC controllers with their full DI graphs (`IMediator`, `IAuditService`, `IAuthAuditService`, `IEntityChangeNotifier`, loggers, etc.). Standing up controller-level HTTP auth tests would mean building a new harness, not a cheap extension of an existing pattern, so per the task instructions this was skipped and is called out here explicitly.

## Test plan
- [x] Build succeeds with no new warnings
- [x] Unit test suite passes (995/995)
- [ ] Manual/integration verification that `POST /api/trash/purge`, `GET /api/auth/audit/failed`, and `GET /api/audit/recent` return 403 for non-admin and 200 for admin (not covered by an automated test in this PR — see note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)