### PR TITLE
fix(infrastructure): cut api-key write amplification, index receipts.date, paginate reports in sql

### DIFF
--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -337,7 +337,13 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
 	private List<AuditEntry> CollectAuditEntries()
 	{
-		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity), typeof(SeedHistoryEntry), typeof(YnabSyncRecordEntity), typeof(YnabSelectedBudgetEntity), typeof(YnabAccountMappingEntity), typeof(YnabCategoryMappingEntity), typeof(YnabServerKnowledgeEntity), typeof(YnabSyncEventEntity), typeof(DistinctDescriptionEntity), typeof(ItemSimilarityEdgeEntity)];
+		// ApiKeyEntity is excluded because the auth hot path stamps LastUsedAt on every
+		// authenticated request (RECEIPTS-769). A LastUsedAt bump is telemetry, not an
+		// audit-worthy mutation, and auditing it would grow AuditLogs unbounded — one row
+		// per API request. The service stamps LastUsedAt via ExecuteUpdate (which bypasses
+		// the change tracker and this interceptor entirely); this exclusion is belt-and-braces
+		// so any future tracked write to an ApiKey (create/revoke) also stays out of the log.
+		HashSet<Type> excludedTypes = [typeof(AuditLogEntity), typeof(AuthAuditLogEntity), typeof(SeedHistoryEntry), typeof(YnabSyncRecordEntity), typeof(YnabSelectedBudgetEntity), typeof(YnabAccountMappingEntity), typeof(YnabCategoryMappingEntity), typeof(YnabServerKnowledgeEntity), typeof(YnabSyncEventEntity), typeof(DistinctDescriptionEntity), typeof(ItemSimilarityEdgeEntity), typeof(ApiKeyEntity)];
 		List<AuditEntry> auditEntries = [];
 		DateTimeOffset now = DateTimeOffset.UtcNow;
 

--- a/src/Infrastructure/Configurations/ReceiptEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/ReceiptEntityConfiguration.cs
@@ -22,6 +22,14 @@ public class ReceiptEntityConfiguration : IEntityTypeConfiguration<ReceiptEntity
 		builder.Property(e => e.ProcessedImagePath)
 			.HasMaxLength(1024);
 
+		// RECEIPTS-787: the default receipt list sorts by Date desc with offset pagination and
+		// every DashboardService/report method filters Date within a range — all under the
+		// DeletedAt IS NULL soft-delete filter. Without this the Receipts table has only its PK,
+		// forcing a full scan + sort. A filtered index on Date (partial to active rows) serves the
+		// date-range, date-sort, and soft-delete predicate shapes in one small, hot index.
+		builder.HasIndex(e => e.Date)
+			.HasFilter("\"DeletedAt\" IS NULL");
+
 		builder.HasQueryFilter(e => e.DeletedAt == null);
 	}
 }

--- a/src/Infrastructure/Migrations/20260711201147_AddReceiptDateIndex.Designer.cs
+++ b/src/Infrastructure/Migrations/20260711201147_AddReceiptDateIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711201147_AddReceiptDateIndex")]
+    partial class AddReceiptDateIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260711201147_AddReceiptDateIndex.cs
+++ b/src/Infrastructure/Migrations/20260711201147_AddReceiptDateIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddReceiptDateIndex : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.CreateIndex(
+			name: "IX_Receipts_Date",
+			schema: "receipts",
+			table: "Receipts",
+			column: "Date",
+			filter: "\"DeletedAt\" IS NULL");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.DropIndex(
+			name: "IX_Receipts_Date",
+			schema: "receipts",
+			table: "Receipts");
+	}
+}

--- a/src/Infrastructure/Services/ApiKeyService.cs
+++ b/src/Infrastructure/Services/ApiKeyService.cs
@@ -72,14 +72,27 @@ public class ApiKeyService(IDbContextFactory<ApplicationDbContext> dbContextFact
 		return keys.Count;
 	}
 
