### PR TITLE
fix(infrastructure): purge orphaned ynab sync records so empty trash cannot deadlock

### DIFF
--- a/src/Infrastructure/Extensions/OwnedChildRestoreExtensions.cs
+++ b/src/Infrastructure/Extensions/OwnedChildRestoreExtensions.cs
@@ -47,5 +47,20 @@ public static class OwnedChildRestoreExtensions
 			item.DeletedByApiKeyId = null;
 			item.CascadeDeletedByParentId = null;
 		}
+
+		// Recurse: a restored child may itself own grandchildren that were
+		// cascade-soft-deleted BY it (tagged with the child's own Id, not this parentId).
+		// Restoring the child must revive those too — the exact inverse of the multi-level
+		// cascade in ApplicationDbContext.HandleSoftDelete, which walks the same map.
+		// Only entities that appear as a parent in the owned-children map have children;
+		// others (e.g. ReceiptItem, Adjustment) simply have no map entry and are skipped.
+		if (items.Count > 0 && OwnedChildrenMapProvider.Map.TryGetValue(typeof(TChild), out OwnedChildrenMapProvider.ParentEntry? childAsParent))
+		{
+			foreach (TChild item in items)
+			{
+				Guid childId = (Guid)childAsParent.IdProperty.GetValue(item)!;
+				await context.RestoreOwnedChildrenAsync<TChild>(childId, cancellationToken);
+			}
+		}
 	}
 }

--- a/src/Infrastructure/Repositories/ReceiptRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptRepository.cs
@@ -156,6 +156,18 @@ public class ReceiptRepository(IDbContextFactory<ApplicationDbContext> contextFa
 		await context.Transactions.IgnoreAutoIncludes().Where(t => ids.Contains(t.ReceiptId)).LoadAsync(cancellationToken);
 		await context.Adjustments.IgnoreAutoIncludes().Where(a => ids.Contains(a.ReceiptId)).LoadAsync(cancellationToken);
 
+		// Also load the YnabSyncRecords owned by those transactions so the two-level
+		// cascade (Receipt -> Transaction -> YnabSyncRecord) soft-deletes them in
+		// FK-correct order. Otherwise a synced transaction's active sync record lingers
+		// and later blocks Empty Trash on the NO ACTION FK. See RECEIPTS-755.
+		await context.YnabSyncRecords
+			.IgnoreAutoIncludes()
+			.Where(s => context.Transactions
+				.Where(t => ids.Contains(t.ReceiptId))
+				.Select(t => t.Id)
+				.Contains(s.LocalTransactionId))
+			.LoadAsync(cancellationToken);
+
 		context.Receipts.RemoveRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
 	}

