### PR TITLE
fix(api): reject api keys for deactivated or locked-out users

### DIFF
--- a/src/Application/Interfaces/Services/IApiKeyService.cs
+++ b/src/Application/Interfaces/Services/IApiKeyService.cs
@@ -18,5 +18,6 @@ public interface IApiKeyService
 	Task<CreateApiKeyResult> CreateApiKeyAsync(string userId, string name, DateTimeOffset? expiresAt, bool bypassRateLimit = false, CancellationToken cancellationToken = default);
 	Task<IReadOnlyList<ApiKeyInfo>> GetApiKeysForUserAsync(string userId, CancellationToken cancellationToken = default);
 	Task RevokeApiKeyAsync(Guid id, string userId, CancellationToken cancellationToken = default);
+	Task<int> RevokeAllForUserAsync(string userId, CancellationToken cancellationToken = default);
 	Task<ApiKeyValidationResult?> GetUserIdByApiKeyAsync(string rawKey, CancellationToken cancellationToken = default);
 }

--- a/src/Infrastructure/Services/ApiKeyService.cs
+++ b/src/Infrastructure/Services/ApiKeyService.cs
@@ -51,6 +51,27 @@ public class ApiKeyService(IDbContextFactory<ApplicationDbContext> dbContextFact
 		await context.SaveChangesAsync(cancellationToken);
 	}
 