+	// How recently LastUsedAt must have been stamped before a request skips re-stamping it.
+	// This throttles the auth-path write: within one window we do at most one UPDATE per key,
+	// which turns a per-request write into an occasional one under sustained traffic.
+	private static readonly TimeSpan LastUsedThrottle = TimeSpan.FromMinutes(1);
+
 	public async Task<ApiKeyValidationResult?> GetUserIdByApiKeyAsync(string rawKey, CancellationToken cancellationToken = default)
 	{
 		string keyHash = HashKey(rawKey);
+		DateTimeOffset now = DateTimeOffset.UtcNow;
 
 		await using ApplicationDbContext context = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+		// Validation is unchanged (RECEIPTS-757): the key must exist, not be revoked, and not be
+		// expired. AsNoTracking because we no longer mutate-and-save this entity — LastUsedAt is
+		// stamped below with a targeted UPDATE. The per-request account-state check that rejects
+		// deactivated/locked-out users lives in ApiKeyAuthenticationHandler and is untouched;
+		// this method deliberately does NOT cache the result, so that check runs every request.
 		ApiKeyEntity? key = await context.ApiKeys
+			.AsNoTracking()
 			.FirstOrDefaultAsync(
-				k => k.KeyHash == keyHash && !k.IsRevoked && (k.ExpiresAt == null || k.ExpiresAt > DateTimeOffset.UtcNow),
+				k => k.KeyHash == keyHash && !k.IsRevoked && (k.ExpiresAt == null || k.ExpiresAt > now),
 				cancellationToken);
 
 		if (key is null)
@@ -87,8 +100,35 @@ public class ApiKeyService(IDbContextFactory<ApplicationDbContext> dbContextFact
 			return null;
 		}
 
-		key.LastUsedAt = DateTimeOffset.UtcNow;
-		await context.SaveChangesAsync(cancellationToken);
+		// Stamp LastUsedAt cheaply. The throttle predicate makes the write a no-op when LastUsedAt
+		// was set within the last minute, so sustained traffic on one key writes at most once per
+		// window. Either way NO AuditLogs row is written: ApiKeyEntity is excluded from auditing
+		// (see ApplicationDbContext.CollectAuditEntries) — a LastUsedAt bump is telemetry, not audit.
+		DateTimeOffset throttleThreshold = now - LastUsedThrottle;
+
+		if (context.Database.IsRelational())
+		{
+			// Production path: one targeted UPDATE that bypasses the change tracker entirely —
+			// no load-modify-full-SaveChanges, no snapshot, no audit interceptor. The throttle lives
+			// in the WHERE clause, so it is atomic and race-safe under concurrent requests.
+			await context.ApiKeys
+				.Where(k => k.Id == key.Id && (k.LastUsedAt == null || k.LastUsedAt < throttleThreshold))
+				.ExecuteUpdateAsync(s => s.SetProperty(k => k.LastUsedAt, now), cancellationToken);
+		}
+		else if (key.LastUsedAt == null || key.LastUsedAt < throttleThreshold)
+		{
+			// The InMemory provider (unit tests) does not support ExecuteUpdate. Fall back to a
+			// tracked update behind the same throttle; the audit exclusion above still keeps this
+			// out of AuditLogs. Never taken against PostgreSQL in production.
+			ApiKeyEntity? tracked = await context.ApiKeys
+				.FirstOrDefaultAsync(k => k.Id == key.Id, cancellationToken);
+			if (tracked is not null)
+			{
+				tracked.LastUsedAt = now;
+				await context.SaveChangesAsync(cancellationToken);
+			}
+		}
+
 		return new ApiKeyValidationResult(key.UserId, key.Id, key.BypassRateLimit);
 	}
 

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -49,22 +49,24 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 							Difference = difference
 						};
 
-		// Get total count and total discrepancy before pagination
-		// Materialize the filtered set once so both aggregations happen in a single enumeration.
-		var allItems = await baseQuery.ToListAsync(cancellationToken);
-		int totalCount = allItems.Count;
-		decimal totalDiscrepancy = allItems.Sum(x => Math.Abs(x.Difference));
+		// Count and total-discrepancy are computed in SQL over the filtered set (COUNT / SUM(ABS)),
+		// not by materializing every out-of-balance row into memory (RECEIPTS-791).
+		int totalCount = await baseQuery.CountAsync(cancellationToken);
+		decimal totalDiscrepancy = totalCount == 0
+			? 0m
+			: await baseQuery.SumAsync(x => Math.Abs(x.Difference), cancellationToken);
 
-		// Apply sorting in memory (the data set is bounded by "out of balance" receipts, typically small)
-		var sorted = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
+		// Sort in SQL: every sort key is a plain/computed column EF can translate to ORDER BY.
+		var sortedQuery = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
 		{
-			("difference", "asc") => allItems.OrderBy(x => x.Difference).AsEnumerable(),
-			("difference", "desc") => allItems.OrderByDescending(x => x.Difference).AsEnumerable(),
-			("date", "desc") => allItems.OrderByDescending(x => x.Date).AsEnumerable(),
-			_ => allItems.OrderBy(x => x.Date).AsEnumerable(), // default: date asc
+			("difference", "asc") => baseQuery.OrderBy(x => x.Difference),
+			("difference", "desc") => baseQuery.OrderByDescending(x => x.Difference),
+			("date", "desc") => baseQuery.OrderByDescending(x => x.Date),
+			_ => baseQuery.OrderBy(x => x.Date), // default: date asc
 		};
 