--- a/src/Infrastructure/Repositories/ReceiptRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptRepository.cs
@@ -229,6 +229,9 @@ public class ReceiptRepository(IDbContextFactory<ApplicationDbContext> contextFa
 		entity.DeletedByApiKeyId = null;
 		entity.CascadeDeletedByParentId = null;
 
+		// Restores cascade-soft-deleted children recursively: the receipt's transactions
+		// and, in turn, the YnabSyncRecords those transactions cascade-soft-deleted
+		// (tagged with the transaction id). Mirrors the two-level cascade delete. RECEIPTS-755
 		await context.RestoreOwnedChildrenAsync<ReceiptEntity>(id, cancellationToken);
 
 		await context.SaveChangesAsync(cancellationToken);

--- a/src/Infrastructure/Repositories/TransactionRepository.cs
+++ b/src/Infrastructure/Repositories/TransactionRepository.cs
@@ -154,6 +154,15 @@ public class TransactionRepository(IDbContextFactory<ApplicationDbContext> conte
 			.Where(e => ids.Contains(e.Id))
 			.ToListAsync(cancellationToken);
 
+		// Load owned YnabSyncRecords into the change tracker so the cascade soft-delete
+		// fires (they carry a LocalTransactionId FK to Transactions). Without this a
+		// synced transaction's active sync record lingers after the transaction is
+		// soft-deleted and later blocks Empty Trash on the NO ACTION FK. See RECEIPTS-755.
+		await context.YnabSyncRecords
+			.IgnoreAutoIncludes()
+			.Where(s => ids.Contains(s.LocalTransactionId))
+			.LoadAsync(cancellationToken);
+
 		context.Transactions.RemoveRange(entities);
 		await context.SaveChangesAsync(cancellationToken);
 	}

--- a/src/Infrastructure/Repositories/TransactionRepository.cs
+++ b/src/Infrastructure/Repositories/TransactionRepository.cs
@@ -195,6 +195,14 @@ public class TransactionRepository(IDbContextFactory<ApplicationDbContext> conte
 		entity.DeletedByUserId = null;
 		entity.DeletedByApiKeyId = null;
 		entity.CascadeDeletedByParentId = null;
+
+		// Symmetric with DeleteAsync: revive the YnabSyncRecords this transaction
+		// cascade-soft-deleted (tagged CascadeDeletedByParentId == transaction id), so a
+		// delete -> restore round-trip does not leave a live transaction with dead sync
+		// history. Only cascade-deleted children are restored; independently soft-deleted
+		// sync records stay deleted. See RECEIPTS-755.
+		await context.RestoreOwnedChildrenAsync<TransactionEntity>(id, cancellationToken);
+
 		await context.SaveChangesAsync(cancellationToken);
 		return true;
 	}

--- a/src/Infrastructure/Services/TrashService.cs
+++ b/src/Infrastructure/Services/TrashService.cs
@@ -10,9 +10,18 @@ public class TrashService(ApplicationDbContext context) : ITrashService
 		await using Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction = await context.Database.BeginTransactionAsync(cancellationToken);
 
 		// Delete in FK dependency order (children first)
+		// Delete both soft-deleted sync records AND active sync records whose parent
+		// Transaction is about to be purged. The YnabSyncRecords -> Transactions FK is
+		// ClientCascade (DB-level NO ACTION), so an orphaned ACTIVE sync record pointing
+		// at a soft-deleted transaction would block the Transactions delete below with an
+		// FK violation — permanently breaking Empty Trash for every item. Purging it here
+		// first keeps the operation FK-safe even for historical orphans. See RECEIPTS-755.
 		await context.YnabSyncRecords
 			.IgnoreQueryFilters()
-			.Where(e => e.DeletedAt != null)
+			.Where(s => s.DeletedAt != null
+				|| context.Transactions
+					.IgnoreQueryFilters()
+					.Any(t => t.Id == s.LocalTransactionId && t.DeletedAt != null))
 			.ExecuteDeleteAsync(cancellationToken);
 
 		await context.Adjustments

--- a/tests/Infrastructure.IntegrationTests/PurgeTrashServiceTests.cs
+++ b/tests/Infrastructure.IntegrationTests/PurgeTrashServiceTests.cs
@@ -132,4 +132,63 @@ public class PurgeTrashServiceTests(PostgresFixture fixture)
 		(await verify.YnabSyncRecords.IgnoreQueryFilters().AnyAsync(e => e.Id == deletedSync.Id)).Should().BeFalse();
 		(await verify.YnabSyncRecords.IgnoreQueryFilters().AnyAsync(e => e.Id == activeSync.Id)).Should().BeTrue();
 	}
