### PR TITLE
fix(client): surface api errors, honest bulk-push feedback, unsaved-work guard, and timezone-safe dates

### DIFF
--- a/src/client/src/components/ErrorState.tsx
+++ b/src/client/src/components/ErrorState.tsx
@@ -1,0 +1,50 @@
+import { Icon } from "@/components/primitives";
+
+interface ErrorStateProps {
+  /** Short headline, e.g. "Couldn't load receipts". */
+  title?: string;
+  /** One-line explanation of what went wrong / what to try. */
+  message?: string;
+  /** Wire to the query's `refetch` to let the user retry in place. */
+  onRetry?: () => void;
+  /** Disables the retry button and shows a pending label while refetching. */
+  isRetrying?: boolean;
+}
+
+/**
+ * Full-width error placeholder for a failed list/data query.
+ *
+ * Mirrors the app's native empty-state markup (`.empty` / `.icon-frame` /
+ * `.btn`, the same structure ReceiptDetail's error uses) so a failed query is
+ * visually distinct from a genuinely-empty result — the bug in RECEIPTS-784
+ * was that `data ?? []` made both look identical ("No receipts yet"). The
+ * Retry button re-runs the query so users aren't stranded.
+ */
+export function ErrorState({
+  title = "Something went wrong",
+  message = "We couldn't load this data. Check your connection and try again.",
+  onRetry,
+  isRetrying = false,
+}: ErrorStateProps) {
+  return (
+    <div className="empty" role="alert">
+      <div className="icon-frame">
+        <Icon.AlertTriangle />
+      </div>
+      <h3>{title}</h3>
+      <p>{message}</p>
+      {onRetry && (
+        <div className="actions">
+          <button
+            type="button"
+            className="btn primary"
+            onClick={onRetry}
+            disabled={isRetrying}
+          >
+            {isRetrying ? "Retrying…" : "Try again"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/client/src/components/ReceiptForm.test.tsx
+++ b/src/client/src/components/ReceiptForm.test.tsx
@@ -100,6 +100,31 @@ describe("ReceiptForm", () => {
     expect(defaultProps.onSubmit).not.toHaveBeenCalled();
   });
 
+  // RECEIPTS-782: catch the server's "Date cannot be in the future" rejection
+  // on the client so the user gets inline feedback before submitting.
+  it("rejects a future date with an inline error and does not submit", async () => {
+    const user = userEvent.setup();
+    render(<ReceiptForm {...defaultProps} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const searchInput = screen.getByPlaceholderText("Search locations...");
+    await user.type(searchInput, "Target");
+    await user.click(screen.getByText(/Use "Target"/));
+
+    const futureYear = new Date().getFullYear() + 1;
+    await user.type(screen.getByLabelText(/^Date/), `${futureYear}-01-15`);
+    await user.click(
+      screen.getByRole("button", { name: /create receipt/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Date cannot be in the future"),
+      ).toBeInTheDocument();
+    });
+    expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+  });
+
   it("calls onCancel when cancel button is clicked", async () => {
     const user = userEvent.setup();
     render(<ReceiptForm {...defaultProps} />);

--- a/src/client/src/components/ReceiptForm.tsx
+++ b/src/client/src/components/ReceiptForm.tsx
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFormShortcuts } from "@/hooks/useFormShortcuts";
 import { useLocationHistory } from "@/hooks/useLocationHistory";
+import { isFutureDate } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { Combobox } from "@/components/ui/combobox";
@@ -23,7 +24,10 @@ const receiptSchema = z.object({
     .string()
     .min(1, "Location is required")
     .max(200, "Location must be 200 characters or fewer"),
-  date: z.string().min(1, "Date is required"),
+  date: z
+    .string()
+    .min(1, "Date is required")
+    .refine((v) => !isFutureDate(v), "Date cannot be in the future"),
   taxAmount: z.number().min(0, "Tax amount must be non-negative"),
 });
 

--- a/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
+++ b/src/client/src/components/dashboard/RecentReceiptsWidget.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
-import { format } from "date-fns";
 import { Link } from "react-router";
 import { ChartCard } from "@/components/charts";
 import { useReceipts } from "@/hooks/useReceipts";
+import { formatDate } from "@/lib/format";
 
 interface RecentReceiptsWidgetProps {
   className?: string;
@@ -49,7 +49,7 @@ export function RecentReceiptsWidget({ className }: RecentReceiptsWidgetProps) {
                   {receipt.location}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  {format(new Date(receipt.date), "MMM d, yyyy")}
+                  {formatDate(receipt.date)}
                 </p>
               </div>
               <span className="ml-4 text-xs text-muted-foreground tabular-nums">

--- a/src/client/src/hooks/useAccounts.test.ts
+++ b/src/client/src/hooks/useAccounts.test.ts
@@ -152,7 +152,7 @@ describe("useCreateAccount", () => {
     expect(toast.success).toHaveBeenCalledWith("Account created");
   });
 
-  it("toasts error on failure", async () => {
+  it("does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ data: undefined, error: { message: "boom" } });
 
     const { result } = renderHook(() => useCreateAccount(), {
@@ -162,7 +162,7 @@ describe("useCreateAccount", () => {
     await expect(
       result.current.mutateAsync({ name: "Apple Card", isActive: true }),
     ).rejects.toBeDefined();
-    expect(toast.error).toHaveBeenCalledWith("Failed to create account");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });
 

--- a/src/client/src/hooks/useAccounts.ts
+++ b/src/client/src/hooks/useAccounts.ts
@@ -74,9 +74,6 @@ export function useCreateAccount() {
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       toast.success("Account created");
     },
-    onError: () => {
-      toast.error("Failed to create account");
-    },
   });
 }
 
@@ -97,9 +94,6 @@ export function useUpdateAccount() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       toast.success("Account updated");
-    },
-    onError: () => {
-      toast.error("Failed to update account");
     },
   });
 }
@@ -132,9 +126,8 @@ export function useDeleteAccount() {
       const err = error as { conflict?: boolean; message?: string; cardCount?: number };
       if (err.conflict) {
         toast.error(err.message ?? "Cannot delete — cards reference this account");
-      } else {
-        toast.error("Failed to delete account");
       }
+      // Non-conflict failures fall through to the global error handler.
     },
   });
 }

--- a/src/client/src/hooks/useAdjustments.test.ts
+++ b/src/client/src/hooks/useAdjustments.test.ts
@@ -182,7 +182,7 @@ describe("useAdjustments", () => {
 
   // --- Branch coverage: error callbacks ---
 
-  it("create mutation shows error toast on failure", async () => {
+  it("create mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useCreateAdjustment(), {
@@ -192,10 +192,10 @@ describe("useAdjustments", () => {
     result.current.mutate({ receiptId: "r-1", body: { type: "discount", amount: 5.0 } });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to create adjustment");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("update mutation shows error toast on failure", async () => {
+  it("update mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useUpdateAdjustment(), {
@@ -205,10 +205,10 @@ describe("useAdjustments", () => {
     result.current.mutate({ body: { id: "1", type: "discount", amount: 5.0 } });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to update adjustment");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+  it("delete mutation rolls back cache on failure (error surfaced by the global handler)", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: 0 } },
     });
@@ -236,7 +236,7 @@ describe("useAdjustments", () => {
     result.current.mutate(["1"]);
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to delete adjustment(s)");
+    expect(toast.error).not.toHaveBeenCalled();
 
     // Verify rollback restored the original data (not just the optimistic update from onMutate)
     expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
@@ -265,7 +265,7 @@ describe("useAdjustments", () => {
     expect(toast.success).toHaveBeenCalledWith("Adjustment(s) deleted");
   });
 
-  it("restore mutation shows error toast on failure", async () => {
+  it("restore mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useRestoreAdjustment(), {
@@ -275,7 +275,7 @@ describe("useAdjustments", () => {
     result.current.mutate("1");
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to restore adjustment");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("list query throws on API error", async () => {

--- a/src/client/src/hooks/useAdjustments.ts
+++ b/src/client/src/hooks/useAdjustments.ts
@@ -76,9 +76,6 @@ export function useCreateAdjustment() {
       queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Adjustment created");
     },
-    onError: () => {
-      toast.error("Failed to create adjustment");
-    },
   });
 }
 
@@ -106,9 +103,6 @@ export function useUpdateAdjustment() {
       queryClient.invalidateQueries({ queryKey: ["receipts-with-items"] });
       queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Adjustment updated");
-    },
-    onError: () => {
-      toast.error("Failed to update adjustment");
     },
   });
 }
@@ -138,7 +132,6 @@ export function useDeleteAdjustments() {
       for (const [key, data] of context?.previous ?? []) {
         queryClient.setQueryData(key, data);
       }
-      toast.error("Failed to delete adjustment(s)");
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["adjustments"] });
@@ -182,9 +175,6 @@ export function useRestoreAdjustment() {
       queryClient.invalidateQueries({ queryKey: ["receipts-with-items"] });
       queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Adjustment restored");
-    },
-    onError: () => {
-      toast.error("Failed to restore adjustment");
     },
   });
 }

--- a/src/client/src/hooks/useCards.test.ts
+++ b/src/client/src/hooks/useCards.test.ts
@@ -179,7 +179,7 @@ describe("useCards", () => {
     });
   });
 
-  it("delete mutation shows generic error toast on non-409 failure", async () => {
+  it("delete mutation does not toast on non-409 failure (surfaced by the global handler)", async () => {
     (client.DELETE as Mock).mockResolvedValue({
       error: { message: "Server error" },
       response: { status: 500 },
@@ -192,7 +192,7 @@ describe("useCards", () => {
     await expect(result.current.mutateAsync("1")).rejects.toThrow();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to delete card");
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 
@@ -241,7 +241,7 @@ describe("useCards", () => {
     });
   });
 
-  it("merge mutation shows generic error toast on non-409 failure", async () => {
+  it("merge mutation does not toast on non-409 failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({
       error: { message: "boom" },
       response: { status: 500 },
@@ -256,7 +256,7 @@ describe("useCards", () => {
     ).rejects.toThrow();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to merge cards");
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 

--- a/src/client/src/hooks/useCards.ts
+++ b/src/client/src/hooks/useCards.ts
@@ -52,9 +52,6 @@ export function useCreateCard() {
       queryClient.invalidateQueries({ queryKey: ["cards"] });
       toast.success("Card created");
     },
-    onError: () => {
-      toast.error("Failed to create card");
-    },
   });
 }
 
@@ -77,9 +74,6 @@ export function useUpdateCard() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cards"] });
       toast.success("Card updated");
-    },
-    onError: () => {
-      toast.error("Failed to update card");
     },
   });
 }
@@ -112,9 +106,8 @@ export function useDeleteCard() {
       const err = error as { conflict?: boolean; message?: string; transactionCount?: number };
       if (err.conflict) {
         toast.error(err.message ?? "Cannot delete — transactions reference this card");
-      } else {
-        toast.error("Failed to delete card");
       }
+      // Non-conflict failures fall through to the global error handler.
     },
   });
 }
@@ -174,7 +167,7 @@ export function useMergeCards() {
         // Caller handles conflict via onError or by inspecting mutation state.
         return;
       }
-      toast.error("Failed to merge cards");
+      // Non-conflict failures fall through to the global error handler.
     },
   });
 }

--- a/src/client/src/hooks/useCategories.ts
+++ b/src/client/src/hooks/useCategories.ts
@@ -94,7 +94,10 @@ export function useCreateCategory() {
       toast.success("Category created");
     },
     onError: (err) => {
-      toast.error(typeof err === "string" ? err : "Failed to create category");
+      // A string error carries a specific, already-formatted message; anything
+      // else falls through to the global handler (which surfaces the server's
+      // ProblemDetails detail, e.g. a duplicate-name message).
+      if (typeof err === "string") toast.error(err);
     },
   });
 }