-		List<OutOfBalanceItem> pagedItems = sorted
+		// Skip/Take BEFORE materializing — the database paginates, only one page crosses the wire.
+		List<OutOfBalanceItem> pagedItems = await sortedQuery
 			.Skip((page - 1) * pageSize)
 			.Take(pageSize)
 			.Select(x => new OutOfBalanceItem(
@@ -77,7 +79,7 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 				x.ExpectedTotal,
 				x.TransactionTotal,
 				x.Difference))
-			.ToList();
+			.ToListAsync(cancellationToken);
 
 		return new OutOfBalanceResult(pagedItems, totalCount, totalDiscrepancy);
 	}
@@ -118,23 +120,29 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 							Total = g.Sum(x => x.TransactionTotal),
 						};
 
-		var allItems = await baseQuery.ToListAsync(cancellationToken);
-		int totalCount = allItems.Count;
-		decimal grandTotal = allItems.Sum(x => x.Total);
+		// Count (number of location groups) and grand total are aggregated in SQL over the grouped
+		// query, not by pulling every group into memory (RECEIPTS-791).
+		int totalCount = await baseQuery.CountAsync(cancellationToken);
+		decimal grandTotal = totalCount == 0
+			? 0m
+			: await baseQuery.SumAsync(x => x.Total, cancellationToken);
 
-		var sorted = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
+		// Sort in SQL: every sort key (including the average = Total / Visits expression) is
+		// EF-translatable to ORDER BY. Visits is a group COUNT and therefore always >= 1.
+		var sortedQuery = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
 		{
-			("location", "asc") => allItems.OrderBy(x => x.Location).AsEnumerable(),
-			("location", "desc") => allItems.OrderByDescending(x => x.Location).AsEnumerable(),
-			("visits", "asc") => allItems.OrderBy(x => x.Visits).AsEnumerable(),
-			("visits", "desc") => allItems.OrderByDescending(x => x.Visits).AsEnumerable(),
-			("averagepervisit", "asc") => allItems.OrderBy(x => x.Visits > 0 ? x.Total / x.Visits : 0).AsEnumerable(),
-			("averagepervisit", "desc") => allItems.OrderByDescending(x => x.Visits > 0 ? x.Total / x.Visits : 0).AsEnumerable(),
-			("total", "asc") => allItems.OrderBy(x => x.Total).AsEnumerable(),
-			_ => allItems.OrderByDescending(x => x.Total).AsEnumerable(), // default: total desc
+			("location", "asc") => baseQuery.OrderBy(x => x.Location),
+			("location", "desc") => baseQuery.OrderByDescending(x => x.Location),
+			("visits", "asc") => baseQuery.OrderBy(x => x.Visits),
+			("visits", "desc") => baseQuery.OrderByDescending(x => x.Visits),
+			("averagepervisit", "asc") => baseQuery.OrderBy(x => x.Visits > 0 ? x.Total / x.Visits : 0),
+			("averagepervisit", "desc") => baseQuery.OrderByDescending(x => x.Visits > 0 ? x.Total / x.Visits : 0),
+			("total", "asc") => baseQuery.OrderBy(x => x.Total),
+			_ => baseQuery.OrderByDescending(x => x.Total), // default: total desc
 		};
 
-		List<SpendingByLocationItem> pagedItems = sorted
+		// Skip/Take BEFORE materializing — only the requested page is fetched.
+		List<SpendingByLocationItem> pagedItems = await sortedQuery
 			.Skip((page - 1) * pageSize)
 			.Take(pageSize)
 			.Select(x => new SpendingByLocationItem(
@@ -142,7 +150,7 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 				x.Visits,
 				x.Total,
 				x.Visits > 0 ? Math.Round(x.Total / x.Visits, 2, MidpointRounding.AwayFromZero) : 0m))
-			.ToList();
+			.ToListAsync(cancellationToken);
 
 		return new SpendingByLocationResult(pagedItems, totalCount, grandTotal);
 	}
@@ -796,20 +804,23 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 							ri.Subcategory
 						};
 
-		var allItems = await baseQuery.ToListAsync(cancellationToken);
-		int totalCount = allItems.Count;
+		// Count in SQL over the filtered set instead of materializing every uncategorized item
+		// just to read its length (RECEIPTS-791).
+		int totalCount = await baseQuery.CountAsync(cancellationToken);
 
