### PR TITLE
fix(infrastructure): backup round-trip fidelity (invariant decimals, ynab tables, image paths)

### DIFF
--- a/src/Application/Models/BackupImportResult.cs
+++ b/src/Application/Models/BackupImportResult.cs
@@ -18,13 +18,27 @@ public record BackupImportResult(
 	int TransactionsCreated,
 	int TransactionsUpdated,
 	int AdjustmentsCreated,
-	int AdjustmentsUpdated)
+	int AdjustmentsUpdated,
+	int YnabSelectedBudgetsCreated = 0,
+	int YnabSelectedBudgetsUpdated = 0,
+	int YnabAccountMappingsCreated = 0,
+	int YnabAccountMappingsUpdated = 0,
+	int YnabCategoryMappingsCreated = 0,
+	int YnabCategoryMappingsUpdated = 0,
+	int YnabSyncRecordsCreated = 0,
+	int YnabSyncRecordsUpdated = 0,
+	int NormalizedDescriptionsCreated = 0,
+	int NormalizedDescriptionsUpdated = 0)
 {
 	public int TotalCreated => AccountsCreated + CardsCreated + CategoriesCreated + SubcategoriesCreated +
 		ItemTemplatesCreated + ReceiptsCreated + ReceiptItemsCreated +
-		TransactionsCreated + AdjustmentsCreated;
+		TransactionsCreated + AdjustmentsCreated +
+		YnabSelectedBudgetsCreated + YnabAccountMappingsCreated + YnabCategoryMappingsCreated +
+		YnabSyncRecordsCreated + NormalizedDescriptionsCreated;
 
 	public int TotalUpdated => AccountsUpdated + CardsUpdated + CategoriesUpdated + SubcategoriesUpdated +
 		ItemTemplatesUpdated + ReceiptsUpdated + ReceiptItemsUpdated +
-		TransactionsUpdated + AdjustmentsUpdated;
+		TransactionsUpdated + AdjustmentsUpdated +
+		YnabSelectedBudgetsUpdated + YnabAccountMappingsUpdated + YnabCategoryMappingsUpdated +
+		YnabSyncRecordsUpdated + NormalizedDescriptionsUpdated;
 }

--- a/src/Application/Models/BackupImportResult.cs
+++ b/src/Application/Models/BackupImportResult.cs
@@ -28,17 +28,19 @@ public record BackupImportResult(
 	int YnabSyncRecordsCreated = 0,
 	int YnabSyncRecordsUpdated = 0,
 	int NormalizedDescriptionsCreated = 0,
-	int NormalizedDescriptionsUpdated = 0)
+	int NormalizedDescriptionsUpdated = 0,
+	int NormalizedDescriptionSettingsCreated = 0,
+	int NormalizedDescriptionSettingsUpdated = 0)
 {
 	public int TotalCreated => AccountsCreated + CardsCreated + CategoriesCreated + SubcategoriesCreated +
 		ItemTemplatesCreated + ReceiptsCreated + ReceiptItemsCreated +
 		TransactionsCreated + AdjustmentsCreated +
 		YnabSelectedBudgetsCreated + YnabAccountMappingsCreated + YnabCategoryMappingsCreated +
-		YnabSyncRecordsCreated + NormalizedDescriptionsCreated;
+		YnabSyncRecordsCreated + NormalizedDescriptionsCreated + NormalizedDescriptionSettingsCreated;
 
 	public int TotalUpdated => AccountsUpdated + CardsUpdated + CategoriesUpdated + SubcategoriesUpdated +
 		ItemTemplatesUpdated + ReceiptsUpdated + ReceiptItemsUpdated +
 		TransactionsUpdated + AdjustmentsUpdated +
 		YnabSelectedBudgetsUpdated + YnabAccountMappingsUpdated + YnabCategoryMappingsUpdated +
-		YnabSyncRecordsUpdated + NormalizedDescriptionsUpdated;
+		YnabSyncRecordsUpdated + NormalizedDescriptionsUpdated + NormalizedDescriptionSettingsUpdated;
 }

--- a/src/Infrastructure/Services/BackupImportService.cs
+++ b/src/Infrastructure/Services/BackupImportService.cs
@@ -1,6 +1,8 @@
+using System.Globalization;
 using Application.Interfaces.Services;
 using Application.Models;
 using Common;
+using Domain.NormalizedDescriptions;
 using Infrastructure.Entities.Core;
 using Infrastructure.Interfaces;
 using Microsoft.Data.Sqlite;
@@ -73,10 +75,20 @@ public class BackupImportService(
 			(int categoriesCreated, int categoriesUpdated) = await UpsertCategoriesAsync(context, sqlite, cancellationToken);
 			(int subcategoriesCreated, int subcategoriesUpdated) = await UpsertSubcategoriesAsync(context, sqlite, cancellationToken);
 			(int itemTemplatesCreated, int itemTemplatesUpdated) = await UpsertItemTemplatesAsync(context, sqlite, cancellationToken);
-			(int receiptsCreated, int receiptsUpdated) = await UpsertReceiptsAsync(context, sqlite, cancellationToken);
+			(int receiptsCreated, int receiptsUpdated) = await UpsertReceiptsAsync(context, sqlite, exportVersion, cancellationToken);
 			(int receiptItemsCreated, int receiptItemsUpdated) = await UpsertReceiptItemsAsync(context, sqlite, cancellationToken);
 			(int transactionsCreated, int transactionsUpdated) = await UpsertTransactionsAsync(context, sqlite, exportVersion, cancellationToken);
 			(int adjustmentsCreated, int adjustmentsUpdated) = await UpsertAdjustmentsAsync(context, sqlite, cancellationToken);
+
+			// v4 tables. Each method is gated on export_version >= 4, so older backups (v1-3)
+			// skip them entirely and restore with these tables treated as absent. YnabAccountMappings
+			// reference Accounts and YnabSyncRecords reference Transactions — both already imported
+			// above — so the FK import order is satisfied.
+			(int ynabSelectedBudgetsCreated, int ynabSelectedBudgetsUpdated) = await UpsertYnabSelectedBudgetsAsync(context, sqlite, exportVersion, cancellationToken);
+			(int ynabAccountMappingsCreated, int ynabAccountMappingsUpdated) = await UpsertYnabAccountMappingsAsync(context, sqlite, exportVersion, cancellationToken);
+			(int ynabCategoryMappingsCreated, int ynabCategoryMappingsUpdated) = await UpsertYnabCategoryMappingsAsync(context, sqlite, exportVersion, cancellationToken);
+			(int ynabSyncRecordsCreated, int ynabSyncRecordsUpdated) = await UpsertYnabSyncRecordsAsync(context, sqlite, exportVersion, cancellationToken);
+			(int normalizedDescriptionsCreated, int normalizedDescriptionsUpdated) = await UpsertNormalizedDescriptionsAsync(context, sqlite, exportVersion, cancellationToken);
 
 			await transaction.CommitAsync(cancellationToken);
 
@@ -89,7 +101,12 @@ public class BackupImportService(
 				receiptsCreated, receiptsUpdated,
 				receiptItemsCreated, receiptItemsUpdated,
 				transactionsCreated, transactionsUpdated,
-				adjustmentsCreated, adjustmentsUpdated);
+				adjustmentsCreated, adjustmentsUpdated,
+				ynabSelectedBudgetsCreated, ynabSelectedBudgetsUpdated,
+				ynabAccountMappingsCreated, ynabAccountMappingsUpdated,
+				ynabCategoryMappingsCreated, ynabCategoryMappingsUpdated,
+				ynabSyncRecordsCreated, ynabSyncRecordsUpdated,
+				normalizedDescriptionsCreated, normalizedDescriptionsUpdated);
 
 			logger.LogInformation(
 				"Backup import complete: {TotalCreated} created, {TotalUpdated} updated",
@@ -488,25 +505,34 @@ public class BackupImportService(
 	}
 
 	private static async Task<(int Created, int Updated)> UpsertReceiptsAsync(
-		ApplicationDbContext context, SqliteConnection sqlite, CancellationToken cancellationToken)
+		ApplicationDbContext context, SqliteConnection sqlite, int exportVersion, CancellationToken cancellationToken)
 	{
 		if (!TableExists(sqlite, "receipts"))
 		{
 			return (0, 0);
 		}
 
+		// v4 adds the image-path columns. Older backups (<4) never carried them, so we neither
+		// read them nor touch a receipt's existing paths on update — preserving pre-v4 behaviour.
+		bool hasImagePaths = exportVersion >= 4;
+		string selectColumns = hasImagePaths
+			? "id, location, date, tax_amount, tax_amount_currency, original_image_path, processed_image_path"
+			: "id, location, date, tax_amount, tax_amount_currency";
+
 		int created = 0, updated = 0;
 		await using SqliteCommand cmd = sqlite.CreateCommand();
-		cmd.CommandText = "SELECT id, location, date, tax_amount, tax_amount_currency FROM receipts";
+		cmd.CommandText = $"SELECT {selectColumns} FROM receipts";
 		await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
 
 		while (await reader.ReadAsync(cancellationToken))
 		{
 			Guid id = Guid.Parse(reader.GetString(0));
 			string location = reader.GetString(1);
-			DateOnly date = DateOnly.Parse(reader.GetString(2));
+			DateOnly date = DateOnly.Parse(reader.GetString(2), CultureInfo.InvariantCulture);
 			decimal taxAmount = reader.GetDecimal(3);
 			Currency taxAmountCurrency = Enum.Parse<Currency>(reader.GetString(4));
+			string? originalImagePath = hasImagePaths && !reader.IsDBNull(5) ? reader.GetString(5) : null;
+			string? processedImagePath = hasImagePaths && !reader.IsDBNull(6) ? reader.GetString(6) : null;
 
 			ReceiptEntity? existing = await context.Receipts
 				.IgnoreQueryFilters()
@@ -517,6 +543,13 @@ public class BackupImportService(
 				existing.Date = date;
 				existing.TaxAmount = taxAmount;
 				existing.TaxAmountCurrency = taxAmountCurrency;
+				// Only overwrite image paths when the backup actually carried them (v4+); a v1-3
+				// restore must not null out paths already present on the existing receipt.
+				if (hasImagePaths)
+				{
+					existing.OriginalImagePath = originalImagePath;
+					existing.ProcessedImagePath = processedImagePath;
+				}
 				ClearSoftDelete(existing);
 				updated++;
 			}
@@ -529,6 +562,8 @@ public class BackupImportService(
 					Date = date,
 					TaxAmount = taxAmount,
 					TaxAmountCurrency = taxAmountCurrency,
+					OriginalImagePath = originalImagePath,
+					ProcessedImagePath = processedImagePath,
 				});
 				created++;
 			}