+
+	[Fact]
+	public async Task PurgeAllDeletedAsync_SoftDeletedTransactionWithActiveSyncRecord_PurgesBothWithoutFkViolation()
+	{
+		// RECEIPTS-755 regression against a real PostgreSQL instance where the
+		// YnabSyncRecords -> Transactions FK is enforced as NO ACTION.
+		//
+		// Scenario: a synced transaction was soft-deleted while its YnabSyncRecord
+		// stayed ACTIVE (DeletedAt IS NULL) — the orphan that broke Empty Trash.
+		// Purging the soft-deleted transaction while an active sync record still
+		// references it would throw a 23503 FK violation and roll the entire purge
+		// back, permanently deadlocking Empty Trash for every trash item. The purge
+		// must instead delete the orphaned active sync record first, in FK order.
+		DateTimeOffset deletedAt = DateTimeOffset.UtcNow;
+
+		AccountEntity account = AccountEntityGenerator.Generate();
+		CardEntity card = CardEntityGenerator.Generate();
+		card.Id = account.Id;
+		card.AccountId = account.Id;
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+
+		TransactionEntity deletedTransaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+		deletedTransaction.DeletedAt = deletedAt;
+
+		// The orphaned ACTIVE sync record pointing at the soft-deleted transaction.
+		YnabSyncRecordEntity orphanedActiveSync = YnabSyncRecordEntityGenerator.Generate(localTransactionId: deletedTransaction.Id);
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			setup.Accounts.Add(account);
+			setup.Cards.Add(card);
+			setup.Receipts.Add(receipt);
+			await setup.SaveChangesAsync();
+
+			setup.Transactions.Add(deletedTransaction);
+			await setup.SaveChangesAsync();
+
+			setup.YnabSyncRecords.Add(orphanedActiveSync);
+			await setup.SaveChangesAsync();
+		}
+
+		// Act — must not throw an FK violation.
+		await using (ApplicationDbContext act = fixture.CreateDbContext())
+		{
+			TrashService service = new(act);
+			Func<Task> purge = async () => await service.PurgeAllDeletedAsync(CancellationToken.None);
+			await purge.Should().NotThrowAsync();
+		}
+
+		// Assert — the soft-deleted transaction and its orphaned active sync record are
+		// both gone; the active parent rows survive.
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+
+		(await verify.Transactions.IgnoreQueryFilters().AnyAsync(e => e.Id == deletedTransaction.Id)).Should().BeFalse();
+		(await verify.YnabSyncRecords.IgnoreQueryFilters().AnyAsync(e => e.Id == orphanedActiveSync.Id))
+			.Should().BeFalse("no orphaned active sync record may survive the purge");
+		(await verify.Accounts.IgnoreQueryFilters().AnyAsync(e => e.Id == account.Id)).Should().BeTrue();
+		(await verify.Receipts.IgnoreQueryFilters().AnyAsync(e => e.Id == receipt.Id)).Should().BeTrue();
+	}
 }

--- a/tests/Infrastructure.Tests/Repositories/ReceiptRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Repositories/ReceiptRepositoryTests.cs
@@ -204,6 +204,49 @@ public class ReceiptRepositoryTests
 	}
 
 	[Fact]
+	public async Task DeleteThenRestore_ReceiptWithSyncedTransaction_RevivesYnabSyncRecord()
+	{
+		// RECEIPTS-755 restore symmetry across two levels: restoring a receipt revives its
+		// transactions AND the YnabSyncRecords those transactions cascade-soft-deleted (which
+		// are tagged with the transaction id, not the receipt id).
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		AccountEntity account = AccountEntityGenerator.Generate();
+		CardEntity card = CardEntityGenerator.Generate();
+		card.AccountId = account.Id;
+		card.Id = account.Id;
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+		YnabSyncRecordEntity syncRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id);
+
+		using (ApplicationDbContext context = _contextFactory.CreateDbContext())
+		{
+			await context.Receipts.AddAsync(receipt);
+			await context.Accounts.AddAsync(account);
+			await context.Cards.AddAsync(card);
+			await context.Transactions.AddAsync(transaction);
+			await context.YnabSyncRecords.AddAsync(syncRecord);
+			await context.SaveChangesAsync(CancellationToken.None);
+		}
+
+		ReceiptRepository repository = new(_contextFactory);
+
+		// Act — delete then restore the receipt.
+		await repository.DeleteAsync([receipt.Id], CancellationToken.None);
+		bool restored = await repository.RestoreAsync(receipt.Id, CancellationToken.None);
+
+		// Assert — receipt, transaction, and sync record all active again.
+		restored.Should().BeTrue();
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		(await verify.Receipts.AnyAsync(r => r.Id == receipt.Id)).Should().BeTrue();
+		(await verify.Transactions.AnyAsync(t => t.Id == transaction.Id)).Should().BeTrue();
+
+		YnabSyncRecordEntity revived = await verify.YnabSyncRecords.IgnoreQueryFilters().SingleAsync(s => s.Id == syncRecord.Id);
+		revived.DeletedAt.Should().BeNull("restoring the receipt must revive its transaction's cascade-soft-deleted sync record");
+		revived.CascadeDeletedByParentId.Should().BeNull();
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
 	public async Task ExistsAsync_ExistingId_ReturnsTrue()
 	{
 		// Arrange

--- a/tests/Infrastructure.Tests/Repositories/ReceiptRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Repositories/ReceiptRepositoryTests.cs
@@ -161,6 +161,49 @@ public class ReceiptRepositoryTests
 	}
 
 	[Fact]