-		var sorted = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
+		// Sort in SQL: all keys are plain columns (ReceiptItemCode uses COALESCE for its null case).
+		var sortedQuery = (sortBy.ToLowerInvariant(), sortDirection.ToLowerInvariant()) switch
 		{
-			("total", "asc") => allItems.OrderBy(x => x.TotalAmount).AsEnumerable(),
-			("total", "desc") => allItems.OrderByDescending(x => x.TotalAmount).AsEnumerable(),
-			("itemcode", "asc") => allItems.OrderBy(x => x.ReceiptItemCode ?? string.Empty).AsEnumerable(),
-			("itemcode", "desc") => allItems.OrderByDescending(x => x.ReceiptItemCode ?? string.Empty).AsEnumerable(),
-			("description", "desc") => allItems.OrderByDescending(x => x.Description).AsEnumerable(),
-			_ => allItems.OrderBy(x => x.Description).AsEnumerable(),
+			("total", "asc") => baseQuery.OrderBy(x => x.TotalAmount),
+			("total", "desc") => baseQuery.OrderByDescending(x => x.TotalAmount),
+			("itemcode", "asc") => baseQuery.OrderBy(x => x.ReceiptItemCode ?? string.Empty),
+			("itemcode", "desc") => baseQuery.OrderByDescending(x => x.ReceiptItemCode ?? string.Empty),
+			("description", "desc") => baseQuery.OrderByDescending(x => x.Description),
+			_ => baseQuery.OrderBy(x => x.Description),
 		};
 
-		List<UncategorizedItemRecord> pagedItems = sorted
+		// Skip/Take BEFORE materializing — only the requested page is fetched.
+		List<UncategorizedItemRecord> pagedItems = await sortedQuery
 			.Skip((page - 1) * pageSize)
 			.Take(pageSize)
 			.Select(x => new UncategorizedItemRecord(
@@ -822,7 +833,7 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 				x.TotalAmount,
 				x.Category,
 				x.Subcategory))
-			.ToList();
+			.ToListAsync(cancellationToken);
 
 		return new UncategorizedItemsResult(pagedItems, totalCount);
 	}

--- a/src/Infrastructure/Services/ReportService.cs
+++ b/src/Infrastructure/Services/ReportService.cs
@@ -65,6 +65,12 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 			_ => baseQuery.OrderBy(x => x.Date), // default: date asc
 		};
 
+		// Deterministic total order (RECEIPTS-791 follow-up): the primary keys above (Difference,
+		// Date) are non-unique, so append the unique receipt Id ascending as a tiebreaker regardless
+		// of primary direction. Without it, offset pagination over tied rows can skip or repeat a row
+		// between page requests — the same determinism fix RECEIPTS-768 applied to the repositories.
+		sortedQuery = sortedQuery.ThenBy(x => x.Id);
+
 		// Skip/Take BEFORE materializing — the database paginates, only one page crosses the wire.
 		List<OutOfBalanceItem> pagedItems = await sortedQuery
 			.Skip((page - 1) * pageSize)
@@ -140,6 +146,12 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 			("total", "asc") => baseQuery.OrderBy(x => x.Total),
 			_ => baseQuery.OrderByDescending(x => x.Total), // default: total desc
 		};
+
+		// Deterministic total order (RECEIPTS-791 follow-up): the query GROUPs BY location, so the
+		// Location value is unique per row — the two location sorts are already a total order. The
+		// measure sorts (visits/total/averagepervisit) are non-unique, so append the unique group key
+		// (Location) ascending as a tiebreaker to keep offset pagination stable across page requests.
+		sortedQuery = sortedQuery.ThenBy(x => x.Location);
 
 		// Skip/Take BEFORE materializing — only the requested page is fetched.
 		List<SpendingByLocationItem> pagedItems = await sortedQuery
@@ -818,6 +830,12 @@ public partial class ReportService(IDbContextFactory<ApplicationDbContext> conte
 			("description", "desc") => baseQuery.OrderByDescending(x => x.Description),
 			_ => baseQuery.OrderBy(x => x.Description),
 		};
+
+		// Deterministic total order (RECEIPTS-791 follow-up): the primary keys above (TotalAmount,
+		// ReceiptItemCode, Description) are non-unique, so append the unique receipt-item Id ascending
+		// as a tiebreaker regardless of primary direction, keeping offset pagination stable across
+		// page requests.
+		sortedQuery = sortedQuery.ThenBy(x => x.Id);
 
 		// Skip/Take BEFORE materializing — only the requested page is fetched.
 		List<UncategorizedItemRecord> pagedItems = await sortedQuery

--- a/tests/Infrastructure.Tests/Services/ApiKeyServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ApiKeyServiceTests.cs
@@ -73,6 +73,70 @@ public class ApiKeyServiceTests
 	}
 
 	[Fact]
