### PR TITLE
fix(api): return 404 for missing update targets, stabilize pagination, validate route id

### DIFF
--- a/src/Application/Commands/Adjustment/Update/UpdateAdjustmentCommandHandler.cs
+++ b/src/Application/Commands/Adjustment/Update/UpdateAdjustmentCommandHandler.cs
@@ -7,8 +7,11 @@ public class UpdateAdjustmentCommandHandler(IAdjustmentService adjustmentService
 {
 	public async ValueTask<bool> Handle(UpdateAdjustmentCommand request, CancellationToken cancellationToken)
 	{
-		Domain.Core.Adjustment existingAdjustment = await adjustmentService.GetByIdAsync(request.Adjustments[0].Id, cancellationToken)
-			?? throw new InvalidOperationException("Adjustment not found");
+		Domain.Core.Adjustment? existingAdjustment = await adjustmentService.GetByIdAsync(request.Adjustments[0].Id, cancellationToken);
+		if (existingAdjustment is null)
+		{
+			return false;
+		}
 
 		await adjustmentService.UpdateAsync([.. request.Adjustments], existingAdjustment.ReceiptId, cancellationToken);
 		return true;

--- a/src/Application/Commands/Card/Update/UpdateCardCommandHandler.cs
+++ b/src/Application/Commands/Card/Update/UpdateCardCommandHandler.cs
@@ -7,6 +7,15 @@ public class UpdateCardCommandHandler(ICardService cardService) : IRequestHandle
 {
 	public async ValueTask<bool> Handle(UpdateCardCommand request, CancellationToken cancellationToken)
 	{
+		foreach (Domain.Core.Card card in request.Cards)
+		{
+			bool exists = await cardService.ExistsAsync(card.Id, cancellationToken);
+			if (!exists)
+			{
+				return false;
+			}
+		}
+
 		await cardService.UpdateAsync([.. request.Cards], cancellationToken);
 		return true;
 	}

--- a/src/Application/Commands/Category/Update/UpdateCategoryCommandHandler.cs
+++ b/src/Application/Commands/Category/Update/UpdateCategoryCommandHandler.cs
@@ -7,6 +7,15 @@ public class UpdateCategoryCommandHandler(ICategoryService categoryService) : IR
 {
 	public async ValueTask<bool> Handle(UpdateCategoryCommand request, CancellationToken cancellationToken)
 	{
+		foreach (Domain.Core.Category category in request.Categories)
+		{
+			bool exists = await categoryService.ExistsAsync(category.Id, cancellationToken);
+			if (!exists)
+			{
+				return false;
+			}
+		}
+
 		await categoryService.UpdateAsync([.. request.Categories], cancellationToken);
 		return true;
 	}

--- a/src/Application/Commands/ItemTemplate/Update/UpdateItemTemplateCommandHandler.cs
+++ b/src/Application/Commands/ItemTemplate/Update/UpdateItemTemplateCommandHandler.cs
@@ -7,6 +7,15 @@ public class UpdateItemTemplateCommandHandler(IItemTemplateService itemTemplateS
 {
 	public async ValueTask<bool> Handle(UpdateItemTemplateCommand request, CancellationToken cancellationToken)
 	{
+		foreach (Domain.Core.ItemTemplate itemTemplate in request.ItemTemplates)
+		{
+			bool exists = await itemTemplateService.ExistsAsync(itemTemplate.Id, cancellationToken);
+			if (!exists)
+			{
+				return false;
+			}
+		}
+
 		await itemTemplateService.UpdateAsync([.. request.ItemTemplates], cancellationToken);
 		return true;
 	}

--- a/src/Application/Commands/Receipt/Update/UpdateReceiptCommandHandler.cs
+++ b/src/Application/Commands/Receipt/Update/UpdateReceiptCommandHandler.cs
@@ -7,6 +7,15 @@ public class UpdateReceiptCommandHandler(IReceiptService receiptService) : IRequ
 {
 	public async ValueTask<bool> Handle(UpdateReceiptCommand request, CancellationToken cancellationToken)
 	{
+		foreach (Domain.Core.Receipt receipt in request.Receipts)
+		{
+			bool exists = await receiptService.ExistsAsync(receipt.Id, cancellationToken);
+			if (!exists)
+			{
+				return false;
+			}
+		}
+
 		await receiptService.UpdateAsync([.. request.Receipts], cancellationToken);
 		return true;
 	}

--- a/src/Application/Commands/ReceiptItem/Update/UpdateReceiptItemCommandHandler.cs
+++ b/src/Application/Commands/ReceiptItem/Update/UpdateReceiptItemCommandHandler.cs
@@ -7,8 +7,11 @@ public class UpdateReceiptItemCommandHandler(IReceiptItemService receiptitemServ
 {
 	public async ValueTask<bool> Handle(UpdateReceiptItemCommand request, CancellationToken cancellationToken)
 	{
-		Domain.Core.ReceiptItem existingItem = await receiptitemService.GetByIdAsync(request.ReceiptItems[0].Id, cancellationToken)
-			?? throw new InvalidOperationException("Receipt item not found");
+		Domain.Core.ReceiptItem? existingItem = await receiptitemService.GetByIdAsync(request.ReceiptItems[0].Id, cancellationToken);
+		if (existingItem is null)
+		{
+			return false;
+		}
 
 		await receiptitemService.UpdateAsync([.. request.ReceiptItems], existingItem.ReceiptId, cancellationToken);
 		return true;

--- a/src/Application/Commands/Subcategory/Update/UpdateSubcategoryCommandHandler.cs
+++ b/src/Application/Commands/Subcategory/Update/UpdateSubcategoryCommandHandler.cs
@@ -7,6 +7,15 @@ public class UpdateSubcategoryCommandHandler(ISubcategoryService subcategoryServ
 {
 	public async ValueTask<bool> Handle(UpdateSubcategoryCommand request, CancellationToken cancellationToken)
 	{
+		foreach (Domain.Core.Subcategory subcategory in request.Subcategories)
+		{
+			bool exists = await subcategoryService.ExistsAsync(subcategory.Id, cancellationToken);
+			if (!exists)
+			{
+				return false;
+			}
+		}
+
 		await subcategoryService.UpdateAsync([.. request.Subcategories], cancellationToken);
 		return true;
 	}

--- a/src/Application/Commands/Transaction/Update/UpdateTransactionCommandHandler.cs
+++ b/src/Application/Commands/Transaction/Update/UpdateTransactionCommandHandler.cs
@@ -14,8 +14,11 @@ public class UpdateTransactionCommandHandler(
 {
 	public async ValueTask<bool> Handle(UpdateTransactionCommand request, CancellationToken cancellationToken)
 	{
-		Domain.Core.Transaction existingTransaction = await transactionService.GetByIdAsync(request.Transactions[0].Id, cancellationToken)
-			?? throw new InvalidOperationException("Transaction not found");
+		Domain.Core.Transaction? existingTransaction = await transactionService.GetByIdAsync(request.Transactions[0].Id, cancellationToken);
+		if (existingTransaction is null)
+		{
+			return false;
+		}
 
 		Guid receiptId = existingTransaction.ReceiptId;
 

--- a/src/Infrastructure/Extensions/QueryableSortExtensions.cs
+++ b/src/Infrastructure/Extensions/QueryableSortExtensions.cs
@@ -5,11 +5,23 @@ namespace Infrastructure.Extensions;
 
 public static class QueryableSortExtensions
 {
+	/// <summary>
+	/// Applies the requested (or default) primary sort, then a mandatory ascending
+	/// tiebreaker on a unique key so the total order is deterministic. Without the
+	/// tiebreaker, rows sharing the primary sort value (e.g. many receipts on the same
+	/// Date) have no stable order across separate queries, which lets consecutive
+	/// paginated requests duplicate one row and skip another (RECEIPTS-767).
+	/// </summary>
+	/// <param name="tiebreaker">
+	/// A unique-key selector (typically <c>e =&gt; e.Id</c>) applied ascending regardless
+	/// of the primary sort direction. Required so no paged query is left non-deterministic.
+	/// </param>
 	public static IOrderedQueryable<T> ApplySort<T>(
 		this IQueryable<T> query,
 		SortParams sort,
 		Dictionary<string, Expression<Func<T, object>>> allowedColumns,
 		Expression<Func<T, object>> defaultSort,
+		Expression<Func<T, object>> tiebreaker,
 		bool defaultDescending = false)
 	{
 		Expression<Func<T, object>> sortExpression = defaultSort;
@@ -22,8 +34,10 @@ public static class QueryableSortExtensions
 			descending = sort.IsDescending;
 		}
 
-		return descending
+		IOrderedQueryable<T> ordered = descending
 			? query.OrderByDescending(sortExpression)
 			: query.OrderBy(sortExpression);
+
+		return ordered.ThenBy(tiebreaker);
 	}
 }

--- a/src/Infrastructure/Repositories/AccountRepository.cs
+++ b/src/Infrastructure/Repositories/AccountRepository.cs
@@ -40,7 +40,7 @@ public class AccountRepository(IDbContextFactory<ApplicationDbContext> contextFa
 		}
 
 		return await query
-			.ApplySort(sort, AllowedSortColumns, e => e.Name)
+			.ApplySort(sort, AllowedSortColumns, e => e.Name, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => new AccountEntity

--- a/src/Infrastructure/Repositories/AdjustmentRepository.cs
+++ b/src/Infrastructure/Repositories/AdjustmentRepository.cs
@@ -29,7 +29,7 @@ public class AdjustmentRepository(IDbContextFactory<ApplicationDbContext> contex
 			.IgnoreAutoIncludes()
 			.Where(a => a.ReceiptId == receiptId)
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Type)
+			.ApplySort(sort, AllowedSortColumns, e => e.Type, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => new AdjustmentEntity
@@ -58,7 +58,7 @@ public class AdjustmentRepository(IDbContextFactory<ApplicationDbContext> contex
 		return await context.Adjustments
 			.IgnoreAutoIncludes()
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Type)
+			.ApplySort(sort, AllowedSortColumns, e => e.Type, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => new AdjustmentEntity
@@ -81,7 +81,7 @@ public class AdjustmentRepository(IDbContextFactory<ApplicationDbContext> contex
 			.Where(a => a.CascadeDeletedByParentId == null)
 			.IgnoreAutoIncludes()
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Type)
+			.ApplySort(sort, AllowedSortColumns, e => e.Type, e => e.Id)
 			.Select(a => new AdjustmentEntity
 			{
 				Id = a.Id,

--- a/src/Infrastructure/Repositories/CardRepository.cs
+++ b/src/Infrastructure/Repositories/CardRepository.cs
@@ -55,7 +55,7 @@ public class CardRepository(IDbContextFactory<ApplicationDbContext> contextFacto
 		}
 
 		return await query
-			.ApplySort(sort, AllowedSortColumns, e => e.Name)
+			.ApplySort(sort, AllowedSortColumns, e => e.Name, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => new CardEntity

--- a/src/Infrastructure/Repositories/CategoryRepository.cs
+++ b/src/Infrastructure/Repositories/CategoryRepository.cs
@@ -30,7 +30,7 @@ public class CategoryRepository(IDbContextFactory<ApplicationDbContext> contextF
 		}
 
 		return await query
-			.ApplySort(sort, AllowedSortColumns, e => e.Name)
+			.ApplySort(sort, AllowedSortColumns, e => e.Name, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.ToListAsync(cancellationToken);
@@ -42,7 +42,7 @@ public class CategoryRepository(IDbContextFactory<ApplicationDbContext> contextF
 		return await context.Categories
 			.OnlyDeleted()
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Name)
+			.ApplySort(sort, AllowedSortColumns, e => e.Name, e => e.Id)
 			.Select(c => new CategoryEntity
 			{
 				Id = c.Id,

--- a/src/Infrastructure/Repositories/ItemTemplateRepository.cs
+++ b/src/Infrastructure/Repositories/ItemTemplateRepository.cs
@@ -25,7 +25,7 @@ public class ItemTemplateRepository(IDbContextFactory<ApplicationDbContext> cont
 		using ApplicationDbContext context = contextFactory.CreateDbContext();
 		return await context.ItemTemplates
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Name)
+			.ApplySort(sort, AllowedSortColumns, e => e.Name, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.ToListAsync(cancellationToken);
@@ -37,7 +37,7 @@ public class ItemTemplateRepository(IDbContextFactory<ApplicationDbContext> cont
 		return await context.ItemTemplates
 			.OnlyDeleted()
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Name)
+			.ApplySort(sort, AllowedSortColumns, e => e.Name, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.ToListAsync(cancellationToken);

--- a/src/Infrastructure/Repositories/ReceiptItemRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptItemRepository.cs
@@ -32,7 +32,7 @@ public class ReceiptItemRepository(IDbContextFactory<ApplicationDbContext> conte
 			.IgnoreAutoIncludes()
 			.Where(ri => ri.ReceiptId == receiptId)
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Description)
+			.ApplySort(sort, AllowedSortColumns, e => e.Description, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.Select(ri => new ReceiptItemEntity
@@ -71,7 +71,7 @@ public class ReceiptItemRepository(IDbContextFactory<ApplicationDbContext> conte
 			.AsNoTracking();
 		query = ApplySearchFilter(query, q);
 		return await query
-			.ApplySort(sort, AllowedSortColumns, e => e.Description)
+			.ApplySort(sort, AllowedSortColumns, e => e.Description, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.Select(ri => new ReceiptItemEntity
@@ -114,7 +114,7 @@ public class ReceiptItemRepository(IDbContextFactory<ApplicationDbContext> conte
 			.Where(ri => ri.CascadeDeletedByParentId == null)
 			.IgnoreAutoIncludes()
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Description)
+			.ApplySort(sort, AllowedSortColumns, e => e.Description, e => e.Id)
 			.Select(ri => new ReceiptItemEntity
 			{
 				Id = ri.Id,

--- a/src/Infrastructure/Repositories/ReceiptRepository.cs
+++ b/src/Infrastructure/Repositories/ReceiptRepository.cs
@@ -31,7 +31,7 @@ public class ReceiptRepository(IDbContextFactory<ApplicationDbContext> contextFa
 		IQueryable<ReceiptEntity> query = ApplyTransactionFilters(context, context.Receipts.AsNoTracking(), accountId, cardId);
 		query = ApplySearchFilter(query, q);
 		return await query
-			.ApplySort(sort, AllowedSortColumns, e => e.Date, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, e => e.Date, e => e.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(r => new ReceiptEntity
@@ -84,7 +84,7 @@ public class ReceiptRepository(IDbContextFactory<ApplicationDbContext> contextFa
 		return await context.Receipts
 			.OnlyDeleted()
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Date, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, e => e.Date, e => e.Id, defaultDescending: true)
 			.Select(r => new ReceiptEntity
 			{
 				Id = r.Id,

--- a/src/Infrastructure/Repositories/SubcategoryRepository.cs
+++ b/src/Infrastructure/Repositories/SubcategoryRepository.cs
@@ -30,7 +30,7 @@ public class SubcategoryRepository(IDbContextFactory<ApplicationDbContext> conte
 		}
 
 		return await query
-			.ApplySort(sort, AllowedSortColumns, e => e.Name)
+			.ApplySort(sort, AllowedSortColumns, e => e.Name, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.ToListAsync(cancellationToken);
@@ -42,7 +42,7 @@ public class SubcategoryRepository(IDbContextFactory<ApplicationDbContext> conte
 		return await context.Subcategories
 			.OnlyDeleted()
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Name)
+			.ApplySort(sort, AllowedSortColumns, e => e.Name, e => e.Id)
 			.Select(s => new SubcategoryEntity
 			{
 				Id = s.Id,
@@ -77,7 +77,7 @@ public class SubcategoryRepository(IDbContextFactory<ApplicationDbContext> conte
 
 		return await query
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Name)
+			.ApplySort(sort, AllowedSortColumns, e => e.Name, e => e.Id)
 			.Skip(offset)
 			.Take(limit)
 			.ToListAsync(cancellationToken);

--- a/src/Infrastructure/Repositories/TransactionRepository.cs
+++ b/src/Infrastructure/Repositories/TransactionRepository.cs
@@ -28,7 +28,7 @@ public class TransactionRepository(IDbContextFactory<ApplicationDbContext> conte
 			.IgnoreAutoIncludes()
 			.Where(t => t.ReceiptId == receiptId)
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Date, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, e => e.Date, e => e.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(t => new TransactionEntity
@@ -70,7 +70,7 @@ public class TransactionRepository(IDbContextFactory<ApplicationDbContext> conte
 		return await context.Transactions
 			.IgnoreAutoIncludes()
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Date, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, e => e.Date, e => e.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(t => new TransactionEntity
@@ -94,7 +94,7 @@ public class TransactionRepository(IDbContextFactory<ApplicationDbContext> conte
 			.Where(t => t.CascadeDeletedByParentId == null)
 			.IgnoreAutoIncludes()
 			.AsNoTracking()
-			.ApplySort(sort, AllowedSortColumns, e => e.Date, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, e => e.Date, e => e.Id, defaultDescending: true)
 			.Select(t => new TransactionEntity
 			{
 				Id = t.Id,

--- a/src/Infrastructure/Services/AuditService.cs
+++ b/src/Infrastructure/Services/AuditService.cs
@@ -29,7 +29,7 @@ public class AuditService(IDbContextFactory<ApplicationDbContext> contextFactory
 		int total = await query.CountAsync(cancellationToken);
 
 		List<AuditLogDto> data = await query
-			.ApplySort(sort, AllowedSortColumns, DefaultSort, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, DefaultSort, a => a.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => ToDto(a))
@@ -74,7 +74,7 @@ public class AuditService(IDbContextFactory<ApplicationDbContext> contextFactory
 		int total = await query.CountAsync(cancellationToken);
 
 		List<AuditLogDto> data = await query
-			.ApplySort(sort, AllowedSortColumns, DefaultSort, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, DefaultSort, a => a.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => ToDto(a))
@@ -93,7 +93,7 @@ public class AuditService(IDbContextFactory<ApplicationDbContext> contextFactory
 		int total = await query.CountAsync(cancellationToken);
 
 		List<AuditLogDto> data = await query
-			.ApplySort(sort, AllowedSortColumns, DefaultSort, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, DefaultSort, a => a.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => ToDto(a))
@@ -112,7 +112,7 @@ public class AuditService(IDbContextFactory<ApplicationDbContext> contextFactory
 		int total = await query.CountAsync(cancellationToken);
 
 		List<AuditLogDto> data = await query
-			.ApplySort(sort, AllowedSortColumns, DefaultSort, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, DefaultSort, a => a.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => ToDto(a))

--- a/src/Infrastructure/Services/AuthAuditService.cs
+++ b/src/Infrastructure/Services/AuthAuditService.cs
@@ -52,7 +52,7 @@ public class AuthAuditService(IDbContextFactory<ApplicationDbContext> contextFac
 		int total = await query.CountAsync(cancellationToken);
 
 		List<AuthAuditEntryDto> data = await query
-			.ApplySort(sort, AllowedSortColumns, DefaultSort, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, DefaultSort, a => a.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => ToDto(a))
@@ -70,7 +70,7 @@ public class AuthAuditService(IDbContextFactory<ApplicationDbContext> contextFac
 		int total = await query.CountAsync(cancellationToken);
 
 		List<AuthAuditEntryDto> data = await query
-			.ApplySort(sort, AllowedSortColumns, DefaultSort, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, DefaultSort, a => a.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => ToDto(a))
@@ -89,7 +89,7 @@ public class AuthAuditService(IDbContextFactory<ApplicationDbContext> contextFac
 		int total = await query.CountAsync(cancellationToken);
 
 		List<AuthAuditEntryDto> data = await query
-			.ApplySort(sort, AllowedSortColumns, DefaultSort, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, DefaultSort, a => a.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(a => ToDto(a))

--- a/src/Infrastructure/Services/UserService.cs
+++ b/src/Infrastructure/Services/UserService.cs
@@ -26,7 +26,7 @@ public class UserService(ApplicationDbContext dbContext) : IUserService
 		int totalCount = await dbContext.Users.CountAsync(cancellationToken);
 
 		List<ApplicationUser> users = await dbContext.Users
-			.ApplySort(sort, AllowedSortColumns, u => u.Email!)
+			.ApplySort(sort, AllowedSortColumns, u => u.Email!, u => u.Id)
 			.Skip(offset)
 			.Take(limit)
 			.ToListAsync(cancellationToken);

--- a/src/Infrastructure/Services/YnabSyncEventService.cs
+++ b/src/Infrastructure/Services/YnabSyncEventService.cs
@@ -84,7 +84,7 @@ public class YnabSyncEventService(
 		int total = await query.CountAsync(cancellationToken);
 
 		List<YnabSyncEventDto> data = await query
-			.ApplySort(sort, AllowedSortColumns, DefaultSort, defaultDescending: true)
+			.ApplySort(sort, AllowedSortColumns, DefaultSort, e => e.Id, defaultDescending: true)
 			.Skip(offset)
 			.Take(limit)
 			.Select(e => ToDto(e))

--- a/src/Presentation/API/Controllers/Core/AccountsController.cs
+++ b/src/Presentation/API/Controllers/Core/AccountsController.cs
@@ -128,6 +128,8 @@ public class AccountsController(IMediator mediator, AccountMapper mapper, CardMa
 	[EndpointSummary("Update a single account")]
 	public async Task<Results<NoContent, NotFound>> UpdateAccount([FromRoute] Guid id, [FromBody] UpdateAccountRequest model)
 	{
+		// Route id is authoritative; ignore any mismatched body id (RECEIPTS-793).
+		model.Id = id;
 		UpdateAccountCommand command = new([mapper.ToDomain(model)]);
 		bool result = await mediator.Send(command, HttpContext.RequestAborted);
 

--- a/src/Presentation/API/Controllers/Core/AdjustmentsController.cs
+++ b/src/Presentation/API/Controllers/Core/AdjustmentsController.cs
@@ -153,6 +153,9 @@ public class AdjustmentsController(IMediator mediator, AdjustmentMapper mapper, 
 	[EndpointSummary("Update a single adjustment")]
 	public async Task<Results<NoContent, NotFound>> UpdateAdjustment([FromBody] UpdateAdjustmentRequest model, [FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
+		// Route id is authoritative; ignore any mismatched body id so a PUT can never
+		// silently update a resource other than the one the URL names (RECEIPTS-793).
+		model.Id = id;
 		UpdateAdjustmentCommand command = new([mapper.ToDomain(model)]);
 		bool result = await mediator.Send(command, cancellationToken);
 

--- a/src/Presentation/API/Controllers/Core/CardsController.cs
+++ b/src/Presentation/API/Controllers/Core/CardsController.cs
@@ -132,6 +132,8 @@ public class CardsController(IMediator mediator, CardMapper mapper, ILogger<Card
 			return TypedResults.BadRequest($"Account {model.AccountId} does not exist.");
 		}
 
+		// Route id is authoritative; ignore any mismatched body id (RECEIPTS-793).
+		model.Id = id;
 		UpdateCardCommand command = new([mapper.ToDomain(model)]);
 		bool result = await mediator.Send(command, cancellationToken);
 

--- a/src/Presentation/API/Controllers/Core/CategoriesController.cs
+++ b/src/Presentation/API/Controllers/Core/CategoriesController.cs
@@ -151,6 +151,8 @@ public class CategoriesController(IMediator mediator, CategoryMapper mapper, ILo
 	[EndpointSummary("Update a single category")]
 	public async Task<Results<NoContent, NotFound>> UpdateCategory([FromRoute] Guid id, [FromBody] UpdateCategoryRequest model, CancellationToken cancellationToken = default)
 	{
+		// Route id is authoritative; ignore any mismatched body id (RECEIPTS-793).
+		model.Id = id;
 		UpdateCategoryCommand command = new([mapper.ToDomain(model)]);
 		bool result = await mediator.Send(command, cancellationToken);
 

--- a/src/Presentation/API/Controllers/Core/ItemTemplatesController.cs
+++ b/src/Presentation/API/Controllers/Core/ItemTemplatesController.cs
@@ -142,6 +142,8 @@ public class ItemTemplatesController(IMediator mediator, ItemTemplateMapper mapp
 	[EndpointSummary("Update a single item template")]
 	public async Task<Results<NoContent, NotFound>> UpdateItemTemplate([FromRoute] Guid id, [FromBody] UpdateItemTemplateRequest model, CancellationToken cancellationToken = default)
 	{
+		// Route id is authoritative; ignore any mismatched body id (RECEIPTS-793).
+		model.Id = id;
 		UpdateItemTemplateCommand command = new([mapper.ToDomain(model)]);
 		bool result = await mediator.Send(command, cancellationToken);
 

--- a/src/Presentation/API/Controllers/Core/ReceiptItemsController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptItemsController.cs
@@ -170,6 +170,8 @@ public class ReceiptItemsController(IMediator mediator, ReceiptItemMapper mapper
 	[EndpointSummary("Update a single receipt item")]
 	public async Task<Results<NoContent, NotFound>> UpdateReceiptItem([FromBody] UpdateReceiptItemRequest model, [FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
+		// Route id is authoritative; ignore any mismatched body id (RECEIPTS-793).
+		model.Id = id;
 		UpdateReceiptItemCommand command = new([mapper.ToDomain(model)]);
 		bool result = await mediator.Send(command, cancellationToken);
 

--- a/src/Presentation/API/Controllers/Core/ReceiptsController.cs
+++ b/src/Presentation/API/Controllers/Core/ReceiptsController.cs
@@ -213,6 +213,8 @@ public class ReceiptsController(
 	[EndpointSummary("Update a single receipt")]
 	public async Task<Results<NoContent, NotFound>> UpdateReceipt([FromRoute] Guid id, [FromBody] UpdateReceiptRequest model, CancellationToken cancellationToken = default)
 	{
+		// Route id is authoritative; ignore any mismatched body id (RECEIPTS-793).
+		model.Id = id;
 		UpdateReceiptCommand command = new([mapper.ToDomain(model)]);
 		bool result = await mediator.Send(command, cancellationToken);
 

--- a/src/Presentation/API/Controllers/Core/SubcategoriesController.cs
+++ b/src/Presentation/API/Controllers/Core/SubcategoriesController.cs
@@ -166,6 +166,8 @@ public class SubcategoriesController(IMediator mediator, SubcategoryMapper mappe
 	[EndpointSummary("Update a single subcategory")]
 	public async Task<Results<NoContent, NotFound>> UpdateSubcategory([FromRoute] Guid id, [FromBody] UpdateSubcategoryRequest model, CancellationToken cancellationToken = default)
 	{
+		// Route id is authoritative; ignore any mismatched body id (RECEIPTS-793).
+		model.Id = id;
 		UpdateSubcategoryCommand command = new([mapper.ToDomain(model)]);
 		bool result = await mediator.Send(command, cancellationToken);
 

--- a/src/Presentation/API/Controllers/Core/TransactionsController.cs
+++ b/src/Presentation/API/Controllers/Core/TransactionsController.cs
@@ -176,6 +176,8 @@ public class TransactionsController(IMediator mediator, TransactionMapper mapper
 	[EndpointSummary("Update a single transaction")]
 	public async Task<Results<NoContent, NotFound>> UpdateTransaction([FromBody] UpdateTransactionRequest model, [FromRoute] Guid id, CancellationToken cancellationToken = default)
 	{
+		// Route id is authoritative; ignore any mismatched body id (RECEIPTS-793).
+		model.Id = id;
 		Transaction transaction = mapper.ToDomain(model);
 		transaction.AccountId = model.AccountId;
 		UpdateTransactionCommand command = new([transaction]);

--- a/tests/Application.Tests/Commands/Adjustment/UpdateAdjustmentCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Adjustment/UpdateAdjustmentCommandHandlerTests.cs
@@ -1,0 +1,51 @@
+using Application.Commands.Adjustment.Update;
+using Application.Interfaces.Services;
+using Moq;
+using SampleData.Domain.Core;
+
+namespace Application.Tests.Commands.Adjustment;
+
+public class UpdateAdjustmentCommandHandlerTests
+{
+	[Fact]
+	public async Task UpdateAdjustmentCommandHandler_WithValidCommand_ReturnsTrueAndCallsUpdate()
+	{
+		Mock<IAdjustmentService> mockService = new();
+		UpdateAdjustmentCommandHandler handler = new(mockService.Object);
+
+		List<Domain.Core.Adjustment> input = AdjustmentGenerator.GenerateList(2);
+
+		// The handler calls GetByIdAsync to resolve the ReceiptId from the existing adjustment.
+		Domain.Core.Adjustment existing = AdjustmentGenerator.Generate();
+		mockService.Setup(r => r.GetByIdAsync(input[0].Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(existing);
+
+		mockService.Setup(r => r
+			.UpdateAsync(It.IsAny<List<Domain.Core.Adjustment>>(), existing.ReceiptId, It.IsAny<CancellationToken>()))
+			.Returns(Task.CompletedTask);
+
+		UpdateAdjustmentCommand command = new(input);
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		Assert.True(result);
+	}
+
+	[Fact]
+	public async Task UpdateAdjustmentCommandHandler_WithMissingAdjustment_ReturnsFalseAndNeverPersists()
+	{
+		Mock<IAdjustmentService> mockService = new();
+		UpdateAdjustmentCommandHandler handler = new(mockService.Object);
+
+		List<Domain.Core.Adjustment> input = AdjustmentGenerator.GenerateList(1);
+
+		// A soft-deleted/missing target yields null from GetByIdAsync → 404 (RECEIPTS-761).
+		mockService.Setup(r => r.GetByIdAsync(input[0].Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Domain.Core.Adjustment?)null);
+
+		UpdateAdjustmentCommand command = new(input);
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		Assert.False(result);
+		mockService.Verify(r => r.UpdateAsync(It.IsAny<List<Domain.Core.Adjustment>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+}

--- a/tests/Application.Tests/Commands/Card/UpdateCardCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Card/UpdateCardCommandHandlerTests.cs
@@ -16,6 +16,10 @@ public class UpdateCardCommandHandlerTests
 		List<Domain.Core.Card> input = CardGenerator.GenerateList(2);
 
 		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		mockService.Setup(r => r
 			.UpdateAsync(It.IsAny<List<Domain.Core.Card>>(), It.IsAny<CancellationToken>()))
 			.Returns(Task.CompletedTask);
 
@@ -23,5 +27,24 @@ public class UpdateCardCommandHandlerTests
 		bool result = await handler.Handle(command, CancellationToken.None);
 
 		Assert.True(result);
+	}
+
+	[Fact]
+	public async Task UpdateCardCommandHandler_WithMissingCard_ReturnsFalseAndNeverPersists()
+	{
+		Mock<ICardService> mockService = new();
+		UpdateCardCommandHandler handler = new(mockService.Object);
+
+		List<Domain.Core.Card> input = CardGenerator.GenerateList(1);
+
+		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		UpdateCardCommand command = new(input);
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		Assert.False(result);
+		mockService.Verify(r => r.UpdateAsync(It.IsAny<List<Domain.Core.Card>>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 }

--- a/tests/Application.Tests/Commands/Category/UpdateCategoryCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Category/UpdateCategoryCommandHandlerTests.cs
@@ -16,6 +16,10 @@ public class UpdateCategoryCommandHandlerTests
 		List<Domain.Core.Category> input = CategoryGenerator.GenerateList(2);
 
 		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		mockService.Setup(r => r
 			.UpdateAsync(It.IsAny<List<Domain.Core.Category>>(), It.IsAny<CancellationToken>()))
 			.Returns(Task.CompletedTask);
 
@@ -23,5 +27,24 @@ public class UpdateCategoryCommandHandlerTests
 		bool result = await handler.Handle(command, CancellationToken.None);
 
 		Assert.True(result);
+	}
+
+	[Fact]
+	public async Task UpdateCategoryCommandHandler_WithMissingCategory_ReturnsFalseAndNeverPersists()
+	{
+		Mock<ICategoryService> mockService = new();
+		UpdateCategoryCommandHandler handler = new(mockService.Object);
+
+		List<Domain.Core.Category> input = CategoryGenerator.GenerateList(1);
+
+		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		UpdateCategoryCommand command = new(input);
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		Assert.False(result);
+		mockService.Verify(r => r.UpdateAsync(It.IsAny<List<Domain.Core.Category>>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 }

--- a/tests/Application.Tests/Commands/ItemTemplate/UpdateItemTemplateCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/ItemTemplate/UpdateItemTemplateCommandHandlerTests.cs
@@ -16,6 +16,10 @@ public class UpdateItemTemplateCommandHandlerTests
 		List<Domain.Core.ItemTemplate> input = ItemTemplateGenerator.GenerateList(2);
 
 		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		mockService.Setup(r => r
 			.UpdateAsync(It.IsAny<List<Domain.Core.ItemTemplate>>(), It.IsAny<CancellationToken>()))
 			.Returns(Task.CompletedTask);
 
@@ -23,5 +27,24 @@ public class UpdateItemTemplateCommandHandlerTests
 		bool result = await handler.Handle(command, CancellationToken.None);
 
 		Assert.True(result);
+	}
+
+	[Fact]
+	public async Task UpdateItemTemplateCommandHandler_WithMissingItemTemplate_ReturnsFalseAndNeverPersists()
+	{
+		Mock<IItemTemplateService> mockService = new();
+		UpdateItemTemplateCommandHandler handler = new(mockService.Object);
+
+		List<Domain.Core.ItemTemplate> input = ItemTemplateGenerator.GenerateList(1);
+
+		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		UpdateItemTemplateCommand command = new(input);
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		Assert.False(result);
+		mockService.Verify(r => r.UpdateAsync(It.IsAny<List<Domain.Core.ItemTemplate>>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 }

--- a/tests/Application.Tests/Commands/Receipt/UpdateReceiptCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/UpdateReceiptCommandHandlerTests.cs
@@ -16,6 +16,10 @@ public class UpdateReceiptCommandHandlerTests
 		List<Domain.Core.Receipt> input = ReceiptGenerator.GenerateList(2);
 
 		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		mockService.Setup(r => r
 			.UpdateAsync(It.IsAny<List<Domain.Core.Receipt>>(), It.IsAny<CancellationToken>()))
 			.Returns(Task.CompletedTask);
 
@@ -23,5 +27,25 @@ public class UpdateReceiptCommandHandlerTests
 		bool result = await handler.Handle(command, CancellationToken.None);
 
 		Assert.True(result);
+	}
+
+	[Fact]
+	public async Task UpdateReceiptCommandHandler_WithMissingReceipt_ReturnsFalseAndNeverPersists()
+	{
+		Mock<IReceiptService> mockService = new();
+		UpdateReceiptCommandHandler handler = new(mockService.Object);
+
+		List<Domain.Core.Receipt> input = ReceiptGenerator.GenerateList(1);
+
+		// A soft-deleted/missing target is hidden by the query filter, so ExistsAsync is false.
+		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		UpdateReceiptCommand command = new(input);
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		Assert.False(result);
+		mockService.Verify(r => r.UpdateAsync(It.IsAny<List<Domain.Core.Receipt>>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 }

--- a/tests/Application.Tests/Commands/ReceiptItem/UpdateReceiptItemCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/ReceiptItem/UpdateReceiptItemCommandHandlerTests.cs
@@ -30,4 +30,23 @@ public class UpdateReceiptItemCommandHandlerTests
 
 		Assert.True(result);
 	}
+
+	[Fact]
+	public async Task UpdateReceiptItemCommandHandler_WithMissingItem_ReturnsFalseAndNeverPersists()
+	{
+		Mock<IReceiptItemService> mockService = new();
+		UpdateReceiptItemCommandHandler handler = new(mockService.Object);
+
+		List<Domain.Core.ReceiptItem> input = ReceiptItemGenerator.GenerateList(1);
+
+		// A soft-deleted/missing target yields null from GetByIdAsync → 404 (RECEIPTS-761).
+		mockService.Setup(r => r.GetByIdAsync(input[0].Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Domain.Core.ReceiptItem?)null);
+
+		UpdateReceiptItemCommand command = new(input);
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		Assert.False(result);
+		mockService.Verify(r => r.UpdateAsync(It.IsAny<List<Domain.Core.ReceiptItem>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
 }

--- a/tests/Application.Tests/Commands/Subcategory/UpdateSubcategoryCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Subcategory/UpdateSubcategoryCommandHandlerTests.cs
@@ -16,6 +16,10 @@ public class UpdateSubcategoryCommandHandlerTests
 		List<Domain.Core.Subcategory> input = SubcategoryGenerator.GenerateList(2);
 
 		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		mockService.Setup(r => r
 			.UpdateAsync(It.IsAny<List<Domain.Core.Subcategory>>(), It.IsAny<CancellationToken>()))
 			.Returns(Task.CompletedTask);
 
@@ -23,5 +27,24 @@ public class UpdateSubcategoryCommandHandlerTests
 		bool result = await handler.Handle(command, CancellationToken.None);
 
 		Assert.True(result);
+	}
+
+	[Fact]
+	public async Task UpdateSubcategoryCommandHandler_WithMissingSubcategory_ReturnsFalseAndNeverPersists()
+	{
+		Mock<ISubcategoryService> mockService = new();
+		UpdateSubcategoryCommandHandler handler = new(mockService.Object);
+
+		List<Domain.Core.Subcategory> input = SubcategoryGenerator.GenerateList(1);
+
+		mockService.Setup(r => r
+			.ExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		UpdateSubcategoryCommand command = new(input);
+		bool result = await handler.Handle(command, CancellationToken.None);
+
+		Assert.False(result);
+		mockService.Verify(r => r.UpdateAsync(It.IsAny<List<Domain.Core.Subcategory>>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 }

--- a/tests/Application.Tests/Commands/Transaction/Update/UpdateTransactionCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Transaction/Update/UpdateTransactionCommandHandlerTests.cs
@@ -173,9 +173,10 @@ public class UpdateTransactionCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task Handle_TransactionNotFound_ThrowsInvalidOperationException()
+	public async Task Handle_TransactionNotFound_ReturnsFalseAndNeverPersists()
 	{
-		// Arrange
+		// Arrange — the update target is missing/soft-deleted, so the endpoint must 404
+		// (handler returns false) rather than 500 (RECEIPTS-761).
 		Guid txId = Guid.NewGuid();
 		_transactionService.Setup(s => s.GetByIdAsync(txId, It.IsAny<CancellationToken>()))
 			.ReturnsAsync((Domain.Core.Transaction?)null);
@@ -186,10 +187,12 @@ public class UpdateTransactionCommandHandlerTests
 		UpdateTransactionCommand command = new(updated);
 
 		// Act
-		Func<Task> act = async () => await handler.Handle(command, CancellationToken.None);
+		bool result = await handler.Handle(command, CancellationToken.None);
 
 		// Assert
-		await act.Should().ThrowAsync<InvalidOperationException>();
+		result.Should().BeFalse();
+		_transactionService.Verify(s => s.UpdateAsync(
+			It.IsAny<List<Domain.Core.Transaction>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
 	}
 
 	[Fact]

--- a/tests/Infrastructure.Tests/Extensions/QueryableSortExtensionsTests.cs
+++ b/tests/Infrastructure.Tests/Extensions/QueryableSortExtensionsTests.cs
@@ -30,7 +30,7 @@ public class QueryableSortExtensionsTests
 		IQueryable<TestEntity> query = TestData.AsQueryable();
 
 		// Act
-		List<TestEntity> result = query.ApplySort(SortParams.Default, AllowedColumns, DefaultSort).ToList();
+		List<TestEntity> result = query.ApplySort(SortParams.Default, AllowedColumns, DefaultSort, e => e.Id).ToList();
 
 		// Assert
 		result.Should().HaveCount(3);
@@ -47,7 +47,7 @@ public class QueryableSortExtensionsTests
 		SortParams sort = new("age", "asc");
 
 		// Act
-		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort).ToList();
+		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, e => e.Id).ToList();
 
 		// Assert
 		result.Should().HaveCount(3);
@@ -64,7 +64,7 @@ public class QueryableSortExtensionsTests
 		SortParams sort = new("age", "desc");
 
 		// Act
-		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort).ToList();
+		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, e => e.Id).ToList();
 
 		// Assert
 		result.Should().HaveCount(3);
@@ -81,7 +81,7 @@ public class QueryableSortExtensionsTests
 		SortParams sort = new("nonexistent", "asc");
 
 		// Act
-		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort).ToList();
+		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, e => e.Id).ToList();
 
 		// Assert
 		result[0].Name.Should().Be("Alice");
@@ -101,7 +101,7 @@ public class QueryableSortExtensionsTests
 		SortParams sort = new(columnName, "desc");
 
 		// Act
-		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort).ToList();
+		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, e => e.Id).ToList();
 
 		// Assert
 		result[0].Name.Should().Be("Charlie");
@@ -117,7 +117,7 @@ public class QueryableSortExtensionsTests
 		SortParams sort = new(null, "desc");
 
 		// Act
-		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort).ToList();
+		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, e => e.Id).ToList();
 
 		// Assert — default sort is ascending by name regardless of the explicit direction
 		result[0].Name.Should().Be("Alice");
@@ -132,7 +132,7 @@ public class QueryableSortExtensionsTests
 		IQueryable<TestEntity> query = TestData.AsQueryable();
 
 		// Act
-		List<TestEntity> result = query.ApplySort(SortParams.Default, AllowedColumns, DefaultSort, defaultDescending: true).ToList();
+		List<TestEntity> result = query.ApplySort(SortParams.Default, AllowedColumns, DefaultSort, e => e.Id, defaultDescending: true).ToList();
 
 		// Assert
 		result[0].Name.Should().Be("Charlie");
@@ -148,7 +148,7 @@ public class QueryableSortExtensionsTests
 		SortParams sort = new("name", "asc");
 
 		// Act — defaultDescending is true but explicit column sort should use sort.IsDescending (false)
-		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, defaultDescending: true).ToList();
+		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, e => e.Id, defaultDescending: true).ToList();
 
 		// Assert
 		result[0].Name.Should().Be("Alice");
@@ -164,7 +164,7 @@ public class QueryableSortExtensionsTests
 		SortParams sort = new("", "desc");
 
 		// Act
-		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort).ToList();
+		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, e => e.Id).ToList();
 
 		// Assert — empty string is treated as no sort column, so default ascending
 		result[0].Name.Should().Be("Alice");
@@ -180,12 +180,79 @@ public class QueryableSortExtensionsTests
 		SortParams sort = new("   ", "desc");
 
 		// Act
-		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort).ToList();
+		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, e => e.Id).ToList();
 
 		// Assert — whitespace-only is treated as no sort column, so default ascending
 		result[0].Name.Should().Be("Alice");
 		result[1].Name.Should().Be("Bob");
 		result[2].Name.Should().Be("Charlie");
+	}
+
+	[Fact]
+	public void ApplySort_EqualPrimaryKeys_BreaksTiesByIdAscending()
+	{
+		// Arrange — all three rows share the primary sort key (Name), so only the
+		// tiebreaker determines their relative order (RECEIPTS-767).
+		List<TestEntity> data =
+		[
+			new() { Id = 3, Name = "Same", Age = 1 },
+			new() { Id = 1, Name = "Same", Age = 2 },
+			new() { Id = 2, Name = "Same", Age = 3 },
+		];
+		IQueryable<TestEntity> query = data.AsQueryable();
+
+		// Act
+		List<TestEntity> result = query.ApplySort(SortParams.Default, AllowedColumns, DefaultSort, e => e.Id).ToList();
+
+		// Assert — deterministic ascending-by-Id order
+		result.Select(e => e.Id).Should().Equal(1, 2, 3);
+	}
+
+	[Fact]
+	public void ApplySort_EqualPrimaryKeysDescendingSort_StillBreaksTiesByIdAscending()
+	{
+		// Arrange
+		List<TestEntity> data =
+		[
+			new() { Id = 3, Name = "Same", Age = 1 },
+			new() { Id = 1, Name = "Same", Age = 2 },
+			new() { Id = 2, Name = "Same", Age = 3 },
+		];
+		IQueryable<TestEntity> query = data.AsQueryable();
+		SortParams sort = new("name", "desc");
+
+		// Act — primary sort is descending, but the tiebreaker is always ascending by Id
+		List<TestEntity> result = query.ApplySort(sort, AllowedColumns, DefaultSort, e => e.Id).ToList();
+
+		// Assert
+		result.Select(e => e.Id).Should().Equal(1, 2, 3);
+	}
+
+	[Fact]
+	public void ApplySort_PaginationAcrossOffsets_NoDuplicatesOrGapsWhenPrimaryKeysEqual()
+	{
+		// Arrange — worst case: every row shares the same primary sort key, so without a
+		// unique tiebreaker consecutive pages could duplicate one row and skip another.
+		List<TestEntity> data = [.. Enumerable.Range(1, 10).Select(i => new TestEntity { Id = i, Name = "Same", Age = i })];
+		IQueryable<TestEntity> query = data.AsQueryable();
+
+		const int pageSize = 3;
+		List<int> collected = [];
+
+		// Act — walk every page and accumulate the ids returned
+		for (int offset = 0; offset < data.Count; offset += pageSize)
+		{
+			List<int> page = query
+				.ApplySort(SortParams.Default, AllowedColumns, DefaultSort, e => e.Id)
+				.Skip(offset)
+				.Take(pageSize)
+				.Select(e => e.Id)
+				.ToList();
+			collected.AddRange(page);
+		}
+
+		// Assert — each id appears exactly once, in a stable total order
+		collected.Should().Equal(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 	}
 
 	private sealed class TestEntity

--- a/tests/Presentation.API.Tests/Controllers/Core/AdjustmentsControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/Core/AdjustmentsControllerTests.cs
@@ -372,6 +372,31 @@ public class AdjustmentsControllerTests
 	}
 
 	[Fact]
+	public async Task UpdateAdjustment_RouteIdIsAuthoritative_WhenBodyIdMismatches()
+	{
+		// Arrange — RECEIPTS-793: the URL names resource A but the body carries a different
+		// id B. The route id must win so the PUT can't silently overwrite the wrong resource.
+		Guid routeId = Guid.NewGuid();
+		UpdateAdjustmentRequest controllerInput = AdjustmentDtoGenerator.GenerateUpdateRequest();
+		controllerInput.Id = Guid.NewGuid(); // body id B, distinct from the route id A
+
+		_mediatorMock.Setup(m => m.Send(
+			It.IsAny<UpdateAdjustmentCommand>(),
+			It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		// Act
+		Results<NoContent, NotFound> result = await _controller.UpdateAdjustment(controllerInput, routeId);
+
+		// Assert — the dispatched command targets the route id, and the notification names it too
+		Assert.IsType<NoContent>(result.Result);
+		_mediatorMock.Verify(m => m.Send(
+			It.Is<UpdateAdjustmentCommand>(c => c.Adjustments[0].Id == routeId),
+			It.IsAny<CancellationToken>()), Times.Once);
+		_notifierMock.Verify(n => n.NotifyUpdated("adjustment", routeId), Times.Once);
+	}
+
+	[Fact]
 	public async Task UpdateAdjustment_ThrowsException_WhenMediatorFails()
 	{
 		// Arrange


### PR DESCRIPTION
Three API request-handling correctness fixes. None required an OpenAPI spec change — the spec already declares the correct responses.

## Fix 1 — RECEIPTS-761: PUT returned 500 instead of the spec-declared 404 for a missing target
The `NotFound` branch in every update controller was unreachable. Fetch-based handlers (Adjustment, ReceiptItem, Transaction) threw `InvalidOperationException` on a missing entity; check-less handlers (Receipt, Card, Category, Subcategory, ItemTemplate) relied on the repository's `.Single(...)` throwing. Both map to a generic 500 in the middleware, so a soft-deleted target (hidden by the query filter) returned 500 instead of 404.

**Fix:** match the existing `UpdateAccountCommandHandler` pattern. Fetch-based handlers now null-check and `return false`; check-less handlers add an `ExistsAsync` guard that returns false. The controllers' existing `if (!result) return NotFound()` branch then yields 404 (`KeyNotFoundException` → 404 mapping confirmed in `GlobalExceptionHandlerMiddleware`, but `return false` is the Account-consistent path and needs no exception).

## Fix 2 — RECEIPTS-767: non-deterministic pagination (missing tiebreaker)
`ApplySort` ordered by a single, often non-unique column (Date/Name/Location/…) then `Skip/Take`, with no tiebreaker on a unique key. Postgres gave no stable order among equal keys across separate queries, so consecutive pages could duplicate one row and skip another.

**Fix:** added a required ascending Id tiebreaker to `ApplySort`. Used a **key-selector parameter** rather than an `IHasId` interface constraint, because `ApplicationUser.Id` is a `string` and the entities share no common `Guid Id` base — an interface couldn't cover all callers. Threaded `e => e.Id` (`a => a.Id` / `u => u.Id`) through all 29 call sites. Primary sort semantics unchanged.

## Fix 3 — RECEIPTS-793: PUT ignored the route {id}, updated the body id
Single-resource PUT actions built the command from the body id, while the route `{id}` drove only logging, the SignalR `NotifyUpdated` broadcast, and the `X-Resource-Id` header (`ResourceIdResultFilter`). `PUT /api/x/{A}` with body id B silently overwrote B while telling every client A had changed.

**Fix:** stamp the route id onto the model before dispatch (`model.Id = id`) so the URL is authoritative — chosen over 400-on-mismatch because the spec declares PUT as only `204` (+ `X-Resource-Id`) and `404`; a 400 would introduce an undeclared response. This also keeps `NotifyUpdated` and the `X-Resource-Id` header consistent with the resource actually updated. Applied to Adjustments, Transactions, ReceiptItems, Receipts, Cards, Categories, Subcategories, ItemTemplates and Accounts.

## Validation
- `dotnet build Receipts.slnx` — 0 errors, no new warnings.
- `dotnet test tests/Application.Tests --filter "Category!=Integration"` — 457 passed.
- `dotnet test tests/Infrastructure.Tests --filter "Category!=Integration"` — 647 passed.
- `dotnet test tests/Presentation.API.Tests --filter "Category!=Integration"` — 1010 passed.

**Tests added/updated:**
- Added per-entity missing-target handler tests (return false → 404) for Adjustment (new file), Card, Category, ItemTemplate, Receipt, ReceiptItem, Subcategory; updated the Transaction handler test that asserted the old 500/throw behavior.
- Added `ExistsAsync` setup to the five check-less handlers' happy-path tests (previously they set up only `UpdateAsync`).
- Added `ApplySort` stability tests: deterministic Id order for equal primary keys (ascending and descending primary sort) and a paginate-across-offsets test proving no dropped/duplicated rows.
- Added a controller test asserting the route id wins over a mismatched body id.

Closes RECEIPTS-761, RECEIPTS-767, RECEIPTS-793

🤖 Generated with [Claude Code](https://claude.com/claude-code)