@@ -117,9 +120,6 @@ export function useUpdateCategory() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["categories"] });
       toast.success("Category updated");
-    },
-    onError: () => {
-      toast.error("Failed to update category");
     },
   });
 }
@@ -153,9 +153,8 @@ export function useDeleteCategory() {
       const err = error as { conflict?: boolean; message?: string };
       if (err.conflict) {
         toast.error(err.message ?? "Cannot delete — dependencies reference this category");
-      } else {
-        toast.error("Failed to delete category");
       }
+      // Non-conflict failures fall through to the global error handler.
     },
   });
 }
@@ -188,9 +187,6 @@ export function useRestoreCategory() {
       queryClient.invalidateQueries({ queryKey: ["categories"] });
       queryClient.invalidateQueries({ queryKey: ["categories", "deleted"] });
       toast.success("Category restored");
-    },
-    onError: () => {
-      toast.error("Failed to restore category");
     },
   });
 }

--- a/src/client/src/hooks/useItemSimilarityReport.ts
+++ b/src/client/src/hooks/useItemSimilarityReport.ts
@@ -71,9 +71,6 @@ export function useRenameItemSimilarityGroup() {
         `Renamed ${variables.itemIds.length} items to "${variables.newDescription}"`,
       );
     },
-    onError: () => {
-      toast.error("Failed to rename items");
-    },
   });
 }
 
@@ -91,9 +88,6 @@ export function useRefreshItemSimilarity() {
       toast.success(
         "Refresh requested — report will update in about a minute.",
       );
-    },
-    onError: () => {
-      toast.error("Failed to request refresh.");
     },
   });
 }

--- a/src/client/src/hooks/useItemTemplates.test.ts
+++ b/src/client/src/hooks/useItemTemplates.test.ts
@@ -186,7 +186,7 @@ describe("useItemTemplates", () => {
 
   // --- Branch coverage: error callbacks ---
 
-  it("create mutation shows error toast on failure", async () => {
+  it("create mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useCreateItemTemplate(), {
@@ -196,10 +196,10 @@ describe("useItemTemplates", () => {
     result.current.mutate({ name: "Template", description: null });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to create item template");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("update mutation shows error toast on failure", async () => {
+  it("update mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useUpdateItemTemplate(), {
@@ -209,10 +209,10 @@ describe("useItemTemplates", () => {
     result.current.mutate({ id: "1", name: "Template", description: null });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to update item template");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+  it("delete mutation rolls back cache on failure (error surfaced by the global handler)", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: 0 } },
     });
@@ -240,7 +240,7 @@ describe("useItemTemplates", () => {
     result.current.mutate(["1"]);
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to delete item template(s)");
+    expect(toast.error).not.toHaveBeenCalled();
 
     // Verify rollback restored the original data (not just the optimistic update from onMutate)
     expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
@@ -269,7 +269,7 @@ describe("useItemTemplates", () => {
     expect(toast.success).toHaveBeenCalledWith("Item template(s) deleted");
   });
 
-  it("restore mutation shows error toast on failure", async () => {
+  it("restore mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useRestoreItemTemplate(), {
@@ -279,7 +279,7 @@ describe("useItemTemplates", () => {
     result.current.mutate("1");
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to restore item template");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("list query throws on API error", async () => {
@@ -358,7 +358,7 @@ describe("useItemTemplates", () => {
     );
   });
 
-  it("hide mutation shows error toast on failure", async () => {
+  it("hide mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.DELETE as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useHideItemTemplate(), {
@@ -368,7 +368,7 @@ describe("useItemTemplates", () => {
     result.current.mutate("template-1");
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to hide item template");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("hide mutation rolls back cache on failure", async () => {
@@ -399,7 +399,7 @@ describe("useItemTemplates", () => {
     result.current.mutate("template-1");
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to hide item template");
+    expect(toast.error).not.toHaveBeenCalled();
     expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
   });
 

--- a/src/client/src/hooks/useItemTemplates.ts
+++ b/src/client/src/hooks/useItemTemplates.ts
@@ -54,9 +54,6 @@ export function useCreateItemTemplate() {
       queryClient.invalidateQueries({ queryKey: ["itemTemplates"] });
       toast.success("Item template created");
     },
-    onError: () => {
-      toast.error("Failed to create item template");
-    },
   });
 }
 
@@ -81,9 +78,6 @@ export function useUpdateItemTemplate() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["itemTemplates"] });
       toast.success("Item template updated");
-    },
-    onError: () => {
-      toast.error("Failed to update item template");
     },
   });
 }
@@ -113,7 +107,6 @@ export function useDeleteItemTemplates() {
       for (const [key, data] of context?.previous ?? []) {
         queryClient.setQueryData(key, data);
       }
-      toast.error("Failed to delete item template(s)");
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["itemTemplates"] });
@@ -152,7 +145,6 @@ export function useHideItemTemplate() {
       for (const [key, data] of context?.previous ?? []) {
         queryClient.setQueryData(key, data);
       }
-      toast.error("Failed to hide item template");
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["itemTemplates"] });
@@ -196,9 +188,6 @@ export function useRestoreItemTemplate() {
         queryKey: ["itemTemplates", "deleted"],
       });
       toast.success("Item template restored");
-    },
-    onError: () => {
-      toast.error("Failed to restore item template");
     },
   });
 }

--- a/src/client/src/hooks/useNormalizedDescriptionActions.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionActions.ts
@@ -36,9 +36,6 @@ export function useMergeMutation() {
         toast.success("Merge completed");
       }
     },
-    onError: () => {
-      toast.error("Failed to merge normalized descriptions");
-    },
   });
 }
 
@@ -66,9 +63,6 @@ export function useSplitMutation() {
       queryClient.invalidateQueries({ queryKey: ["normalized-descriptions"] });
       queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
       toast.success("Receipt item split into a new normalized description");
-    },
-    onError: () => {
-      toast.error("Failed to split normalized description");
     },
   });
 }
@@ -99,9 +93,6 @@ export function useUpdateStatusMutation() {
           ? "Approved as active"
           : "Moved to pending review",
       );
-    },
-    onError: () => {
-      toast.error("Failed to update status");
     },
   });
 }

--- a/src/client/src/hooks/useNormalizedDescriptionSettings.ts
+++ b/src/client/src/hooks/useNormalizedDescriptionSettings.ts
@@ -40,9 +40,6 @@ export function useUpdateSettingsMutation() {
       });
       toast.success("Settings saved");
     },
-    onError: () => {
-      toast.error("Failed to save settings");
-    },
   });
 }
 
@@ -75,9 +72,6 @@ export function useTestMatchMutation() {
       if (error) throw error;
       return data;
     },
-    onError: () => {
-      toast.error("Failed to test description");
-    },
   });
 }
 
@@ -98,9 +92,6 @@ export function usePreviewImpactMutation() {
       );
       if (error) throw error;
       return data;
-    },
-    onError: () => {
-      toast.error("Failed to preview impact");
     },
   });
 }