+	public async Task DeleteAsync_ReceiptWithSyncedTransaction_CascadeSoftDeletesYnabSyncRecord()
+	{
+		// RECEIPTS-755 regression: deleting a receipt must cascade two levels
+		// (Receipt -> Transaction -> YnabSyncRecord) so a synced transaction's ACTIVE
+		// sync record does not linger and later block Empty Trash on the NO ACTION FK.
+		// Arrange — receipt -> transaction -> active sync record.
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		AccountEntity account = AccountEntityGenerator.Generate();
+		CardEntity card = CardEntityGenerator.Generate();
+		card.AccountId = account.Id;
+		card.Id = account.Id;
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+		YnabSyncRecordEntity syncRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id);
+
+		using (ApplicationDbContext context = _contextFactory.CreateDbContext())
+		{
+			await context.Receipts.AddAsync(receipt);
+			await context.Accounts.AddAsync(account);
+			await context.Cards.AddAsync(card);
+			await context.Transactions.AddAsync(transaction);
+			await context.YnabSyncRecords.AddAsync(syncRecord);
+			await context.SaveChangesAsync(CancellationToken.None);
+		}
+
+		ReceiptRepository repository = new(_contextFactory);
+
+		// Act — deleting the receipt must reach the transaction's sync record.
+		await repository.DeleteAsync([receipt.Id], CancellationToken.None);
+
+		// Assert — no active sync record survives; it was cascade soft-deleted.
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		(await verify.YnabSyncRecords.AnyAsync()).Should().BeFalse("the active sync record must not linger after its receipt is deleted");
+
+		YnabSyncRecordEntity deletedRecord = await verify.YnabSyncRecords
+			.IgnoreQueryFilters()
+			.SingleAsync(s => s.Id == syncRecord.Id);
+		deletedRecord.DeletedAt.Should().NotBeNull();
+		deletedRecord.CascadeDeletedByParentId.Should().Be(transaction.Id);
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
 	public async Task ExistsAsync_ExistingId_ReturnsTrue()
 	{
 		// Arrange

--- a/tests/Infrastructure.Tests/Repositories/TransactionRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Repositories/TransactionRepositoryTests.cs
@@ -207,6 +207,43 @@ public class TransactionRepositoryTests
 	}
 
 	[Fact]
+	public async Task DeleteAsync_SyncedTransaction_CascadeSoftDeletesActiveYnabSyncRecord()
+	{
+		// RECEIPTS-755 regression: deleting a synced transaction must cascade
+		// soft-delete its ACTIVE YnabSyncRecord so no orphaned active record lingers
+		// to later block Empty Trash on the NO ACTION LocalTransactionId FK.
+		// Arrange — a transaction with an active sync record (the state after a YNAB push).
+		(ReceiptEntity receipt, AccountEntity account) = await CreateParentEntitiesAsync();
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+		YnabSyncRecordEntity syncRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id);
+
+		using (ApplicationDbContext context = _contextFactory.CreateDbContext())
+		{
+			await context.Transactions.AddAsync(transaction);
+			await context.YnabSyncRecords.AddAsync(syncRecord);
+			await context.SaveChangesAsync(CancellationToken.None);
+		}
+
+		TransactionRepository repository = new(_contextFactory);
+
+		// Act — the repository must load the sync record so HandleSoftDelete cascades to it.
+		await repository.DeleteAsync([transaction.Id], CancellationToken.None);
+
+		// Assert — no active sync record survives; it was cascade soft-deleted and
+		// tagged with the parent transaction id.
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		(await verify.YnabSyncRecords.AnyAsync()).Should().BeFalse("the active sync record must not linger after its transaction is deleted");
+
+		YnabSyncRecordEntity deletedRecord = await verify.YnabSyncRecords
+			.IgnoreQueryFilters()
+			.SingleAsync(s => s.Id == syncRecord.Id);
+		deletedRecord.DeletedAt.Should().NotBeNull();
+		deletedRecord.CascadeDeletedByParentId.Should().Be(transaction.Id);
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
 	public async Task ExistsAsync_ExistingId_ReturnsTrue()
 	{
 		// Arrange

--- a/tests/Infrastructure.Tests/Repositories/TransactionRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Repositories/TransactionRepositoryTests.cs
@@ -244,6 +244,108 @@ public class TransactionRepositoryTests
 	}
 
 	[Fact]