@@ -640,7 +675,7 @@ public class BackupImportService(
 			Guid cardId = Guid.Parse(reader.GetString(2));
 			decimal amount = reader.GetDecimal(3);
 			Currency amountCurrency = Enum.Parse<Currency>(reader.GetString(4));
-			DateOnly date = DateOnly.Parse(reader.GetString(5));
+			DateOnly date = DateOnly.Parse(reader.GetString(5), CultureInfo.InvariantCulture);
 
 			// Fall back to cardId when the Card is missing from the lookup (shouldn't happen
 			// in practice — Cards are upserted before Transactions — but defensive).
@@ -727,6 +762,286 @@ public class BackupImportService(
 					Amount = amount,
 					AmountCurrency = amountCurrency,
 					Description = description,
+				});
+				created++;
+			}
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+		return (created, updated);
+	}
+
+	// Parses an ISO-8601 round-trip timestamp written by the exporter, culture-independently.
+	private static DateTimeOffset ParseTimestamp(string value) =>
+		DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
+	// v4 tables. Each returns (0, 0) when export_version < 4 or when the table is absent, so a
+	// v1-3 backup restores with these treated as empty and never throws.
+	private static async Task<(int Created, int Updated)> UpsertYnabSelectedBudgetsAsync(
+		ApplicationDbContext context, SqliteConnection sqlite, int exportVersion, CancellationToken cancellationToken)
+	{
+		if (exportVersion < 4 || !TableExists(sqlite, "ynab_selected_budgets"))
+		{
+			return (0, 0);
+		}
+
+		int created = 0, updated = 0;
+		await using SqliteCommand cmd = sqlite.CreateCommand();
+		cmd.CommandText = "SELECT id, budget_id, updated_at FROM ynab_selected_budgets";
+		await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+		while (await reader.ReadAsync(cancellationToken))
+		{
+			Guid id = Guid.Parse(reader.GetString(0));
+			string budgetId = reader.GetString(1);
+			DateTimeOffset updatedAt = ParseTimestamp(reader.GetString(2));
+
+			YnabSelectedBudgetEntity? existing = await context.YnabSelectedBudgets.FindAsync([id], cancellationToken);
+			if (existing is not null)
+			{
+				existing.BudgetId = budgetId;
+				existing.UpdatedAt = updatedAt;
+				updated++;
+			}
+			else
+			{
+				context.YnabSelectedBudgets.Add(new YnabSelectedBudgetEntity
+				{
+					Id = id,
+					BudgetId = budgetId,
+					UpdatedAt = updatedAt,
+				});
+				created++;
+			}
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+		return (created, updated);
+	}
+
+	// FK: ReceiptsAccountId → Accounts.Id. Accounts are upserted before this method runs.
+	private static async Task<(int Created, int Updated)> UpsertYnabAccountMappingsAsync(
+		ApplicationDbContext context, SqliteConnection sqlite, int exportVersion, CancellationToken cancellationToken)
+	{
+		if (exportVersion < 4 || !TableExists(sqlite, "ynab_account_mappings"))
+		{
+			return (0, 0);
+		}
+
+		int created = 0, updated = 0;
+		await using SqliteCommand cmd = sqlite.CreateCommand();
+		cmd.CommandText = "SELECT id, receipts_account_id, ynab_account_id, ynab_account_name, ynab_budget_id, created_at, updated_at FROM ynab_account_mappings";
+		await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+		while (await reader.ReadAsync(cancellationToken))
+		{
+			Guid id = Guid.Parse(reader.GetString(0));
+			Guid receiptsAccountId = Guid.Parse(reader.GetString(1));
+			string ynabAccountId = reader.GetString(2);
+			string ynabAccountName = reader.GetString(3);
+			string ynabBudgetId = reader.GetString(4);
+			DateTimeOffset createdAt = ParseTimestamp(reader.GetString(5));
+			DateTimeOffset updatedAt = ParseTimestamp(reader.GetString(6));
+
+			YnabAccountMappingEntity? existing = await context.YnabAccountMappings.FindAsync([id], cancellationToken);
+			if (existing is not null)
+			{
+				existing.ReceiptsAccountId = receiptsAccountId;
+				existing.YnabAccountId = ynabAccountId;
+				existing.YnabAccountName = ynabAccountName;
+				existing.YnabBudgetId = ynabBudgetId;
+				existing.CreatedAt = createdAt;
+				existing.UpdatedAt = updatedAt;
+				updated++;
+			}
+			else
+			{
+				context.YnabAccountMappings.Add(new YnabAccountMappingEntity
+				{
+					Id = id,
+					ReceiptsAccountId = receiptsAccountId,
+					YnabAccountId = ynabAccountId,
+					YnabAccountName = ynabAccountName,
+					YnabBudgetId = ynabBudgetId,
+					CreatedAt = createdAt,
+					UpdatedAt = updatedAt,
+				});
+				created++;
+			}
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+		return (created, updated);
+	}
+
+	private static async Task<(int Created, int Updated)> UpsertYnabCategoryMappingsAsync(
+		ApplicationDbContext context, SqliteConnection sqlite, int exportVersion, CancellationToken cancellationToken)
+	{
+		if (exportVersion < 4 || !TableExists(sqlite, "ynab_category_mappings"))
+		{
+			return (0, 0);
+		}
+
+		int created = 0, updated = 0;
+		await using SqliteCommand cmd = sqlite.CreateCommand();
+		cmd.CommandText = "SELECT id, receipts_category, ynab_category_id, ynab_category_name, ynab_category_group_name, ynab_budget_id, created_at, updated_at FROM ynab_category_mappings";
+		await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+		while (await reader.ReadAsync(cancellationToken))
+		{
+			Guid id = Guid.Parse(reader.GetString(0));
+			string receiptsCategory = reader.GetString(1);
+			string ynabCategoryId = reader.GetString(2);
+			string ynabCategoryName = reader.GetString(3);
+			string ynabCategoryGroupName = reader.GetString(4);
+			string ynabBudgetId = reader.GetString(5);
+			DateTimeOffset createdAt = ParseTimestamp(reader.GetString(6));
+			DateTimeOffset updatedAt = ParseTimestamp(reader.GetString(7));
+
+			YnabCategoryMappingEntity? existing = await context.YnabCategoryMappings.FindAsync([id], cancellationToken);
+			if (existing is not null)
+			{
+				existing.ReceiptsCategory = receiptsCategory;
+				existing.YnabCategoryId = ynabCategoryId;
+				existing.YnabCategoryName = ynabCategoryName;
+				existing.YnabCategoryGroupName = ynabCategoryGroupName;
+				existing.YnabBudgetId = ynabBudgetId;
+				existing.CreatedAt = createdAt;
+				existing.UpdatedAt = updatedAt;
+				updated++;
+			}
+			else
+			{
+				context.YnabCategoryMappings.Add(new YnabCategoryMappingEntity
+				{
+					Id = id,
+					ReceiptsCategory = receiptsCategory,
+					YnabCategoryId = ynabCategoryId,
+					YnabCategoryName = ynabCategoryName,
+					YnabCategoryGroupName = ynabCategoryGroupName,
+					YnabBudgetId = ynabBudgetId,
+					CreatedAt = createdAt,
+					UpdatedAt = updatedAt,
+				});
+				created++;
+			}
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+		return (created, updated);
+	}
+
+	// FK: LocalTransactionId → Transactions.Id. Transactions are upserted before this method
+	// runs. YnabSyncRecords are soft-deletable, so lookups ignore the query filter and updates
+	// clear the soft-delete markers, mirroring the other soft-deletable upserts.
+	private static async Task<(int Created, int Updated)> UpsertYnabSyncRecordsAsync(
+		ApplicationDbContext context, SqliteConnection sqlite, int exportVersion, CancellationToken cancellationToken)
+	{
+		if (exportVersion < 4 || !TableExists(sqlite, "ynab_sync_records"))
+		{
+			return (0, 0);
+		}
+
+		int created = 0, updated = 0;
+		await using SqliteCommand cmd = sqlite.CreateCommand();
+		cmd.CommandText = "SELECT id, local_transaction_id, ynab_transaction_id, ynab_budget_id, ynab_account_id, sync_type, sync_status, synced_at_utc, last_error, created_at, updated_at FROM ynab_sync_records";
+		await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+		while (await reader.ReadAsync(cancellationToken))
+		{
+			Guid id = Guid.Parse(reader.GetString(0));
+			Guid localTransactionId = Guid.Parse(reader.GetString(1));
+			string? ynabTransactionId = reader.IsDBNull(2) ? null : reader.GetString(2);
+			string ynabBudgetId = reader.GetString(3);
+			string? ynabAccountId = reader.IsDBNull(4) ? null : reader.GetString(4);
+			YnabSyncType syncType = Enum.Parse<YnabSyncType>(reader.GetString(5));
+			YnabSyncStatus syncStatus = Enum.Parse<YnabSyncStatus>(reader.GetString(6));
+			DateTimeOffset? syncedAtUtc = reader.IsDBNull(7) ? null : ParseTimestamp(reader.GetString(7));
+			string? lastError = reader.IsDBNull(8) ? null : reader.GetString(8);
+			DateTimeOffset createdAt = ParseTimestamp(reader.GetString(9));
+			DateTimeOffset updatedAt = ParseTimestamp(reader.GetString(10));
+
+			YnabSyncRecordEntity? existing = await context.YnabSyncRecords
+				.IgnoreQueryFilters()
+				.FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+			if (existing is not null)
+			{
+				existing.LocalTransactionId = localTransactionId;
+				existing.YnabTransactionId = ynabTransactionId;
+				existing.YnabBudgetId = ynabBudgetId;
+				existing.YnabAccountId = ynabAccountId;
+				existing.SyncType = syncType;
+				existing.SyncStatus = syncStatus;
+				existing.SyncedAtUtc = syncedAtUtc;
+				existing.LastError = lastError;
+				existing.CreatedAt = createdAt;
+				existing.UpdatedAt = updatedAt;
+				ClearSoftDelete(existing);
+				updated++;
+			}
+			else
+			{
+				context.YnabSyncRecords.Add(new YnabSyncRecordEntity
+				{
+					Id = id,
+					LocalTransactionId = localTransactionId,
+					YnabTransactionId = ynabTransactionId,
+					YnabBudgetId = ynabBudgetId,
+					YnabAccountId = ynabAccountId,
+					SyncType = syncType,
+					SyncStatus = syncStatus,
+					SyncedAtUtc = syncedAtUtc,
+					LastError = lastError,
+					CreatedAt = createdAt,
+					UpdatedAt = updatedAt,
+				});
+				created++;
+			}
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+		return (created, updated);
+	}
+
+	// The embedding vector is intentionally not restored (see BackupService for rationale): new
+	// rows are created with a null embedding and repopulated by the embedding pipeline, and the
+	// embedding on an existing row is left untouched so a restore never destroys a valid vector.
+	private static async Task<(int Created, int Updated)> UpsertNormalizedDescriptionsAsync(
+		ApplicationDbContext context, SqliteConnection sqlite, int exportVersion, CancellationToken cancellationToken)
+	{
+		if (exportVersion < 4 || !TableExists(sqlite, "normalized_descriptions"))
+		{
+			return (0, 0);
+		}
+
+		int created = 0, updated = 0;
+		await using SqliteCommand cmd = sqlite.CreateCommand();
+		cmd.CommandText = "SELECT id, canonical_name, status, created_at FROM normalized_descriptions";
+		await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+		while (await reader.ReadAsync(cancellationToken))
+		{
+			Guid id = Guid.Parse(reader.GetString(0));
+			string canonicalName = reader.GetString(1);
+			NormalizedDescriptionStatus status = Enum.Parse<NormalizedDescriptionStatus>(reader.GetString(2));
+			DateTimeOffset createdAt = ParseTimestamp(reader.GetString(3));
+
+			NormalizedDescriptionEntity? existing = await context.NormalizedDescriptions.FindAsync([id], cancellationToken);
+			if (existing is not null)
+			{
+				existing.CanonicalName = canonicalName;
+				existing.Status = status;
+				existing.CreatedAt = createdAt;
+				updated++;
+			}
+			else
+			{
+				context.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+				{
+					Id = id,
+					CanonicalName = canonicalName,
+					Status = status,
+					CreatedAt = createdAt,
 				});
 				created++;
 			}

--- a/src/Infrastructure/Services/BackupImportService.cs
+++ b/src/Infrastructure/Services/BackupImportService.cs
@@ -89,6 +89,7 @@ public class BackupImportService(
 			(int ynabCategoryMappingsCreated, int ynabCategoryMappingsUpdated) = await UpsertYnabCategoryMappingsAsync(context, sqlite, exportVersion, cancellationToken);
 			(int ynabSyncRecordsCreated, int ynabSyncRecordsUpdated) = await UpsertYnabSyncRecordsAsync(context, sqlite, exportVersion, cancellationToken);
 			(int normalizedDescriptionsCreated, int normalizedDescriptionsUpdated) = await UpsertNormalizedDescriptionsAsync(context, sqlite, exportVersion, cancellationToken);
+			(int normalizedDescriptionSettingsCreated, int normalizedDescriptionSettingsUpdated) = await UpsertNormalizedDescriptionSettingsAsync(context, sqlite, exportVersion, cancellationToken);
 
 			await transaction.CommitAsync(cancellationToken);
 
@@ -106,7 +107,8 @@ public class BackupImportService(
 				ynabAccountMappingsCreated, ynabAccountMappingsUpdated,
 				ynabCategoryMappingsCreated, ynabCategoryMappingsUpdated,
 				ynabSyncRecordsCreated, ynabSyncRecordsUpdated,
-				normalizedDescriptionsCreated, normalizedDescriptionsUpdated);
+				normalizedDescriptionsCreated, normalizedDescriptionsUpdated,
+				normalizedDescriptionSettingsCreated, normalizedDescriptionSettingsUpdated);
 
 			logger.LogInformation(
 				"Backup import complete: {TotalCreated} created, {TotalUpdated} updated",
@@ -1042,6 +1044,53 @@ public class BackupImportService(
 					CanonicalName = canonicalName,
 					Status = status,
 					CreatedAt = createdAt,
+				});
+				created++;
+			}
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+		return (created, updated);
+	}
+
+	// Singleton settings row (thresholds). No FK, so order is flexible. Thresholds are parsed
+	// with InvariantCulture to match the culture-safe export.
+	private static async Task<(int Created, int Updated)> UpsertNormalizedDescriptionSettingsAsync(
+		ApplicationDbContext context, SqliteConnection sqlite, int exportVersion, CancellationToken cancellationToken)
+	{
+		if (exportVersion < 4 || !TableExists(sqlite, "normalized_description_settings"))
+		{
+			return (0, 0);
+		}
+
+		int created = 0, updated = 0;
+		await using SqliteCommand cmd = sqlite.CreateCommand();
+		cmd.CommandText = "SELECT id, auto_accept_threshold, pending_review_threshold, updated_at FROM normalized_description_settings";
+		await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+		while (await reader.ReadAsync(cancellationToken))
+		{
+			Guid id = Guid.Parse(reader.GetString(0));
+			double autoAcceptThreshold = double.Parse(reader.GetString(1), CultureInfo.InvariantCulture);
+			double pendingReviewThreshold = double.Parse(reader.GetString(2), CultureInfo.InvariantCulture);
+			DateTimeOffset updatedAt = ParseTimestamp(reader.GetString(3));
+
+			NormalizedDescriptionSettingsEntity? existing = await context.NormalizedDescriptionSettings.FindAsync([id], cancellationToken);
+			if (existing is not null)
+			{
+				existing.AutoAcceptThreshold = autoAcceptThreshold;
+				existing.PendingReviewThreshold = pendingReviewThreshold;
+				existing.UpdatedAt = updatedAt;
+				updated++;
+			}
+			else
+			{
+				context.NormalizedDescriptionSettings.Add(new NormalizedDescriptionSettingsEntity
+				{
+					Id = id,
+					AutoAcceptThreshold = autoAcceptThreshold,
+					PendingReviewThreshold = pendingReviewThreshold,
+					UpdatedAt = updatedAt,
 				});
 				created++;
 			}

--- a/src/Infrastructure/Services/BackupService.cs
+++ b/src/Infrastructure/Services/BackupService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Application.Interfaces.Services;
 using Infrastructure.Entities.Core;
 using Microsoft.Data.Sqlite;
@@ -35,6 +36,11 @@ public class BackupService(
 			await ExportReceiptItemsAsync(source, sqlite, cancellationToken);
 			await ExportTransactionsAsync(source, sqlite, cancellationToken);
 			await ExportAdjustmentsAsync(source, sqlite, cancellationToken);
+			await ExportYnabSelectedBudgetsAsync(source, sqlite, cancellationToken);
+			await ExportYnabAccountMappingsAsync(source, sqlite, cancellationToken);
+			await ExportYnabCategoryMappingsAsync(source, sqlite, cancellationToken);
+			await ExportYnabSyncRecordsAsync(source, sqlite, cancellationToken);
+			await ExportNormalizedDescriptionsAsync(source, sqlite, cancellationToken);
 			await WriteMetadataAsync(sqlite, cancellationToken);
 
 			await transaction.CommitAsync(cancellationToken);
@@ -116,7 +122,9 @@ public class BackupService(
 				location TEXT NOT NULL,
 				date TEXT NOT NULL,
 				tax_amount TEXT NOT NULL,
-				tax_amount_currency TEXT NOT NULL
+				tax_amount_currency TEXT NOT NULL,
+				original_image_path TEXT,
+				processed_image_path TEXT
 			)
 			""",
 			"""
@@ -156,6 +164,61 @@ public class BackupService(
 				amount_currency TEXT NOT NULL,
 				description TEXT,
 				FOREIGN KEY (receipt_id) REFERENCES receipts(id)
+			)
+			""",
+			"""
+			CREATE TABLE ynab_selected_budgets (
+				id TEXT NOT NULL PRIMARY KEY,
+				budget_id TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)
+			""",
+			"""
+			CREATE TABLE ynab_account_mappings (
+				id TEXT NOT NULL PRIMARY KEY,
+				receipts_account_id TEXT NOT NULL,
+				ynab_account_id TEXT NOT NULL,
+				ynab_account_name TEXT NOT NULL,
+				ynab_budget_id TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				FOREIGN KEY (receipts_account_id) REFERENCES accounts(id)
+			)
+			""",
+			"""
+			CREATE TABLE ynab_category_mappings (
+				id TEXT NOT NULL PRIMARY KEY,
+				receipts_category TEXT NOT NULL,
+				ynab_category_id TEXT NOT NULL,
+				ynab_category_name TEXT NOT NULL,
+				ynab_category_group_name TEXT NOT NULL,
+				ynab_budget_id TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)
+			""",
+			"""
+			CREATE TABLE ynab_sync_records (
+				id TEXT NOT NULL PRIMARY KEY,
+				local_transaction_id TEXT NOT NULL,
+				ynab_transaction_id TEXT,
+				ynab_budget_id TEXT NOT NULL,
+				ynab_account_id TEXT,
+				sync_type TEXT NOT NULL,
+				sync_status TEXT NOT NULL,
+				synced_at_utc TEXT,
+				last_error TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				FOREIGN KEY (local_transaction_id) REFERENCES transactions(id)
+			)
+			""",
+			"""
+			CREATE TABLE normalized_descriptions (
+				id TEXT NOT NULL PRIMARY KEY,
+				canonical_name TEXT NOT NULL,
+				status TEXT NOT NULL,
+				created_at TEXT NOT NULL
 			)
 			""",
 		];
@@ -265,7 +328,7 @@ public class BackupService(
 			cmd.Parameters.AddWithValue("$name", template.Name);
 			cmd.Parameters.AddWithValue("$cat", (object?)template.DefaultCategory ?? DBNull.Value);
 			cmd.Parameters.AddWithValue("$subcat", (object?)template.DefaultSubcategory ?? DBNull.Value);
-			cmd.Parameters.AddWithValue("$price", template.DefaultUnitPrice.HasValue ? template.DefaultUnitPrice.Value.ToString("G") : DBNull.Value);
+			cmd.Parameters.AddWithValue("$price", template.DefaultUnitPrice.HasValue ? template.DefaultUnitPrice.Value.ToString(CultureInfo.InvariantCulture) : DBNull.Value);
 			cmd.Parameters.AddWithValue("$priceCurrency", template.DefaultUnitPriceCurrency.HasValue ? template.DefaultUnitPriceCurrency.Value.ToString() : DBNull.Value);
 			cmd.Parameters.AddWithValue("$itemCode", (object?)template.DefaultItemCode ?? DBNull.Value);
 			cmd.Parameters.AddWithValue("$desc", (object?)template.Description ?? DBNull.Value);
@@ -280,7 +343,7 @@ public class BackupService(
 			.Where(r => r.DeletedAt == null)
 			.ToListAsync(cancellationToken);
 
-		const string sql = "INSERT INTO receipts (id, location, date, tax_amount, tax_amount_currency) VALUES ($id, $loc, $date, $tax, $taxCurrency)";
+		const string sql = "INSERT INTO receipts (id, location, date, tax_amount, tax_amount_currency, original_image_path, processed_image_path) VALUES ($id, $loc, $date, $tax, $taxCurrency, $origImg, $procImg)";
 		foreach (ReceiptEntity receipt in receipts)
 		{
 			await using SqliteCommand cmd = sqlite.CreateCommand();
@@ -288,8 +351,10 @@ public class BackupService(
 			cmd.Parameters.AddWithValue("$id", receipt.Id.ToString());
 			cmd.Parameters.AddWithValue("$loc", receipt.Location);
 			cmd.Parameters.AddWithValue("$date", receipt.Date.ToString("O"));
-			cmd.Parameters.AddWithValue("$tax", receipt.TaxAmount.ToString("G"));
+			cmd.Parameters.AddWithValue("$tax", receipt.TaxAmount.ToString(CultureInfo.InvariantCulture));
 			cmd.Parameters.AddWithValue("$taxCurrency", receipt.TaxAmountCurrency.ToString());
+			cmd.Parameters.AddWithValue("$origImg", (object?)receipt.OriginalImagePath ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$procImg", (object?)receipt.ProcessedImagePath ?? DBNull.Value);
 			await cmd.ExecuteNonQueryAsync(cancellationToken);
 		}
 	}
@@ -317,10 +382,10 @@ public class BackupService(
 			cmd.Parameters.AddWithValue("$receiptId", item.ReceiptId.ToString());
 			cmd.Parameters.AddWithValue("$itemCode", (object?)item.ReceiptItemCode ?? DBNull.Value);
 			cmd.Parameters.AddWithValue("$desc", item.Description);
-			cmd.Parameters.AddWithValue("$qty", item.Quantity.ToString("G"));
-			cmd.Parameters.AddWithValue("$unitPrice", item.UnitPrice.ToString("G"));
+			cmd.Parameters.AddWithValue("$qty", item.Quantity.ToString(CultureInfo.InvariantCulture));
+			cmd.Parameters.AddWithValue("$unitPrice", item.UnitPrice.ToString(CultureInfo.InvariantCulture));
 			cmd.Parameters.AddWithValue("$unitPriceCurrency", item.UnitPriceCurrency.ToString());
-			cmd.Parameters.AddWithValue("$totalAmt", item.TotalAmount.ToString("G"));
+			cmd.Parameters.AddWithValue("$totalAmt", item.TotalAmount.ToString(CultureInfo.InvariantCulture));
 			cmd.Parameters.AddWithValue("$totalAmtCurrency", item.TotalAmountCurrency.ToString());
 			cmd.Parameters.AddWithValue("$cat", item.Category);
 			cmd.Parameters.AddWithValue("$subcat", (object?)item.Subcategory ?? DBNull.Value);
@@ -343,7 +408,7 @@ public class BackupService(
 			cmd.Parameters.AddWithValue("$id", txn.Id.ToString());
 			cmd.Parameters.AddWithValue("$receiptId", txn.ReceiptId.ToString());
 			cmd.Parameters.AddWithValue("$cardId", txn.CardId.ToString());
-			cmd.Parameters.AddWithValue("$amt", txn.Amount.ToString("G"));
+			cmd.Parameters.AddWithValue("$amt", txn.Amount.ToString(CultureInfo.InvariantCulture));
 			cmd.Parameters.AddWithValue("$amtCurrency", txn.AmountCurrency.ToString());
 			cmd.Parameters.AddWithValue("$date", txn.Date.ToString("O"));
 			await cmd.ExecuteNonQueryAsync(cancellationToken);
@@ -365,9 +430,133 @@ public class BackupService(
 			cmd.Parameters.AddWithValue("$id", adj.Id.ToString());
 			cmd.Parameters.AddWithValue("$receiptId", adj.ReceiptId.ToString());
 			cmd.Parameters.AddWithValue("$type", adj.Type.ToString());
-			cmd.Parameters.AddWithValue("$amt", adj.Amount.ToString("G"));
+			cmd.Parameters.AddWithValue("$amt", adj.Amount.ToString(CultureInfo.InvariantCulture));
 			cmd.Parameters.AddWithValue("$amtCurrency", adj.AmountCurrency.ToString());
 			cmd.Parameters.AddWithValue("$desc", (object?)adj.Description ?? DBNull.Value);
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	// v4: YNAB configuration/state and normalized descriptions. These are gated on
+	// export_version >= 4 in the importer so older backups (v1-3) still restore with the
+	// tables treated as absent.
+	private static async Task ExportYnabSelectedBudgetsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<YnabSelectedBudgetEntity> budgets = await source.YnabSelectedBudgets.AsNoTracking().ToListAsync(cancellationToken);
+
+		const string sql = "INSERT INTO ynab_selected_budgets (id, budget_id, updated_at) VALUES ($id, $budgetId, $updatedAt)";
+		foreach (YnabSelectedBudgetEntity budget in budgets)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", budget.Id.ToString());
+			cmd.Parameters.AddWithValue("$budgetId", budget.BudgetId);
+			cmd.Parameters.AddWithValue("$updatedAt", budget.UpdatedAt.ToString("O"));
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportYnabAccountMappingsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<YnabAccountMappingEntity> mappings = await source.YnabAccountMappings.AsNoTracking().ToListAsync(cancellationToken);
+
+		const string sql = """
+			INSERT INTO ynab_account_mappings (id, receipts_account_id, ynab_account_id, ynab_account_name,
+				ynab_budget_id, created_at, updated_at)
+			VALUES ($id, $accountId, $ynabAccountId, $ynabAccountName, $ynabBudgetId, $createdAt, $updatedAt)
+			""";
+
+		foreach (YnabAccountMappingEntity mapping in mappings)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", mapping.Id.ToString());
+			cmd.Parameters.AddWithValue("$accountId", mapping.ReceiptsAccountId.ToString());
+			cmd.Parameters.AddWithValue("$ynabAccountId", mapping.YnabAccountId);
+			cmd.Parameters.AddWithValue("$ynabAccountName", mapping.YnabAccountName);
+			cmd.Parameters.AddWithValue("$ynabBudgetId", mapping.YnabBudgetId);
+			cmd.Parameters.AddWithValue("$createdAt", mapping.CreatedAt.ToString("O"));
+			cmd.Parameters.AddWithValue("$updatedAt", mapping.UpdatedAt.ToString("O"));
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	private static async Task ExportYnabCategoryMappingsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<YnabCategoryMappingEntity> mappings = await source.YnabCategoryMappings.AsNoTracking().ToListAsync(cancellationToken);
+
+		const string sql = """
+			INSERT INTO ynab_category_mappings (id, receipts_category, ynab_category_id, ynab_category_name,
+				ynab_category_group_name, ynab_budget_id, created_at, updated_at)
+			VALUES ($id, $receiptsCategory, $ynabCategoryId, $ynabCategoryName, $ynabCategoryGroupName,
+				$ynabBudgetId, $createdAt, $updatedAt)
+			""";
+
+		foreach (YnabCategoryMappingEntity mapping in mappings)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", mapping.Id.ToString());
+			cmd.Parameters.AddWithValue("$receiptsCategory", mapping.ReceiptsCategory);
+			cmd.Parameters.AddWithValue("$ynabCategoryId", mapping.YnabCategoryId);
+			cmd.Parameters.AddWithValue("$ynabCategoryName", mapping.YnabCategoryName);
+			cmd.Parameters.AddWithValue("$ynabCategoryGroupName", mapping.YnabCategoryGroupName);
+			cmd.Parameters.AddWithValue("$ynabBudgetId", mapping.YnabBudgetId);
+			cmd.Parameters.AddWithValue("$createdAt", mapping.CreatedAt.ToString("O"));
+			cmd.Parameters.AddWithValue("$updatedAt", mapping.UpdatedAt.ToString("O"));
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	// Soft-deleted sync records are excluded by the entity's global query filter, mirroring
+	// the export behaviour of the other soft-deletable tables.
+	private static async Task ExportYnabSyncRecordsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<YnabSyncRecordEntity> records = await source.YnabSyncRecords.AsNoTracking().ToListAsync(cancellationToken);
+
+		const string sql = """
+			INSERT INTO ynab_sync_records (id, local_transaction_id, ynab_transaction_id, ynab_budget_id,
+				ynab_account_id, sync_type, sync_status, synced_at_utc, last_error, created_at, updated_at)
+			VALUES ($id, $localTransactionId, $ynabTransactionId, $ynabBudgetId, $ynabAccountId, $syncType,
+				$syncStatus, $syncedAtUtc, $lastError, $createdAt, $updatedAt)
+			""";
+
+		foreach (YnabSyncRecordEntity record in records)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", record.Id.ToString());
+			cmd.Parameters.AddWithValue("$localTransactionId", record.LocalTransactionId.ToString());
+			cmd.Parameters.AddWithValue("$ynabTransactionId", (object?)record.YnabTransactionId ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$ynabBudgetId", record.YnabBudgetId);
+			cmd.Parameters.AddWithValue("$ynabAccountId", (object?)record.YnabAccountId ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$syncType", record.SyncType.ToString());
+			cmd.Parameters.AddWithValue("$syncStatus", record.SyncStatus.ToString());
+			cmd.Parameters.AddWithValue("$syncedAtUtc", record.SyncedAtUtc.HasValue ? record.SyncedAtUtc.Value.ToString("O") : DBNull.Value);
+			cmd.Parameters.AddWithValue("$lastError", (object?)record.LastError ?? DBNull.Value);
+			cmd.Parameters.AddWithValue("$createdAt", record.CreatedAt.ToString("O"));
+			cmd.Parameters.AddWithValue("$updatedAt", record.UpdatedAt.ToString("O"));
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	// The embedding vector is intentionally NOT exported: it is large, regenerable derived
+	// data whose dimension is a build-time constant that has changed across versions
+	// (384 -> 1024). Restoring a stale-dimension vector would abort the whole import, so the
+	// embedding is left null and repopulated by the embedding-generation pipeline after restore.
+	private static async Task ExportNormalizedDescriptionsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<NormalizedDescriptionEntity> descriptions = await source.NormalizedDescriptions.AsNoTracking().ToListAsync(cancellationToken);
+
+		const string sql = "INSERT INTO normalized_descriptions (id, canonical_name, status, created_at) VALUES ($id, $canonicalName, $status, $createdAt)";
+		foreach (NormalizedDescriptionEntity description in descriptions)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", description.Id.ToString());
+			cmd.Parameters.AddWithValue("$canonicalName", description.CanonicalName);
+			cmd.Parameters.AddWithValue("$status", description.Status.ToString());
+			cmd.Parameters.AddWithValue("$createdAt", description.CreatedAt.ToString("O"));
 			await cmd.ExecuteNonQueryAsync(cancellationToken);
 		}
 	}
@@ -376,7 +565,7 @@ public class BackupService(
 	{
 		Dictionary<string, string> metadata = new()
 		{
-			["export_version"] = "3",
+			["export_version"] = "4",
 			["exported_at"] = DateTimeOffset.UtcNow.ToString("O"),
 			["format"] = "receipts-sqlite-backup",
 		};

--- a/src/Infrastructure/Services/BackupService.cs
+++ b/src/Infrastructure/Services/BackupService.cs
@@ -41,6 +41,7 @@ public class BackupService(
 			await ExportYnabCategoryMappingsAsync(source, sqlite, cancellationToken);
 			await ExportYnabSyncRecordsAsync(source, sqlite, cancellationToken);
 			await ExportNormalizedDescriptionsAsync(source, sqlite, cancellationToken);
+			await ExportNormalizedDescriptionSettingsAsync(source, sqlite, cancellationToken);
 			await WriteMetadataAsync(sqlite, cancellationToken);
 
 			await transaction.CommitAsync(cancellationToken);
@@ -219,6 +220,14 @@ public class BackupService(
 				canonical_name TEXT NOT NULL,
 				status TEXT NOT NULL,
 				created_at TEXT NOT NULL
+			)
+			""",
+			"""
+			CREATE TABLE normalized_description_settings (
+				id TEXT NOT NULL PRIMARY KEY,
+				auto_accept_threshold TEXT NOT NULL,
+				pending_review_threshold TEXT NOT NULL,
+				updated_at TEXT NOT NULL
 			)
 			""",
 		];
@@ -557,6 +566,29 @@ public class BackupService(
 			cmd.Parameters.AddWithValue("$canonicalName", description.CanonicalName);
 			cmd.Parameters.AddWithValue("$status", description.Status.ToString());
 			cmd.Parameters.AddWithValue("$createdAt", description.CreatedAt.ToString("O"));
+			await cmd.ExecuteNonQueryAsync(cancellationToken);
+		}
+	}
+
+	// Singleton settings row holding non-regenerable user thresholds. Doubles are written with
+	// InvariantCulture for the same reason decimals are (RECEIPTS-771) — a comma-decimal host
+	// must not corrupt the values.
+	private static async Task ExportNormalizedDescriptionSettingsAsync(ApplicationDbContext source, SqliteConnection sqlite, CancellationToken cancellationToken)
+	{
+		List<NormalizedDescriptionSettingsEntity> settings = await source.NormalizedDescriptionSettings.AsNoTracking().ToListAsync(cancellationToken);
+
+		const string sql = """
+			INSERT INTO normalized_description_settings (id, auto_accept_threshold, pending_review_threshold, updated_at)
+			VALUES ($id, $autoAccept, $pendingReview, $updatedAt)
+			""";
+		foreach (NormalizedDescriptionSettingsEntity setting in settings)
+		{
+			await using SqliteCommand cmd = sqlite.CreateCommand();
+			cmd.CommandText = sql;
+			cmd.Parameters.AddWithValue("$id", setting.Id.ToString());
+			cmd.Parameters.AddWithValue("$autoAccept", setting.AutoAcceptThreshold.ToString(CultureInfo.InvariantCulture));
+			cmd.Parameters.AddWithValue("$pendingReview", setting.PendingReviewThreshold.ToString(CultureInfo.InvariantCulture));
+			cmd.Parameters.AddWithValue("$updatedAt", setting.UpdatedAt.ToString("O"));
 			await cmd.ExecuteNonQueryAsync(cancellationToken);
 		}
 	}

--- a/src/Presentation/API/Controllers/BackupController.cs
+++ b/src/Presentation/API/Controllers/BackupController.cs
@@ -28,7 +28,7 @@ public class BackupController(
 
 	[HttpPost("export")]
 	[EndpointSummary("Export database to a portable SQLite file")]
-	[EndpointDescription("Generates a SQLite database containing all domain data (accounts, categories, receipts, items, transactions, adjustments, item templates). Admin-only. Soft-deleted records are excluded.")]
+	[EndpointDescription("Generates a SQLite database containing all domain data (accounts, categories, receipts, items, transactions, adjustments, item templates), YNAB configuration (budget selection and account/category mappings and sync records), and normalized descriptions. Receipt image file paths are included, but the image binaries themselves are stored outside the database and must be backed up separately. User accounts and authentication settings are excluded. Admin-only. Soft-deleted records are excluded.")]
 	public async Task<Results<FileStreamHttpResult, StatusCodeHttpResult>> Export(CancellationToken cancellationToken)
 	{
 		string? filePath = null;
@@ -65,7 +65,7 @@ public class BackupController(
 	[HttpPost("import")]
 	[RequestSizeLimit(100 * 1024 * 1024)]
 	[EndpointSummary("Import data from a SQLite backup file")]
-	[EndpointDescription("Accepts a SQLite database file exported by the backup endpoint, reads all entity tables, and upserts each row into the current database. Requires the Admin role.")]
+	[EndpointDescription("Accepts a SQLite database file exported by the backup endpoint, reads all entity tables, and upserts each row into the current database. Backups from older export versions are accepted; tables and columns they lack are treated as absent. Requires the Admin role.")]
 	public async Task<Results<Ok<BackupImportResponse>, BadRequest<string>>> ImportBackup(
 		IFormFile? file)
 	{

--- a/src/client/src/pages/BackupRestore.test.tsx
+++ b/src/client/src/pages/BackupRestore.test.tsx
@@ -7,8 +7,7 @@ vi.mock("@/hooks/usePageTitle", () => ({
 }));
 
 vi.mock("@tanstack/react-query", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@tanstack/react-query")>();
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
   return {
     ...actual,
     useMutation: vi.fn(() => ({
@@ -46,17 +45,21 @@ describe("BackupRestore", () => {
   it("renders the Export Backup card", () => {
     renderWithQueryClient(<BackupRestore />);
     expect(
-      screen.getByText(/export backup/i, { selector: "[data-slot='card-title']" }),
+      screen.getByText(/export backup/i, {
+        selector: "[data-slot='card-title']",
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/download a complete sqlite backup/i),
+      screen.getByText(/download a sqlite backup of your database/i),
     ).toBeInTheDocument();
   });
 
   it("renders the Import Backup card", () => {
     renderWithQueryClient(<BackupRestore />);
     expect(
-      screen.getByText(/import backup/i, { selector: "[data-slot='card-title']" }),
+      screen.getByText(/import backup/i, {
+        selector: "[data-slot='card-title']",
+      }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/upload a previously exported sqlite backup/i),
@@ -84,7 +87,7 @@ describe("BackupRestore", () => {
   it("renders the info alert about what backups include", () => {
     renderWithQueryClient(<BackupRestore />);
     expect(
-      screen.getByText(/backups include all receipts/i),
+      screen.getByText(/backups include your receipts/i),
     ).toBeInTheDocument();
   });
 
@@ -92,7 +95,9 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
@@ -106,28 +111,32 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test-data"], "my-backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    expect(screen.getByText(/selected: my-backup\.sqlite/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/selected: my-backup\.sqlite/i),
+    ).toBeInTheDocument();
   });
 
   it("opens confirmation dialog when Import Backup is clicked", async () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
 
     expect(
       screen.getByRole("heading", { name: /confirm import/i }),
@@ -141,15 +150,15 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
 
     expect(screen.getByRole("alertdialog")).toBeInTheDocument();
   });
@@ -158,15 +167,15 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
 
     expect(screen.getByRole("alertdialog")).toBeInTheDocument();
 
@@ -189,21 +198,19 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
 
     expect(screen.getByRole("alertdialog")).toBeInTheDocument();
 
-    await user.click(
-      screen.getByRole("button", { name: /confirm import/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /confirm import/i }));
 
     expect(mockMutate).toHaveBeenCalled();
   });
@@ -212,15 +219,15 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
 
     expect(
       screen.getByRole("heading", { name: /confirm import/i }),
@@ -247,19 +254,17 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
 
-    await user.click(
-      screen.getByRole("button", { name: /confirm import/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /confirm import/i }));
 
     // The import mutation is the second useMutation call
     expect(mockMutate).toHaveBeenCalled();
@@ -277,9 +282,7 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    await user.click(
-      screen.getByRole("button", { name: /export backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /export backup/i }));
 
     expect(mockMutate).toHaveBeenCalled();
   });
@@ -339,9 +342,7 @@ describe("BackupRestore", () => {
     })) as unknown as typeof useMutation);
 
     renderWithQueryClient(<BackupRestore />);
-    await user.click(
-      screen.getByRole("button", { name: /export backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /export backup/i }));
 
     await vi.waitFor(() => {
       expect(showSuccess).toHaveBeenCalledWith("Backup exported successfully.");
@@ -365,9 +366,7 @@ describe("BackupRestore", () => {
     })) as unknown as typeof useMutation);
 
     renderWithQueryClient(<BackupRestore />);
-    await user.click(
-      screen.getByRole("button", { name: /export backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /export backup/i }));
 
     await vi.waitFor(() => {
       expect(showError).toHaveBeenCalledWith("Export failed (500).");
@@ -405,18 +404,16 @@ describe("BackupRestore", () => {
 
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
-    await user.click(
-      screen.getByRole("button", { name: /confirm import/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
+    await user.click(screen.getByRole("button", { name: /confirm import/i }));
 
     await vi.waitFor(() => {
       expect(showSuccess).toHaveBeenCalledWith(
@@ -456,23 +453,19 @@ describe("BackupRestore", () => {
 
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
-    await user.click(
-      screen.getByRole("button", { name: /confirm import/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
+    await user.click(screen.getByRole("button", { name: /confirm import/i }));
 
     await vi.waitFor(() => {
-      expect(showError).toHaveBeenCalledWith(
-        "Invalid or corrupt backup file.",
-      );
+      expect(showError).toHaveBeenCalledWith("Invalid or corrupt backup file.");
     });
   });
 
@@ -480,15 +473,15 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test-data-content"], "my-backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
 
     expect(screen.getByText(/file: my-backup\.sqlite/i)).toBeInTheDocument();
   });
@@ -497,15 +490,15 @@ describe("BackupRestore", () => {
     const user = (await import("@testing-library/user-event")).default.setup();
     renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
 
     expect(
       screen.getByRole("heading", { name: /confirm import/i }),
@@ -522,7 +515,9 @@ describe("BackupRestore", () => {
 
   it("accepts .sqlite files in the file input", () => {
     renderWithQueryClient(<BackupRestore />);
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     expect(fileInput.accept).toBe(".sqlite,.db");
   });
 
@@ -554,25 +549,23 @@ describe("BackupRestore", () => {
 
     const { rerender } = renderWithQueryClient(<BackupRestore />);
 
-    const fileInput = document.getElementById("backup-file") as HTMLInputElement;
+    const fileInput = document.getElementById(
+      "backup-file",
+    ) as HTMLInputElement;
     const testFile = new File(["test"], "backup.sqlite", {
       type: "application/octet-stream",
     });
     await user.upload(fileInput, testFile);
 
     // Open the confirmation dialog
-    await user.click(
-      screen.getByRole("button", { name: /import backup/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /import backup/i }));
 
     expect(
       screen.getByRole("heading", { name: /confirm import/i }),
     ).toBeInTheDocument();
 
     // Click Confirm Import (this triggers mutate, setting importPending = true)
-    await user.click(
-      screen.getByRole("button", { name: /confirm import/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /confirm import/i }));
 
     // Re-render to pick up the pending state change
     // Reset mock call count for the re-render

--- a/src/client/src/pages/BackupRestore.tsx
+++ b/src/client/src/pages/BackupRestore.tsx
@@ -62,8 +62,10 @@ function BackupRestore() {
       });
 
       if (!res.ok) {
-        if (res.status === 400) throw new Error("Invalid or corrupt backup file.");
-        if (res.status === 403) throw new Error("You do not have permission to import backups.");
+        if (res.status === 400)
+          throw new Error("Invalid or corrupt backup file.");
+        if (res.status === 403)
+          throw new Error("You do not have permission to import backups.");
         throw new Error(`Import failed (${res.status}).`);
       }
 
@@ -108,127 +110,131 @@ function BackupRestore() {
         sub="Export or import a portable SQLite backup of your data"
       />
       <div className="space-y-6">
+        <div className="grid gap-6 md:grid-cols-2">
+          {/* Export Card */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Download className="h-5 w-5" />
+                Export Backup
+              </CardTitle>
+              <CardDescription>
+                Download a SQLite backup of your database. It can be used to
+                restore your data on another instance. Note that receipt image
+                files are stored outside the database and are not included
+                &mdash; only their file paths are.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                onClick={() => exportMutation.mutate()}
+                disabled={exportMutation.isPending}
+                className="w-full"
+              >
+                {exportMutation.isPending && <Spinner size="sm" />}
+                {exportMutation.isPending ? "Exporting..." : "Export Backup"}
+              </Button>
+            </CardContent>
+          </Card>
 
-      <div className="grid gap-6 md:grid-cols-2">
-        {/* Export Card */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Download className="h-5 w-5" />
-              Export Backup
-            </CardTitle>
-            <CardDescription>
-              Download a complete SQLite backup of all your data. This file can
-              be used to restore your data on another instance or recover from
-              data loss.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button
-              onClick={() => exportMutation.mutate()}
-              disabled={exportMutation.isPending}
-              className="w-full"
-            >
-              {exportMutation.isPending && <Spinner size="sm" />}
-              {exportMutation.isPending ? "Exporting..." : "Export Backup"}
-            </Button>
-          </CardContent>
-        </Card>
+          {/* Import Card */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Upload className="h-5 w-5" />
+                Import Backup
+              </CardTitle>
+              <CardDescription>
+                Upload a previously exported SQLite backup file. Existing
+                records will be updated and new records will be added.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <label htmlFor="backup-file" className="sr-only">
+                  Select backup file
+                </label>
+                <input
+                  ref={fileInputRef}
+                  id="backup-file"
+                  type="file"
+                  accept=".sqlite,.db"
+                  onChange={handleFileChange}
+                  className="block w-full text-sm text-muted-foreground file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90 file:cursor-pointer"
+                />
+                {selectedFile && (
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Selected: {selectedFile.name} (
+                    {formatFileSize(selectedFile.size)})
+                  </p>
+                )}
+              </div>
+              <Button
+                onClick={handleImportClick}
+                disabled={!selectedFile || importMutation.isPending}
+                variant="outline"
+                className="w-full"
+              >
+                {importMutation.isPending && <Spinner size="sm" />}
+                {importMutation.isPending ? "Importing..." : "Import Backup"}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
 
-        {/* Import Card */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Upload className="h-5 w-5" />
-              Import Backup
-            </CardTitle>
-            <CardDescription>
-              Upload a previously exported SQLite backup file. Existing records
-              will be updated and new records will be added.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
-              <label htmlFor="backup-file" className="sr-only">
-                Select backup file
-              </label>
-              <input
-                ref={fileInputRef}
-                id="backup-file"
-                type="file"
-                accept=".sqlite,.db"
-                onChange={handleFileChange}
-                className="block w-full text-sm text-muted-foreground file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90 file:cursor-pointer"
-              />
-              {selectedFile && (
-                <p className="mt-2 text-sm text-muted-foreground">
-                  Selected: {selectedFile.name} ({formatFileSize(selectedFile.size)})
-                </p>
-              )}
-            </div>
-            <Button
-              onClick={handleImportClick}
-              disabled={!selectedFile || importMutation.isPending}
-              variant="outline"
-              className="w-full"
-            >
-              {importMutation.isPending && <Spinner size="sm" />}
-              {importMutation.isPending ? "Importing..." : "Import Backup"}
-            </Button>
-          </CardContent>
-        </Card>
+        <Alert>
+          <DatabaseBackup className="h-4 w-4" />
+          <AlertDescription>
+            Backups include your receipts, transactions, accounts, categories,
+            item templates, adjustments, YNAB configuration, and normalized
+            descriptions. Receipt image files are stored outside the database:
+            their paths are backed up, but the image files themselves must be
+            backed up separately. User accounts and authentication settings are
+            excluded for security reasons.
+          </AlertDescription>
+        </Alert>
+
+        {/* Import Confirmation Dialog */}
+        <AlertDialog
+          open={confirmImportOpen}
+          onOpenChange={(open) => {
+            if (!importMutation.isPending) setConfirmImportOpen(open);
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle className="flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-yellow-500" />
+                Confirm Import
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                Importing a backup will update existing records and add new
+                ones. This action may modify your current data.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            {selectedFile && (
+              <p className="text-sm text-muted-foreground">
+                File: {selectedFile.name} ({formatFileSize(selectedFile.size)})
+              </p>
+            )}
+            <AlertDialogFooter>
+              <AlertDialogCancel
+                onClick={() => setConfirmImportOpen(false)}
+                disabled={importMutation.isPending}
+              >
+                Cancel
+              </AlertDialogCancel>
+              <Button
+                onClick={handleConfirmImport}
+                disabled={importMutation.isPending}
+              >
+                {importMutation.isPending && <Spinner size="sm" />}
+                {importMutation.isPending ? "Importing..." : "Confirm Import"}
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
-
-      <Alert>
-        <DatabaseBackup className="h-4 w-4" />
-        <AlertDescription>
-          Backups include all receipts, transactions, accounts, categories, and
-          related data. User accounts and authentication settings are not
-          included in backups for security reasons.
-        </AlertDescription>
-      </Alert>
-
-      {/* Import Confirmation Dialog */}
-      <AlertDialog
-        open={confirmImportOpen}
-        onOpenChange={(open) => {
-          if (!importMutation.isPending) setConfirmImportOpen(open);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-yellow-500" />
-              Confirm Import
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              Importing a backup will update existing records and add new ones.
-              This action may modify your current data.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          {selectedFile && (
-            <p className="text-sm text-muted-foreground">
-              File: {selectedFile.name} ({formatFileSize(selectedFile.size)})
-            </p>
-          )}
-          <AlertDialogFooter>
-            <AlertDialogCancel
-              onClick={() => setConfirmImportOpen(false)}
-              disabled={importMutation.isPending}
-            >
-              Cancel
-            </AlertDialogCancel>
-            <Button
-              onClick={handleConfirmImport}
-              disabled={importMutation.isPending}
-            >
-              {importMutation.isPending && <Spinner size="sm" />}
-              {importMutation.isPending ? "Importing..." : "Confirm Import"}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
     </>
   );
 }

--- a/tests/Infrastructure.Tests/Services/BackupRoundTripFidelityTests.cs
+++ b/tests/Infrastructure.Tests/Services/BackupRoundTripFidelityTests.cs
@@ -1,0 +1,372 @@
+using System.Globalization;
+using Application.Models;
+using Common;
+using Domain.NormalizedDescriptions;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Infrastructure.Tests.Services;
+
+/// <summary>
+/// End-to-end export → import round-trip coverage for RECEIPTS-771/770/789: culture-safe decimals,
+/// the v4 YNAB/normalized-description tables, receipt image paths, and backward compatibility with
+/// pre-v4 backups. Export runs against one in-memory database and import against a second so the
+/// round-trip is genuine.
+/// </summary>
+public class BackupRoundTripFidelityTests : IDisposable
+{
+	private readonly DbContextOptions<ApplicationDbContext> _sourceOptions;
+	private readonly DbContextOptions<ApplicationDbContext> _targetOptions;
+	private readonly BackupService _exportService;
+	private readonly BackupImportService _importService;
+	private readonly string _tempDir;
+
+	public BackupRoundTripFidelityTests()
+	{
+		_sourceOptions = BuildOptions($"BackupRtSource_{Guid.NewGuid()}");
+		_targetOptions = BuildOptions($"BackupRtTarget_{Guid.NewGuid()}");
+		_exportService = new BackupService(new Factory(_sourceOptions), NullLogger<BackupService>.Instance);
+		_importService = new BackupImportService(new Factory(_targetOptions), NullLogger<BackupImportService>.Instance);
+		_tempDir = Path.Combine(Path.GetTempPath(), $"backup-roundtrip-test-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(_tempDir);
+	}
+
+	private static DbContextOptions<ApplicationDbContext> BuildOptions(string name) =>
+		new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase(name)
+			.ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+
+	private ApplicationDbContext Source() => new(_sourceOptions);
+	private ApplicationDbContext Target() => new(_targetOptions);
+
+	private async Task<BackupImportResult> RoundTripAsync()
+	{
+		string path = await _exportService.ExportToSqliteAsync();
+		// The exporter uses a pooled SQLite connection; clear the pool so the underlying file
+		// handle is released before we open the file for import (Windows otherwise reports the
+		// file as locked). Production streams the file via FileOptions.DeleteOnClose instead.
+		SqliteConnection.ClearAllPools();
+		try
+		{
+			await using FileStream stream = File.OpenRead(path);
+			return await _importService.ImportFromSqliteAsync(stream, CancellationToken.None);
+		}
+		finally
+		{
+			try
+			{
+				File.Delete(path);
+			}
+			catch
+			{
+				// Best effort cleanup
+			}
+		}
+	}
+
+	// RECEIPTS-771: on a comma-decimal host (de-DE) the old exporter wrote "12,34" for 12.34m via
+	// CurrentCulture, and the invariant importer read that back as 1234 — a silent 100x corruption.
+	// The exporter now writes invariant text, so every amount round-trips regardless of host culture.
+	[Fact]
+	public async Task RoundTrip_UnderGermanCulture_PreservesDecimalValues()
+	{
+		CultureInfo previousCulture = CultureInfo.CurrentCulture;
+		CultureInfo? previousDefault = CultureInfo.DefaultThreadCurrentCulture;
+		CultureInfo german = CultureInfo.GetCultureInfo("de-DE");
+		try
+		{
+			CultureInfo.CurrentCulture = german;
+			CultureInfo.DefaultThreadCurrentCulture = german;
+
+			Guid accountId = Guid.NewGuid();
+			Guid receiptId = Guid.NewGuid();
+			Guid itemId = Guid.NewGuid();
+			Guid txId = Guid.NewGuid();
+			Guid adjId = Guid.NewGuid();
+			Guid templateId = Guid.NewGuid();
+
+			await using (ApplicationDbContext ctx = Source())
+			{
+				ctx.Accounts.Add(new AccountEntity { Id = accountId, Name = "Checking", IsActive = true });
+				ctx.Cards.Add(new CardEntity { Id = accountId, CardCode = "1000", Name = "Checking", IsActive = true, AccountId = accountId });
+				ctx.Receipts.Add(new ReceiptEntity
+				{
+					Id = receiptId,
+					Location = "Kaufland",
+					Date = new DateOnly(2024, 3, 4),
+					TaxAmount = 12.34m,
+					TaxAmountCurrency = Currency.USD,
+				});
+				ctx.ReceiptItems.Add(new ReceiptItemEntity
+				{
+					Id = itemId,
+					ReceiptId = receiptId,
+					Description = "Butter",
+					Quantity = 2.5m,
+					UnitPrice = 1234.56m,
+					UnitPriceCurrency = Currency.USD,
+					TotalAmount = 3086.40m,
+					TotalAmountCurrency = Currency.USD,
+					Category = "Food",
+				});
+				ctx.Transactions.Add(new TransactionEntity
+				{
+					Id = txId,
+					ReceiptId = receiptId,
+					AccountId = accountId,
+					CardId = accountId,
+					Amount = 99.99m,
+					AmountCurrency = Currency.USD,
+					Date = new DateOnly(2024, 3, 4),
+				});
+				ctx.Adjustments.Add(new AdjustmentEntity
+				{
+					Id = adjId,
+					ReceiptId = receiptId,
+					Type = AdjustmentType.Tip,
+					Amount = 7.77m,
+					AmountCurrency = Currency.USD,
+				});
+				ctx.ItemTemplates.Add(new ItemTemplateEntity
+				{
+					Id = templateId,
+					Name = "Butter",
+					DefaultUnitPrice = 4.99m,
+					DefaultUnitPriceCurrency = Currency.USD,
+				});
+				await ctx.SaveChangesAsync();
+			}
+
+			await RoundTripAsync();
+
+			await using ApplicationDbContext assert = Target();
+			(await assert.Receipts.FindAsync(receiptId))!.TaxAmount.Should().Be(12.34m);
+			ReceiptItemEntity item = (await assert.ReceiptItems.FindAsync(itemId))!;
+			item.Quantity.Should().Be(2.5m);
+			item.UnitPrice.Should().Be(1234.56m);
+			item.TotalAmount.Should().Be(3086.40m);
+			(await assert.Transactions.FindAsync(txId))!.Amount.Should().Be(99.99m);
+			(await assert.Adjustments.FindAsync(adjId))!.Amount.Should().Be(7.77m);
+			(await assert.ItemTemplates.FindAsync(templateId))!.DefaultUnitPrice.Should().Be(4.99m);
+		}
+		finally
+		{
+			CultureInfo.CurrentCulture = previousCulture;
+			CultureInfo.DefaultThreadCurrentCulture = previousDefault;
+		}
+	}
+
+	// RECEIPTS-770 + RECEIPTS-789: the v4 export adds the YNAB config/state tables, normalized
+	// descriptions, and receipt image paths. All must round-trip faithfully.
+	[Fact]
+	public async Task RoundTrip_V4Tables_AndImagePaths_RoundTripFaithfully()
+	{
+		Guid accountId = Guid.NewGuid();
+		Guid receiptId = Guid.NewGuid();
+		Guid txId = Guid.NewGuid();
+		Guid budgetRowId = Guid.NewGuid();
+		Guid acctMapId = Guid.NewGuid();
+		Guid catMapId = Guid.NewGuid();
+		Guid syncId = Guid.NewGuid();
+		Guid normId = Guid.NewGuid();
+		DateTimeOffset ts = new(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+
+		await using (ApplicationDbContext ctx = Source())
+		{
+			ctx.Accounts.Add(new AccountEntity { Id = accountId, Name = "Checking", IsActive = true });
+			ctx.Cards.Add(new CardEntity { Id = accountId, CardCode = "1000", Name = "Checking", IsActive = true, AccountId = accountId });
+			ctx.Receipts.Add(new ReceiptEntity
+			{
+				Id = receiptId,
+				Location = "Target",
+				Date = new DateOnly(2024, 1, 15),
+				TaxAmount = 1.23m,
+				TaxAmountCurrency = Currency.USD,
+				OriginalImagePath = "receipts/orig/abc.jpg",
+				ProcessedImagePath = "receipts/proc/abc.png",
+			});
+			ctx.Transactions.Add(new TransactionEntity
+			{
+				Id = txId,
+				ReceiptId = receiptId,
+				AccountId = accountId,
+				CardId = accountId,
+				Amount = 10m,
+				AmountCurrency = Currency.USD,
+				Date = new DateOnly(2024, 1, 15),
+			});
+			ctx.YnabSelectedBudgets.Add(new YnabSelectedBudgetEntity { Id = budgetRowId, BudgetId = "budget-123", UpdatedAt = ts });
+			ctx.YnabAccountMappings.Add(new YnabAccountMappingEntity
+			{
+				Id = acctMapId,
+				ReceiptsAccountId = accountId,
+				YnabAccountId = "ynab-acct-1",
+				YnabAccountName = "YNAB Checking",
+				YnabBudgetId = "budget-123",
+				CreatedAt = ts,
+				UpdatedAt = ts,
+			});
+			ctx.YnabCategoryMappings.Add(new YnabCategoryMappingEntity
+			{
+				Id = catMapId,
+				ReceiptsCategory = "Food",
+				YnabCategoryId = "ynab-cat-1",
+				YnabCategoryName = "Groceries",
+				YnabCategoryGroupName = "Everyday",
+				YnabBudgetId = "budget-123",
+				CreatedAt = ts,
+				UpdatedAt = ts,
+			});
+			ctx.YnabSyncRecords.Add(new YnabSyncRecordEntity
+			{
+				Id = syncId,
+				LocalTransactionId = txId,
+				YnabTransactionId = "ynab-txn-1",
+				YnabBudgetId = "budget-123",
+				YnabAccountId = "ynab-acct-1",
+				SyncType = YnabSyncType.TransactionPush,
+				SyncStatus = YnabSyncStatus.Synced,
+				SyncedAtUtc = ts,
+				LastError = null,
+				CreatedAt = ts,
+				UpdatedAt = ts,
+			});
+			ctx.NormalizedDescriptions.Add(new NormalizedDescriptionEntity
+			{
+				Id = normId,
+				CanonicalName = "milk",
+				Status = NormalizedDescriptionStatus.PendingReview,
+				CreatedAt = ts,
+			});
+			await ctx.SaveChangesAsync();
+		}
+
+		BackupImportResult result = await RoundTripAsync();
+
+		result.YnabSelectedBudgetsCreated.Should().Be(1);
+		result.YnabAccountMappingsCreated.Should().Be(1);
+		result.YnabCategoryMappingsCreated.Should().Be(1);
+		result.YnabSyncRecordsCreated.Should().Be(1);
+		result.NormalizedDescriptionsCreated.Should().Be(1);
+
+		await using ApplicationDbContext assert = Target();
+
+		ReceiptEntity receipt = (await assert.Receipts.FindAsync(receiptId))!;
+		receipt.OriginalImagePath.Should().Be("receipts/orig/abc.jpg");
+		receipt.ProcessedImagePath.Should().Be("receipts/proc/abc.png");
+
+		YnabSelectedBudgetEntity budget = (await assert.YnabSelectedBudgets.FindAsync(budgetRowId))!;
+		budget.BudgetId.Should().Be("budget-123");
+		budget.UpdatedAt.Should().Be(ts);
+
+		YnabAccountMappingEntity acctMap = (await assert.YnabAccountMappings.FindAsync(acctMapId))!;
+		acctMap.ReceiptsAccountId.Should().Be(accountId);
+		acctMap.YnabAccountId.Should().Be("ynab-acct-1");
+		acctMap.YnabAccountName.Should().Be("YNAB Checking");
+		acctMap.YnabBudgetId.Should().Be("budget-123");
+
+		YnabCategoryMappingEntity catMap = (await assert.YnabCategoryMappings.FindAsync(catMapId))!;
+		catMap.ReceiptsCategory.Should().Be("Food");
+		catMap.YnabCategoryId.Should().Be("ynab-cat-1");
+		catMap.YnabCategoryName.Should().Be("Groceries");
+		catMap.YnabCategoryGroupName.Should().Be("Everyday");
+
+		YnabSyncRecordEntity sync = (await assert.YnabSyncRecords.FindAsync(syncId))!;
+		sync.LocalTransactionId.Should().Be(txId);
+		sync.YnabTransactionId.Should().Be("ynab-txn-1");
+		sync.SyncType.Should().Be(YnabSyncType.TransactionPush);
+		sync.SyncStatus.Should().Be(YnabSyncStatus.Synced);
+		sync.SyncedAtUtc.Should().Be(ts);
+		sync.DeletedAt.Should().BeNull();
+
+		NormalizedDescriptionEntity norm = (await assert.NormalizedDescriptions.FindAsync(normId))!;
+		norm.CanonicalName.Should().Be("milk");
+		norm.Status.Should().Be(NormalizedDescriptionStatus.PendingReview);
+		norm.CreatedAt.Should().Be(ts);
+		norm.Embedding.Should().BeNull("embeddings are regenerated after restore, not carried in the backup");
+	}
+
+	// RECEIPTS-770/789 backward compatibility: a v3-style backup (no v4 tables, no image-path
+	// columns) must still import cleanly, with the new fields treated as null/absent.
+	[Fact]
+	public async Task Import_LegacyV3Backup_SucceedsWithNewFieldsAbsent()
+	{
+		Guid accountId = Guid.NewGuid();
+		Guid receiptId = Guid.NewGuid();
+		string path = CreateV3Backup(accountId, receiptId);
+
+		await using FileStream stream = File.OpenRead(path);
+		BackupImportResult result = await _importService.ImportFromSqliteAsync(stream, CancellationToken.None);
+
+		// New v4 tables are absent → nothing created for them, and no exception thrown.
+		result.YnabSelectedBudgetsCreated.Should().Be(0);
+		result.YnabAccountMappingsCreated.Should().Be(0);
+		result.YnabCategoryMappingsCreated.Should().Be(0);
+		result.YnabSyncRecordsCreated.Should().Be(0);
+		result.NormalizedDescriptionsCreated.Should().Be(0);
+		result.ReceiptsCreated.Should().Be(1);
+
+		await using ApplicationDbContext assert = Target();
+		ReceiptEntity receipt = (await assert.Receipts.FindAsync(receiptId))!;
+		receipt.Location.Should().Be("Legacy Store");
+		receipt.OriginalImagePath.Should().BeNull("v3 backups never carried image paths");
+		receipt.ProcessedImagePath.Should().BeNull();
+		(await assert.YnabSelectedBudgets.CountAsync()).Should().Be(0);
+		(await assert.NormalizedDescriptions.CountAsync()).Should().Be(0);
+	}
+
+	private string CreateV3Backup(Guid accountId, Guid receiptId)
+	{
+		string path = Path.Combine(_tempDir, $"{Guid.NewGuid():N}.sqlite");
+		using SqliteConnection conn = new($"Data Source={path};Pooling=False");
+		conn.Open();
+
+		Exec(conn, "CREATE TABLE backup_metadata (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)");
+		Exec(conn, "INSERT INTO backup_metadata (key, value) VALUES ('export_version', '3')");
+
+		Exec(conn, "CREATE TABLE accounts (id TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, is_active INTEGER NOT NULL)");
+		Exec(conn, $"INSERT INTO accounts (id, name, is_active) VALUES ('{accountId}', 'Checking', 1)");
+
+		Exec(conn, "CREATE TABLE cards (id TEXT NOT NULL PRIMARY KEY, card_code TEXT NOT NULL, name TEXT NOT NULL, is_active INTEGER NOT NULL, account_id TEXT NOT NULL)");
+		Exec(conn, $"INSERT INTO cards (id, card_code, name, is_active, account_id) VALUES ('{accountId}', '1000', 'Checking', 1, '{accountId}')");
+
+		// v3 receipts table: no image-path columns.
+		Exec(conn, "CREATE TABLE receipts (id TEXT NOT NULL PRIMARY KEY, location TEXT NOT NULL, date TEXT NOT NULL, tax_amount TEXT NOT NULL, tax_amount_currency TEXT NOT NULL)");
+		Exec(conn, $"INSERT INTO receipts (id, location, date, tax_amount, tax_amount_currency) VALUES ('{receiptId}', 'Legacy Store', '2024-01-15', '1.50', 'USD')");
+
+		return path;
+	}
+
+	private static void Exec(SqliteConnection conn, string sql)
+	{
+		using SqliteCommand cmd = conn.CreateCommand();
+		cmd.CommandText = sql;
+		cmd.ExecuteNonQuery();
+	}
+
+	public void Dispose()
+	{
+		try
+		{
+			Directory.Delete(_tempDir, recursive: true);
+		}
+		catch
+		{
+			// Best effort cleanup
+		}
+		GC.SuppressFinalize(this);
+	}
+
+	private sealed class Factory(DbContextOptions<ApplicationDbContext> options) : IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => new(options);
+		public Task<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+			Task.FromResult(new ApplicationDbContext(options));
+	}
+}

--- a/tests/Infrastructure.Tests/Services/BackupRoundTripFidelityTests.cs
+++ b/tests/Infrastructure.Tests/Services/BackupRoundTripFidelityTests.cs
@@ -175,6 +175,7 @@ public class BackupRoundTripFidelityTests : IDisposable
 		Guid catMapId = Guid.NewGuid();
 		Guid syncId = Guid.NewGuid();
 		Guid normId = Guid.NewGuid();
+		Guid settingsId = Guid.NewGuid();
 		DateTimeOffset ts = new(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
 
 		await using (ApplicationDbContext ctx = Source())
@@ -244,6 +245,13 @@ public class BackupRoundTripFidelityTests : IDisposable
 				Status = NormalizedDescriptionStatus.PendingReview,
 				CreatedAt = ts,
 			});
+			ctx.NormalizedDescriptionSettings.Add(new NormalizedDescriptionSettingsEntity
+			{
+				Id = settingsId,
+				AutoAcceptThreshold = 0.87,
+				PendingReviewThreshold = 0.62,
+				UpdatedAt = ts,
+			});
 			await ctx.SaveChangesAsync();
 		}
 
@@ -254,6 +262,7 @@ public class BackupRoundTripFidelityTests : IDisposable
 		result.YnabCategoryMappingsCreated.Should().Be(1);
 		result.YnabSyncRecordsCreated.Should().Be(1);
 		result.NormalizedDescriptionsCreated.Should().Be(1);
+		result.NormalizedDescriptionSettingsCreated.Should().Be(1);
 
 		await using ApplicationDbContext assert = Target();
 
@@ -290,6 +299,11 @@ public class BackupRoundTripFidelityTests : IDisposable
 		norm.Status.Should().Be(NormalizedDescriptionStatus.PendingReview);
 		norm.CreatedAt.Should().Be(ts);
 		norm.Embedding.Should().BeNull("embeddings are regenerated after restore, not carried in the backup");
+
+		NormalizedDescriptionSettingsEntity settings = (await assert.NormalizedDescriptionSettings.FindAsync(settingsId))!;
+		settings.AutoAcceptThreshold.Should().Be(0.87);
+		settings.PendingReviewThreshold.Should().Be(0.62);
+		settings.UpdatedAt.Should().Be(ts);
 	}
 
 	// RECEIPTS-770/789 backward compatibility: a v3-style backup (no v4 tables, no image-path
@@ -319,6 +333,44 @@ public class BackupRoundTripFidelityTests : IDisposable
 		receipt.ProcessedImagePath.Should().BeNull();
 		(await assert.YnabSelectedBudgets.CountAsync()).Should().Be(0);
 		(await assert.NormalizedDescriptions.CountAsync()).Should().Be(0);
+	}
+
+	// RECEIPTS-789 regression guard: importing a v3 backup (no image-path columns) over an
+	// EXISTING receipt must update the row but must NOT null out its already-present image paths.
+	[Fact]
+	public async Task Import_LegacyV3Backup_DoesNotNullExistingReceiptImagePaths()
+	{
+		Guid accountId = Guid.NewGuid();
+		Guid receiptId = Guid.NewGuid();
+
+		// Seed the target DB with a receipt (same Id) that already has non-null image paths.
+		await using (ApplicationDbContext seed = Target())
+		{
+			seed.Receipts.Add(new ReceiptEntity
+			{
+				Id = receiptId,
+				Location = "Original Store",
+				Date = new DateOnly(2020, 1, 1),
+				TaxAmount = 9.99m,
+				TaxAmountCurrency = Currency.USD,
+				OriginalImagePath = "receipts/orig/keep-me.jpg",
+				ProcessedImagePath = "receipts/proc/keep-me.png",
+			});
+			await seed.SaveChangesAsync();
+		}
+
+		// v3 backup contains the same receipt Id (no image-path columns) → hits the UPDATE path.
+		string path = CreateV3Backup(accountId, receiptId);
+		await using FileStream stream = File.OpenRead(path);
+		BackupImportResult result = await _importService.ImportFromSqliteAsync(stream, CancellationToken.None);
+
+		result.ReceiptsUpdated.Should().Be(1, "the receipt already exists, so import must take the update path");
+
+		await using ApplicationDbContext assert = Target();
+		ReceiptEntity receipt = (await assert.Receipts.FindAsync(receiptId))!;
+		receipt.Location.Should().Be("Legacy Store", "the v3 import must still update the row");
+		receipt.OriginalImagePath.Should().Be("receipts/orig/keep-me.jpg", "a v3 restore must not null out existing image paths");
+		receipt.ProcessedImagePath.Should().Be("receipts/proc/keep-me.png");
 	}
 
 	private string CreateV3Backup(Guid accountId, Guid receiptId)

--- a/tests/Infrastructure.Tests/Services/BackupServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/BackupServiceTests.cs
@@ -59,7 +59,7 @@ public class BackupServiceTests : IDisposable
 		await using SqliteCommand versionCmd = conn.CreateCommand();
 		versionCmd.CommandText = "SELECT value FROM backup_metadata WHERE key='export_version'";
 		string? version = (string?)await versionCmd.ExecuteScalarAsync();
-		version.Should().Be("3");
+		version.Should().Be("4");
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

Fixes three confirmed backup export→import fidelity findings in the SQLite backup subsystem and makes the user-facing messaging honest. All live in the backup subsystem, so they ship as one PR. The SQLite backup **`export_version` is bumped 3 → 4**.

## Fixes

### Fix 1 — RECEIPTS-771: decimal (and date) culture corruption
Export wrote every decimal via `decimal.ToString("G")`, which uses **CurrentCulture**, while import parses invariantly (`GetDecimal`). On a comma-decimal host (e.g. de-DE) `12.34` exported as `"12,34"` and was read back as `1234` — a silent **100x corruption** of every amount, with no error. All **seven** decimal export sites now use `CultureInfo.InvariantCulture` (item-template price, receipt tax, receipt-item quantity/unit price/total, transaction amount, adjustment amount). Import date parsing (receipt + transaction dates) is now invariant too, for full export/import symmetry. Format-compatible, so no version gate needed; existing US-culture v1–v3 backups still parse.

### Fix 2 — RECEIPTS-770: export omits YNAB config + normalized descriptions
Export now includes `YnabSelectedBudgets`, `YnabAccountMappings`, `YnabCategoryMappings`, `YnabSyncRecords`, and `NormalizedDescriptions` — user-created config/state a restore previously wiped (losing YNAB budget selection + all mappings, and resetting every receipt to "not synced"). FK import order is respected: account mappings import after Accounts, sync records after Transactions. `YnabSyncRecords` soft-delete semantics mirror the existing tables. The `NormalizedDescription` **embedding vector is intentionally not carried** — it is large, regenerable derived data whose dimension is a build-time constant that has changed across versions (384 → 1024); shipping a stale-dimension vector would abort the entire import. Embeddings are repopulated by the embedding pipeline after restore; canonical name / status / created-at round-trip faithfully.

### Fix 3 — RECEIPTS-789: receipts export omits image path columns
Receipts export/import now round-trips `OriginalImagePath` / `ProcessedImagePath`, the only DB link to a receipt's images. Image **binaries** live outside the DB and are **not** embedded.

### Fix 4 — honest client/endpoint messaging
`BackupRestore.tsx` and the `BackupController` `[EndpointDescription]`s now accurately state that the backup includes YNAB config + normalized descriptions + receipt image **paths**, but not image **files** (back those up separately) and not auth settings.

## Backward compatibility (hard requirement)
The new tables and columns are gated on `exportVersion >= 4` in the importer. Older backups (v1/v2/v3, which default to version 1 when metadata is absent) still restore: the new tables/columns are treated as absent (empty/null), never throwing. A v1–v3 restore also never nulls out a receipt's existing image paths on update. Covered by a dedicated backward-compat test.

## Validation
- `dotnet build Receipts.slnx` — 0 errors, no new warnings (only pre-existing NU19xx package advisories).
- `dotnet test tests/Infrastructure.Tests --filter "Category!=Integration"` — 638/638 pass.
- Full pre-commit hook (format verify, warnings-as-errors build, spec-drift, all .NET non-integration tests, tsc, eslint, 2106 vitest tests) passed.
- **New tests** (`BackupRoundTripFidelityTests`): de-DE decimal regression (export under de-DE culture, import, assert no 100x), v4 new-tables + image-paths round-trip, and v3 backward-compat import. Existing client tests updated for the new copy.

Closes RECEIPTS-771, RECEIPTS-770, RECEIPTS-789

🤖 Generated with [Claude Code](https://claude.com/claude-code)
