### PR TITLE
fix(api): remove committed jwt signing key from base appsettings

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -82,6 +82,12 @@ jobs:
 
       - name: Build with warnings-as-errors
         run: dotnet build Receipts.slnx --no-restore -p:TreatWarningsAsErrors=true
+        env:
+          # GenerateOpenApiDocuments boots the host to extract the OpenAPI spec at build
+          # time. Since Jwt:Key is no longer committed in appsettings.json (RECEIPTS-760),
+          # supply a non-secret placeholder so AuthConfiguration's fail-fast guard doesn't
+          # block the build. The real key is required at runtime via Docker secrets/Aspire.
+          Jwt__Key: build-time-spec-extraction-only-not-for-runtime
 
       - name: Test
         run: >-

--- a/src/Presentation/API/appsettings.Development.json
+++ b/src/Presentation/API/appsettings.Development.json
@@ -5,7 +5,7 @@
 	"POSTGRES_PASSWORD": "postgres",
 	"POSTGRES_DB": "receipts",
 	"Jwt": {
-		"Key": "dev-secret-key-at-least-32-characters-long-for-hs256",
+		"Key": "dev-only-local-signing-key-not-for-production-use-min32",
 		"Issuer": "receipts-api",
 		"Audience": "receipts-app"
 	},

--- a/src/Presentation/API/appsettings.json
+++ b/src/Presentation/API/appsettings.json
@@ -1,6 +1,5 @@
 {
 	"Jwt": {
-		"Key": "dev-secret-key-at-least-32-characters-long-for-hs256",
 		"Issuer": "receipts-api",
 		"Audience": "receipts-app"
 	},


### PR DESCRIPTION
## Summary

The base `src/Presentation/API/appsettings.json` committed a real JWT HS256 signing key (`dev-secret-key-at-least-32-characters-long-for-hs256`). Because that base file is loaded in every environment, the fail-fast guard in `AuthConfiguration.cs` (which throws when `Jwt:Key` is missing) could **never** fire — so a Production deployment that forgot to set the real `Jwt__Key` secret would silently ship with this public, source-controlled key.

## Changes

- **`src/Presentation/API/appsettings.json`** — removed the `Jwt:Key` line. `Jwt:Issuer` and `Jwt:Audience` are retained. With no key in the base file, Production with no `Jwt__Key` env var now correctly throws at startup (the desired fail-fast behavior — the guard in `AuthConfiguration.cs:17-18` is unchanged).
- **`src/Presentation/API/appsettings.Development.json`** — replaced the old key with an obviously-non-production dev-only value (`dev-only-local-signing-key-not-for-production-use-min32`). This file is loaded **only** in the Development environment, so it never ships to Production. Local `dotnet run` still works.
- **`.github/workflows/github-ci.yml`** — the build-time `GenerateOpenApiDocuments` step boots the host to extract the OpenAPI spec, which now trips the fail-fast guard. Injected a non-secret `Jwt__Key` placeholder on the `dotnet build` step only, mirroring the existing pattern in `.githooks/pre-commit`. Docker's build already passes `-p:OpenApiGenerateDocumentsOnBuild=false`, so the Dockerfile needs no change; the real runtime key still comes from `docker-entrypoint.sh` via `/secrets/jwt_key`.

## What was NOT changed

- The fail-fast guard in `AuthConfiguration.cs` is intact.
- `docker-entrypoint.sh` (real key injected at runtime from `/secrets/jwt_key`) is untouched.
- Unit tests inject their own in-memory `Jwt:Key` and do not depend on the appsettings value.

## Grep for other hardcoded keys

Searched the repo for `Jwt:Key` / `Jwt__Key` / the old key literal. Findings:
- No other committed config file (no `appsettings.Production.json`, no docker-compose override, no `launchSettings.json`) reintroduces a hardcoded signing key.
- `.githooks/pre-commit` and the CI workflow use a clearly-labeled non-secret build-time placeholder (`build-time-spec-extraction-only-not-for-runtime`), not a real key.
- `docs/deployment.md` documents that `/secrets/jwt_key` maps to `Jwt__Key` — no literal key.

## Validation

- `dotnet build Receipts.slnx` (with build-time `Jwt__Key` placeholder): succeeds, 0 errors, only pre-existing NuGet vulnerability warnings.
- `dotnet test tests/Infrastructure.Tests --filter "Category!=Integration"`: **623 passed, 0 failed**.
- `dotnet test tests/Presentation.API.Tests --filter "Category!=Integration"`: **995 passed, 0 failed**.
- Full pre-commit hook suite (spec lint, format check, warnings-as-errors build, drift check, .NET tests, tsc, eslint, vitest) passed on commit.

Closes RECEIPTS-760

🤖 Generated with [Claude Code](https://claude.com/claude-code)