### PR TITLE
fix(application): correct ynab account-mapping validation and push-retry idempotency

### DIFF
--- a/src/Application/Commands/Ynab/AccountMapping/CreateYnabAccountMappingCommandHandler.cs
+++ b/src/Application/Commands/Ynab/AccountMapping/CreateYnabAccountMappingCommandHandler.cs
@@ -6,11 +6,15 @@ namespace Application.Commands.Ynab.AccountMapping;
 
 public class CreateYnabAccountMappingCommandHandler(
 	IYnabAccountMappingService accountMappingService,
-	ICardService cardService) : IRequestHandler<CreateYnabAccountMappingCommand, YnabAccountMappingDto>
+	IAccountService accountService) : IRequestHandler<CreateYnabAccountMappingCommand, YnabAccountMappingDto>
 {
 	public async ValueTask<YnabAccountMappingDto> Handle(CreateYnabAccountMappingCommand request, CancellationToken cancellationToken)
 	{
-		bool accountExists = await cardService.ExistsAsync(request.ReceiptsAccountId, cancellationToken);
+		// ReceiptsAccountId is an FK to Accounts (see YnabAccountMappingEntityConfiguration),
+		// so validate existence against Accounts — not Cards (RECEIPTS-751). Validating against
+		// Cards only worked for legacy data where each Card shared its Account's Guid, and
+		// rejected any Account created after the account/card split.
+		bool accountExists = await accountService.ExistsAsync(request.ReceiptsAccountId, cancellationToken);
 		if (!accountExists)
 		{
 			throw new ArgumentException($"Account with ID '{request.ReceiptsAccountId}' does not exist.", nameof(request));

--- a/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
+++ b/src/Application/Commands/Ynab/PushTransactions/PushYnabTransactionsCommandHandler.cs
@@ -135,9 +135,36 @@ public class PushYnabTransactionsCommandHandler(
 			return new PushYnabTransactionsResult(false, [], Error: ex.Message);
 		}
 
-		// 8. Create YNAB transactions and track sync
-		List<PushedTransactionInfo> pushedTransactions = [];
+		// 8. Assign a stable import_id to EVERY split up front — including already-synced ones
+		// (RECEIPTS-752). YNAB import_ids disambiguate transactions sharing amount+date via an
+		// occurrence counter. If the counter only advanced for the splits actually pushed, a
+		// retry (where a synced sibling is skipped) would recompute occurrence 1 for a still-
+		// unsynced transaction with the same amount+date, colliding with the sibling's already-
+		// consumed import_id. YNAB would 409 and recovery would bind both local transactions to
+		// the sibling's single YNAB transaction, silently dropping the second amount. Counting
+		// every split here keeps occurrence numbering deterministic across retries.
 		Dictionary<(long Milliunits, DateOnly Date), int> importIdOccurrences = [];
+		Dictionary<Guid, string> importIdByTransactionId = [];
+		foreach (YnabTransactionSplit txSplit in splitResult.TransactionSplits)
+		{
+			Domain.Core.Transaction localTx = transactions.First(t => t.Id == txSplit.LocalTransactionId);
+			(long Milliunits, DateOnly Date) importIdKey = (txSplit.TotalMilliunits, localTx.Date);
+			int occurrence = importIdOccurrences.TryGetValue(importIdKey, out int current) ? current + 1 : 1;
+			importIdOccurrences[importIdKey] = occurrence;
+			importIdByTransactionId[txSplit.LocalTransactionId] = YnabImportId.Generate(
+				txSplit.TotalMilliunits, localTx.Date, request.ReceiptId, occurrence);
+		}
+
+		// Track YNAB transaction ids already bound to a sync record for this receipt so recovery
+		// can never double-bind two local transactions to one YNAB transaction (RECEIPTS-752).
+		// Seed with the ids of already-synced siblings preserved from a prior push.
+		HashSet<string> boundYnabTransactionIds = existingSyncRecords.Values
+			.Where(r => r.SyncStatus == YnabSyncStatus.Synced && r.YnabTransactionId is not null)
+			.Select(r => r.YnabTransactionId!)
+			.ToHashSet();
+
+		// 9. Create YNAB transactions and track sync
+		List<PushedTransactionInfo> pushedTransactions = [];
 
 		foreach (YnabTransactionSplit txSplit in splitResult.TransactionSplits)
 		{
@@ -153,11 +180,9 @@ public class PushYnabTransactionsCommandHandler(
 
 			string ynabAccountId = accountToYnabId[localTx.AccountId];
 
-			// Compute import_id for deduplication (includes receipt prefix to avoid cross-receipt collision)
-			(long Milliunits, DateOnly Date) importIdKey = (txSplit.TotalMilliunits, localTx.Date);
-			int occurrence = importIdOccurrences.TryGetValue(importIdKey, out int current) ? current + 1 : 1;
-			importIdOccurrences[importIdKey] = occurrence;
-			string importId = YnabImportId.Generate(txSplit.TotalMilliunits, localTx.Date, request.ReceiptId, occurrence);
+			// import_id was assigned deterministically in the first pass above so occurrence
+			// numbering stays stable across retries.
+			string importId = importIdByTransactionId[txSplit.LocalTransactionId];
 
 			YnabSyncRecordDto? syncRecord = null;
 			try
@@ -219,6 +244,23 @@ public class PushYnabTransactionsCommandHandler(
 						throw;
 					}
 
+					// Reject a recovered id already bound to another local transaction's sync
+					// record for this receipt: binding it here would point two local transactions
+					// at one YNAB transaction and silently drop this amount (RECEIPTS-752). Fail
+					// loudly instead of reporting a false success. Add returns false if present.
+					if (!boundYnabTransactionIds.Add(recoveredId))
+					{
+						string dupError = $"YNAB transaction '{recoveredId}' is already bound to another sync record " +
+							$"for this receipt; refusing to double-bind local transaction {localTx.Id}.";
+
+						await syncRecordService.UpdateStatusAsync(
+							syncRecord!.Id, YnabSyncStatus.Failed, null, dupError, cancellationToken);
+
+						await LogPushEventAsync(request.ReceiptId, localTx.Id, success: false, dupError, cancellationToken);
+
+						return new PushYnabTransactionsResult(false, pushedTransactions, Error: dupError);
+					}
+
 					await syncRecordService.UpdateStatusAsync(
 						syncRecord!.Id, YnabSyncStatus.Synced, recoveredId, null, cancellationToken);
 
@@ -231,6 +273,10 @@ public class PushYnabTransactionsCommandHandler(
 					await LogPushEventAsync(request.ReceiptId, localTx.Id, success: true, errorMessage: null, cancellationToken);
 					continue;
 				}
+
+				// Record the freshly created YNAB id so a later split in this push cannot
+				// recover-bind onto it (RECEIPTS-752 double-bind guard).
+				boundYnabTransactionIds.Add(ynabResponse.TransactionId);
 
 				await LogPushEventAsync(request.ReceiptId, localTx.Id, success: true, errorMessage: null, cancellationToken);
 

--- a/tests/Application.Tests/Commands/Ynab/CreateYnabAccountMappingCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/CreateYnabAccountMappingCommandHandlerTests.cs
@@ -9,7 +9,9 @@ namespace Application.Tests.Commands.Ynab;
 public class CreateYnabAccountMappingCommandHandlerTests
 {
 	private readonly Mock<IYnabAccountMappingService> _mappingServiceMock = new();
-	private readonly Mock<ICardService> _accountServiceMock = new();
+	// RECEIPTS-751: the handler validates ReceiptsAccountId (an FK to Accounts) against
+	// IAccountService, not ICardService.
+	private readonly Mock<IAccountService> _accountServiceMock = new();
 	private readonly CreateYnabAccountMappingCommandHandler _handler;
 
 	public CreateYnabAccountMappingCommandHandlerTests()
@@ -73,5 +75,44 @@ public class CreateYnabAccountMappingCommandHandlerTests
 		_mappingServiceMock.Verify(s => s.CreateAsync(
 			It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
 			It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	// RECEIPTS-751 regression: an Account created after the account/card split has no Card
+	// sharing its Guid. Validation must consult Accounts (IAccountService.ExistsAsync), which
+	// returns true here, so mapping succeeds. Before the fix this validated against Cards and
+	// 400'd with "Account ... does not exist" even though the Account existed.
+	[Fact]
+	public async Task Handle_WhenAccountHasNoMatchingCard_ValidatesAgainstAccountsAndCreatesMapping()
+	{
+		// Arrange
+		Guid accountId = Guid.NewGuid();
+		string ynabAccountId = "ynab-acc-2";
+		string ynabAccountName = "New Account";
+		string ynabBudgetId = "budget-2";
+
+		// Account exists (no Card shares its id — the account/card-split scenario).
+		_accountServiceMock.Setup(s => s.ExistsAsync(accountId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		YnabAccountMappingDto expected = new(
+			Guid.NewGuid(), accountId, ynabAccountId, ynabAccountName, ynabBudgetId,
+			DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+		_mappingServiceMock.Setup(s => s.CreateAsync(
+			accountId, ynabAccountId, ynabAccountName, ynabBudgetId,
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(expected);
+
+		CreateYnabAccountMappingCommand command = new(accountId, ynabAccountId, ynabAccountName, ynabBudgetId);
+
+		// Act
+		YnabAccountMappingDto result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Should().BeSameAs(expected);
+		_accountServiceMock.Verify(s => s.ExistsAsync(accountId, It.IsAny<CancellationToken>()), Times.Once);
+		_mappingServiceMock.Verify(s => s.CreateAsync(
+			accountId, ynabAccountId, ynabAccountName, ynabBudgetId,
+			It.IsAny<CancellationToken>()), Times.Once);
 	}
 }

--- a/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsImportIdStabilityTests.cs
+++ b/tests/Application.Tests/Commands/Ynab/PushYnabTransactionsImportIdStabilityTests.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using Application.Commands.Ynab.PushTransactions;
+using Application.Interfaces.Services;
+using Application.Models;
+using Application.Models.Ynab;
+using Application.Utilities;
+using Common;
+using Domain;
+using Domain.Aggregates;
+using FluentAssertions;
+using Moq;
+
+namespace Application.Tests.Commands.Ynab;
+
+// RECEIPTS-752: two local transactions on a receipt can share the same amount+date (e.g. a
+// receipt split into two $50.00 payments on the same card/date). YNAB import_ids disambiguate
+// them with an occurrence counter. On a retry after a partial push, the already-synced sibling
+// is skipped — but its occurrence must still be "consumed" so the still-unsynced sibling keeps
+// its own distinct import_id. If it didn't, the retry would reuse the synced sibling's import_id,
+// YNAB would 409, and the recovery path would bind BOTH local transactions to the sibling's one
+// YNAB transaction — silently dropping the second $50 while reporting success.
+public class PushYnabTransactionsImportIdStabilityTests
+{
+	private readonly Mock<IReceiptService> _receiptServiceMock = new();
+	private readonly Mock<IReceiptItemService> _receiptItemServiceMock = new();
+	private readonly Mock<IAdjustmentService> _adjustmentServiceMock = new();
+	private readonly Mock<ITransactionService> _transactionServiceMock = new();
+	private readonly Mock<IYnabCategoryMappingService> _categoryMappingServiceMock = new();
+	private readonly Mock<IYnabAccountMappingService> _accountMappingServiceMock = new();
+	private readonly Mock<IYnabBudgetSelectionService> _budgetSelectionServiceMock = new();
+	private readonly Mock<IYnabSyncRecordService> _syncRecordServiceMock = new();
+	private readonly Mock<IYnabApiClient> _ynabApiClientMock = new();
+	private readonly Mock<IYnabSplitCalculator> _splitCalculatorMock = new();
+	private readonly PushYnabTransactionsCommandHandler _handler;
+
+	private readonly Guid _receiptId = Guid.NewGuid();
+	private readonly Guid _accountId = Guid.NewGuid();
+	private readonly Guid _tx1Id = Guid.NewGuid();
+	private readonly Guid _tx2Id = Guid.NewGuid();
+	private readonly Guid _syncRecord1Id = Guid.NewGuid();
+	private readonly Guid _syncRecord2Id = Guid.NewGuid();
+	private readonly string _budgetId = "budget-123";
+	private readonly string _ynabAccountId = "ynab-acc-1";
+
+	// Both transactions: same amount ($50.00 → -50000 milliunits) and same date.
+	private readonly DateOnly _date = DateOnly.FromDateTime(DateTime.Today.AddDays(-1));
+	private const long Milliunits = -50000;
+
+	public PushYnabTransactionsImportIdStabilityTests()
+	{
+		_handler = new PushYnabTransactionsCommandHandler(
+			_receiptServiceMock.Object,
+			_receiptItemServiceMock.Object,
+			_adjustmentServiceMock.Object,
+			_transactionServiceMock.Object,
+			_categoryMappingServiceMock.Object,
+			_accountMappingServiceMock.Object,
+			_budgetSelectionServiceMock.Object,
+			_syncRecordServiceMock.Object,
+			_ynabApiClientMock.Object,
+			_splitCalculatorMock.Object,
+			Mock.Of<IYnabSyncEventService>(),
+			Mock.Of<IYnabResponseContext>(),
+			Mock.Of<Microsoft.Extensions.Logging.ILogger<PushYnabTransactionsCommandHandler>>());
+	}
+
+	// Sets up a receipt with two same-amount, same-date transactions in a RETRY state:
+	// tx1 already Synced (YNAB id "ynab-tx-1"), tx2 previously Failed.
+	private void SetupRetryPipeline()
+	{
+		Domain.Core.Receipt receipt = new(_receiptId, "Store", _date, new Money(1.00m));
+		_receiptServiceMock.Setup(s => s.GetByIdAsync(_receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(receipt);
+
+		List<Domain.Core.ReceiptItem> items =
+		[
+			new(Guid.NewGuid(), null, "Item1", 1, new Money(100.00m), new Money(100.00m), "Groceries", null),
+		];
+		_receiptItemServiceMock.Setup(s => s.GetByReceiptIdAsync(_receiptId, 0, 10000, It.IsAny<SortParams>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Domain.Core.ReceiptItem>(items, items.Count, 0, 10000));
+
+		_adjustmentServiceMock.Setup(s => s.GetByReceiptIdAsync(_receiptId, 0, 10000, It.IsAny<SortParams>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new PagedResult<Domain.Core.Adjustment>([], 0, 0, 10000));
+
+		Domain.Core.Transaction tx1 = new(_tx1Id, Guid.NewGuid(), new Money(50.00m), _date) { AccountId = _accountId, ReceiptId = _receiptId };
+		Domain.Core.Transaction tx2 = new(_tx2Id, Guid.NewGuid(), new Money(50.00m), _date) { AccountId = _accountId, ReceiptId = _receiptId };
+		Domain.Core.Account account = new(_accountId, "Checking", true);
+		_transactionServiceMock.Setup(s => s.GetTransactionAccountsByReceiptIdAsync(_receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(
+			[
+				new TransactionAccount { Transaction = tx1, Account = account },
+				new TransactionAccount { Transaction = tx2, Account = account },
+			]);
+
+		_categoryMappingServiceMock.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync([
+				new YnabCategoryMappingDto(Guid.NewGuid(), "Groceries", "ynab-cat-1", "Groceries", "Food", _budgetId, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+			]);
+
+		_budgetSelectionServiceMock.Setup(s => s.GetSelectedBudgetIdAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(_budgetId);
+
+		_accountMappingServiceMock.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync([
+				new YnabAccountMappingDto(Guid.NewGuid(), _accountId, _ynabAccountId, "Checking", _budgetId, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+			]);
+
+		// Retry state: tx1 already Synced to "ynab-tx-1"; tx2 previously Failed.
+		_syncRecordServiceMock.Setup(s => s.GetByTransactionAndTypeAsync(_tx1Id, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabSyncRecordDto(_syncRecord1Id, _tx1Id, "ynab-tx-1", _budgetId, _ynabAccountId, YnabSyncType.TransactionPush, YnabSyncStatus.Synced, DateTimeOffset.UtcNow, null, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+		_syncRecordServiceMock.Setup(s => s.GetByTransactionAndTypeAsync(_tx2Id, YnabSyncType.TransactionPush, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new YnabSyncRecordDto(_syncRecord2Id, _tx2Id, null, _budgetId, null, YnabSyncType.TransactionPush, YnabSyncStatus.Failed, null, "previous failure", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+
+		// tx1 first, tx2 second — same amount and date.
+		_splitCalculatorMock.Setup(s => s.ComputeWaterfallSplits(It.IsAny<ReceiptWithItems>(), It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Dictionary<string, string>>()))
+			.Returns(new YnabSplitResult([
+				new YnabTransactionSplit(_tx1Id, Milliunits, [new YnabSubTransactionSplit("ynab-cat-1", Milliunits)]),
+				new YnabTransactionSplit(_tx2Id, Milliunits, [new YnabSubTransactionSplit("ynab-cat-1", Milliunits)]),
+			]));
+	}
+
+	[Fact]
+	public async Task Retry_SkippedSyncedSibling_StillConsumesOccurrence_UnsyncedTxGetsDistinctImportId()
+	{
+		SetupRetryPipeline();
+
+		string? capturedImportId = null;
+		int createCallCount = 0;
+		_ynabApiClientMock
+			.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.Callback<string, YnabCreateTransactionRequest, CancellationToken>((_, req, _) => { capturedImportId = req.ImportId; createCallCount++; })
+			.ReturnsAsync(new YnabCreateTransactionResponse("ynab-tx-2"));
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		result.Success.Should().BeTrue();
+
+		// Only the still-unsynced tx2 is pushed; the synced tx1 is skipped.
+		createCallCount.Should().Be(1);
+
+		// tx2 must get occurrence 2 (tx1's occurrence is still consumed despite being skipped),
+		// NOT occurrence 1 which would collide with the import_id tx1 already used.
+		string tx1ImportId = YnabImportId.Generate(Milliunits, _date, _receiptId, 1);
+		string tx2ImportId = YnabImportId.Generate(Milliunits, _date, _receiptId, 2);
+		capturedImportId.Should().Be(tx2ImportId);
+		capturedImportId.Should().NotBe(tx1ImportId);
+		capturedImportId.Should().EndWith(":2");
+
+		// tx2's own record is stamped Synced with its OWN (distinct) YNAB transaction.
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_syncRecord2Id, YnabSyncStatus.Synced, "ynab-tx-2", null, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Retry_409RecoversSyncedSiblingsYnabId_DoesNotDoubleBind_ReportsFailure()
+	{
+		SetupRetryPipeline();
+
+		// Force tx2's create to 409, and have recovery resolve to tx1's ALREADY-BOUND YNAB id.
+		// The double-bind guard must reject it rather than stamping tx2 Synced to "ynab-tx-1".
+		_ynabApiClientMock.Setup(s => s.CreateTransactionAsync(_budgetId, It.IsAny<YnabCreateTransactionRequest>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("conflict", null, HttpStatusCode.Conflict));
+
+		_ynabApiClientMock.Setup(s => s.FindTransactionByImportIdAsync(
+				_budgetId, _ynabAccountId, It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync("ynab-tx-1");
+
+		PushYnabTransactionsResult result = await _handler.Handle(
+			new PushYnabTransactionsCommand(_receiptId), CancellationToken.None);
+
+		// No false success.
+		result.Success.Should().BeFalse();
+		result.Error.Should().Contain("ynab-tx-1");
+
+		// tx2 must NOT be bound to tx1's YNAB transaction.
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_syncRecord2Id, YnabSyncStatus.Synced, "ynab-tx-1", null, It.IsAny<CancellationToken>()), Times.Never);
+		result.PushedTransactions.Should().NotContain(p => p.YnabTransactionId == "ynab-tx-1");
+
+		// tx2's record is marked Failed with an explanatory error.
+		_syncRecordServiceMock.Verify(s => s.UpdateStatusAsync(
+			_syncRecord2Id, YnabSyncStatus.Failed, null, It.Is<string>(m => m.Contains("ynab-tx-1")), It.IsAny<CancellationToken>()), Times.Once);
+	}
+}


### PR DESCRIPTION
Fixes two confirmed HIGH-severity YNAB-sync correctness bugs in the Application command layer.

## Fix 1 — RECEIPTS-751: account-mapping validated against the wrong table
`CreateYnabAccountMappingCommandHandler` validated `ReceiptsAccountId` (an FK to **Accounts**) via `ICardService.ExistsAsync`, which queries the **Cards** table. It only worked for legacy data where each Card shared its Account's `Guid`; any Account created after the account/card split could never be mapped — `POST /api/ynab/account-mappings` returned `400 "Account with ID <guid> does not exist"` even though the Account existed.

**Change:** inject `IAccountService` and validate against Accounts. Added a regression test for an Account with no matching Card.

## Fix 2 — RECEIPTS-752: push retry reused a consumed import_id → silent amount loss
YNAB import_ids disambiguate transactions sharing amount+date via an occurrence counter. The push loop advanced that counter only for splits it actually pushed, skipping already-`Synced` records **before** incrementing. On a retry, a still-unsynced transaction sharing amount+date with a `Synced` sibling recomputed occurrence 1 — reusing the sibling's already-consumed import_id. YNAB `409`'d, and the recovery path bound the retried record to the sibling's YNAB transaction: two local transactions pointed at one YNAB transaction, the second amount never entered the ledger, and the push reported success.

**Changes:**
- Assign import_ids in a **first pass over ALL splits**, incrementing the occurrence counter for skipped `Synced` records too, so occurrence numbering is deterministic across retries. The push loop reads the pre-assigned import_id and still skips `Synced` records.
- Harden 409 recovery: track YNAB transaction ids already bound to a sync record for this receipt (seeded from already-synced siblings) and **reject** a recovered id already bound — mark the record `Failed` and return an error instead of double-binding two local transactions to one YNAB transaction and reporting a false success.
- Added a two-same-amount-same-date retry regression test: the unsynced sibling gets a distinct import_id (stable occurrence 2), and a 409 recovering the sibling's id does not double-bind and does not report success.

## Validation
- `dotnet build Receipts.slnx`: 0 errors (60 pre-existing NuGet-advisory warnings only; Application builds 0-warning).
- Pre-commit hook (full): `dotnet format --verify-no-changes`, build with `TreatWarningsAsErrors=true`, and full non-integration .NET suite all pass — Common 18, Domain 132, **Application 449**, Infrastructure 1007, Presentation.API 635 (0 failed); client `tsc`/eslint/vitest (2117) pass.

Closes RECEIPTS-751, RECEIPTS-752