+	public async Task GetUserIdByApiKeyAsync_StampsLastUsedAt_WithoutWritingAuditLog()
+	{
+		// Arrange — a real key created by the service, with a current user set so that any
+		// AUDITED write on this path would be attributed and persisted to AuditLogs.
+		(IDbContextFactory<ApplicationDbContext> contextFactory, MockCurrentUserAccessor accessor) =
+			DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		accessor.UserId = "user-a";
+
+		ApiKeyService service = new(contextFactory);
+		CreateApiKeyResult created = await service.CreateApiKeyAsync("user-a", "my-key", expiresAt: null);
+
+		// Act — the auth hot path.
+		ApiKeyValidationResult? result = await service.GetUserIdByApiKeyAsync(created.RawKey);
+
+		// Assert — the key validated, LastUsedAt was stamped (was null after create)...
+		result.Should().NotBeNull();
+		result!.UserId.Should().Be("user-a");
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ApiKeyEntity persisted = await context.ApiKeys.SingleAsync(k => k.Id == created.Id);
+			persisted.LastUsedAt.Should().NotBeNull();
+
+			// ...and NOT a single AuditLog row was written for the API-key auth path
+			// (RECEIPTS-769): the LastUsedAt bump is telemetry, not an audit event.
+			(await context.AuditLogs.CountAsync()).Should().Be(0);
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetUserIdByApiKeyAsync_DoesNotRestampLastUsedAt_WithinThrottleWindow()
+	{
+		// Arrange — a key whose LastUsedAt was stamped moments ago (inside the ~1-minute throttle).
+		(IDbContextFactory<ApplicationDbContext> contextFactory, _) =
+			DbContextWithUserHelpers.CreateInMemoryContextFactoryWithUser();
+		ApiKeyService service = new(contextFactory);
+		CreateApiKeyResult created = await service.CreateApiKeyAsync("user-a", "my-key", expiresAt: null);
+
+		DateTimeOffset recent = DateTimeOffset.UtcNow.AddSeconds(-10);
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ApiKeyEntity key = await context.ApiKeys.SingleAsync(k => k.Id == created.Id);
+			key.LastUsedAt = recent;
+			await context.SaveChangesAsync();
+		}
+
+		// Act — a second authentication within the throttle window.
+		ApiKeyValidationResult? result = await service.GetUserIdByApiKeyAsync(created.RawKey);
+
+		// Assert — still validates, but LastUsedAt is left untouched (the throttled UPDATE is a no-op),
+		// so sustained traffic on one key does not write on every request.
+		result.Should().NotBeNull();
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			ApiKeyEntity persisted = await context.ApiKeys.SingleAsync(k => k.Id == created.Id);
+			persisted.LastUsedAt.Should().BeCloseTo(recent, TimeSpan.FromMilliseconds(1));
+		}
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
 	public async Task RevokeAllForUserAsync_CausesKeyToStopAuthenticating()
 	{
 		// Arrange — a real key that validates before revocation.

--- a/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
@@ -1125,6 +1125,149 @@ public class ReportServiceTests
 		contextFactory.ResetDatabase();
 	}
 