--- a/src/client/src/hooks/useReceiptItems.test.ts
+++ b/src/client/src/hooks/useReceiptItems.test.ts
@@ -226,7 +226,7 @@ describe("useReceiptItems", () => {
 
   // --- Branch coverage: error callbacks ---
 
-  it("create mutation shows error toast on failure", async () => {
+  it("create mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useCreateReceiptItem(), {
@@ -236,10 +236,10 @@ describe("useReceiptItems", () => {
     result.current.mutate({ receiptId: "r-1", body: { receiptItemCode: "RI-1", description: "X", quantity: 1, unitPrice: 1, category: "C", subcategory: "S" } });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to create receipt item");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("batch create mutation shows error toast on failure", async () => {
+  it("batch create mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useCreateReceiptItemsBatch(), {
@@ -249,7 +249,7 @@ describe("useReceiptItems", () => {
     result.current.mutate({ receiptId: "r-1", body: [{ receiptItemCode: "RI-1", description: "X", quantity: 1, unitPrice: 1, category: "C", subcategory: "S" }] });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to create receipt items");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("batch create mutation invalidates cache on success", async () => {
@@ -274,7 +274,7 @@ describe("useReceiptItems", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["receipt-items"] });
   });
 
-  it("update mutation shows error toast on failure", async () => {
+  it("update mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useUpdateReceiptItem(), {
@@ -284,10 +284,10 @@ describe("useReceiptItems", () => {
     result.current.mutate({ body: { id: "1", receiptItemCode: "RI-1", description: "X", quantity: 1, unitPrice: 1, category: "C", subcategory: "S" } });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to update receipt item");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+  it("delete mutation rolls back cache on failure (error surfaced by the global handler)", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: 0 } },
     });
@@ -316,7 +316,7 @@ describe("useReceiptItems", () => {
     result.current.mutate(["1"]);
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to delete receipt item(s)");
+    expect(toast.error).not.toHaveBeenCalled();
 
     // Verify rollback restored the original data (not just the optimistic update from onMutate)
     expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
@@ -346,7 +346,7 @@ describe("useReceiptItems", () => {
     expect(toast.success).toHaveBeenCalledWith("Receipt item(s) deleted");
   });
 
-  it("restore mutation shows error toast on failure", async () => {
+  it("restore mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useRestoreReceiptItem(), {
@@ -356,7 +356,7 @@ describe("useReceiptItems", () => {
     result.current.mutate("1");
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to restore receipt item");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("list query throws on API error", async () => {

--- a/src/client/src/hooks/useReceiptItems.ts
+++ b/src/client/src/hooks/useReceiptItems.ts
@@ -78,9 +78,6 @@ export function useCreateReceiptItem() {
       queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
       toast.success("Receipt item created");
     },
-    onError: () => {
-      toast.error("Failed to create receipt item");
-    },
   });
 }
 
@@ -111,9 +108,6 @@ export function useCreateReceiptItemsBatch() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
     },
-    onError: () => {
-      toast.error("Failed to create receipt items");
-    },
   });
 }
 
@@ -143,9 +137,6 @@ export function useUpdateReceiptItem() {
       queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
       toast.success("Receipt item updated");
     },
-    onError: () => {
-      toast.error("Failed to update receipt item");
-    },
   });
 }
 
@@ -174,7 +165,6 @@ export function useDeleteReceiptItems() {
       for (const [key, data] of context?.previous ?? []) {
         queryClient.setQueryData(key, data);
       }
-      toast.error("Failed to delete receipt item(s)");
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
@@ -214,9 +204,6 @@ export function useRestoreReceiptItem() {
       queryClient.invalidateQueries({ queryKey: ["receipt-items"] });
       queryClient.invalidateQueries({ queryKey: ["receipt-items", "deleted"] });
       toast.success("Receipt item restored");
-    },
-    onError: () => {
-      toast.error("Failed to restore receipt item");
     },
   });
 }

--- a/src/client/src/hooks/useReceipts.test.ts
+++ b/src/client/src/hooks/useReceipts.test.ts
@@ -171,7 +171,7 @@ describe("useReceipts", () => {
 
   // --- Branch coverage: error callbacks ---
 
-  it("create mutation shows error toast on failure", async () => {
+  it("create mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useCreateReceipt(), {
@@ -181,10 +181,10 @@ describe("useReceipts", () => {
     result.current.mutate({ location: "Store", date: "2025-01-01", taxAmount: 1.0 });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to create receipt");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("update mutation shows error toast on failure", async () => {
+  it("update mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useUpdateReceipt(), {
@@ -194,10 +194,10 @@ describe("useReceipts", () => {
     result.current.mutate({ id: "1", location: "Store", date: "2025-01-01", taxAmount: 1.0 });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to update receipt");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+  it("delete mutation rolls back cache on failure (error surfaced by the global handler)", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: 0 } },
     });
@@ -225,7 +225,7 @@ describe("useReceipts", () => {
     result.current.mutate(["1"]);
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to delete receipt(s)");
+    expect(toast.error).not.toHaveBeenCalled();
 
     // Verify rollback restored the original data (not just the optimistic update from onMutate)
     expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
@@ -254,7 +254,7 @@ describe("useReceipts", () => {
     expect(toast.success).toHaveBeenCalledWith("Receipt(s) deleted");
   });
 
-  it("restore mutation shows error toast on failure", async () => {
+  it("restore mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useRestoreReceipt(), {
@@ -264,7 +264,7 @@ describe("useReceipts", () => {
     result.current.mutate("1");
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to restore receipt");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("list query throws on API error", async () => {

--- a/src/client/src/hooks/useReceipts.ts
+++ b/src/client/src/hooks/useReceipts.ts
@@ -69,9 +69,6 @@ export function useCreateReceipt() {
       queryClient.invalidateQueries({ queryKey: ["receipts"] });
       toast.success("Receipt created");
     },
-    onError: () => {
-      toast.error("Failed to create receipt");
-    },
   });
 }
 
@@ -95,9 +92,6 @@ export function useUpdateReceipt() {
       queryClient.invalidateQueries({ queryKey: ["receipts"] });
       queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Receipt updated");
-    },
-    onError: () => {
-      toast.error("Failed to update receipt");
     },
   });
 }
@@ -125,7 +119,6 @@ export function useDeleteReceipts() {
       for (const [key, data] of context?.previous ?? []) {
         queryClient.setQueryData(key, data);
       }
-      toast.error("Failed to delete receipt(s)");
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["receipts"] });
@@ -206,9 +199,6 @@ export function useRestoreReceipt() {
       queryClient.invalidateQueries({ queryKey: ["receipts"] });
       queryClient.invalidateQueries({ queryKey: ["receipts", "deleted"] });
       toast.success("Receipt restored");
-    },
-    onError: () => {
-      toast.error("Failed to restore receipt");
     },
   });
 }

--- a/src/client/src/hooks/useRoles.test.ts
+++ b/src/client/src/hooks/useRoles.test.ts
@@ -112,6 +112,6 @@ describe("useRemoveRole", () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    expect(toast.error).toHaveBeenCalledWith('Failed to remove role "Admin"');
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/client/src/hooks/useRoles.ts
+++ b/src/client/src/hooks/useRoles.ts
@@ -35,9 +35,6 @@ export function useAssignRole() {
       queryClient.invalidateQueries({ queryKey: ["userRoles", userId] });
       toast.success(`Role "${role}" assigned`);
     },
-    onError: (_error, { role }) => {
-      toast.error(`Failed to assign role "${role}"`);
-    },
   });
 }
 
@@ -54,9 +51,6 @@ export function useRemoveRole() {
     onSuccess: (_data, { userId, role }) => {
       queryClient.invalidateQueries({ queryKey: ["userRoles", userId] });
       toast.success(`Role "${role}" removed`);
-    },
-    onError: (_error, { role }) => {
-      toast.error(`Failed to remove role "${role}"`);
     },
   });
 }

--- a/src/client/src/hooks/useSubcategories.ts
+++ b/src/client/src/hooks/useSubcategories.ts
@@ -114,9 +114,9 @@ export function useCreateSubcategory() {
       toast.success("Subcategory created");
     },
     onError: (err) => {
-      toast.error(
-        typeof err === "string" ? err : "Failed to create subcategory",
-      );
+      // A string error carries a specific, already-formatted message; anything
+      // else falls through to the global handler (server ProblemDetails detail).
+      if (typeof err === "string") toast.error(err);
     },
   });
 }
@@ -140,9 +140,6 @@ export function useUpdateSubcategory() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["subcategories"] });
       toast.success("Subcategory updated");
-    },
-    onError: () => {
-      toast.error("Failed to update subcategory");
     },
   });
 }
@@ -187,9 +184,8 @@ export function useDeleteSubcategory() {
       }
       if (err.conflict) {
         toast.error(err.message ?? "Cannot delete — receipt items reference this subcategory");
-      } else {
-        toast.error("Failed to delete subcategory");
       }
+      // Non-conflict failures fall through to the global error handler.
     },
   });
 }
@@ -222,9 +218,6 @@ export function useRestoreSubcategory() {
       queryClient.invalidateQueries({ queryKey: ["subcategories"] });
       queryClient.invalidateQueries({ queryKey: ["subcategories", "deleted"] });
       toast.success("Subcategory restored");
-    },
-    onError: () => {
-      toast.error("Failed to restore subcategory");
     },
   });
 }

--- a/src/client/src/hooks/useTransactions.test.ts
+++ b/src/client/src/hooks/useTransactions.test.ts
@@ -183,7 +183,7 @@ describe("useTransactions", () => {
 
   // --- Branch coverage: error callbacks ---
 
-  it("create mutation shows error toast on failure", async () => {
+  it("create mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useCreateTransaction(), {
@@ -193,10 +193,10 @@ describe("useTransactions", () => {
     result.current.mutate({ receiptId: "r-1", body: { amount: 100, date: "2025-01-01", accountId: "acc-1", cardId: "card-1" } });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to create transaction");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("batch create mutation shows error toast on failure", async () => {
+  it("batch create mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useCreateTransactionsBatch(), {
@@ -206,7 +206,7 @@ describe("useTransactions", () => {
     result.current.mutate({ receiptId: "r-1", body: [{ amount: 100, date: "2025-01-01", accountId: "acc-1", cardId: "card-1" }] });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to create transactions");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("batch create mutation invalidates cache on success", async () => {
@@ -231,7 +231,7 @@ describe("useTransactions", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["transactions"] });
   });
 
-  it("update mutation shows error toast on failure", async () => {
+  it("update mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.PUT as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useUpdateTransaction(), {
@@ -241,10 +241,10 @@ describe("useTransactions", () => {
     result.current.mutate({ body: { id: "1", amount: 100, date: "2025-01-01", accountId: "acc-1", cardId: "card-1" } });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to update transaction");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("delete mutation shows error toast and rolls back cache on failure", async () => {
+  it("delete mutation rolls back cache on failure (error surfaced by the global handler)", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: 0 } },
     });
@@ -272,7 +272,7 @@ describe("useTransactions", () => {
     result.current.mutate(["1"]);
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to delete transaction(s)");
+    expect(toast.error).not.toHaveBeenCalled();
 
     // Verify rollback restored the original data (not just the optimistic update from onMutate)
     expect(setQueryDataSpy).toHaveBeenCalledWith(cacheKey, cacheValue);
@@ -301,7 +301,7 @@ describe("useTransactions", () => {
     expect(toast.success).toHaveBeenCalledWith("Transaction(s) deleted");
   });
 
-  it("restore mutation shows error toast on failure", async () => {
+  it("restore mutation does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: { message: "Server error" } });
 
     const { result } = renderHook(() => useRestoreTransaction(), {
@@ -311,7 +311,7 @@ describe("useTransactions", () => {
     result.current.mutate("1");
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith("Failed to restore transaction");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("list query throws on API error", async () => {

--- a/src/client/src/hooks/useTransactions.ts
+++ b/src/client/src/hooks/useTransactions.ts
@@ -71,9 +71,6 @@ export function useCreateTransaction() {
       queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Transaction created");
     },
-    onError: () => {
-      toast.error("Failed to create transaction");
-    },
   });
 }
 
@@ -97,9 +94,6 @@ export function useCreateTransactionsBatch() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
     },
-    onError: () => {
-      toast.error("Failed to create transactions");
-    },
   });
 }
 
@@ -121,9 +115,6 @@ export function useUpdateTransaction() {
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Transaction updated");
-    },
-    onError: () => {
-      toast.error("Failed to update transaction");
     },
   });
 }
@@ -153,7 +144,6 @@ export function useDeleteTransactions() {
       for (const [key, data] of context?.previous ?? []) {
         queryClient.setQueryData(key, data);
       }
-      toast.error("Failed to delete transaction(s)");
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
@@ -195,9 +185,6 @@ export function useRestoreTransaction() {
       queryClient.invalidateQueries({ queryKey: ["transactions", "deleted"] });
       queryClient.invalidateQueries({ queryKey: ["trips"] });
       toast.success("Transaction restored");
-    },
-    onError: () => {
-      toast.error("Failed to restore transaction");
     },
   });
 }

--- a/src/client/src/hooks/useTrash.test.ts
+++ b/src/client/src/hooks/useTrash.test.ts
@@ -62,7 +62,7 @@ describe("usePurgeTrash", () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    expect(toast.error).toHaveBeenCalledWith("Failed to empty trash");
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("invalidates all deleted query keys on success", async () => {

--- a/src/client/src/hooks/useTrash.ts
+++ b/src/client/src/hooks/useTrash.ts
@@ -20,8 +20,5 @@ export function usePurgeTrash() {
       });
       toast.success("Trash emptied successfully");
     },
-    onError: () => {
-      toast.error("Failed to empty trash");
-    },
   });
 }

--- a/src/client/src/hooks/useUsers.ts
+++ b/src/client/src/hooks/useUsers.ts
@@ -63,9 +63,6 @@ export function useCreateUser() {
       queryClient.invalidateQueries({ queryKey: ["users"] });
       toast.success("User created");
     },
-    onError: () => {
-      toast.error("Failed to create user");
-    },
   });
 }
 
@@ -99,9 +96,6 @@ export function useUpdateUser(currentUserId?: string) {
         attemptTokenRefresh();
       }
     },
-    onError: () => {
-      toast.error("Failed to update user");
-    },
   });
 }
 
@@ -117,9 +111,6 @@ export function useDeleteUser() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users"] });
       toast.success("User deactivated");
-    },
-    onError: () => {
-      toast.error("Failed to deactivate user");
     },
   });
 }
@@ -146,9 +137,6 @@ export function useResetUserPassword() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users"] });
       toast.success("Password reset successfully");