+	public async Task DeleteThenRestore_SyncedTransaction_RevivesAllCascadeSoftDeletedYnabSyncRecords()
+	{
+		// RECEIPTS-755 restore symmetry: the unique index is per (LocalTransactionId, SyncType),
+		// so one transaction can carry several active sync records. Deleting the transaction must
+		// cascade-soft-delete ALL of them, and restoring it must revive every one — otherwise a
+		// live transaction ends up with dead sync history.
+		// Arrange — one transaction with TWO active sync records of different SyncType.
+		(ReceiptEntity receipt, AccountEntity account) = await CreateParentEntitiesAsync();
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+		YnabSyncRecordEntity pushRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id);
+		YnabSyncRecordEntity memoRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id, syncType: Common.YnabSyncType.MemoUpdate);
+
+		using (ApplicationDbContext context = _contextFactory.CreateDbContext())
+		{
+			await context.Transactions.AddAsync(transaction);
+			await context.YnabSyncRecords.AddRangeAsync(pushRecord, memoRecord);
+			await context.SaveChangesAsync(CancellationToken.None);
+		}
+
+		TransactionRepository repository = new(_contextFactory);
+
+		// Act — delete the transaction; both sync records cascade-soft-delete.
+		await repository.DeleteAsync([transaction.Id], CancellationToken.None);
+
+		using (ApplicationDbContext afterDelete = _contextFactory.CreateDbContext())
+		{
+			(await afterDelete.YnabSyncRecords.AnyAsync()).Should().BeFalse("both sync records should be soft-deleted with their transaction");
+			List<YnabSyncRecordEntity> deleted = await afterDelete.YnabSyncRecords.IgnoreQueryFilters().ToListAsync();
+			deleted.Should().HaveCount(2);
+			deleted.Should().AllSatisfy(r =>
+			{
+				r.DeletedAt.Should().NotBeNull();
+				r.CascadeDeletedByParentId.Should().Be(transaction.Id);
+			});
+		}
+
+		// Act — restore the transaction; both sync records must come back active.
+		bool restored = await repository.RestoreAsync(transaction.Id, CancellationToken.None);
+
+		// Assert
+		restored.Should().BeTrue();
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+		(await verify.Transactions.AnyAsync(t => t.Id == transaction.Id)).Should().BeTrue();
+
+		List<YnabSyncRecordEntity> activeRecords = await verify.YnabSyncRecords.ToListAsync();
+		activeRecords.Should().HaveCount(2, "both cascade-soft-deleted sync records must be revived on restore");
+		activeRecords.Should().AllSatisfy(r =>
+		{
+			r.DeletedAt.Should().BeNull();
+			r.CascadeDeletedByParentId.Should().BeNull();
+		});
+		activeRecords.Select(r => r.Id).Should().BeEquivalentTo([pushRecord.Id, memoRecord.Id]);
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task RestoreAsync_SyncedTransaction_DoesNotReviveIndependentlySoftDeletedSyncRecord()
+	{
+		// Restore must be the exact inverse of the cascade delete: only sync records
+		// cascade-soft-deleted BY the transaction (CascadeDeletedByParentId == tx id) are
+		// revived. A sync record the user soft-deleted independently beforehand stays deleted.
+		(ReceiptEntity receipt, AccountEntity account) = await CreateParentEntitiesAsync();
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id);
+		YnabSyncRecordEntity cascadeRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id);
+		YnabSyncRecordEntity independentRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id, syncType: Common.YnabSyncType.MemoUpdate);
+
+		using (ApplicationDbContext context = _contextFactory.CreateDbContext())
+		{
+			await context.Transactions.AddAsync(transaction);
+			await context.YnabSyncRecords.AddRangeAsync(cascadeRecord, independentRecord);
+			await context.SaveChangesAsync(CancellationToken.None);
+		}
+
+		// Independently soft-delete one sync record BEFORE the transaction is deleted.
+		using (ApplicationDbContext context = _contextFactory.CreateDbContext())
+		{
+			YnabSyncRecordEntity toDelete = await context.YnabSyncRecords.FirstAsync(r => r.Id == independentRecord.Id);
+			context.YnabSyncRecords.Remove(toDelete);
+			await context.SaveChangesAsync(CancellationToken.None);
+		}
+
+		TransactionRepository repository = new(_contextFactory);
+
+		// Act — delete (cascades only the still-active cascadeRecord) then restore.
+		await repository.DeleteAsync([transaction.Id], CancellationToken.None);
+		await repository.RestoreAsync(transaction.Id, CancellationToken.None);
+
+		// Assert — cascadeRecord revived; independentRecord stays soft-deleted.
+		using ApplicationDbContext verify = _contextFactory.CreateDbContext();
+
+		YnabSyncRecordEntity revived = await verify.YnabSyncRecords.IgnoreQueryFilters().SingleAsync(r => r.Id == cascadeRecord.Id);
+		revived.DeletedAt.Should().BeNull();
+		revived.CascadeDeletedByParentId.Should().BeNull();
+
+		YnabSyncRecordEntity stillDeleted = await verify.YnabSyncRecords.IgnoreQueryFilters().SingleAsync(r => r.Id == independentRecord.Id);
+		stillDeleted.DeletedAt.Should().NotBeNull("an independently soft-deleted sync record must not be revived by restoring the transaction");
+
+		_contextFactory.ResetDatabase();
+	}
+
+	[Fact]
 	public async Task ExistsAsync_ExistingId_ReturnsTrue()
 	{
 		// Arrange


### PR DESCRIPTION
## Problem (RECEIPTS-755)

A synced transaction carries an **active** `YnabSyncRecord` whose `LocalTransactionId` FK to `Transactions` is `DeleteBehavior.ClientCascade` (DB-level **NO ACTION**; EF only cascades when the related records are loaded in the same change tracker).

- When a synced transaction was soft-deleted, no path loaded its `YnabSyncRecords` into the tracker, so the `ClientCascade` never fired — the sync record stayed active (`DeletedAt = null`).
- On **Empty Trash**, `TrashService.PurgeAllDeletedAsync` purged only sync records `WHERE DeletedAt != null` (the orphan didn't match), then `ExecuteDelete`d the soft-deleted transactions → the still-active sync record's FK (NO ACTION in Postgres) blocked the delete → **23503 FK violation + full rollback**. Empty Trash then failed **permanently for every trash item** until manual DB surgery.

## Fix (code only — no migration)

Both prongs of the audit's recommendation, for defense in depth:

1. **Close the cascade gap at the source.** `TransactionRepository.DeleteAsync` and `ReceiptRepository.DeleteAsync` now load the affected transactions' `YnabSyncRecords` into the change tracker before `RemoveRange`, so `HandleSoftDelete`'s owned-child cascade (the entity is already `IOwnedBy<TransactionEntity>` via `[OwnedByFk]`) soft-deletes them in FK-correct order. No orphaned active sync record is created going forward.
2. **Harden the purge.** `TrashService.PurgeAllDeletedAsync` also purges **active** sync records whose `LocalTransactionId` references a soft-deleted transaction being purged (mirrors the existing Subcategory/Category guard). This keeps Empty Trash FK-safe even for historical orphans created before this fix.

No schema change: the FK behavior, model snapshot, and migrations are untouched.

## Tests added

- **Unit** (`Infrastructure.Tests`, runs in CI): deleting a synced transaction/receipt via the repository cascade soft-deletes its active `YnabSyncRecord`; no orphan survives (asserts `DeletedAt` set and `CascadeDeletedByParentId`).
- **Integration** (`Infrastructure.IntegrationTests`, real Postgres): `PurgeAllDeletedAsync` purges a soft-deleted transaction plus its **orphaned active** sync record without an FK violation; active parent rows survive.

## Validation

- `dotnet build Receipts.slnx` — 0 errors, no new warnings.
- `dotnet test tests/Infrastructure.Tests --filter "Category!=Integration"` — **625 passed**.
- New integration test + existing `PurgeTrashServiceTests` — **2 passed** against Dockerized Postgres.
- `dotnet format --verify-no-changes` on all edited files — clean.

Closes RECEIPTS-755