+	// ── Deterministic pagination when the primary sort key ties (RECEIPTS-791 follow-up) ──
+	// Mirrors the ApplySort determinism tests (RECEIPTS-768): when every row shares the primary
+	// sort value, only the unique-key tiebreaker gives a stable total order, so walking the pages
+	// must cover every row exactly once (no gap, no duplicate) in a repeatable order.
+
+	[Fact]
+	public async Task GetUncategorizedItemsAsync_TiedTotal_PaginatesWithoutGapsOrDuplicates()
+	{
+		// Arrange — five uncategorized items that all TIE on the primary sort key (TotalAmount).
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid receiptId = Guid.NewGuid();
+
+		List<Guid> seededIds = [];
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "Store", Date = new DateOnly(2025, 3, 1), TaxAmount = 0m });
+
+			for (int i = 0; i < 5; i++)
+			{
+				Guid id = Guid.NewGuid();
+				seededIds.Add(id);
+				context.ReceiptItems.Add(new ReceiptItemEntity
+				{
+					Id = id,
+					ReceiptId = receiptId,
+					Description = $"Item {i}",
+					Quantity = 1,
+					UnitPrice = 5m,
+					TotalAmount = 5m, // identical => primary sort ties for every row
+					Category = "Uncategorized",
+				});
+			}
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act — walk every page (size 2) with a tied primary sort.
+		List<Guid> pagedIds = [];
+		for (int page = 1; page <= 3; page++)
+		{
+			UncategorizedItemsResult result =
+				await service.GetUncategorizedItemsAsync("total", "desc", page, 2, CancellationToken.None);
+			result.TotalCount.Should().Be(5);
+			pagedIds.AddRange(result.Items.Select(i => i.Id));
+		}
+
+		// Assert — every row appears exactly once, ordered by the ascending-Id tiebreaker.
+		pagedIds.Should().HaveCount(5);
+		pagedIds.Should().OnlyHaveUniqueItems();
+		pagedIds.Should().Equal(seededIds.OrderBy(id => id));
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_TiedDateAndDifference_PaginatesWithoutGapsOrDuplicates()
+	{
+		// Arrange — five receipts identical in Date AND out-of-balance Difference, so both primary
+		// sort keys tie and only the unique receipt-Id tiebreaker orders them.
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid accountId = Guid.NewGuid();
+		DateOnly sameDate = new(2025, 3, 1);
+
+		List<Guid> seededIds = [];
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			for (int i = 0; i < 5; i++)
+			{
+				Guid receiptId = Guid.NewGuid();
+				seededIds.Add(receiptId);
+				// expected total = 0, transaction = 50 => difference = -50 for every receipt.
+				context.Receipts.Add(
+					new ReceiptEntity { Id = receiptId, Location = $"Store {i}", Date = sameDate, TaxAmount = 0m });
+				context.Transactions.Add(
+					new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, AccountId = accountId, Amount = 50m, Date = sameDate });
+			}
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act — walk every page (size 2) with the default tied date sort.
+		List<Guid> pagedIds = [];
+		for (int page = 1; page <= 3; page++)
+		{
+			OutOfBalanceResult result =
+				await service.GetOutOfBalanceAsync("date", "asc", page, 2, CancellationToken.None);
+			result.TotalCount.Should().Be(5);
+			pagedIds.AddRange(result.Items.Select(i => i.ReceiptId));
+		}
+
+		// Assert — every receipt appears exactly once, ordered by the ascending receipt-Id tiebreaker.
+		pagedIds.Should().HaveCount(5);
+		pagedIds.Should().OnlyHaveUniqueItems();
+		pagedIds.Should().Equal(seededIds.OrderBy(id => id));
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetSpendingByLocationAsync_TiedTotal_PaginatesWithoutGapsOrDuplicates()
+	{
+		// Arrange — five distinct locations, each a single visit of the SAME total, so the "total"
+		// measure ties for every group and only the unique Location tiebreaker orders them.
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid accountId = Guid.NewGuid();
+		List<string> locations = ["Alpha", "Bravo", "Charlie", "Delta", "Echo"];
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			DateOnly date = new(2025, 1, 1);
+			foreach (string loc in locations)
+			{
+				AddReceiptWithTransaction(context, loc, date, accountId, 10m);
+			}
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act — walk every page (size 2) with a tied total-desc sort.
+		List<string> pagedLocations = [];
+		for (int page = 1; page <= 3; page++)
+		{
+			SpendingByLocationResult result =
+				await service.GetSpendingByLocationAsync(null, null, "total", "desc", page, 2, CancellationToken.None);
+			result.TotalCount.Should().Be(5);
+			pagedLocations.AddRange(result.Items.Select(i => i.Location));
+		}
+
+		// Assert — every location appears exactly once, ordered by the ascending Location tiebreaker.
+		pagedLocations.Should().HaveCount(5);
+		pagedLocations.Should().OnlyHaveUniqueItems();
+		pagedLocations.Should().Equal(locations.OrderBy(l => l));
+
+		contextFactory.ResetDatabase();
+	}
+
 	private static void AddReceiptWithTransaction(
 		ApplicationDbContext context, string location, DateOnly date, Guid accountId, decimal amount)
 	{

--- a/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ReportServiceTests.cs
@@ -994,4 +994,144 @@ public class ReportServiceTests
 
 		contextFactory.ResetDatabase();
 	}