-    },
-    onError: () => {
-      toast.error("Failed to reset password");
     },
   });
 }

--- a/src/client/src/hooks/useYnab.test.ts
+++ b/src/client/src/hooks/useYnab.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/api-client", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
 }));
 
 import client from "@/lib/api-client";
@@ -160,7 +160,7 @@ describe("useYnab", () => {
     expect(toast.success).toHaveBeenCalledWith("YNAB budget selected");
   });
 
-  it("useSelectYnabBudget shows error toast on failure", async () => {
+  it("useSelectYnabBudget does not toast on failure (surfaced by the global handler)", async () => {
     (client.PUT as Mock).mockResolvedValue({ error: "Failed" });
 
     const { result } = renderHook(() => useSelectYnabBudget(), {
@@ -170,7 +170,7 @@ describe("useYnab", () => {
     await expect(result.current.mutateAsync("budget-123")).rejects.toThrow();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to select YNAB budget");
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 
@@ -281,7 +281,7 @@ describe("useYnab", () => {
     expect(toast.success).toHaveBeenCalledWith("Account mapping removed");
   });
 
-  it("useCreateYnabAccountMapping shows error toast on failure", async () => {
+  it("useCreateYnabAccountMapping does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: "Failed" });
 
     const { result } = renderHook(() => useCreateYnabAccountMapping(), {
@@ -298,7 +298,7 @@ describe("useYnab", () => {
     ).rejects.toThrow();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to create account mapping");
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 
@@ -442,7 +442,7 @@ describe("useYnab", () => {
     expect(toast.success).toHaveBeenCalledWith("Category mapping deleted");
   });
 
-  it("useCreateYnabCategoryMapping shows error toast on failure", async () => {
+  it("useCreateYnabCategoryMapping does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: "Conflict" });
 
     const { result } = renderHook(() => useCreateYnabCategoryMapping(), {
@@ -460,7 +460,7 @@ describe("useYnab", () => {
     ).rejects.toThrow();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to create category mapping");
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 
@@ -501,7 +501,7 @@ describe("useYnab", () => {
     expect(toast.info).toHaveBeenCalledWith("No transactions were synced");
   });
 
-  it("useSyncYnabMemos shows error toast on failure", async () => {
+  it("useSyncYnabMemos does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: "Server error" });
 
     const { result } = renderHook(() => useSyncYnabMemos(), {
@@ -511,7 +511,7 @@ describe("useYnab", () => {
     await expect(result.current.mutateAsync("r-1")).rejects.toThrow();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to sync YNAB memos");
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 
@@ -536,7 +536,7 @@ describe("useYnab", () => {
     expect(toast.success).toHaveBeenCalledWith("Synced 2 transaction memo(s) to YNAB");
   });
 
-  it("useSyncYnabMemosBulk shows error toast on failure", async () => {
+  it("useSyncYnabMemosBulk does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: "Server error" });
 
     const { result } = renderHook(() => useSyncYnabMemosBulk(), {
@@ -546,7 +546,7 @@ describe("useYnab", () => {
     await expect(result.current.mutateAsync(["r-1"])).rejects.toThrow();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to bulk sync YNAB memos");
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 
@@ -574,7 +574,7 @@ describe("useYnab", () => {
     expect(toast.success).toHaveBeenCalledWith("YNAB memo sync resolved");
   });
 
-  it("useResolveYnabMemoSync shows error toast on failure", async () => {
+  it("useResolveYnabMemoSync does not toast on failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({ error: "Server error" });
 
     const { result } = renderHook(() => useResolveYnabMemoSync(), {
@@ -589,7 +589,7 @@ describe("useYnab", () => {
     ).rejects.toThrow();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to resolve YNAB memo sync");
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 
@@ -681,7 +681,7 @@ describe("useYnab", () => {
     );
   });
 
-  it("usePushYnabTransactions shows error toast on failure response", async () => {
+  it("usePushYnabTransactions does not toast on failure (surfaced by the global handler) response", async () => {
     const pushResult = {
       success: false,
       pushedTransactions: [],
@@ -702,7 +702,7 @@ describe("useYnab", () => {
     expect(toast.error).toHaveBeenCalledWith("Unmapped categories found.");
   });
 
-  it("usePushYnabTransactions shows error toast on network failure", async () => {
+  it("usePushYnabTransactions does not toast on network failure (surfaced by the global handler)", async () => {
     (client.POST as Mock).mockResolvedValue({
       error: "Network error",
     });
@@ -714,13 +714,11 @@ describe("useYnab", () => {
     await expect(result.current.mutateAsync("receipt-123")).rejects.toThrow();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "Failed to push transactions to YNAB",
-      );
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 
-  it("useBulkPushYnabTransactions calls POST and shows success toast", async () => {
+  it("useBulkPushYnabTransactions warns (not success) on partial success and lists unmapped categories", async () => {
     const bulkResult = {
       results: [
         {
@@ -729,7 +727,12 @@ describe("useYnab", () => {
         },
         {
           receiptId: "r2",
-          result: { success: false, pushedTransactions: [], error: "Not found" },
+          result: {
+            success: false,
+            pushedTransactions: [],
+            error: "Unmapped categories",
+            unmappedCategories: ["Gas", "Dining"],
+          },
         },
       ],
     };
@@ -750,9 +753,76 @@ describe("useYnab", () => {
         body: { receiptIds: ["r1", "r2"] },
       },
     );
-    expect(toast.success).toHaveBeenCalledWith(
-      "Pushed 1/2 receipt(s) to YNAB",
+    // Partial success must NOT read as a plain success (RECEIPTS-783).
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.warning).toHaveBeenCalledWith(
+      "Pushed 1/2 receipt(s); 1 failed. Unmapped categories: Gas, Dining. Map them in YNAB Settings.",
     );
+  });
+
+  it("useBulkPushYnabTransactions shows an error toast when every receipt fails", async () => {
+    const bulkResult = {
+      results: [
+        {
+          receiptId: "r1",
+          result: {
+            success: false,
+            pushedTransactions: [],
+            error: "Unmapped categories",
+            unmappedCategories: ["Gas"],
+          },
+        },
+        {
+          receiptId: "r2",
+          result: {
+            success: false,
+            pushedTransactions: [],
+            error: "Unmapped categories",
+            unmappedCategories: ["Gas", "Fuel"],
+          },
+        },
+      ],
+    };
+    (client.POST as Mock).mockResolvedValue({
+      data: bulkResult,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useBulkPushYnabTransactions(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync(["r1", "r2"]);
+
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+    // Distinct unmapped categories aggregated across all failed receipts.
+    expect(toast.error).toHaveBeenCalledWith(
+      "Failed to push 2 receipt(s) to YNAB. Unmapped categories: Gas, Fuel. Map them in YNAB Settings.",
+    );
+  });
+
+  it("useBulkPushYnabTransactions shows a success toast when every receipt succeeds", async () => {
+    const bulkResult = {
+      results: [
+        { receiptId: "r1", result: { success: true, pushedTransactions: [], error: null } },
+        { receiptId: "r2", result: { success: true, pushedTransactions: [], error: null } },
+      ],
+    };
+    (client.POST as Mock).mockResolvedValue({
+      data: bulkResult,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useBulkPushYnabTransactions(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync(["r1", "r2"]);
+
+    expect(toast.success).toHaveBeenCalledWith("Pushed 2/2 receipt(s) to YNAB");
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("useAllReceiptIds returns receipt IDs from a single page", async () => {
@@ -960,7 +1030,7 @@ describe("useYnab", () => {
     expect(toast.success).toHaveBeenCalledWith("Cleared 5 stale mapping(s)");
   });
 
-  it("useClearStaleMappings shows error toast on failure", async () => {
+  it("useClearStaleMappings does not toast on failure (surfaced by the global handler)", async () => {
     (client.DELETE as Mock).mockResolvedValue({
       data: undefined,
       error: "Server error",
@@ -971,9 +1041,7 @@ describe("useYnab", () => {
     });
 
     await expect(result.current.mutateAsync()).rejects.toBeDefined();
-    expect(toast.error).toHaveBeenCalledWith(
-      "Failed to clear stale mappings",
-    );
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("useYnabRateLimitStatus returns rate limit data on success", async () => {

--- a/src/client/src/hooks/useYnab.ts
+++ b/src/client/src/hooks/useYnab.ts
@@ -93,9 +93,6 @@ export function useSelectYnabBudget() {
       queryClient.invalidateQueries({ queryKey: ["ynab"] });
       toast.success("YNAB budget selected");
     },
-    onError: () => {
-      toast.error("Failed to select YNAB budget");
-    },
   });
 }
 
@@ -154,9 +151,6 @@ export function useCreateYnabAccountMapping() {
       queryClient.invalidateQueries({ queryKey: ["ynab", "account-mappings"] });
       toast.success("Account mapping created");
     },
-    onError: () => {
-      toast.error("Failed to create account mapping");
-    },
   });
 }
 
@@ -186,9 +180,6 @@ export function useUpdateYnabAccountMapping() {
       queryClient.invalidateQueries({ queryKey: ["ynab", "account-mappings"] });
       toast.success("Account mapping updated");
     },
-    onError: () => {
-      toast.error("Failed to update account mapping");
-    },
   });
 }
 
@@ -207,9 +198,6 @@ export function useDeleteYnabAccountMapping() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["ynab", "account-mappings"] });
       toast.success("Account mapping removed");
-    },
-    onError: () => {
-      toast.error("Failed to remove account mapping");
     },
   });
 }
@@ -313,9 +301,6 @@ export function useCreateYnabCategoryMapping() {
       queryClient.invalidateQueries({ queryKey: ["ynab", "category-mappings"] });
       toast.success("Category mapping created");
     },
-    onError: () => {
-      toast.error("Failed to create category mapping");
-    },
   });
 }
 
@@ -341,9 +326,6 @@ export function useUpdateYnabCategoryMapping() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["ynab", "category-mappings"] });
       toast.success("Category mapping updated");
-    },
-    onError: () => {
-      toast.error("Failed to update category mapping");
     },
   });
 }
@@ -398,9 +380,6 @@ export function useClearStaleMappings() {
         (data?.deletedCategoryMappings ?? 0);
       toast.success(`Cleared ${total} stale mapping(s)`);
     },
-    onError: () => {
-      toast.error("Failed to clear stale mappings");
-    },
   });
 }
 
@@ -417,9 +396,6 @@ export function useDeleteYnabCategoryMapping() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["ynab", "category-mappings"] });
       toast.success("Category mapping deleted");
-    },
-    onError: () => {
-      toast.error("Failed to delete category mapping");
     },
   });
 }
@@ -498,9 +474,6 @@ export function useSyncYnabMemos() {
         toast.info("No transactions were synced");
       }
     },
-    onError: () => {
-      toast.error("Failed to sync YNAB memos");
-    },
   });
 }
 
@@ -521,9 +494,6 @@ export function useSyncYnabMemosBulk() {
         (r) => r.outcome === "Synced",
       ).length;
       toast.success(`Synced ${synced ?? 0} transaction memo(s) to YNAB`);
-    },
-    onError: () => {
-      toast.error("Failed to bulk sync YNAB memos");
     },
   });
 }
@@ -546,9 +516,6 @@ export function useResolveYnabMemoSync() {
       queryClient.invalidateQueries({ queryKey: ["ynab", "sync-status"] });
       queryClient.invalidateQueries({ queryKey: ["ynab", "receipt-sync-statuses"] });
       toast.success("YNAB memo sync resolved");
-    },
-    onError: () => {
-      toast.error("Failed to resolve YNAB memo sync");
     },
   });
 }
@@ -647,9 +614,6 @@ export function usePushYnabTransactions() {
         toast.error(data?.error ?? "Failed to push transactions to YNAB");
       }
     },
-    onError: () => {
-      toast.error("Failed to push transactions to YNAB");
-    },
   });
 }
 
@@ -667,13 +631,37 @@ export function useBulkPushYnabTransactions() {
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["ynab", "sync-status"] });
       queryClient.invalidateQueries({ queryKey: ["ynab", "receipt-sync-statuses"] });
-      const total = data?.results?.length ?? 0;
-      const succeeded =
-        data?.results?.filter((r) => r.result.success).length ?? 0;
-      toast.success(`Pushed ${succeeded}/${total} receipt(s) to YNAB`);
-    },
-    onError: () => {
-      toast.error("Failed to bulk push transactions to YNAB");
+
+      const results = data?.results ?? [];
+      const total = results.length;
+      if (total === 0) return;
+
+      const succeeded = results.filter((r) => r.result.success).length;
+      const failed = total - succeeded;
+
+      // Aggregate the distinct unmapped categories the server reported across
+      // the failed receipts so the user knows exactly what to map (the same
+      // detail the single-receipt push button surfaces). RECEIPTS-783.
+      const unmapped = Array.from(
+        new Set(results.flatMap((r) => r.result.unmappedCategories ?? [])),
+      );
+      const unmappedSuffix = unmapped.length
+        ? ` Unmapped categories: ${unmapped.join(", ")}. Map them in YNAB Settings.`
+        : "";
+
+      if (succeeded === 0) {
+        // Every receipt failed — this is an error, not a success.
+        toast.error(
+          `Failed to push ${failed} receipt(s) to YNAB.${unmappedSuffix}`,
+        );
+      } else if (failed > 0) {
+        // Partial success — warn and name what needs attention.
+        toast.warning(
+          `Pushed ${succeeded}/${total} receipt(s); ${failed} failed.${unmappedSuffix}`,
+        );
+      } else {
+        toast.success(`Pushed ${succeeded}/${total} receipt(s) to YNAB`);
+      }
     },
   });
 }

--- a/src/client/src/lib/format.test.ts
+++ b/src/client/src/lib/format.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { formatCurrency, formatDecimal, parseCurrencyInput, camelToTitle, capitalize, evaluateMathExpression } from "./format";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { formatCurrency, formatDecimal, parseCurrencyInput, camelToTitle, capitalize, evaluateMathExpression, formatDate, formatShortDate, parseDateValue } from "./format";
 
 describe("formatCurrency", () => {
   it("formats a positive number as USD", () => {
@@ -181,6 +181,63 @@ describe("evaluateMathExpression", () => {
 
   it("handles multiplication with decimals", () => {
     expect(evaluateMathExpression("4.50*3")).toBeCloseTo(13.5);
+  });
+});
+
+// RECEIPTS-788: date-only strings ('yyyy-MM-dd') must format to the same
+// calendar day in every timezone. The old `new Date("2024-01-15")` parsed the
+// value as UTC midnight, which formatted to Jan 14 in negative-UTC-offset
+// zones (all of the US). These run under America/New_York (UTC-5) to prove the
+// off-by-one is gone.
+describe("formatDate / formatShortDate (timezone-safe date-only)", () => {
+  const originalTz = process.env.TZ;
+  beforeAll(() => {
+    process.env.TZ = "America/New_York";
+  });
+  afterAll(() => {
+    process.env.TZ = originalTz;
+  });
+
+  it("formatDate keeps the calendar day in a negative-UTC-offset timezone", () => {
+    expect(formatDate("2024-01-15")).toBe("Jan 15, 2024");
+  });
+
+  it("formatDate does NOT shift a day earlier (the old new Date() bug)", () => {
+    // `new Date("2024-01-15")` in America/New_York would render Jan 14.
+    expect(formatDate("2024-01-15")).not.toContain("14");
+  });
+
+  it("formatShortDate returns MMM d for a date-only string", () => {
+    expect(formatShortDate("2024-01-15")).toBe("Jan 15");
+  });
+
+  it("formatDate accepts a custom pattern", () => {
+    expect(formatDate("2024-12-31", "yyyy-MM-dd")).toBe("2024-12-31");
+  });
+
+  it("formatDate returns an em dash for empty/nullish input", () => {
+    expect(formatDate(null)).toBe("—");
+    expect(formatDate(undefined)).toBe("—");
+    expect(formatDate("")).toBe("—");
+  });
+
+  it("formatDate returns the raw value when it can't be parsed", () => {
+    expect(formatDate("not-a-date")).toBe("not-a-date");
+  });
+
+  it("parseDateValue anchors a date-only string to local midnight", () => {
+    const d = parseDateValue("2024-01-15");
+    expect(d).not.toBeNull();
+    expect(d?.getFullYear()).toBe(2024);
+    expect(d?.getMonth()).toBe(0);
+    expect(d?.getDate()).toBe(15);
+    expect(d?.getHours()).toBe(0);
+  });
+
+  it("parseDateValue still handles full ISO datetimes", () => {
+    const d = parseDateValue("2024-01-15T18:30:00Z");
+    expect(d).not.toBeNull();
+    expect(Number.isNaN(d?.getTime())).toBe(false);
   });
 });
 

--- a/src/client/src/lib/format.ts
+++ b/src/client/src/lib/format.ts
@@ -1,8 +1,79 @@
+import { format as formatDateFns, parse, isValid } from "date-fns";
+
 export function formatCurrency(amount: number): string {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
   }).format(amount);
+}
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Parses a date value into a Date anchored in the LOCAL timezone.
+ *
+ * A bare `yyyy-MM-dd` string (how the API serializes `DateOnly`) fed to
+ * `new Date(...)` is parsed as UTC midnight, which formats to the *previous*
+ * day in every negative-UTC-offset timezone (all of the US). Parsing it with
+ * date-fns `parse(value, "yyyy-MM-dd", ...)` instead anchors it to local
+ * midnight so the calendar date is preserved everywhere (RECEIPTS-788).
+ *
+ * Full ISO datetimes (with a time component) still go through `new Date(...)`.
+ * Returns null when the value is empty or cannot be parsed.
+ */
+export function parseDateValue(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  if (DATE_ONLY_PATTERN.test(value)) {
+    const parsed = parse(value, "yyyy-MM-dd", new Date());
+    return isValid(parsed) ? parsed : null;
+  }
+  const fallback = new Date(value);
+  return isValid(fallback) ? fallback : null;
+}
+
+/**
+ * Formats a receipt/transaction date for display, timezone-safe for the
+ * date-only strings the API returns. Falls back to the raw value when the
+ * input can't be parsed and to an em dash when it's empty. Use this (or
+ * `formatShortDate`) for ALL receipt-date display so the list, dashboard, and
+ * widgets always agree on the calendar day (RECEIPTS-788).
+ */
+export function formatDate(
+  value: string | null | undefined,
+  pattern = "MMM d, yyyy",
+): string {
+  if (!value) return "—";
+  const parsed = parseDateValue(value);
+  return parsed ? formatDateFns(parsed, pattern) : value;
+}
+
+/** Short "MMM d" variant of {@link formatDate}, e.g. "Jan 15". */
+export function formatShortDate(value: string | null | undefined): string {
+  return formatDate(value, "MMM d");
+}
+
+/**
+ * True when `value` is a calendar date strictly after today (local time).
+ *
+ * Used to catch the server's "Date cannot be in the future" rejection on the
+ * client so users get inline feedback before submitting (RECEIPTS-782).
+ * Compares date-parts only, so "today" is never considered in the future.
+ */
+export function isFutureDate(value: string | null | undefined): boolean {
+  const parsed = parseDateValue(value);
+  if (!parsed) return false;
+  const now = new Date();
+  const todayStart = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  ).getTime();
+  const valueStart = new Date(
+    parsed.getFullYear(),
+    parsed.getMonth(),
+    parsed.getDate(),
+  ).getTime();
+  return valueStart > todayStart;
 }
 
 export function formatDecimal(value: number, decimals = 2): string {

--- a/src/client/src/lib/global-error-handler.test.ts
+++ b/src/client/src/lib/global-error-handler.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/toast", () => ({
+  showApiError: vi.fn(),
+  showNetworkError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+import { handleGlobalError } from "./global-error-handler";
+import { showApiError, showNetworkError } from "@/lib/toast";
+import { toast } from "sonner";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handleGlobalError", () => {
+  it("passes the ProblemDetails detail to showApiError for a 400", () => {
+    handleGlobalError({
+      status: 400,
+      title: "Bad Request",
+      detail: "Date cannot be in the future",
+    });
+    expect(showApiError).toHaveBeenCalledWith(
+      400,
+      "Date cannot be in the future",
+    );
+  });
+
+  it("falls back to the first field error when detail is absent", () => {
+    handleGlobalError({
+      status: 400,
+      title: "One or more validation errors occurred.",
+      errors: { Date: ["Date cannot be in the future"] },
+    });
+    expect(showApiError).toHaveBeenCalledWith(
+      400,
+      "Date cannot be in the future",
+    );
+  });
+
+  it("passes the 409 duplicate-name detail", () => {
+    handleGlobalError({
+      status: 409,
+      detail: "A card named 'Visa' already exists.",
+    });
+    expect(showApiError).toHaveBeenCalledWith(
+      409,
+      "A card named 'Visa' already exists.",
+    );
+  });
+
+  it("ignores the generic ASP.NET validation title (no useful message)", () => {
+    handleGlobalError({
+      status: 400,
+      title: "One or more validation errors occurred.",
+    });
+    expect(showApiError).toHaveBeenCalledWith(400, undefined);
+  });
+
+  it("passes undefined when the error carries no ProblemDetails text", () => {
+    handleGlobalError({ status: 500 });
+    expect(showApiError).toHaveBeenCalledWith(500, undefined);
+  });
+
+  it("shows a network toast for Chrome's 'Failed to fetch' TypeError", () => {
+    handleGlobalError(new TypeError("Failed to fetch"));
+    expect(showNetworkError).toHaveBeenCalledTimes(1);
+    expect(showApiError).not.toHaveBeenCalled();
+  });
+
+  it("shows a network toast for Firefox's network TypeError", () => {
+    handleGlobalError(
+      new TypeError("NetworkError when attempting to fetch resource."),
+    );
+    expect(showNetworkError).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a network toast for Safari's 'Load failed' TypeError", () => {
+    handleGlobalError(new TypeError("Load failed"));
+    expect(showNetworkError).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a timeout toast for a TimeoutError DOMException", () => {
+    handleGlobalError(new DOMException("timed out", "TimeoutError"));
+    expect(toast.error).toHaveBeenCalledWith(
+      "Request timed out. Please try again.",
+    );
+    expect(showApiError).not.toHaveBeenCalled();
+    expect(showNetworkError).not.toHaveBeenCalled();
+  });
+});

--- a/src/client/src/lib/global-error-handler.ts
+++ b/src/client/src/lib/global-error-handler.ts
@@ -1,0 +1,44 @@
+import { toast } from "sonner";
+import { showApiError, showNetworkError } from "@/lib/toast";
+import { isTimeoutError, isNetworkError } from "@/lib/api-client";
+import { extractErrorMessage } from "@/lib/problem-details";
+
+/**
+ * Single source of truth for surfacing query/mutation errors as toasts.
+ *
+ * Wired into React Query's `QueryCache` and `MutationCache` `onError` so every
+ * failed request produces exactly one actionable toast. Individual mutation
+ * hooks no longer toast generic "Failed to X" strings (RECEIPTS-782); they let
+ * this handler surface the real server message instead.
+ */
+export function handleGlobalError(error: unknown) {
+  if (isTimeoutError(error)) {
+    toast.error("Request timed out. Please try again.");
+    return;
+  }
+
+  if (
+    error &&
+    typeof error === "object" &&
+    "status" in error &&
+    typeof (error as Record<string, unknown>).status === "number"
+  ) {
+    // Surface the server's ProblemDetails message (400 "Date cannot be in the
+    // future", 409 duplicate-name, field validation) instead of a bare status.
+    showApiError(
+      (error as Record<string, unknown>).status as number,
+      extractErrorMessage(error),
+    );
+    return;
+  }
+
+  // Network failures throw a TypeError whose message varies by browser
+  // ("Failed to fetch" in Chrome, "NetworkError when attempting to fetch
+  // resource" in Firefox, "Load failed" in Safari). Match the error *type*
+  // rather than an exact string so non-Chrome users still get a toast
+  // (RECEIPTS-784).
+  if (isNetworkError(error) || error instanceof TypeError) {
+    showNetworkError();
+    return;
+  }
+}

--- a/src/client/src/lib/problem-details.test.ts
+++ b/src/client/src/lib/problem-details.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseProblemDetails,
   extractFieldErrors,
+  extractErrorMessage,
   type ProblemDetailsError,
 } from "./problem-details";
 
@@ -95,5 +96,49 @@ describe("extractFieldErrors", () => {
 
     const result = extractFieldErrors(problem);
     expect(result).toEqual({ type: "Required" });
+  });
+});
+
+describe("extractErrorMessage", () => {
+  it("returns undefined for non-ProblemDetails errors", () => {
+    expect(extractErrorMessage(null)).toBeUndefined();
+    expect(extractErrorMessage({ message: "boom" })).toBeUndefined();
+    expect(extractErrorMessage("boom")).toBeUndefined();
+  });
+
+  it("prefers detail over field errors and title", () => {
+    expect(
+      extractErrorMessage({
+        status: 400,
+        title: "Bad Request",
+        detail: "Date cannot be in the future",
+        errors: { Date: ["ignored"] },
+      }),
+    ).toBe("Date cannot be in the future");
+  });
+
+  it("falls back to the first field error when detail is absent", () => {
+    expect(
+      extractErrorMessage({
+        status: 400,
+        title: "One or more validation errors occurred.",
+        errors: { Date: ["Date cannot be in the future"] },
+      }),
+    ).toBe("Date cannot be in the future");
+  });
+
+  it("uses a specific title when there is no detail or field error", () => {
+    expect(extractErrorMessage({ status: 409, title: "Conflict" })).toBe(
+      "Conflict",
+    );
+  });
+
+  it("ignores the generic ASP.NET validation title", () => {
+    expect(
+      extractErrorMessage({
+        status: 400,
+        title: "One or more validation errors occurred.",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/client/src/lib/problem-details.ts
+++ b/src/client/src/lib/problem-details.ts
@@ -51,3 +51,33 @@ export function extractFieldErrors(
 
   return result;
 }
+
+// ASP.NET emits this generic title for any ValidationProblemDetails; the
+// useful, actionable text lives in `errors` (field messages), so we prefer a
+// field message over this boilerplate title.
+const GENERIC_VALIDATION_TITLE = "One or more validation errors occurred.";
+
+/**
+ * Derives the single most actionable human-readable message from an error
+ * thrown by openapi-fetch (which throws the ProblemDetails response body).
+ *
+ * Priority: `detail` (specific 4xx/409 messages like "Date cannot be in the
+ * future" or "A card named X already exists") → first field-level validation
+ * error → `title`. Returns undefined when the error isn't ProblemDetails-shaped
+ * so callers can fall back to a status-based default. RECEIPTS-782.
+ */
+export function extractErrorMessage(error: unknown): string | undefined {
+  const problem = parseProblemDetails(error);
+  if (!problem) return undefined;
+
+  const detail = problem.detail?.trim();
+  if (detail) return detail;
+
+  const firstFieldError = Object.values(extractFieldErrors(problem))[0];
+  if (firstFieldError) return firstFieldError;
+
+  const title = problem.title?.trim();
+  if (title && title !== GENERIC_VALIDATION_TITLE) return title;
+
+  return undefined;
+}

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -7,10 +7,8 @@ import {
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
-import { toast } from "sonner";
-import { showApiError, showNetworkError } from "@/lib/toast";
-import { isTimeoutError } from "@/lib/api-client";
 import { sentryCreateBrowserRouter } from "@/lib/sentry";
+import { handleGlobalError } from "@/lib/global-error-handler";
 import { AppearanceProvider } from "@/contexts/AppearanceContext";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/contexts/AuthContext";
@@ -19,28 +17,6 @@ import { routeConfig } from "./App.tsx";
 import "./index.css";
 
 const router = sentryCreateBrowserRouter(routeConfig);
-
-function handleGlobalError(error: unknown) {
-  if (isTimeoutError(error)) {
-    toast.error("Request timed out. Please try again.");
-    return;
-  }
-
-  if (
-    error &&
-    typeof error === "object" &&
-    "status" in error &&
-    typeof (error as Record<string, unknown>).status === "number"
-  ) {
-    showApiError((error as Record<string, unknown>).status as number);
-    return;
-  }
-
-  if (error instanceof TypeError && error.message === "Failed to fetch") {
-    showNetworkError();
-    return;
-  }
-}
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/client/src/pages/Dashboard.tsx
+++ b/src/client/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 import { format, subMonths } from "date-fns";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReceipts } from "@/hooks/useReceipts";
+import { formatShortDate } from "@/lib/format";
 import type { DateRange } from "@/hooks/useDashboard";
 import { PageHead, Icon } from "@/components/primitives";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -29,12 +30,6 @@ function formatMoney(value: number | string | null | undefined): string {
   }).format(n);
 }
 
-function formatShortDate(value: string | null | undefined): string {
-  if (!value) return "—";
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return value;
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-}
 
 function Dashboard() {
   usePageTitle("Dashboard");

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -548,4 +548,86 @@ describe("Receipts", () => {
       screen.getByRole("heading", { name: /create receipt/i }),
     ).toBeInTheDocument();
   });
+
+  // RECEIPTS-784: a failed query must render an error state (with retry), not
+  // the "No receipts yet" empty state.
+  it("renders an ErrorState with a working Retry button when the query fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const refetch = vi.fn();
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useReceipts).mockReturnValue(
+      mockQueryResult({
+        data: [],
+        total: 0,
+        isLoading: false,
+        isError: true,
+        isRefetching: false,
+        refetch,
+      }),
+    );
+
+    renderWithProviders(<Receipts />);
+
+    expect(screen.getByText(/couldn't load receipts/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no receipts yet/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  // RECEIPTS-783: after a partial bulk YNAB push, only the succeeded receipts
+  // are deselected — failed ones stay selected so the user can retry.
+  it("keeps failed receipts selected after a partial bulk YNAB push", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const items = [
+      mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }),
+      mockReceiptResponse({ id: "2", location: "Target", date: "2024-01-20", taxAmount: 3.5 }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useReceipts).mockReturnValue(mockQueryResult({
+      data: items,
+      total: items.length,
+      isLoading: false,
+    }));
+
+    const bulkMutate = vi.fn(
+      (_ids: string[], opts?: { onSuccess?: (data: unknown) => void }) => {
+        opts?.onSuccess?.({
+          results: [
+            { receiptId: "1", result: { success: true, pushedTransactions: [] } },
+            { receiptId: "2", result: { success: false, pushedTransactions: [], error: "nope" } },
+          ],
+        });
+      },
+    );
+    const { useBulkPushYnabTransactions } = await import("@/hooks/useYnab");
+    vi.mocked(useBulkPushYnabTransactions).mockReturnValue(
+      mockMutationResult({ mutate: bulkMutate, isPending: false }),
+    );
+
+    renderWithProviders(<Receipts />);
+
+    await user.click(screen.getByLabelText("Select all rows"));
+    const bar = await screen.findByRole("region", { name: "Bulk actions" });
+    expect(bar).toHaveTextContent(/2.*receipts selected/);
+
+    await user.click(screen.getByRole("button", { name: /push to ynab/i }));
+
+    expect(bulkMutate).toHaveBeenCalledWith(["1", "2"], expect.any(Object));
+    // r1 pushed (cleared); r2 failed (still selected) → "1 of 2 receipt selected".
+    expect(
+      screen.getByRole("region", { name: "Bulk actions" }),
+    ).toHaveTextContent(/1 of 2 receipt selected/);
+  });
 });

--- a/src/client/src/pages/Receipts.test.tsx
+++ b/src/client/src/pages/Receipts.test.tsx
@@ -575,6 +575,45 @@ describe("Receipts", () => {
     expect(refetch).toHaveBeenCalled();
   });
 
+  // RECEIPTS-784 (regression guard): a background refetch that errors while
+  // rows are already cached must NOT blank the list with the ErrorState — the
+  // data stays on screen (the global toast surfaces the transient failure).
+  it("keeps the list visible when a background refetch fails but data is cached", async () => {
+    const items = [
+      mockReceiptResponse({ id: "1", location: "Walmart", date: "2024-01-15", taxAmount: 5.25 }),
+      mockReceiptResponse({ id: "2", location: "Target", date: "2024-01-20", taxAmount: 3.5 }),
+    ];
+
+    const { useFuzzySearch } = await import("@/hooks/useFuzzySearch");
+    vi.mocked(useFuzzySearch).mockReturnValue(mockQueryResult({
+      search: "",
+      setSearch: vi.fn(),
+      results: items.map((item) => ({ item, matches: [], score: 0, refIndex: 0 })),
+      totalCount: items.length,
+      isSearching: false,
+      clearSearch: vi.fn(),
+    }));
+
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    vi.mocked(useReceipts).mockReturnValue(
+      mockQueryResult({
+        data: items,
+        total: items.length,
+        isLoading: false,
+        // Refetch-after-success failure: error is set but cached rows remain.
+        isError: true,
+        isRefetching: true,
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderWithProviders(<Receipts />);
+
+    expect(screen.getByText("Walmart")).toBeInTheDocument();
+    expect(screen.getByText("Target")).toBeInTheDocument();
+    expect(screen.queryByText(/couldn't load receipts/i)).not.toBeInTheDocument();
+  });
+
   // RECEIPTS-783: after a partial bulk YNAB push, only the succeeded receipts
   // are deselected — failed ones stay selected so the user can retry.
   it("keeps failed receipts selected after a partial bulk YNAB push", async () => {

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -26,6 +26,7 @@ import { SearchHighlight } from "@/components/SearchHighlight";
 import { getMatchIndices } from "@/lib/search-highlight";
 import { SortableTableHead } from "@/components/SortableTableHead";
 import { NoResults } from "@/components/NoResults";
+import { ErrorState } from "@/components/ErrorState";
 import { Pagination } from "@/components/Pagination";
 import {
   Dialog,
@@ -35,7 +36,7 @@ import {
 } from "@/components/ui/dialog";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { formatCurrency } from "@/lib/format";
+import { formatCurrency, formatDate } from "@/lib/format";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Info } from "lucide-react";
 import {
@@ -113,6 +114,9 @@ function Receipts() {
     data: receiptsData,
     total: serverTotal,
     isLoading,
+    isError,
+    isRefetching,
+    refetch,
   } = useReceipts(
     offset,
     limit,
@@ -311,7 +315,15 @@ function Receipts() {
         </Alert>
       )}
 
-      {isLoading ? (
+      {isError ? (
+        // A failed query must not masquerade as an empty list (RECEIPTS-784).
+        <ErrorState
+          title="Couldn't load receipts"
+          message="Something went wrong loading your receipts. Check your connection and try again."
+          onRetry={() => void refetch()}
+          isRetrying={isRefetching}
+        />
+      ) : isLoading ? (
         <TableSkeleton columns={6} />
       ) : filteredResults.length === 0 ? (
         // Three-way split: search vs. filters vs. genuinely empty. The
@@ -483,7 +495,7 @@ function Receipts() {
                         className="num"
                         style={{ color: "var(--mute)", fontSize: 12 }}
                       >
-                        {receipt.date}
+                        {formatDate(receipt.date)}
                       </td>
                       <td className="money">
                         {formatCurrency(receipt.taxAmount)}
@@ -536,7 +548,20 @@ function Receipts() {
             onDelete={() => setDeleteOpen(true)}
             onPushToYnab={() => {
               bulkPushYnab.mutate(Array.from(selected), {
-                onSuccess: () => setSelected(new Set()),
+                onSuccess: (data) => {
+                  // Only clear the receipts that actually pushed; keep the
+                  // failed ones selected so the user can retry. RECEIPTS-783.
+                  const succeededIds = new Set(
+                    (data?.results ?? [])
+                      .filter((r) => r.result.success)
+                      .map((r) => r.receiptId),
+                  );
+                  setSelected((prev) => {
+                    const next = new Set(prev);
+                    for (const id of succeededIds) next.delete(id);
+                    return next;
+                  });
+                },
               });
             }}
             isPushingToYnab={bulkPushYnab.isPending}

--- a/src/client/src/pages/Receipts.tsx
+++ b/src/client/src/pages/Receipts.tsx
@@ -315,8 +315,11 @@ function Receipts() {
         </Alert>
       )}
 
-      {isError ? (
-        // A failed query must not masquerade as an empty list (RECEIPTS-784).
+      {isError && data.length === 0 ? (
+        // A *failed initial load* (error with no cached rows) must not
+        // masquerade as an empty list (RECEIPTS-784). A background-refetch
+        // error while rows are already on screen keeps the data visible —
+        // the global handler still toasts the failure.
         <ErrorState
           title="Couldn't load receipts"
           message="Something went wrong loading your receipts. Check your connection and try again."

--- a/src/client/src/pages/RecycleBin.test.tsx
+++ b/src/client/src/pages/RecycleBin.test.tsx
@@ -393,4 +393,44 @@ describe("RecycleBin", () => {
     await user.click(screen.getByRole("button", { name: /try again/i }));
     expect(refetch).toHaveBeenCalled();
   });
+
+  // RECEIPTS-784 (regression guard): a background-refetch error on ONE of the
+  // six queries while data is present must NOT blank the whole bin.
+  it("keeps deleted items visible when one query's refetch fails but data is present", async () => {
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    const { useDeletedReceiptItems } = await import("@/hooks/useReceiptItems");
+    const { useDeletedTransactions } = await import("@/hooks/useTransactions");
+    const { useDeletedItemTemplates } = await import("@/hooks/useItemTemplates");
+    const { useDeletedCategories } = await import("@/hooks/useCategories");
+    const { useDeletedSubcategories } = await import("@/hooks/useSubcategories");
+
+    // Receipts query still holds a cached row but its background refetch errored.
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+      isError: true,
+      isRefetching: true,
+      refetch: vi.fn(),
+    }));
+    for (const hook of [
+      useDeletedReceiptItems,
+      useDeletedTransactions,
+      useDeletedItemTemplates,
+      useDeletedCategories,
+      useDeletedSubcategories,
+    ]) {
+      vi.mocked(hook).mockReturnValue(
+        mockQueryResult({ data: [], total: 0, isLoading: false }),
+      );
+    }
+
+    renderWithProviders(<RecycleBin />);
+
+    // The bin still renders the cached row, not the full-page error state.
+    expect(screen.getByText("Store - 2026-01-01")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't load the recycle bin/i),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/client/src/pages/RecycleBin.test.tsx
+++ b/src/client/src/pages/RecycleBin.test.tsx
@@ -345,4 +345,52 @@ describe("RecycleBin", () => {
     renderWithProviders(<RecycleBin />);
     expect(screen.getByText(/emptying/i)).toBeInTheDocument();
   });
+
+  // RECEIPTS-784: a failed deleted-items query must show an error state with a
+  // Retry, not the misleading "No deleted items found" empty state.
+  it("renders an ErrorState with a working Retry when a query fails", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const refetch = vi.fn();
+
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    const { useDeletedReceiptItems } = await import("@/hooks/useReceiptItems");
+    const { useDeletedTransactions } = await import("@/hooks/useTransactions");
+    const { useDeletedItemTemplates } = await import("@/hooks/useItemTemplates");
+    const { useDeletedCategories } = await import("@/hooks/useCategories");
+    const { useDeletedSubcategories } = await import("@/hooks/useSubcategories");
+
+    // The receipts query fails; the rest succeed. All must expose refetch since
+    // Retry re-runs every deleted-entity query.
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: undefined,
+      total: 0,
+      isLoading: false,
+      isError: true,
+      isRefetching: false,
+      refetch,
+    }));
+    for (const hook of [
+      useDeletedReceiptItems,
+      useDeletedTransactions,
+      useDeletedItemTemplates,
+      useDeletedCategories,
+      useDeletedSubcategories,
+    ]) {
+      vi.mocked(hook).mockReturnValue(
+        mockQueryResult({ data: [], total: 0, isLoading: false }),
+      );
+    }
+
+    renderWithProviders(<RecycleBin />);
+
+    expect(
+      screen.getByText(/couldn't load the recycle bin/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/no deleted items found/i),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+    expect(refetch).toHaveBeenCalled();
+  });
 });

--- a/src/client/src/pages/RecycleBin.tsx
+++ b/src/client/src/pages/RecycleBin.tsx
@@ -207,8 +207,10 @@ function RecycleBin() {
     categories.isLoading ||
     subcategories.isLoading;
 
-  // If ANY of the deleted-entity queries failed, surface an error state rather
-  // than rendering a misleading "No deleted items found" (RECEIPTS-784).
+  // If a deleted-entity query failed, we only want the full-page error state
+  // when there's genuinely nothing to show — otherwise a background-refetch
+  // blip on one of the six queries would blank a bin that still has data from
+  // the other five (RECEIPTS-784). The no-data gate is applied at the return.
   const isError =
     receipts.isError ||
     receiptItems.isError ||
@@ -318,7 +320,7 @@ function RecycleBin() {
     return map;
   }, [allItems]);
 
-  if (isError) {
+  if (isError && allItems.length === 0) {
     return (
       <>
         <PageHead title="Trash" sub="Couldn't load" />

--- a/src/client/src/pages/RecycleBin.tsx
+++ b/src/client/src/pages/RecycleBin.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { Trash2 } from "lucide-react";
 import { useListKeyboardNav } from "@/hooks/useListKeyboardNav";
+import { ErrorState } from "@/components/ErrorState";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useDeletedReceipts, useRestoreReceipt } from "@/hooks/useReceipts";
 import {
@@ -206,6 +207,40 @@ function RecycleBin() {
     categories.isLoading ||
     subcategories.isLoading;
 
+  // If ANY of the deleted-entity queries failed, surface an error state rather
+  // than rendering a misleading "No deleted items found" (RECEIPTS-784).
+  const isError =
+    receipts.isError ||
+    receiptItems.isError ||
+    transactions.isError ||
+    itemTemplates.isError ||
+    categories.isError ||
+    subcategories.isError;
+
+  const isRefetching =
+    receipts.isRefetching ||
+    receiptItems.isRefetching ||
+    transactions.isRefetching ||
+    itemTemplates.isRefetching ||
+    categories.isRefetching ||
+    subcategories.isRefetching;
+
+  const refetchAll = useCallback(() => {
+    void receipts.refetch();
+    void receiptItems.refetch();
+    void transactions.refetch();
+    void itemTemplates.refetch();
+    void categories.refetch();
+    void subcategories.refetch();
+  }, [
+    receipts,
+    receiptItems,
+    transactions,
+    itemTemplates,
+    categories,
+    subcategories,
+  ]);
+
   const allItems = useMemo(() => {
     const items: DeletedItem[] = [];
 
@@ -282,6 +317,20 @@ function RecycleBin() {
     }
     return map;
   }, [allItems]);
+
+  if (isError) {
+    return (
+      <>
+        <PageHead title="Trash" sub="Couldn't load" />
+        <ErrorState
+          title="Couldn't load the recycle bin"
+          message="Something went wrong loading deleted items. Check your connection and try again."
+          onRetry={refetchAll}
+          isRetrying={isRefetching}
+        />
+      </>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.test.tsx
@@ -27,11 +27,35 @@ vi.mock("@/hooks/useLocationHistory", () => ({
 }));
 
 const mockNavigate = vi.fn();
+
+type BlockerLike = {
+  state: "unblocked" | "blocked" | "proceeding";
+  proceed: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+};
+const mockBlocker: BlockerLike = {
+  state: "unblocked",
+  proceed: vi.fn(),
+  reset: vi.fn(),
+};
+type ShouldBlock = (args: {
+  currentLocation: { pathname: string };
+  nextLocation: { pathname: string };
+}) => boolean;
+let capturedShouldBlock: ShouldBlock | undefined;
+
 vi.mock("react-router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-router")>();
   return {
     ...actual,
     useNavigate: vi.fn(() => mockNavigate),
+    // MemoryRouter (used by the test wrapper) is not a data router, so the real
+    // useBlocker would throw. Capture the predicate so tests can exercise the
+    // "has unsaved data" gate directly, and return a controllable blocker.
+    useBlocker: (shouldBlock: ShouldBlock) => {
+      capturedShouldBlock = shouldBlock;
+      return mockBlocker;
+    },
   };
 });
 
@@ -116,6 +140,8 @@ vi.mock("./BalanceSidebar", () => ({
 describe("NewReceiptPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockBlocker.state = "unblocked";
+    capturedShouldBlock = undefined;
     mockCreateCompleteReceiptAsync.mockResolvedValue({
       receipt: { id: "receipt-123" },
       transactions: [],
@@ -410,5 +436,85 @@ describe("NewReceiptPage", () => {
       expect(liveRegion).not.toBeNull();
       expect(liveRegion?.textContent?.trim()).toBeTruthy();
     });
+  });
+
+  // RECEIPTS-785 — unsaved-work guard (useBlocker + discard dialog).
+  it("blocks in-app navigation when there is unsaved data (but not same-path)", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Enter data via the (mocked) transactions section.
+    await user.click(screen.getAllByText("Add Transaction")[0]);
+
+    expect(capturedShouldBlock).toBeDefined();
+    // Navigating away from /receipts/new is blocked...
+    expect(
+      capturedShouldBlock!({
+        currentLocation: { pathname: "/receipts/new" },
+        nextLocation: { pathname: "/dashboard" },
+      }),
+    ).toBe(true);
+    // ...but a same-path navigation is not.
+    expect(
+      capturedShouldBlock!({
+        currentLocation: { pathname: "/receipts/new" },
+        nextLocation: { pathname: "/receipts/new" },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not block navigation when the form is empty", () => {
+    renderWithProviders(<NewReceiptPage />);
+    expect(capturedShouldBlock).toBeDefined();
+    expect(
+      capturedShouldBlock!({
+        currentLocation: { pathname: "/receipts/new" },
+        nextLocation: { pathname: "/dashboard" },
+      }),
+    ).toBe(false);
+  });
+
+  it("stops blocking after a successful save", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewReceiptPage />);
+
+    // Fill header + add a transaction and an item so the submit succeeds.
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const walmart = await screen.findByText("Walmart");
+    await user.click(walmart);
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    await user.click(dateInput);
+    await user.type(dateInput, "01/15/2024");
+    await user.click(screen.getAllByText("Add Transaction")[0]);
+    await user.click(screen.getAllByText("Add Item")[0]);
+
+    await user.click(screen.getAllByText("Submit Receipt")[0]);
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/receipts/receipt-123");
+    });
+
+    // The guard must not block the post-save redirect.
+    expect(
+      capturedShouldBlock!({
+        currentLocation: { pathname: "/receipts/new" },
+        nextLocation: { pathname: "/receipts/receipt-123" },
+      }),
+    ).toBe(false);
+  });
+
+  it("opens the discard dialog when the blocker reports a blocked navigation", () => {
+    mockBlocker.state = "blocked";
+    renderWithProviders(<NewReceiptPage />);
+    expect(screen.getByText("Discard receipt?")).toBeInTheDocument();
+  });
+
+  it("proceeds the blocked navigation when Discard is confirmed", async () => {
+    const user = userEvent.setup();
+    mockBlocker.state = "blocked";
+    renderWithProviders(<NewReceiptPage />);
+
+    await user.click(screen.getByText("Discard"));
+    expect(mockBlocker.proceed).toHaveBeenCalled();
   });
 });

--- a/src/client/src/pages/new-receipt/NewReceiptPage.tsx
+++ b/src/client/src/pages/new-receipt/NewReceiptPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useId } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useBlocker } from "react-router";
 import { useForm } from "react-hook-form";
 import { z } from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -17,7 +17,7 @@ import { DateInput } from "@/components/ui/date-input";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { formatCurrency } from "@/lib/format";
+import { formatCurrency, isFutureDate } from "@/lib/format";
 import {
   Form,
   FormControl,
@@ -43,7 +43,10 @@ const headerSchema = z.object({
     .string()
     .min(1, "Location is required")
     .max(200, "Location must be 200 characters or fewer"),
-  date: z.string().min(1, "Date is required"),
+  date: z
+    .string()
+    .min(1, "Date is required")
+    .refine((v) => !isFutureDate(v), "Date cannot be in the future"),
   taxAmount: z.number().min(0, "Tax amount must be non-negative"),
 });
 
@@ -113,6 +116,52 @@ export default function NewReceiptPage() {
     transactions.length > 0 ||
     items.length > 0;
 
+  // Tracks a successful save (so we don't block the post-save redirect) and an
+  // in-flight discard decision (so the dialog's close handler doesn't cancel a
+  // navigation we deliberately let through). RECEIPTS-785.
+  const hasSavedRef = useRef(false);
+  const proceedingRef = useRef(false);
+  const discardingRef = useRef(false);
+
+  // Intercept in-app navigation (sidebar links, the g>r chord, browser
+  // back/forward) whenever there's unsaved data, so a long manual entry isn't
+  // silently destroyed. Inert when the form is empty or after a successful save.
+  const blocker = useBlocker(
+    useCallback(
+      ({
+        currentLocation,
+        nextLocation,
+      }: {
+        currentLocation: { pathname: string };
+        nextLocation: { pathname: string };
+      }) =>
+        hasData &&
+        !hasSavedRef.current &&
+        !discardingRef.current &&
+        currentLocation.pathname !== nextLocation.pathname,
+      [hasData],
+    ),
+  );
+
+  // Surface the existing discard dialog when the blocker trips.
+  useEffect(() => {
+    if (blocker.state === "blocked") {
+      setShowDiscard(true);
+    }
+  }, [blocker.state]);
+
+  // Warn on hard exits the in-app blocker can't see: refresh, tab/window close,
+  // and full-page browser navigation.
+  useEffect(() => {
+    if (!hasData) return;
+    function onBeforeUnload(e: BeforeUnloadEvent) {
+      e.preventDefault();
+      e.returnValue = "";
+    }
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [hasData]);
+
   const handleCancel = useCallback(() => {
     if (hasData) {
       setShowDiscard(true);
@@ -123,8 +172,29 @@ export default function NewReceiptPage() {
 
   const handleDiscard = useCallback(() => {
     setShowDiscard(false);
-    navigate("/receipts");
-  }, [navigate]);
+    if (blocker.state === "blocked") {
+      // A real navigation is pending (sidebar link, back button) — let it go.
+      proceedingRef.current = true;
+      blocker.proceed();
+    } else {
+      // Dialog was opened by the Cancel button; navigate past the blocker.
+      discardingRef.current = true;
+      navigate("/receipts");
+    }
+  }, [blocker, navigate]);
+
+  const handleDiscardDialogOpenChange = useCallback(
+    (open: boolean) => {
+      setShowDiscard(open);
+      // Closing without choosing "Discard" (Continue editing, Escape) means the
+      // user is staying — release any pending navigation block.
+      if (!open && !proceedingRef.current && blocker.state === "blocked") {
+        blocker.reset();
+      }
+      if (!open) proceedingRef.current = false;
+    },
+    [blocker],
+  );
 
   const handleSubmit = useCallback(async () => {
     // Validate header form first
@@ -183,6 +253,9 @@ export default function NewReceiptPage() {
 
       const receiptId = (result as { receipt: { id: string } }).receipt.id;
 
+      // Mark saved BEFORE navigating so the unsaved-work blocker lets the
+      // success redirect through (RECEIPTS-785).
+      hasSavedRef.current = true;
       toast.success("Receipt created successfully!");
       navigate(`/receipts/${receiptId}`);
     } catch {
@@ -332,7 +405,7 @@ export default function NewReceiptPage() {
         </div>
       </div>
 
-      <AlertDialog open={showDiscard} onOpenChange={setShowDiscard}>
+      <AlertDialog open={showDiscard} onOpenChange={handleDiscardDialogOpenChange}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Discard receipt?</AlertDialogTitle>


### PR DESCRIPTION
Fixes five confirmed client UX correctness findings in the React client. Theme: the client must show the user correct, actionable feedback and never lose their work. One logical commit per fix.

## Fix 1 — RECEIPTS-782: server error messages were swallowed
Backend `ProblemDetails` (400 "Date cannot be in the future", 409 duplicate-name, field validation) never reached the user — the global `MutationCache` handler called `showApiError(status)` with no message while ~50 hooks toasted a generic "Failed to X".
- New `extractErrorMessage` (detail → first field error → specific title, ignoring ASP.NET's generic validation title), passed to `showApiError`.
- Global handler moved to `lib/global-error-handler.ts` and made the **single error-toast source**; **51 per-hook generic `onError` toasts removed across 15 hooks** (rollback logic and bespoke conflict messages kept — they fall through to the global handler for non-conflict errors).
- Network detection broadened from exact `'Failed to fetch'` to `isNetworkError()` + `TypeError` catch-all so Firefox/Safari network errors toast.
- Client-side future-date validation (`isFutureDate`) added to `ReceiptForm` and the New Receipt header.

## Fix 2 — RECEIPTS-783: bulk YNAB push showed success even when all failed
`useBulkPushYnabTransactions` now branches: `toast.error` when 0 succeed, a warning listing the distinct unmapped categories on partial success, success only when all push. `Receipts.tsx` keeps the **failed receipt ids selected** (only clears succeeded ones) so the user can retry.

## Fix 3 — RECEIPTS-784: failed list queries rendered the empty state
New shared `ErrorState` (empty-state markup + Retry wired to `refetch`) and an `isError` branch added to `Receipts` and `RecycleBin`. Global handler now uses `isNetworkError` + a `TypeError` catch-all so non-Chrome network errors still toast.

## Fix 4 — RECEIPTS-785: New Receipt page destroyed entered data on any exit
`react-router` `useBlocker` (app uses `createBrowserRouter`, a data router — `useBlocker` supported) gated on "has unsaved data" intercepts in-app navigation (sidebar links, `g>r`, back) and reuses the existing discard dialog; a `beforeunload` listener covers refresh/close. Inert when empty or after a successful save.

## Fix 5 — RECEIPTS-788: dashboard showed dates one day early
Date-only `'yyyy-MM-dd'` fed to `new Date(...)` parses as UTC midnight → shifts back a day in negative-UTC-offset timezones. New shared `parseDateValue`/`formatDate`/`formatShortDate` parse date-only strings as local dates; used by the dashboard, the Recent Receipts widget, and the Receipts list so all receipt-date display agrees.

## Validation
- `npx tsc -b` clean; `npm run lint` clean (only 2 pre-existing baseline warnings, unrelated); `npx vitest run` — **2150 passed**.
- Tests added: global-handler ProblemDetails extraction; `extractErrorMessage`; `formatDate` timezone-safety (runs under America/New_York); bulk-push error/partial/success toasts; Receipts failed-selection retention; Receipts & RecycleBin `isError` ErrorState + Retry; New Receipt blocker fires with data / not when empty / stops after save; ReceiptForm future-date rejection.
- Tests updated to the corrected behavior: ~37 hook "shows error toast on failure" assertions now assert the hook does **not** toast (global handler owns it); the bulk-push "always success" test now asserts warning/error branches.

Closes RECEIPTS-782, RECEIPTS-783, RECEIPTS-784, RECEIPTS-785, RECEIPTS-788

🤖 Generated with [Claude Code](https://claude.com/claude-code)