+	public async Task<int> RevokeAllForUserAsync(string userId, CancellationToken cancellationToken = default)
+	{
+		await using ApplicationDbContext context = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+		List<ApiKeyEntity> keys = await context.ApiKeys
+			.Where(k => k.UserId == userId && !k.IsRevoked)
+			.ToListAsync(cancellationToken);
+
+		if (keys.Count == 0)
+		{
+			return 0;
+		}
+
+		foreach (ApiKeyEntity key in keys)
+		{
+			key.IsRevoked = true;
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+		return keys.Count;
+	}
+
 	public async Task<ApiKeyValidationResult?> GetUserIdByApiKeyAsync(string rawKey, CancellationToken cancellationToken = default)
 	{
 		string keyHash = HashKey(rawKey);

--- a/src/Presentation/API/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/src/Presentation/API/Authentication/ApiKeyAuthenticationHandler.cs
@@ -47,6 +47,22 @@ public class ApiKeyAuthenticationHandler(
 			return AuthenticateResult.Fail("Invalid API key.");
 		}
 
+		// Re-check the owning account's persisted state on every request. A valid key
+		// must not authenticate for a user who has been deleted, deactivated, or locked
+		// out since the key was issued (RECEIPTS-757).
+		ApplicationUser? user = await userManager.FindByIdAsync(validationResult.UserId);
+		if (user is null)
+		{
+			await LogApiKeyUsageAsync(validationResult, null, false, "API key owner account no longer exists");
+			return AuthenticateResult.Fail("API key owner account not found.");
+		}
+
+		if (await userManager.IsLockedOutAsync(user))
+		{
+			await LogApiKeyUsageAsync(validationResult, user.Email, false, "API key owner account is disabled or locked out");
+			return AuthenticateResult.Fail("API key owner account is disabled.");
+		}
+
 		List<Claim> claims =
 		[
 			new Claim(ClaimTypes.NameIdentifier, validationResult.UserId),
@@ -54,25 +70,28 @@ public class ApiKeyAuthenticationHandler(
 			new Claim("BypassRateLimit", validationResult.BypassRateLimit.ToString().ToLowerInvariant()),
 		];
 
-		ApplicationUser? user = await userManager.FindByIdAsync(validationResult.UserId);
-		if (user is not null)
+		if (user.Email is not null)
 		{
-			if (user.Email is not null)
-			{
-				claims.Add(new Claim(ClaimTypes.Email, user.Email));
-			}
+			claims.Add(new Claim(ClaimTypes.Email, user.Email));
+		}
 
-			IList<string> roles = await userManager.GetRolesAsync(user);
-			foreach (string role in roles)
-			{
-				claims.Add(new Claim(ClaimTypes.Role, role));
-			}
+		IList<string> roles = await userManager.GetRolesAsync(user);
+		foreach (string role in roles)
+		{
+			claims.Add(new Claim(ClaimTypes.Role, role));
 		}
 
 		ClaimsIdentity identity = new(claims, Scheme.Name);
 		ClaimsPrincipal principal = new(identity);
 		AuthenticationTicket ticket = new(principal, Scheme.Name);
 
+		await LogApiKeyUsageAsync(validationResult, user.Email, true, null);
+
+		return AuthenticateResult.Success(ticket);
+	}
+
+	private async Task LogApiKeyUsageAsync(ApiKeyValidationResult validationResult, string? email, bool success, string? failureReason)
+	{
 		try
 		{
 			await authAuditService.LogAsync(new AuthAuditEntryDto(
@@ -80,9 +99,9 @@ public class ApiKeyAuthenticationHandler(
 				nameof(AuthEventType.ApiKeyUsed),
 				validationResult.UserId,
 				validationResult.KeyId,
-				user?.Email,
-				true,
-				null,
+				email,
+				success,
+				failureReason,
 				Context.Connection.RemoteIpAddress?.ToString(),
 				Request.Headers.UserAgent.ToString(),
 				DateTimeOffset.UtcNow,
@@ -92,7 +111,5 @@ public class ApiKeyAuthenticationHandler(
 		{
 			Logger.LogError(ex, "Failed to log API key usage audit event");
 		}
-
-		return AuthenticateResult.Success(ticket);
 	}
 }

--- a/src/Presentation/API/Controllers/UsersController.cs
+++ b/src/Presentation/API/Controllers/UsersController.cs
@@ -21,6 +21,7 @@ public class UsersController(
 	IUserService userService,
 	UserManager<ApplicationUser> userManager,
 	IAuthAuditService authAuditService,
+	IApiKeyService apiKeyService,
 	ILogger<UsersController> logger) : ControllerBase
 {
 	[HttpGet]
@@ -179,6 +180,13 @@ public class UsersController(
 			return TypedResults.BadRequest(updateResult.Errors.Select(e => e.Description));
 		}
 
+		if (request.IsDisabled)
+		{
+			// Disabling an account must also cut off any pre-existing API keys, otherwise
+			// they keep authenticating with the user's roles indefinitely (RECEIPTS-757).
+			await apiKeyService.RevokeAllForUserAsync(user.Id);
+		}
+
 		IList<string> roles = await userManager.GetRolesAsync(user);
 		if (roles.Count > 0)
 		{
@@ -216,6 +224,9 @@ public class UsersController(
 		user.RefreshTokenExpiresAt = null;
 		await userManager.UpdateAsync(user);
 
+		// Revoke API keys so a deactivated user cannot keep authenticating via a stale key.
+		await apiKeyService.RevokeAllForUserAsync(user.Id);
+
 		await LogAuthEventAsync(nameof(AuthEventType.AccountDisabled), user.Id, user.Email);
 
 		return TypedResults.NoContent();
@@ -242,6 +253,10 @@ public class UsersController(
 		user.RefreshToken = null;
 		user.RefreshTokenExpiresAt = null;
 		await userManager.UpdateAsync(user);
+
+		// Force-resetting a password invalidates the old credential; revoke API keys too so
+		// they cannot be used to bypass the reset (defense in depth, RECEIPTS-757).
+		await apiKeyService.RevokeAllForUserAsync(user.Id);
 
 		await LogAuthEventAsync(nameof(AuthEventType.PasswordChanged), user.Id, user.Email);
 

--- a/tests/Infrastructure.Tests/Services/ApiKeyServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ApiKeyServiceTests.cs
@@ -1,0 +1,94 @@
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Infrastructure.Services;
+using Infrastructure.Tests.Helpers;
+using Infrastructure.Tests.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Tests.Services;
+
+public class ApiKeyServiceTests
+{
+	private static ApiKeyEntity CreateKey(string userId, bool isRevoked = false) => new()
+	{
+		Id = Guid.NewGuid(),
+		Name = "test-key",
+		KeyHash = Guid.NewGuid().ToString("N"),
+		UserId = userId,
+		CreatedAt = DateTimeOffset.UtcNow,
+		IsRevoked = isRevoked,
+	};
+
+	[Fact]
+	public async Task RevokeAllForUserAsync_RevokesAllActiveKeysForUser_AndReturnsCount()
+	{
+		// Arrange
+		(IDbContextFactory<ApplicationDbContext> contextFactory, _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		ApiKeyEntity active1 = CreateKey("user-a");
+		ApiKeyEntity active2 = CreateKey("user-a");
+		ApiKeyEntity alreadyRevoked = CreateKey("user-a", isRevoked: true);
+		ApiKeyEntity otherUserKey = CreateKey("user-b");
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			await context.ApiKeys.AddRangeAsync(active1, active2, alreadyRevoked, otherUserKey);
+			await context.SaveChangesAsync();
+		}
+
+		ApiKeyService service = new(contextFactory);
+
+		// Act
+		int revokedCount = await service.RevokeAllForUserAsync("user-a");
+
+		// Assert — only the two active keys for user-a were revoked
+		revokedCount.Should().Be(2);
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			(await context.ApiKeys.FindAsync(active1.Id))!.IsRevoked.Should().BeTrue();
+			(await context.ApiKeys.FindAsync(active2.Id))!.IsRevoked.Should().BeTrue();
+			(await context.ApiKeys.FindAsync(alreadyRevoked.Id))!.IsRevoked.Should().BeTrue();
+			// Another user's key must not be touched.
+			(await context.ApiKeys.FindAsync(otherUserKey.Id))!.IsRevoked.Should().BeFalse();
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task RevokeAllForUserAsync_ReturnsZero_WhenUserHasNoActiveKeys()
+	{
+		// Arrange
+		(IDbContextFactory<ApplicationDbContext> contextFactory, _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		ApiKeyService service = new(contextFactory);
+
+		// Act
+		int revokedCount = await service.RevokeAllForUserAsync("user-with-no-keys");
+
+		// Assert
+		revokedCount.Should().Be(0);
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task RevokeAllForUserAsync_CausesKeyToStopAuthenticating()
+	{
+		// Arrange — a real key that validates before revocation.
+		(IDbContextFactory<ApplicationDbContext> contextFactory, _) = DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		ApiKeyService service = new(contextFactory);
+		CreateApiKeyResult created = await service.CreateApiKeyAsync("user-a", "my-key", expiresAt: null);
+
+		(await service.GetUserIdByApiKeyAsync(created.RawKey)).Should().NotBeNull();
+
+		// Act
+		int revokedCount = await service.RevokeAllForUserAsync("user-a");
+
+		// Assert — key no longer authenticates once bulk-revoked.
+		revokedCount.Should().Be(1);
+		(await service.GetUserIdByApiKeyAsync(created.RawKey)).Should().BeNull();
+
+		contextFactory.ResetDatabase();
+	}
+}

--- a/tests/Presentation.API.Tests/Authentication/ApiKeyAuthenticationHandlerTests.cs
+++ b/tests/Presentation.API.Tests/Authentication/ApiKeyAuthenticationHandlerTests.cs
@@ -95,6 +95,8 @@ public class ApiKeyAuthenticationHandlerTests
 			.ReturnsAsync(new ApiKeyValidationResult(userId, keyId, false));
 		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
 			.ReturnsAsync(user);
+		_userManagerMock.Setup(u => u.IsLockedOutAsync(user))
+			.ReturnsAsync(false);
 		_userManagerMock.Setup(u => u.GetRolesAsync(user))
 			.ReturnsAsync(new List<string> { "Admin" });
 
@@ -119,6 +121,7 @@ public class ApiKeyAuthenticationHandlerTests
 		// Arrange
 		string userId = Guid.NewGuid().ToString();
 		Guid keyId = Guid.NewGuid();
+		ApplicationUser user = new() { Id = userId, Email = "bypass@example.com" };
 
 		DefaultHttpContext context = new();
 		context.Request.Headers["X-API-Key"] = "valid-key";
@@ -126,7 +129,11 @@ public class ApiKeyAuthenticationHandlerTests
 		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
 			.ReturnsAsync(new ApiKeyValidationResult(userId, keyId, true));
 		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
-			.ReturnsAsync((ApplicationUser?)null);
+			.ReturnsAsync(user);
+		_userManagerMock.Setup(u => u.IsLockedOutAsync(user))
+			.ReturnsAsync(false);
+		_userManagerMock.Setup(u => u.GetRolesAsync(user))
+			.ReturnsAsync(new List<string>());
 
 		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
 
@@ -153,6 +160,8 @@ public class ApiKeyAuthenticationHandlerTests
 			.ReturnsAsync(new ApiKeyValidationResult(userId, keyId, false));
 		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
 			.ReturnsAsync(user);
+		_userManagerMock.Setup(u => u.IsLockedOutAsync(user))
+			.ReturnsAsync(false);
 		_userManagerMock.Setup(u => u.GetRolesAsync(user))
 			.ReturnsAsync(new List<string>());
 
@@ -167,9 +176,9 @@ public class ApiKeyAuthenticationHandlerTests
 	}
 
 	[Fact]
-	public async Task HandleAuthenticateAsync_OnlyHasNameIdentifierAndApiKeyClaims_WhenUserNotFound()
+	public async Task HandleAuthenticateAsync_ReturnsFail_WhenUserNotFound()
 	{
-		// Arrange
+		// Arrange — a key whose owning account has been deleted must no longer authenticate.
 		string userId = Guid.NewGuid().ToString();
 		Guid keyId = Guid.NewGuid();
 
@@ -187,12 +196,73 @@ public class ApiKeyAuthenticationHandlerTests
 		AuthenticateResult result = await handler.AuthenticateAsync();
 
 		// Assert
-		result.Succeeded.Should().BeTrue();
-		ClaimsPrincipal principal = result.Principal!;
-		principal.FindFirst(ClaimTypes.NameIdentifier)!.Value.Should().Be(userId);
-		principal.FindFirst("ApiKeyId")!.Value.Should().Be(keyId.ToString());
-		principal.FindFirst(ClaimTypes.Email).Should().BeNull();
-		principal.FindFirst(ClaimTypes.Role).Should().BeNull();
+		result.Succeeded.Should().BeFalse();
+		result.Principal.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_ReturnsFail_WhenUserLockedOut()
+	{
+		// Arrange — deactivation is implemented as Identity lockout, so a locked-out
+		// (deactivated) owner's key must be rejected (RECEIPTS-757).
+		string userId = Guid.NewGuid().ToString();
+		Guid keyId = Guid.NewGuid();
+		ApplicationUser user = new() { Id = userId, Email = "locked@example.com" };
+
+		DefaultHttpContext context = new();
+		context.Request.Headers["X-API-Key"] = "valid-key";
+
+		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ApiKeyValidationResult(userId, keyId, false));
+		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
+			.ReturnsAsync(user);
+		_userManagerMock.Setup(u => u.IsLockedOutAsync(user))
+			.ReturnsAsync(true);
+
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
+
+		// Act
+		AuthenticateResult result = await handler.AuthenticateAsync();
+
+		// Assert
+		result.Succeeded.Should().BeFalse();
+		result.Principal.Should().BeNull();
+		// Roles must never be granted for a rejected key.
+		_userManagerMock.Verify(u => u.GetRolesAsync(It.IsAny<ApplicationUser>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task HandleAuthenticateAsync_LogsFailureAuditEvent_WhenUserLockedOut()
+	{
+		// Arrange
+		string userId = Guid.NewGuid().ToString();
+		Guid keyId = Guid.NewGuid();
+		ApplicationUser user = new() { Id = userId, Email = "locked@example.com" };
+
+		DefaultHttpContext context = new();
+		context.Request.Headers["X-API-Key"] = "valid-key";
+
+		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ApiKeyValidationResult(userId, keyId, false));
+		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
+			.ReturnsAsync(user);
+		_userManagerMock.Setup(u => u.IsLockedOutAsync(user))
+			.ReturnsAsync(true);
+
+		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
+
+		// Act
+		await handler.AuthenticateAsync();
+
+		// Assert
+		_authAuditServiceMock.Verify(a => a.LogAsync(
+			It.Is<AuthAuditEntryDto>(e =>
+				e.UserId == userId
+				&& e.ApiKeyId == keyId
+				&& e.EventType == "ApiKeyUsed"
+				&& !e.Success
+				&& e.FailureReason != null),
+			It.IsAny<CancellationToken>()), Times.Once);
 	}
 
 	[Fact]
@@ -201,6 +271,7 @@ public class ApiKeyAuthenticationHandlerTests
 		// Arrange
 		string userId = Guid.NewGuid().ToString();
 		Guid keyId = Guid.NewGuid();
+		ApplicationUser user = new() { Id = userId, Email = "test@example.com" };
 
 		DefaultHttpContext context = new();
 		context.Request.Headers["X-API-Key"] = "valid-key";
@@ -208,7 +279,11 @@ public class ApiKeyAuthenticationHandlerTests
 		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
 			.ReturnsAsync(new ApiKeyValidationResult(userId, keyId, false));
 		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
-			.ReturnsAsync((ApplicationUser?)null);
+			.ReturnsAsync(user);
+		_userManagerMock.Setup(u => u.IsLockedOutAsync(user))
+			.ReturnsAsync(false);
+		_userManagerMock.Setup(u => u.GetRolesAsync(user))
+			.ReturnsAsync(new List<string>());
 
 		ApiKeyAuthenticationHandler handler = await CreateHandlerAsync(context);
 
@@ -231,6 +306,7 @@ public class ApiKeyAuthenticationHandlerTests
 		// Arrange
 		string userId = Guid.NewGuid().ToString();
 		Guid keyId = Guid.NewGuid();
+		ApplicationUser user = new() { Id = userId, Email = "test@example.com" };
 
 		DefaultHttpContext context = new();
 		context.Request.Headers["X-API-Key"] = "valid-key";
@@ -238,7 +314,11 @@ public class ApiKeyAuthenticationHandlerTests
 		_apiKeyServiceMock.Setup(s => s.GetUserIdByApiKeyAsync("valid-key", It.IsAny<CancellationToken>()))
 			.ReturnsAsync(new ApiKeyValidationResult(userId, keyId, false));
 		_userManagerMock.Setup(u => u.FindByIdAsync(userId))
-			.ReturnsAsync((ApplicationUser?)null);
+			.ReturnsAsync(user);
+		_userManagerMock.Setup(u => u.IsLockedOutAsync(user))
+			.ReturnsAsync(false);
+		_userManagerMock.Setup(u => u.GetRolesAsync(user))
+			.ReturnsAsync(new List<string>());
 		_authAuditServiceMock.Setup(a => a.LogAsync(It.IsAny<AuthAuditEntryDto>(), It.IsAny<CancellationToken>()))
 			.ThrowsAsync(new InvalidOperationException("DB connection failed"));
 

--- a/tests/Presentation.API.Tests/Controllers/UsersControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/UsersControllerTests.cs
@@ -20,6 +20,7 @@ public class UsersControllerTests
 	private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
 	private readonly Mock<IUserService> _userServiceMock;
 	private readonly Mock<IAuthAuditService> _authAuditServiceMock;
+	private readonly Mock<IApiKeyService> _apiKeyServiceMock;
 	private readonly Mock<ILogger<UsersController>> _loggerMock;
 	private readonly UsersController _controller;
 
@@ -39,12 +40,14 @@ public class UsersControllerTests
 
 		_userServiceMock = new Mock<IUserService>();
 		_authAuditServiceMock = new Mock<IAuthAuditService>();
+		_apiKeyServiceMock = new Mock<IApiKeyService>();
 		_loggerMock = ControllerTestHelpers.GetLoggerMock<UsersController>();
 
 		_controller = new UsersController(
 			_userServiceMock.Object,
 			_userManagerMock.Object,
 			_authAuditServiceMock.Object,
+			_apiKeyServiceMock.Object,
 			_loggerMock.Object);
 
 		_controller.ControllerContext = new ControllerContext
@@ -209,6 +212,42 @@ public class UsersControllerTests
 	}
 
 	[Fact]
+	public async Task UpdateUser_RevokesAllApiKeys_WhenDisabling()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.RemoveFromRolesAsync(user, It.IsAny<IEnumerable<string>>())).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(user, "User")).ReturnsAsync(IdentityResult.Success);
+
+		await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "User", IsDisabled = true });
+
+		_apiKeyServiceMock.Verify(s => s.RevokeAllForUserAsync("user-123", It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task UpdateUser_DoesNotRevokeApiKeys_WhenNotDisabling()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.RemoveFromRolesAsync(user, It.IsAny<IEnumerable<string>>())).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(user, "User")).ReturnsAsync(IdentityResult.Success);
+
+		await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "User", IsDisabled = false });
+
+		_apiKeyServiceMock.Verify(s => s.RevokeAllForUserAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
 	public async Task UpdateUser_ReturnsNotFound_WhenUserDoesNotExist()
 	{
 		SetupUserClaims("admin-1");
@@ -305,6 +344,19 @@ public class UsersControllerTests
 	}
 
 	[Fact]
+	public async Task DeactivateUser_RevokesAllApiKeys_WhenSuccessful()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+		await _controller.DeactivateUser("user-123");
+
+		_apiKeyServiceMock.Verify(s => s.RevokeAllForUserAsync("user-123", It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
 	public async Task DeactivateUser_ReturnsBadRequest_WhenSelfDeactivate()
 	{
 		SetupUserClaims("user-123");
@@ -342,6 +394,20 @@ public class UsersControllerTests
 			new AdminResetPasswordRequest { NewPassword = "NewPassword1!" });
 
 		Assert.IsType<NoContent>(result.Result);
+	}
+
+	[Fact]
+	public async Task AdminResetPassword_RevokesAllApiKeys_WhenSuccessful()
+	{
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.RemovePasswordAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddPasswordAsync(user, "NewPassword1!")).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+		await _controller.AdminResetPassword(user.Id, new AdminResetPasswordRequest { NewPassword = "NewPassword1!" });
+
+		_apiKeyServiceMock.Verify(s => s.RevokeAllForUserAsync(user.Id, It.IsAny<CancellationToken>()), Times.Once);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

Fixes a confirmed broken-authentication finding (**RECEIPTS-757**). `ApiKeyAuthenticationHandler` validated an API key and copied the owner's roles into the authentication ticket **without ever re-checking the owner's persisted account state**. An admin could deactivate, lock out, or delete a user, but that user's pre-existing API key kept authenticating with full (possibly admin) access indefinitely — deactivation/reset never revoked keys, and the handler never re-checked account state.

## What changed

### Part 1 — reject keys for non-usable accounts (closes the hole)
In `ApiKeyAuthenticationHandler.HandleAuthenticateAsync`, after loading the user:
- **User is `null`** (deleted out from under a valid key) → `AuthenticateResult.Fail` (previously it silently proceeded with only the `NameIdentifier` claim).
- **Account disabled or locked out** → `AuthenticateResult.Fail`.

"Deactivated" is not a custom flag in this codebase — it is ASP.NET Identity **lockout** (`LockoutEnabled = true; LockoutEnd = DateTimeOffset.MaxValue`), set by `UsersController.DeactivateUser` and `UsersController.UpdateUser` (when `IsDisabled`), and already the check `AuthController.Login` uses. So `userManager.IsLockedOutAsync(user)` is the single canonical check that covers both lockout and deactivation.

Rejections write an `ApiKeyUsed` auth-audit event with `success = false` and a reason (mirroring the existing success log via a shared `LogApiKeyUsageAsync` helper).

### Part 2 — revoke keys on deactivation and admin password reset (defense in depth)
- Added `IApiKeyService.RevokeAllForUserAsync(userId, ct)` — soft-revokes every active key for a user the same way single-key revoke does (`IsRevoked = true`).
- `UsersController` now calls it on `DeactivateUser`, on `UpdateUser` when the account is being disabled, and on `AdminResetPassword`. Wired through the service interface — no direct `DbContext` access from the controller.

## Investigation notes
- **How "deactivated" is determined:** ASP.NET Identity lockout (`LockoutEnabled` + `LockoutEnd`), verified in `UsersController.GetUser` (`IsDisabled = LockoutEnabled && LockoutEnd > now`), `UpdateUser`, `DeactivateUser`, and `AuthController.Login` (`IsLockedOutAsync`). There is no `IsActive`/`IsDeactivated` property on `ApplicationUser`.
- **`must_reset_password` (secondary):** deliberately **not** rejected in the handler. It is covered where it matters — admin force-reset now revokes keys (Part 2) — and a handler-level `MustResetPassword` rejection would risk blocking legitimate keys (new users default `MustResetPassword = true`). Reported rather than done.

## Validation
- `dotnet build Receipts.slnx` — 0 errors, no new warnings (only pre-existing NuGet advisory warnings).
- `dotnet test tests/Presentation.API.Tests --filter "Category!=Integration"` — **1001 passed**.
- `dotnet test tests/Infrastructure.Tests --filter "Category!=Integration"` — **626 passed**.

## Tests added
- Handler: locked-out owner's key is **rejected**; deleted owner's key is **rejected**; rejection logs a `success=false` audit event; no roles granted on rejection.
- Controller: `DeactivateUser`, `UpdateUser` (disable), and `AdminResetPassword` each **revoke all keys**; `UpdateUser` without disabling does **not** revoke.
- Service: `RevokeAllForUserAsync` revokes only the target user's active keys (leaves other users' and already-revoked keys correct) and a bulk-revoked key **stops validating** end-to-end.
- Updated pre-existing handler tests that assumed a missing user still authenticated, to the new fail-closed contract.

Closes RECEIPTS-757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