+
+	// ── GetUncategorizedItemsAsync (RECEIPTS-791: paginate/count/sort in SQL) ─────────
+	// These assert the Count + Skip/Take + ORDER-BY semantics are preserved after moving the
+	// work off the client and into the query. They run against the InMemory provider, which
+	// evaluates LINQ in-process, so they prove the query LOGIC — not that the expressions
+	// translate to SQL. True SQL-translation proof requires an integration test on PostgreSQL.
+
+	[Fact]
+	public async Task GetUncategorizedItemsAsync_CountsPaginatesAndSortsByDescription()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid receiptId = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "Store", Date = new DateOnly(2025, 3, 1), TaxAmount = 0m });
+
+			context.ReceiptItems.AddRange(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Cabbage", Quantity = 1, UnitPrice = 3m, TotalAmount = 3m, Category = "Uncategorized" },
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Apple", Quantity = 1, UnitPrice = 1m, TotalAmount = 1m, Category = "Uncategorized" },
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Bread", Quantity = 1, UnitPrice = 2m, TotalAmount = 2m, Category = "Uncategorized" },
+				// Categorized — excluded by the Category == "Uncategorized" filter.
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Milk", Quantity = 1, UnitPrice = 4m, TotalAmount = 4m, Category = "Dairy" },
+				// Soft-deleted uncategorized — excluded by the DeletedAt == null filter.
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Ghost", Quantity = 1, UnitPrice = 9m, TotalAmount = 9m, Category = "Uncategorized", DeletedAt = DateTimeOffset.UtcNow });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act — page 1 of 2, default sort (description asc).
+		UncategorizedItemsResult page1 = await service.GetUncategorizedItemsAsync("description", "asc", 1, 2, CancellationToken.None);
+
+		// Assert — count reflects only the 3 active uncategorized items; the page holds the first
+		// two by description ascending (Apple, Bread).
+		page1.TotalCount.Should().Be(3);
+		page1.Items.Should().HaveCount(2);
+		page1.Items.Select(i => i.Description).Should().ContainInOrder("Apple", "Bread");
+
+		// Act — page 2 carries the remaining item.
+		UncategorizedItemsResult page2 = await service.GetUncategorizedItemsAsync("description", "asc", 2, 2, CancellationToken.None);
+
+		// Assert
+		page2.TotalCount.Should().Be(3);
+		page2.Items.Should().ContainSingle();
+		page2.Items[0].Description.Should().Be("Cabbage");
+
+		contextFactory.ResetDatabase();
+	}
+
+	[Fact]
+	public async Task GetUncategorizedItemsAsync_SortsByTotalDescending()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid receiptId = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			context.Receipts.Add(
+				new ReceiptEntity { Id = receiptId, Location = "Store", Date = new DateOnly(2025, 3, 1), TaxAmount = 0m });
+
+			context.ReceiptItems.AddRange(
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Low", Quantity = 1, UnitPrice = 1m, TotalAmount = 1m, Category = "Uncategorized" },
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "High", Quantity = 1, UnitPrice = 9m, TotalAmount = 9m, Category = "Uncategorized" },
+				new ReceiptItemEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, Description = "Mid", Quantity = 1, UnitPrice = 5m, TotalAmount = 5m, Category = "Uncategorized" });
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act
+		UncategorizedItemsResult result = await service.GetUncategorizedItemsAsync("total", "desc", 1, 50, CancellationToken.None);
+
+		// Assert — ordered by TotalAmount descending.
+		result.TotalCount.Should().Be(3);
+		result.Items.Select(i => i.TotalAmount).Should().ContainInOrder(9m, 5m, 1m);
+
+		contextFactory.ResetDatabase();
+	}
+
+	// ── GetSpendingByLocationAsync (RECEIPTS-791: aggregate/count/paginate in SQL) ────
+
+	[Fact]
+	public async Task GetSpendingByLocationAsync_AggregatesCountsPaginatesAndSortsByTotal()
+	{
+		// Arrange
+		IDbContextFactory<ApplicationDbContext> contextFactory = DbContextHelpers.CreateInMemoryContextFactory();
+		Guid accountId = Guid.NewGuid();
+
+		await using (ApplicationDbContext context = contextFactory.CreateDbContext())
+		{
+			// Store A: two visits totaling 30; Store B: one visit of 20; Store C: one visit of 10.
+			AddReceiptWithTransaction(context, "Store A", new DateOnly(2025, 1, 1), accountId, 10m);
+			AddReceiptWithTransaction(context, "Store A", new DateOnly(2025, 1, 2), accountId, 20m);
+			AddReceiptWithTransaction(context, "Store B", new DateOnly(2025, 1, 3), accountId, 20m);
+			AddReceiptWithTransaction(context, "Store C", new DateOnly(2025, 1, 4), accountId, 10m);
+
+			await context.SaveChangesAsync();
+		}
+
+		ReportService service = new(contextFactory);
+
+		// Act — default sort (total desc), page 1 of 2.
+		SpendingByLocationResult page1 = await service.GetSpendingByLocationAsync(null, null, "total", "desc", 1, 2, CancellationToken.None);
+
+		// Assert — 3 location groups; grand total sums every transaction (60); the page holds the
+		// two highest-total locations in order, with Store A's two visits aggregated.
+		page1.TotalCount.Should().Be(3);
+		page1.GrandTotal.Should().Be(60m);
+		page1.Items.Should().HaveCount(2);
+		page1.Items.Select(i => i.Location).Should().ContainInOrder("Store A", "Store B");
+		page1.Items[0].Total.Should().Be(30m);
+		page1.Items[0].Visits.Should().Be(2);
+		page1.Items[0].AveragePerVisit.Should().Be(15m);
+
+		// Act — page 2 carries the lowest-total location.
+		SpendingByLocationResult page2 = await service.GetSpendingByLocationAsync(null, null, "total", "desc", 2, 2, CancellationToken.None);
+
+		// Assert
+		page2.TotalCount.Should().Be(3);
+		page2.Items.Should().ContainSingle();
+		page2.Items[0].Location.Should().Be("Store C");
+
+		contextFactory.ResetDatabase();
+	}
+
+	private static void AddReceiptWithTransaction(
+		ApplicationDbContext context, string location, DateOnly date, Guid accountId, decimal amount)
+	{
+		Guid receiptId = Guid.NewGuid();
+		context.Receipts.Add(
+			new ReceiptEntity { Id = receiptId, Location = location, Date = date, TaxAmount = 0m });
+		context.Transactions.Add(
+			new TransactionEntity { Id = Guid.NewGuid(), ReceiptId = receiptId, AccountId = accountId, Amount = amount, Date = date });
+	}
 }


