### PR TITLE
fix(client): keyboard accessibility for reports, password toggle, list nav, and subcategory groups

### DIFF
--- a/src/client/src/components/SortableTableHead.test.tsx
+++ b/src/client/src/components/SortableTableHead.test.tsx
@@ -15,6 +15,7 @@ function renderSortableHead(props: {
   currentSortDirection?: "asc" | "desc";
   onToggleSort?: (column: string) => void;
   className?: string;
+  align?: "left" | "right";
 }) {
   const defaults = {
     column: "name",
@@ -134,6 +135,20 @@ describe("SortableTableHead", () => {
       await user.tab();
       const button = screen.getByRole("button", { name: /name/i });
       expect(button).toHaveFocus();
+    });
+  });
+
+  describe("alignment", () => {
+    it("left-aligns the button content by default", () => {
+      renderSortableHead({ label: "Name" });
+      const button = screen.getByRole("button", { name: /name/i });
+      expect(button.className).not.toContain("justify-end");
+    });
+
+    it("right-aligns the button content when align is 'right'", () => {
+      renderSortableHead({ label: "Amount", align: "right" });
+      const button = screen.getByRole("button", { name: /amount/i });
+      expect(button.className).toContain("justify-end");
     });
   });
 

--- a/src/client/src/components/SortableTableHead.tsx
+++ b/src/client/src/components/SortableTableHead.tsx
@@ -8,6 +8,8 @@ interface SortableTableHeadProps {
   currentSortDirection: "asc" | "desc";
   onToggleSort: (column: string) => void;
   className?: string;
+  /** Aligns the label/icon within the header button. Defaults to "left". */
+  align?: "left" | "right";
 }
 
 export function SortableTableHead({
@@ -17,6 +19,7 @@ export function SortableTableHead({
   currentSortDirection,
   onToggleSort,
   className,
+  align = "left",
 }: SortableTableHeadProps) {
   const isActive = currentSortBy === column;
 
@@ -33,7 +36,7 @@ export function SortableTableHead({
     >
       <button
         type="button"
-        className="inline-flex items-center gap-1 cursor-pointer hover:text-foreground w-full h-full"
+        className={`inline-flex items-center gap-1 cursor-pointer hover:text-foreground w-full h-full ${align === "right" ? "justify-end" : ""}`}
         onClick={() => onToggleSort(column)}
       >
         {label}

--- a/src/client/src/components/reports/ItemSimilarity.tsx
+++ b/src/client/src/components/reports/ItemSimilarity.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SortableTableHead } from "@/components/SortableTableHead";
 import {
   Dialog,
   DialogContent,
@@ -84,19 +85,15 @@ export default function ItemSimilarity() {
   const refreshMutation = useRefreshItemSimilarity();
   const { isAdmin } = usePermission();
 
-  function handleSort(column: SortColumn) {
-    if (sortBy === column) {
+  function handleSort(column: string) {
+    const nextColumn = column as SortColumn;
+    if (sortBy === nextColumn) {
       setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
     } else {
-      setSortBy(column);
-      setSortDirection(column === "canonicalName" ? "asc" : "desc");
+      setSortBy(nextColumn);
+      setSortDirection(nextColumn === "canonicalName" ? "asc" : "desc");
     }
     setPage(1);
-  }
-
-  function sortIndicator(column: SortColumn) {
-    if (sortBy !== column) return null;
-    return sortDirection === "asc" ? " \u2191" : " \u2193";
   }
 
   function handleRenameClick(group: {
@@ -208,25 +205,10 @@ export default function ItemSimilarity() {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead
-                  className="cursor-pointer select-none"
-                  onClick={() => handleSort("canonicalName")}
-                >
-                  Canonical Name{sortIndicator("canonicalName")}
-                </TableHead>
+                <SortableTableHead column="canonicalName" label="Canonical Name" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
                 <TableHead>Variants</TableHead>
-                <TableHead
-                  className="cursor-pointer select-none text-right"
-                  onClick={() => handleSort("occurrences")}
-                >
-                  Occurrences{sortIndicator("occurrences")}
-                </TableHead>
-                <TableHead
-                  className="cursor-pointer select-none text-right"
-                  onClick={() => handleSort("maxSimilarity")}
-                >
-                  Max Similarity{sortIndicator("maxSimilarity")}
-                </TableHead>
+                <SortableTableHead column="occurrences" label="Occurrences" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" align="right" />
+                <SortableTableHead column="maxSimilarity" label="Max Similarity" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" align="right" />
                 <TableHead className="text-right">Action</TableHead>
               </TableRow>
             </TableHeader>

--- a/src/client/src/components/reports/OutOfBalance.test.tsx
+++ b/src/client/src/components/reports/OutOfBalance.test.tsx
@@ -152,10 +152,7 @@ describe("OutOfBalance", () => {
     renderWithQueryClient(<OutOfBalance />);
 
     // Initially sorted by date asc
-    const dateHeader = screen
-      .getByText(/Date/)
-      .closest("th")!;
-    await user.click(dateHeader);
+    await user.click(screen.getByRole("button", { name: /date/i }));
 
     // Should have called hook with date desc
     expect(mockHook).toHaveBeenLastCalledWith(
@@ -168,10 +165,7 @@ describe("OutOfBalance", () => {
     setupMock();
     renderWithQueryClient(<OutOfBalance />);
 
-    const diffHeader = screen
-      .getByText(/Difference/)
-      .closest("th")!;
-    await user.click(diffHeader);
+    await user.click(screen.getByRole("button", { name: /difference/i }));
 
     expect(mockHook).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -179,6 +173,36 @@ describe("OutOfBalance", () => {
         sortDirection: "asc",
       }),
     );
+  });
+
+  it("sets aria-sort on the active sort column header", () => {
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+
+    const dateHeader = screen.getByRole("button", { name: /date/i }).closest("th")!;
+    expect(dateHeader).toHaveAttribute("aria-sort", "ascending");
+  });
+
+  it("navigates to receipt on View click", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+
+    const viewButtons = screen.getAllByRole("button", { name: "View" });
+    await user.click(viewButtons[0]);
+    expect(mockNavigate).toHaveBeenCalledWith("/receipts/id-1");
+  });
+
+  it("View button is keyboard focusable", async () => {
+    const user = userEvent.setup();
+    setupMock();
+    renderWithQueryClient(<OutOfBalance />);
+
+    const viewButtons = screen.getAllByRole("button", { name: "View" });
+    viewButtons[0].focus();
+    expect(viewButtons[0]).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(mockNavigate).toHaveBeenCalledWith("/receipts/id-1");
   });
 
   it("does not show pagination when only one page", () => {

--- a/src/client/src/components/reports/OutOfBalance.tsx
+++ b/src/client/src/components/reports/OutOfBalance.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { SortableTableHead } from "@/components/SortableTableHead";
 
 type SortColumn = "date" | "difference";
 type SortDirection = "asc" | "desc";
@@ -35,22 +36,23 @@ export default function OutOfBalance() {
 
   const { data, isLoading, isError } = useOutOfBalanceReport(params);
 
-  function handleSort(column: SortColumn) {
-    if (sortBy === column) {
+  function handleSort(column: string) {
+    const nextColumn = column as SortColumn;
+    if (sortBy === nextColumn) {
       setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
     } else {
-      setSortBy(column);
+      setSortBy(nextColumn);
       setSortDirection("asc");
     }
     setPage(1);
   }
 
-  function sortIndicator(column: SortColumn) {
-    if (sortBy !== column) return null;
-    return sortDirection === "asc" ? " \u2191" : " \u2193";
+  function handleRowClick(receiptId: string) {
+    navigate(`/receipts/${receiptId}`);
   }
 
-  function handleRowClick(receiptId: string) {
+  function handleViewClick(e: React.MouseEvent, receiptId: string) {
+    e.stopPropagation();
     navigate(`/receipts/${receiptId}`);
   }
 
@@ -106,24 +108,15 @@ export default function OutOfBalance() {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead
-              className="cursor-pointer select-none"
-              onClick={() => handleSort("date")}
-            >
-              Date{sortIndicator("date")}
-            </TableHead>
+            <SortableTableHead column="date" label="Date" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
             <TableHead>Location</TableHead>
             <TableHead className="text-right">Item Total</TableHead>
             <TableHead className="text-right">Tax</TableHead>
             <TableHead className="text-right">Adjustments</TableHead>
             <TableHead className="text-right">Expected Total</TableHead>
             <TableHead className="text-right">Actual Total</TableHead>
-            <TableHead
-              className="cursor-pointer select-none text-right"
-              onClick={() => handleSort("difference")}
-            >
-              Difference{sortIndicator("difference")}
-            </TableHead>
+            <SortableTableHead column="difference" label="Difference" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" align="right" />
+            <TableHead className="w-16">View</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -160,6 +153,15 @@ export default function OutOfBalance() {
                 }}
               >
                 {formatCurrency(Number(item.difference ?? 0))}
+              </TableCell>
+              <TableCell>
+                <button
+                  type="button"
+                  className="text-primary underline-offset-4 hover:underline"
+                  onClick={(e) => handleViewClick(e, item.receiptId)}
+                >
+                  View
+                </button>
               </TableCell>
             </TableRow>
           ))}

--- a/src/client/src/components/reports/SpendingByLocation.test.tsx
+++ b/src/client/src/components/reports/SpendingByLocation.test.tsx
@@ -150,10 +150,7 @@ describe("SpendingByLocation", () => {
 
     // Initially sorted by total desc — find it within the table
     const table = screen.getByRole("table");
-    const totalHeader = within(table)
-      .getByText(/^Total/)
-      .closest("th")!;
-    await user.click(totalHeader);
+    await user.click(within(table).getByRole("button", { name: /^total/i }));
 
     // Should have called hook with total asc (toggled from desc)
     expect(mockHook).toHaveBeenLastCalledWith(
@@ -166,10 +163,7 @@ describe("SpendingByLocation", () => {
     setupMock();
     renderWithQueryClient(<SpendingByLocation />);
 
-    const visitsHeader = screen
-      .getByText(/Visits/)
-      .closest("th")!;
-    await user.click(visitsHeader);
+    await user.click(screen.getByRole("button", { name: /visits/i }));
 
     expect(mockHook).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -185,10 +179,7 @@ describe("SpendingByLocation", () => {
     renderWithQueryClient(<SpendingByLocation />);
 
     const table = screen.getByRole("table");
-    const locationHeader = within(table)
-      .getByText(/^Location$/)
-      .closest("th")!;
-    await user.click(locationHeader);
+    await user.click(within(table).getByRole("button", { name: /^location$/i }));
 
     expect(mockHook).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/src/client/src/components/reports/SpendingByLocation.tsx
+++ b/src/client/src/components/reports/SpendingByLocation.tsx
@@ -12,12 +12,12 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableHead,
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { SortableTableHead } from "@/components/SortableTableHead";
 
 type SortColumn = "location" | "visits" | "total" | "averagePerVisit";
 type SortDirection = "asc" | "desc";
@@ -53,19 +53,15 @@ export default function SpendingByLocation() {
     setPage(1);
   }, []);
 
-  function handleSort(column: SortColumn) {
-    if (sortBy === column) {
+  function handleSort(column: string) {
+    const nextColumn = column as SortColumn;
+    if (sortBy === nextColumn) {
       setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
     } else {
-      setSortBy(column);
-      setSortDirection(column === "location" ? "asc" : "desc");
+      setSortBy(nextColumn);
+      setSortDirection(nextColumn === "location" ? "asc" : "desc");
     }
     setPage(1);
-  }
-
-  function sortIndicator(column: SortColumn) {
-    if (sortBy !== column) return null;
-    return sortDirection === "asc" ? " \u2191" : " \u2193";
   }
 
   const chartData = useMemo(
@@ -154,30 +150,10 @@ export default function SpendingByLocation() {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead
-              className="cursor-pointer select-none"
-              onClick={() => handleSort("location")}
-            >
-              Location{sortIndicator("location")}
-            </TableHead>
-            <TableHead
-              className="cursor-pointer select-none text-right"
-              onClick={() => handleSort("visits")}
-            >
-              Visits{sortIndicator("visits")}
-            </TableHead>
-            <TableHead
-              className="cursor-pointer select-none text-right"
-              onClick={() => handleSort("total")}
-            >
-              Total{sortIndicator("total")}
-            </TableHead>
-            <TableHead
-              className="cursor-pointer select-none text-right"
-              onClick={() => handleSort("averagePerVisit")}
-            >
-              Avg/Visit{sortIndicator("averagePerVisit")}
-            </TableHead>
+            <SortableTableHead column="location" label="Location" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
+            <SortableTableHead column="visits" label="Visits" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" align="right" />
+            <SortableTableHead column="total" label="Total" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" align="right" />
+            <SortableTableHead column="averagePerVisit" label="Avg/Visit" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" align="right" />
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/src/client/src/components/reports/UncategorizedItems.test.tsx
+++ b/src/client/src/components/reports/UncategorizedItems.test.tsx
@@ -163,10 +163,7 @@ describe("UncategorizedItems", () => {
     setupMock();
     renderWithQueryClient(<UncategorizedItems />);
 
-    const descHeader = screen
-      .getByText(/Description/)
-      .closest("th")!;
-    await user.click(descHeader);
+    await user.click(screen.getByRole("button", { name: /description/i }));
 
     expect(mockHook).toHaveBeenLastCalledWith(
       expect.objectContaining({ sortBy: "description", sortDirection: "desc" }),
@@ -178,10 +175,7 @@ describe("UncategorizedItems", () => {
     setupMock();
     renderWithQueryClient(<UncategorizedItems />);
 
-    const totalHeader = screen
-      .getByText(/Total/)
-      .closest("th")!;
-    await user.click(totalHeader);
+    await user.click(screen.getByRole("button", { name: /total/i }));
 
     expect(mockHook).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/src/client/src/components/reports/UncategorizedItems.tsx
+++ b/src/client/src/components/reports/UncategorizedItems.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
+import { SortableTableHead } from "@/components/SortableTableHead";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
 
@@ -135,19 +136,15 @@ export default function UncategorizedItems() {
     },
   });
 
-  function handleSort(column: SortColumn) {
-    if (sortBy === column) {
+  function handleSort(column: string) {
+    const nextColumn = column as SortColumn;
+    if (sortBy === nextColumn) {
       setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
     } else {
-      setSortBy(column);
+      setSortBy(nextColumn);
       setSortDirection("asc");
     }
     setPage(1);
-  }
-
-  function sortIndicator(column: SortColumn) {
-    if (sortBy !== column) return null;
-    return sortDirection === "asc" ? " \u2191" : " \u2193";
   }
 
   function handleReceiptClick(e: React.MouseEvent, receiptId: string) {
@@ -296,25 +293,10 @@ export default function UncategorizedItems() {
                 aria-label="Select all items on this page"
               />
             </TableHead>
-            <TableHead
-              className="cursor-pointer select-none"
-              onClick={() => handleSort("description")}
-            >
-              Description{sortIndicator("description")}
-            </TableHead>
-            <TableHead
-              className="cursor-pointer select-none"
-              onClick={() => handleSort("itemCode")}
-            >
-              Item Code{sortIndicator("itemCode")}
-            </TableHead>
+            <SortableTableHead column="description" label="Description" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
+            <SortableTableHead column="itemCode" label="Item Code" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} />
             <TableHead>Receipt</TableHead>
-            <TableHead
-              className="cursor-pointer select-none text-right"
-              onClick={() => handleSort("total")}
-            >
-              Total{sortIndicator("total")}
-            </TableHead>
+            <SortableTableHead column="total" label="Total" currentSortBy={sortBy} currentSortDirection={sortDirection} onToggleSort={handleSort} className="text-right" align="right" />
             <TableHead>Subcategory</TableHead>
           </TableRow>
         </TableHeader>

--- a/src/client/src/components/ui/password-input.test.tsx
+++ b/src/client/src/components/ui/password-input.test.tsx
@@ -61,9 +61,25 @@ describe("PasswordInput", () => {
     expect(input.className).toContain("custom-class");
   });
 
-  it("toggle button has tabIndex -1 to keep focus on input", () => {
+  it("toggle button is in natural tab order so keyboard users can reach it", () => {
     render(<PasswordInput />);
     const toggleButton = screen.getByLabelText("Show password");
-    expect(toggleButton).toHaveAttribute("tabindex", "-1");
+    expect(toggleButton).not.toHaveAttribute("tabindex", "-1");
+  });
+
+  it("toggle button is reachable and activatable via keyboard", async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput placeholder="Enter password" />);
+
+    const input = screen.getByPlaceholderText("Enter password");
+
+    await user.tab(); // password input
+    expect(input).toHaveFocus();
+    await user.tab(); // toggle button
+    expect(screen.getByLabelText("Show password")).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    expect(input).toHaveAttribute("type", "text");
+    expect(screen.getByLabelText("Hide password")).toHaveFocus();
   });
 });

--- a/src/client/src/components/ui/password-input.tsx
+++ b/src/client/src/components/ui/password-input.tsx
@@ -29,7 +29,6 @@ const PasswordInput = React.forwardRef<
         variant="ghost"
         size="icon"
         className="absolute right-0 top-0 h-9 w-9 px-2 hover:bg-transparent"
-        tabIndex={-1}
         aria-label={visible ? "Hide password" : "Show password"}
         onClick={() => setVisible((v) => !v)}
       >

--- a/src/client/src/pages/AdminUsers.test.tsx
+++ b/src/client/src/pages/AdminUsers.test.tsx
@@ -610,6 +610,33 @@ describe("AdminUsers", () => {
     expect(mockSetFocusedIndex).toHaveBeenCalledWith(0);
   });
 
+  it("exposes grid role and row id so keyboard focus is announced to assistive tech", async () => {
+    const { useUsers } = await import("@/hooks/useUsers");
+    vi.mocked(useUsers).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "1",
+          email: "grid@example.com",
+          firstName: "Grid",
+          lastName: "Row",
+          roles: ["User"],
+          isDisabled: false,
+          createdAt: "2024-01-01",
+          lastLoginAt: null,
+        },
+      ],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<AdminUsers />);
+
+    expect(screen.getByRole("grid")).toBeInTheDocument();
+    const row = screen.getByText("grid@example.com").closest("tr")!;
+    expect(row).toHaveAttribute("id", "list-row-1");
+    expect(row).toHaveAttribute("role", "row");
+  });
+
   it("shows just first name when last name is null", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
     vi.mocked(useUsers).mockReturnValue(mockQueryResult({

--- a/src/client/src/pages/AdminUsers.tsx
+++ b/src/client/src/pages/AdminUsers.tsx
@@ -132,9 +132,10 @@ function AdminUsers() {
   const items = usersData ?? [];
 
   const listItems = items.map((u) => ({ id: u.id }));
-  const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
+  const { focusedId, setFocusedIndex, tableRef, containerProps, getRowProps } = useListKeyboardNav({
     items: listItems,
     getId: (u) => u.id,
+    listId: "admin-users",
     enabled: listItems.length > 0,
   });
 
@@ -254,7 +255,7 @@ function AdminUsers() {
             onPageChange={(page) => setPage(page, serverTotal)}
             onPageSizeChange={setPageSize}
           />
-          <div className="rounded-md border" ref={tableRef}>
+          <div className="rounded-md border" ref={tableRef} {...containerProps}>
             <Table>
               <TableHeader>
                 <TableRow>
@@ -277,6 +278,7 @@ function AdminUsers() {
                   return (
                     <TableRow
                       key={user.id}
+                      {...getRowProps(user.id)}
                       className={`cursor-pointer ${focusedId === user.id ? "bg-accent" : ""}`}
                       onClick={(e) => {
                         if (

--- a/src/client/src/pages/ApiKeys.test.tsx
+++ b/src/client/src/pages/ApiKeys.test.tsx
@@ -462,6 +462,30 @@ describe("ApiKeys", () => {
     expect(mockSetFocusedIndex).toHaveBeenCalledWith(0);
   });
 
+  it("exposes grid role and row id so keyboard focus is announced to assistive tech", async () => {
+    const { useQuery } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue(mockQueryResult({
+      data: [
+        {
+          id: "key-1",
+          name: "Grid Row Key",
+          createdAt: "2024-01-01T00:00:00Z",
+          lastUsedAt: null,
+          expiresAt: null,
+          isRevoked: false,
+        },
+      ],
+      isLoading: false,
+    }));
+
+    renderWithQueryClient(<ApiKeys />);
+
+    expect(screen.getByRole("grid")).toBeInTheDocument();
+    const row = screen.getByText("Grid Row Key").closest("tr")!;
+    expect(row).toHaveAttribute("id", "list-row-key-1");
+    expect(row).toHaveAttribute("role", "row");
+  });
+
   it("shows error toast when clipboard copy fails", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     const { useMutation } = await import("@tanstack/react-query");

--- a/src/client/src/pages/ApiKeys.tsx
+++ b/src/client/src/pages/ApiKeys.tsx
@@ -180,9 +180,10 @@ function ApiKeys() {
     }
   }
 
-  const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
+  const { focusedId, setFocusedIndex, tableRef, containerProps, getRowProps } = useListKeyboardNav({
     items: apiKeys as { id: string }[],
     getId: (k) => k.id,
+    listId: "api-keys",
     enabled: !anyDialogOpen && apiKeys.length > 0,
   });
 
@@ -219,7 +220,7 @@ function ApiKeys() {
               No API keys yet. Create one to get started.
             </p>
           ) : (
-            <div ref={tableRef}>
+            <div ref={tableRef} {...containerProps}>
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -237,6 +238,7 @@ function ApiKeys() {
                     return (
                       <TableRow
                         key={key.id}
+                        {...getRowProps(key.id)}
                         className={`cursor-pointer ${focusedId === key.id ? "bg-accent" : ""}`}
                         onClick={(e) => {
                           if (

--- a/src/client/src/pages/RecycleBin.test.tsx
+++ b/src/client/src/pages/RecycleBin.test.tsx
@@ -315,6 +315,22 @@ describe("RecycleBin", () => {
     expect(row?.className).toContain("bg-accent");
   });
 
+  it("exposes grid role and row id so keyboard focus is announced to assistive tech", async () => {
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Grid Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+
+    renderWithProviders(<RecycleBin />);
+
+    expect(screen.getByRole("grid")).toBeInTheDocument();
+    const row = screen.getByText("Grid Store - 2026-01-01").closest("tr")!;
+    expect(row).toHaveAttribute("id", "list-row-Receipt:r1");
+    expect(row).toHaveAttribute("role", "row");
+  });
+
   it("shows Emptying state when purge is pending", async () => {
     const { usePurgeTrash } = await import("@/hooks/useTrash");
     vi.mocked(usePurgeTrash).mockReturnValue(mockMutationResult({ isPending: true }));

--- a/src/client/src/pages/RecycleBin.tsx
+++ b/src/client/src/pages/RecycleBin.tsx
@@ -109,11 +109,15 @@ function DeletedItemsTable({
   focusedKey,
   tableRef,
   onRowClick,
+  containerProps,
+  getRowProps,
 }: {
   items: DeletedItem[];
   focusedKey?: string | null;
   tableRef?: React.RefObject<HTMLDivElement | null>;
   onRowClick?: (index: number) => void;
+  containerProps?: React.HTMLAttributes<HTMLDivElement>;
+  getRowProps?: (itemId: string) => React.ComponentProps<"tr">;
 }) {
   if (items.length === 0) {
     return (
@@ -124,7 +128,7 @@ function DeletedItemsTable({
   }
 
   return (
-    <div className="rounded-md border" ref={tableRef}>
+    <div className="rounded-md border" ref={tableRef} {...containerProps}>
       <Table>
         <TableHeader>
           <TableRow>
@@ -135,47 +139,49 @@ function DeletedItemsTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {items.map((item, index) => (
-            <TableRow
-              key={`${item.entityType}:${item.id}`}
-              className={`${onRowClick ? "cursor-pointer" : ""} ${
-                focusedKey === `${item.entityType}:${item.id}`
-                  ? "bg-accent"
-                  : ""
-              }`}
-              onClick={(e) => {
-                if (!onRowClick) return;
-                if (
-                  (e.target as HTMLElement).closest(
-                    "button, input, a, [role='button']",
+          {items.map((item, index) => {
+            const itemKey = `${item.entityType}:${item.id}`;
+            return (
+              <TableRow
+                key={itemKey}
+                {...(getRowProps ? getRowProps(itemKey) : {})}
+                className={`${onRowClick ? "cursor-pointer" : ""} ${
+                  focusedKey === itemKey ? "bg-accent" : ""
+                }`}
+                onClick={(e) => {
+                  if (!onRowClick) return;
+                  if (
+                    (e.target as HTMLElement).closest(
+                      "button, input, a, [role='button']",
+                    )
                   )
-                )
-                  return;
-                onRowClick(index);
-              }}
-            >
-              <TableCell>{item.entityTypeLabel}</TableCell>
-              <TableCell>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="font-mono text-xs cursor-default">
-                      {truncateId(item.id)}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>{item.id}</TooltipContent>
-                </Tooltip>
-              </TableCell>
-              <TableCell className="text-sm text-muted-foreground">
-                {item.label}
-              </TableCell>
-              <TableCell>
-                <RestoreButton
-                  entityType={item.entityType}
-                  entityId={item.id}
-                />
-              </TableCell>
-            </TableRow>
-          ))}
+                    return;
+                  onRowClick(index);
+                }}
+              >
+                <TableCell>{item.entityTypeLabel}</TableCell>
+                <TableCell>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="font-mono text-xs cursor-default">
+                        {truncateId(item.id)}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>{item.id}</TooltipContent>
+                  </Tooltip>
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {item.label}
+                </TableCell>
+                <TableCell>
+                  <RestoreButton
+                    entityType={item.entityType}
+                    entityId={item.id}
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </div>
@@ -262,9 +268,10 @@ function RecycleBin() {
     subcategories.data,
   ]);
 
-  const { focusedId, setFocusedIndex, tableRef } = useListKeyboardNav({
+  const { focusedId, setFocusedIndex, tableRef, containerProps, getRowProps } = useListKeyboardNav({
     items: allItems,
     getId: (item) => `${item.entityType}:${item.id}`,
+    listId: "recycle-bin",
     enabled: !isLoading,
   });
 
@@ -353,6 +360,8 @@ function RecycleBin() {
             focusedKey={focusedId}
             tableRef={tableRef}
             onRowClick={setFocusedIndex}
+            containerProps={containerProps}
+            getRowProps={getRowProps}
           />
         </TabsContent>
 

--- a/src/client/src/pages/Subcategories.test.tsx
+++ b/src/client/src/pages/Subcategories.test.tsx
@@ -269,6 +269,37 @@ describe("Subcategories", () => {
     expect(within(goodsHeader).getByText("(1)")).toBeInTheDocument();
   });
 
+  it("category header exposes a focusable, labeled toggle button with aria-expanded", async () => {
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    const foodHeader = screen.getByTestId("category-header-c1");
+    const toggle = within(foodHeader).getByRole("button", {
+      name: /expand food/i,
+    });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("expanding a category via keyboard updates aria-expanded and label", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    await setupWithData();
+    renderWithProviders(<Subcategories />);
+
+    const foodHeader = screen.getByTestId("category-header-c1");
+    const toggle = within(foodHeader).getByRole("button", {
+      name: /expand food/i,
+    });
+
+    toggle.focus();
+    expect(toggle).toHaveFocus();
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByText("Dairy")).toBeInTheDocument();
+    expect(
+      within(foodHeader).getByRole("button", { name: /collapse food/i }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("opens create dialog when New Subcategory button is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithProviders(<Subcategories />);

--- a/src/client/src/pages/Subcategories.tsx
+++ b/src/client/src/pages/Subcategories.tsx
@@ -375,21 +375,35 @@ function Subcategories() {
                     <Fragment key={categoryId}>
                       <TableRow
                         className="cursor-pointer bg-muted/50 hover:bg-muted"
-                        onClick={() => toggleCategory(categoryId)}
+                        onClick={(e) => {
+                          if (
+                            (e.target as HTMLElement).closest(
+                              "button, input, a, [role='button']",
+                            )
+                          )
+                            return;
+                          toggleCategory(categoryId);
+                        }}
                         data-testid={`category-header-${categoryId}`}
                       >
                         <TableCell colSpan={5}>
-                          <div className="flex items-center gap-2 font-medium">
+                          <button
+                            type="button"
+                            className="flex w-full items-center gap-2 font-medium text-left cursor-pointer"
+                            onClick={() => toggleCategory(categoryId)}
+                            aria-expanded={isExpanded}
+                            aria-label={`${isExpanded ? "Collapse" : "Expand"} ${categoryName}`}
+                          >
                             {isExpanded ? (
-                              <ChevronDown className="h-4 w-4" />
+                              <ChevronDown className="h-4 w-4" aria-hidden="true" />
                             ) : (
-                              <ChevronRight className="h-4 w-4" />
+                              <ChevronRight className="h-4 w-4" aria-hidden="true" />
                             )}
                             {categoryName}
                             <span className="ml-1 text-xs text-muted-foreground">
                               ({items.length})
                             </span>
-                          </div>
+                          </button>
                         </TableCell>
                       </TableRow>
                       {isExpanded &&


### PR DESCRIPTION
## Summary

Five confirmed WCAG 2.1 AA keyboard/screen-reader findings, fixed by reusing existing compliant patterns already in the codebase:

- **RECEIPTS-779** (2.1.1 / 4.1.2) — `OutOfBalance`, `UncategorizedItems`, `SpendingByLocation`, and `ItemSimilarity` had sort headers built from a raw `TableHead` with `onClick` (not focusable, no `aria-sort`). Replaced with the existing `SortableTableHead` component (same one used on Accounts/Categories/Cards/Subcategories/AdminUsers/Receipts). Added an `align="right"` option to `SortableTableHead` so numeric right-aligned columns (Difference, Total, Occurrences, etc.) keep their existing visual alignment.
- **RECEIPTS-780** (2.1.1) — `OutOfBalance` rows were only reachable via `onClick` on the `TableRow` (mouse-only navigation to the receipt). Added a focusable "View" button per row, mirroring the pattern already used in `UncategorizedItems`. The row's `onClick` stays as a mouse convenience; the button calls `stopPropagation()` so it doesn't double-navigate.
- **RECEIPTS-781** (2.1.1) — the password show/hide toggle in `password-input.tsx` had `tabIndex={-1}`, making it unreachable by keyboard on Login, ChangePassword, and AdminUsers. Removed it; the button already had a correct `aria-label`.
- **RECEIPTS-796** (4.1.2 / 1.4.1) — `ApiKeys`, `AdminUsers`, and `RecycleBin` called `useListKeyboardNav` but only destructured `{focusedId, setFocusedIndex, tableRef}`, so focused rows had no DOM id and the container had no `role=grid`/`aria-activedescendant` — focus was signaled only by a background color. Now destructure and spread `containerProps` (on the wrapper) and `getRowProps(id)` (on each row), matching how `Accounts.tsx`/`Subcategories.tsx` already do it. `RecycleBin`'s shared `DeletedItemsTable` component was extended to accept and forward these props for its "All" tab (the only tab wired to keyboard nav, unchanged from before).
- **RECEIPTS-798** (2.1.1 / 4.1.2) — `Subcategories` category group headers were a bare `TableRow` with `onClick` and a decorative chevron (no button, no `aria-expanded`). Wrapped the header content in a real `<button aria-expanded={isExpanded} aria-label="Expand/Collapse {category}">`, mirroring the Accounts expand-button pattern. The row's `onClick` remains as a mouse convenience, guarded so the button doesn't double-toggle.

Closes RECEIPTS-779, RECEIPTS-780, RECEIPTS-781, RECEIPTS-796, RECEIPTS-798

## Test plan

- [x] `tsc -b` — clean, no type errors
- [x] `vite build` — succeeds (the `prebuild` npm script itself fails locally because it's bash-only syntax under Windows' default script shell — pre-existing environment quirk, unrelated to this change; `tsc -b && vite build`, the actual compile steps, both pass)
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in unrelated files: `useYnab.ts`, `Receipts.tsx`)
- [x] `npx vitest run` — 189 files / 2117 tests passed, 0 failures
- [x] Updated existing sort-header click tests (OutOfBalance, UncategorizedItems, SpendingByLocation) to target the `SortableTableHead` button via role instead of the raw `<th>`, since the click handler now lives on the button
- [x] Updated the password-input test that asserted `tabIndex="-1"` to instead assert the toggle is in the natural tab order and keyboard-activatable
- [x] Added tests: `SortableTableHead` `align` prop; `OutOfBalance` View button (navigation + keyboard focus + aria-sort); `ApiKeys`/`AdminUsers`/`RecycleBin` grid role + row id; `Subcategories` group-header `aria-expanded` + keyboard toggle
- [ ] `ItemSimilarity.tsx` has no existing test file/harness — noted rather than building a new one, per instructions. It builds and is exercised indirectly through `Reports.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)