### PR DESCRIPTION
Three confirmed server-performance findings, disjoint files, one logical commit each. Closes RECEIPTS-769, RECEIPTS-787, RECEIPTS-791.

## Fix 1 — RECEIPTS-769: API-key auth write amplification
`GetUserIdByApiKeyAsync` (the auth hot path) ran a full **audited** `SaveChangesAsync` on every authenticated request just to stamp `LastUsedAt`. Because `ApiKeyEntity` was not in the audit exclusion set, each request wrote a permanent `AuditLogs` row (unbounded growth) on top of the UPDATE.

- Excluded `ApiKeyEntity` from auditing in `ApplicationDbContext.CollectAuditEntries` — a `LastUsedAt` bump is telemetry, not an audit event.
- Stamp `LastUsedAt` via a single targeted `ExecuteUpdate` that bypasses the change tracker and audit interceptor, **throttled to at most once per minute per key** (the throttle lives in the `WHERE` clause, so it is atomic and race-safe). The InMemory provider used by unit tests does not support `ExecuteUpdate`, so a tracked-update fallback behind the same throttle preserves coverage; it is never taken against PostgreSQL.

**Security:** No auth-result cache was introduced. Validation is unchanged (key exists, not revoked, not expired), and the per-request account-state check that rejects deactivated/locked-out users (RECEIPTS-757) still lives in `ApiKeyAuthenticationHandler` and runs on every request.

## Fix 2 — RECEIPTS-787: missing index on Receipts.Date
The Receipts table carried only its PK, yet the default list sorts by `Date desc` with offset pagination and every `DashboardService`/report method filters `Date` within a range — all under `DeletedAt IS NULL`.

Added a partial index on `Date` filtered to active rows. Migration `20260711201147_AddReceiptDateIndex` is surgical and symmetric:

- **Up:** `CreateIndex("IX_Receipts_Date", schema: "receipts", table: "Receipts", column: "Date", filter: "\"DeletedAt\" IS NULL")`
- **Down:** `DropIndex("IX_Receipts_Date", schema: "receipts", table: "Receipts")`

The model snapshot gains only the `HasIndex("Date").HasFilter("\"DeletedAt\" IS NULL")` line — no drift. Building the index briefly locks the table, which is fine at this scale; the repo's other migrations do not use `CREATE INDEX CONCURRENTLY`, so a plain add stays consistent.

## Fix 3 — RECEIPTS-791: report endpoints paginated in memory
`GetUncategorizedItemsAsync`, `GetOutOfBalanceAsync`, and `GetSpendingByLocationAsync` each loaded every matching row into memory, then sorted and `Skip/Take`-d in .NET.

Kept the queries `IQueryable` end to end: expression-based `OrderBy`/`OrderByDescending` (→ SQL `ORDER BY`), `CountAsync` for `totalCount`, `SumAsync` for the out-of-balance discrepancy (`SUM(ABS(...))`) and the spending grand total (SUM over grouped location totals), and `Skip/Take` **before** `ToListAsync`. Results and sort semantics are unchanged; only the work moves into SQL.

## Validation
- `dotnet build Receipts.slnx` — 0 errors, no new warnings (only pre-existing NU19xx package advisories).
- `dotnet test --filter "Category!=Integration"`: Infrastructure.Tests **652**, Application.Tests **457**, Presentation.API.Tests **1010** — all pass. Client suite (pre-commit hook) **2152** pass.
- Tests added: API-key auth path writes zero `AuditLogs` rows while `LastUsedAt` still updates, plus a throttle-window no-op test; Count + Skip/Take + ORDER-BY tests for the uncategorized and spending-by-location reports.
- The InMemory provider evaluates LINQ in-process, so the report tests prove query **logic**; proving the rewritten expressions translate to SQL (rather than client-eval) needs a PostgreSQL integration test. The index is verified by migration inspection + build (CI does not run migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
