### PR TITLE
fix(application): validate receipt image before overwrite and cap decoded megapixels

### DIFF
--- a/src/Application/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandler.cs
+++ b/src/Application/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandler.cs
@@ -16,26 +16,30 @@ public class UploadReceiptImageCommandHandler(
 			throw new KeyNotFoundException($"Receipt {request.ReceiptId} not found.");
 		}
 
+		// Validate and preprocess the uploaded bytes IN MEMORY before writing anything to the
+		// receipt's permanent storage. PreprocessAsync performs the magic-byte/format and
+		// dimension checks, so a rejected upload throws here having touched nothing on disk.
+		//
+		// The previous ordering wrote the new original to the receipt's permanent location first
+		// and, on any failure, recursively deleted ALL of the receipt's images. That meant a user
+		// re-uploading an invalid file destroyed the previously-good original/processed images.
+		// By validating first and only persisting after success, the existing images are always
+		// preserved when a new upload is rejected.
+		ImageProcessingResult processed = await imageProcessingService.PreprocessAsync(
+			request.ImageBytes, request.ContentType, cancellationToken);
+
+		// Validation passed — only now does anything reach disk. Both files are written from
+		// validated bytes, so there is no partially-written invalid state to clean up, and the
+		// receipt's pre-existing images are never deleted on a rejected upload.
 		string originalPath = await imageStorageService.SaveOriginalAsync(
 			request.ReceiptId, request.ImageBytes, request.FileExtension, cancellationToken);
 
-		try
-		{
-			ImageProcessingResult processed = await imageProcessingService.PreprocessAsync(
-				request.ImageBytes, request.ContentType, cancellationToken);
+		string processedPath = await imageStorageService.SaveProcessedAsync(
+			request.ReceiptId, processed.ProcessedBytes, cancellationToken);
 
-			string processedPath = await imageStorageService.SaveProcessedAsync(
-				request.ReceiptId, processed.ProcessedBytes, cancellationToken);
+		await receiptService.UpdateImagePathsAsync(
+			request.ReceiptId, originalPath, processedPath, cancellationToken);
 
-			await receiptService.UpdateImagePathsAsync(
-				request.ReceiptId, originalPath, processedPath, cancellationToken);
-
-			return new UploadReceiptImageResult(originalPath, processedPath);
-		}
-		catch
-		{
-			await imageStorageService.DeleteReceiptImagesAsync(request.ReceiptId, cancellationToken);
-			throw;
-		}
+		return new UploadReceiptImageResult(originalPath, processedPath);
 	}
 }

--- a/src/Infrastructure/Services/ImageProcessingService.cs
+++ b/src/Infrastructure/Services/ImageProcessingService.cs
@@ -16,8 +16,18 @@ public class ImageProcessingService(ILogger<ImageProcessingService> logger) : II
 	private const double DeskewMaxAngle = 10.0;
 	private const double DeskewStepDegrees = 0.5;
 	private const double DeskewMinAngle = 0.5;
-	private const int MaxPixelWidth = 10_000;
-	private const int MaxPixelHeight = 10_000;
+	// Per-dimension caps (defense in depth). Lowered from 10_000 so a square image at the
+	// per-dimension limit no longer slips past into the megapixel guard on its own.
+	private const int MaxPixelWidth = 8_000;
+	private const int MaxPixelHeight = 8_000;
+
+	// PRIMARY guard against decompression bombs: a solid-color 10000x10000 PNG is only tens of
+	// KB compressed but decodes to 100 megapixels, and ApplyAdaptiveThreshold then allocates a
+	// long[height+1, width+1] integral array (~800 MB for 10000x10000) and spins billions of
+	// iterations. Cap the TOTAL decoded pixel count (width * height) and reject before any decode
+	// or allocation. 24 MP comfortably covers legitimate receipt photos (a 12 MP phone camera is
+	// ~4032x3024 = 12.2 MP) while rejecting abusive dimensions.
+	private const long MaxImagePixels = 24_000_000;
 
 	// 256 MB upper bound for ImageSharp memory allocations
 	private const int MemoryBudgetMegabytes = 256;
@@ -61,12 +71,26 @@ public class ImageProcessingService(ILogger<ImageProcessingService> logger) : II
 				"The uploaded file is not a supported image format. Only JPEG and PNG are accepted.");
 		}
 
-		// Check image dimensions before full decode to reject oversized images cheaply
-		ImageInfo info = Image.Identify(imageBytes);
+		// Check image dimensions BEFORE full decode to reject oversized images cheaply.
+		// Image.Identify only reads the header (no full-frame allocation), so these guards run
+		// before Image.Load and before ApplyAdaptiveThreshold's integral-array allocation.
+		DecoderOptions identifyOptions = new() { Configuration = BoundedConfiguration };
+		ImageInfo info = Image.Identify(identifyOptions, imageBytes);
+
 		if (info.Width > MaxPixelWidth || info.Height > MaxPixelHeight)
 		{
 			throw new InvalidOperationException(
 				$"Image dimensions ({info.Width}x{info.Height}) exceed the maximum allowed ({MaxPixelWidth}x{MaxPixelHeight}).");
+		}
+
+		// Cap total decoded pixel count (width * height) to prevent decompression-bomb DoS,
+		// where a tiny compressed file decodes to a huge pixel buffer. Use long arithmetic so
+		// the multiplication cannot overflow for large declared dimensions.
+		long totalPixels = (long)info.Width * info.Height;
+		if (totalPixels > MaxImagePixels)
+		{
+			throw new InvalidOperationException(
+				$"Image resolution ({info.Width}x{info.Height} = {totalPixels:N0} pixels) exceeds the maximum allowed ({MaxImagePixels:N0} pixels).");
 		}
 
 		DecoderOptions decoderOptions = new()

--- a/tests/Application.Tests/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandlerTests.cs
+++ b/tests/Application.Tests/Commands/Receipt/UploadImage/UploadReceiptImageCommandHandlerTests.cs
@@ -199,10 +199,6 @@ public class UploadReceiptImageCommandHandlerTests
 			.Setup(s => s.ExistsAsync(receiptId, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(true);
 
-		_mockStorageService
-			.Setup(s => s.SaveOriginalAsync(receiptId, imageBytes, ".jpg", It.IsAny<CancellationToken>()))
-			.ReturnsAsync($"{receiptId}/original.jpg");
-
 		_mockProcessingService
 			.Setup(s => s.PreprocessAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
 			.ThrowsAsync(new InvalidOperationException("The uploaded file is not a supported image format."));
@@ -214,20 +210,102 @@ public class UploadReceiptImageCommandHandlerTests
 		await act.Should().ThrowAsync<InvalidOperationException>()
 			.WithMessage("*not a supported image format*");
 
-		// Verify SaveProcessedAsync was never called after processing failure
+		// Validation runs before any write, so nothing is persisted for a rejected upload.
+		_mockStorageService.Verify(
+			s => s.SaveOriginalAsync(It.IsAny<Guid>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			Times.Never);
 		_mockStorageService.Verify(
 			s => s.SaveProcessedAsync(It.IsAny<Guid>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
 			Times.Never);
-
-		// Verify orphaned files are cleaned up
-		_mockStorageService.Verify(
-			s => s.DeleteReceiptImagesAsync(receiptId, It.IsAny<CancellationToken>()),
-			Times.Once);
 	}
 
 	[Fact]
-	public async Task Handle_StorageServiceThrows_PropagatesException()
+	public async Task Handle_InvalidImage_DoesNotDeleteExistingReceiptImages()
 	{
+		// Regression test for the untrusted-input-data-loss finding: a receipt that already has
+		// good images must not lose them when a subsequent upload is rejected during validation.
+		// The handler must reject BEFORE touching permanent storage and must NEVER call
+		// DeleteReceiptImagesAsync (which recursively deletes ALL of the receipt's images).
+
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		byte[] badBytes = [0x00, 0x01, 0x02, 0x03]; // not a real image
+		UploadReceiptImageCommand command = new(receiptId, badBytes, "image/png", ".png");
+
+		_mockReceiptService
+			.Setup(s => s.ExistsAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		_mockProcessingService
+			.Setup(s => s.PreprocessAsync(badBytes, "image/png", It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException(
+				"The uploaded file is not a supported image format. Only JPEG and PNG are accepted."));
+
+		// Act
+		Func<Task> act = async () => await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>();
+
+		// The pre-existing images are preserved: no destructive delete, no overwrite, no DB update.
+		_mockStorageService.Verify(
+			s => s.DeleteReceiptImagesAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+		_mockStorageService.Verify(
+			s => s.SaveOriginalAsync(It.IsAny<Guid>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+		_mockReceiptService.Verify(
+			s => s.UpdateImagePathsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_ValidCommand_ValidatesBeforeWritingToStorage()
+	{
+		// Ordering guard: PreprocessAsync (validation) MUST run before SaveOriginalAsync (the first
+		// write to permanent storage), so a rejected upload can never overwrite existing images.
+		// Arrange
+		Guid receiptId = Guid.NewGuid();
+		byte[] imageBytes = [0xFF, 0xD8];
+		UploadReceiptImageCommand command = new(receiptId, imageBytes, "image/jpeg", ".jpg");
+
+		bool preprocessCalled = false;
+
+		_mockReceiptService
+			.Setup(s => s.ExistsAsync(receiptId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		_mockProcessingService
+			.Setup(s => s.PreprocessAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.Callback(() => preprocessCalled = true)
+			.ReturnsAsync(new ImageProcessingResult([0x89, 0x50, 0x4E, 0x47], 100, 100));
+
+		_mockStorageService
+			.Setup(s => s.SaveOriginalAsync(receiptId, imageBytes, ".jpg", It.IsAny<CancellationToken>()))
+			.Callback(() => preprocessCalled.Should().BeTrue("preprocessing/validation must run before the original is written"))
+			.ReturnsAsync($"{receiptId}/original.jpg");
+
+		_mockStorageService
+			.Setup(s => s.SaveProcessedAsync(receiptId, It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync($"{receiptId}/processed.png");
+
+		// Act
+		await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		preprocessCalled.Should().BeTrue();
+		_mockStorageService.Verify(
+			s => s.DeleteReceiptImagesAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_StorageWriteFailsAfterValidation_DoesNotDeleteExistingImages()
+	{
+		// Even when a write fails AFTER a valid upload passes validation, the handler must not
+		// recursively delete the receipt's images. Both files are written from validated bytes,
+		// so there is no invalid partial state that would justify wiping pre-existing images.
+
 		// Arrange
 		Guid receiptId = Guid.NewGuid();
 		byte[] imageBytes = [0xFF, 0xD8];
@@ -236,6 +314,10 @@ public class UploadReceiptImageCommandHandlerTests
 		_mockReceiptService
 			.Setup(s => s.ExistsAsync(receiptId, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(true);
+
+		_mockProcessingService
+			.Setup(s => s.PreprocessAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ImageProcessingResult([0x89, 0x50, 0x4E, 0x47], 100, 100));
 
 		_mockStorageService
 			.Setup(s => s.SaveOriginalAsync(receiptId, imageBytes, ".jpg", It.IsAny<CancellationToken>()))
@@ -248,9 +330,12 @@ public class UploadReceiptImageCommandHandlerTests
 		await act.Should().ThrowAsync<IOException>()
 			.WithMessage("Disk full");
 
-		// Verify preprocessing was never called
+		// Preprocessing (validation) ran first, and no destructive cleanup was performed.
 		_mockProcessingService.Verify(
-			s => s.PreprocessAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+			s => s.PreprocessAsync(imageBytes, "image/jpeg", It.IsAny<CancellationToken>()),
+			Times.Once);
+		_mockStorageService.Verify(
+			s => s.DeleteReceiptImagesAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
 			Times.Never);
 	}
 }

--- a/tests/Infrastructure.Tests/Services/ImageProcessingServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ImageProcessingServiceTests.cs
@@ -287,6 +287,144 @@ public class ImageProcessingServiceTests
 		});
 	}
 
+	[Fact]
+	public async Task PreprocessAsync_ExceedsMegapixelCap_RejectsBeforeAllocation()
+	{
+		// Decompression-bomb guard: a 5000x5000 solid-color PNG is only a few KB compressed but
+		// decodes to 25 megapixels — over the 24 MP cap. Each dimension is under the per-dimension
+		// limit (8000), so this specifically exercises the total-megapixel guard. It must be
+		// rejected at the header-inspection step, BEFORE Image.Load and before ApplyAdaptiveThreshold
+		// allocates its ~200 MB integral array. If the guard failed, this call would allocate
+		// hundreds of MB and run for a long time rather than throwing promptly.
+		byte[] bomb = CreateSolidPng(5000, 5000);
+
+		Func<Task> act = () => _service.PreprocessAsync(bomb, "image/png", CancellationToken.None);
+
+		(await act.Should().ThrowAsync<InvalidOperationException>())
+			.Which.Message.Should().Contain("exceeds the maximum allowed")
+			.And.Contain("pixels");
+	}
+
+	[Fact]
+	public async Task PreprocessAsync_ExceedsPerDimensionCap_Rejects()
+	{
+		// A very wide but low-total-pixel image (8001 x 100 = 0.8 MP) is under the megapixel cap
+		// but over the per-dimension cap, so the per-dimension guard must reject it.
+		byte[] wide = CreateSolidPng(8001, 100);
+
+		Func<Task> act = () => _service.PreprocessAsync(wide, "image/png", CancellationToken.None);
+
+		(await act.Should().ThrowAsync<InvalidOperationException>())
+			.Which.Message.Should().Contain("dimensions").And.Contain("exceed the maximum allowed");
+	}
+
+	[Fact]
+	public async Task PreprocessAsync_ForgedHeaderDeclaring10000Squared_IsRejectedFromHeaderAlone()
+	{
+		// The original vulnerability: a 10000x10000 image (~100 MP, tens of KB on disk) passed the
+		// old "> 10000" per-dimension check and then allocated a ~800 MB integral array. Here we
+		// feed a PNG whose IHDR *declares* 10000x10000 but which carries no pixel data at all. It is
+		// rejected purely from the header via Image.Identify — proving the guard fires before any
+		// Image.Load / decode / large allocation ever happens (there is nothing decodable to load).
+		byte[] forged = CreateForgedPngDeclaringDimensions(10000, 10000);
+
+		Func<Task> act = () => _service.PreprocessAsync(forged, "image/png", CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*exceed*maximum allowed*");
+	}
+
+	[Fact]
+	public async Task PreprocessAsync_NormalMultiHundredKilopixelImage_StillProcesses()
+	{
+		// A legitimate downscaled receipt photo (well under the caps) must still process normally.
+		byte[] imageBytes = CreateTestPng(1200, 900);
+
+		ImageProcessingResult result = await _service.PreprocessAsync(imageBytes, "image/png", CancellationToken.None);
+
+		result.ProcessedBytes.Should().NotBeNullOrEmpty();
+		result.Width.Should().BeGreaterThan(0);
+		result.Height.Should().BeGreaterThan(0);
+	}
+
+	private static byte[] CreateSolidPng(int width, int height)
+	{
+		// Solid color so PNG compression keeps the encoded file tiny regardless of dimensions —
+		// this is exactly the decompression-bomb shape we defend against.
+		using Image<L8> image = new(width, height, new L8(200));
+		using MemoryStream ms = new();
+		image.Save(ms, new PngEncoder());
+		return ms.ToArray();
+	}
+
+	// Builds a minimal, structurally valid PNG whose IHDR declares the given dimensions but which
+	// contains no image data. Image.Identify reports the declared dimensions from the header alone,
+	// so this lets us assert the dimension guard rejects abusive sizes without allocating any large
+	// pixel buffer in the test.
+	private static byte[] CreateForgedPngDeclaringDimensions(int width, int height)
+	{
+		using MemoryStream ms = new();
+		ms.Write([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]); // PNG signature
+
+		byte[] ihdr = new byte[13];
+		WriteBigEndianInt32(ihdr, 0, width);
+		WriteBigEndianInt32(ihdr, 4, height);
+		ihdr[8] = 8;  // bit depth
+		ihdr[9] = 0;  // color type: grayscale
+		ihdr[10] = 0; // compression method
+		ihdr[11] = 0; // filter method
+		ihdr[12] = 0; // interlace method
+		WritePngChunk(ms, "IHDR", ihdr);
+		WritePngChunk(ms, "IEND", []);
+
+		return ms.ToArray();
+	}
+
+	private static void WriteBigEndianInt32(byte[] buffer, int offset, int value)
+	{
+		buffer[offset] = (byte)((value >> 24) & 0xFF);
+		buffer[offset + 1] = (byte)((value >> 16) & 0xFF);
+		buffer[offset + 2] = (byte)((value >> 8) & 0xFF);
+		buffer[offset + 3] = (byte)(value & 0xFF);
+	}
+
+	private static void WritePngChunk(Stream stream, string type, byte[] data)
+	{
+		byte[] length = new byte[4];
+		WriteBigEndianInt32(length, 0, data.Length);
+		stream.Write(length);
+
+		byte[] typeBytes = System.Text.Encoding.ASCII.GetBytes(type);
+		stream.Write(typeBytes);
+		stream.Write(data);
+
+		uint crc = Crc32(typeBytes, data);
+		byte[] crcBytes = new byte[4];
+		WriteBigEndianInt32(crcBytes, 0, (int)crc);
+		stream.Write(crcBytes);
+	}
+
+	private static uint Crc32(byte[] typeBytes, byte[] data)
+	{
+		uint crc = 0xFFFFFFFF;
+		crc = Crc32Update(crc, typeBytes);
+		crc = Crc32Update(crc, data);
+		return crc ^ 0xFFFFFFFF;
+	}
+
+	private static uint Crc32Update(uint crc, byte[] bytes)
+	{
+		foreach (byte b in bytes)
+		{
+			crc ^= b;
+			for (int i = 0; i < 8; i++)
+			{
+				crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320 : crc >> 1;
+			}
+		}
+		return crc;
+	}
+
 	private static byte[] CreateTestJpeg(int width, int height)
 	{
 		using Image<L8> image = new(width, height);


### PR DESCRIPTION
## Summary

Fixes two confirmed receipt-image handling findings from the Fable deep audit (2026-07-11). Both live on the image upload/processing path. One logical commit per fix.

### Fix 1 — `fix(application)`: failed re-upload no longer destroys existing images (RECEIPTS-762, untrusted-input-data-loss)

`UploadReceiptImageCommandHandler` wrote the uploaded bytes to the receipt's **permanent** storage (`SaveOriginalAsync`) *before* validating them, and `PreprocessAsync` was the first magic-byte/format check. On failure the `catch` called `DeleteReceiptImagesAsync`, which recursively deletes the entire `{receiptId}` directory — including previously-good original/processed images — while the DB row kept advertising the now-deleted paths (dangling references).

**Fix (validate-in-memory-first):** `PreprocessAsync` now runs *before* anything reaches disk. A rejected upload throws having written nothing, so the destructive recursive delete is never invoked and the receipt's existing images (and their DB paths) are always preserved. Files are written only from already-validated bytes, so there is no invalid partial state to clean up, and `UpdateImagePathsAsync` only runs on success.

### Fix 2 — `fix(infrastructure)`: cap decoded megapixels to block decompression-bomb OOM (RECEIPTS-773, decompression-bomb-dos)

`ImageProcessingService.PreprocessAsync` guarded only each dimension with `>` against `10000`, so a solid-color `10000x10000` PNG (tens of KB compressed, ~100 MP decoded) slipped through. `ApplyAdaptiveThreshold` then allocated a `long[height+1, width+1]` integral array (~760 MB) plus the L8 decode and deskew buffers — letting an authenticated user OOM the process with a tiny upload. The ImageSharp memory-pool cap does not bound that raw CLR array.

**Fix:** added a **total decoded-pixel cap** (`width * height`, `long` arithmetic) of **24 MP** and lowered the **per-dimension cap to 8000**, both enforced from the header via `Image.Identify` **before** `Image.Load` and before any large allocation. This keeps legitimate captures working (a 12 MP phone photo is ~4032x3024; long receipt scans are tall) while rejecting abusive dimensions — cutting the worst-case allocation from ~950 MB to ~240 MB and bounding it. (A literal 4000x4000 cap as the issue loosely suggested would reject standard 12 MP phone photos and long receipt scans, so the caps are calibrated for this domain.)

**PdfConversionService:** `TryCreatePngFromRawPixels` has a similar `>` per-dimension cap, but `IPdfConversionService` is not injected by any controller or handler (PDF/OCR feature retired, RECEIPTS-710) and is unreachable from any endpoint. Scoped the fix to the reachable image path and left a note.

## Tests

Run with the exact CI coverage command (`--collect:"XPlat Code Coverage" --settings scripts/tests/coverlet.runsettings`):

- **Infrastructure.Tests: 659 passed, 0 failed**
- **Application.Tests: 459 passed, 0 failed**

Added:
- Oversized-dimension image is rejected **before** the big allocation — a forged PNG header declaring `10000x10000` is rejected from the header alone (proving `Image.Load` is never reached), and a `5000x5000` (25 MP) solid PNG is rejected by the total-megapixel guard. Both assert the validation error and run in milliseconds (no large allocation).
- A very-wide `8001x100` image is rejected by the per-dimension guard.
- A normal downscaled receipt photo still processes end-to-end.
- Invalid/failed re-upload does **not** delete the receipt's existing images: the handler never calls `DeleteReceiptImagesAsync`, `SaveOriginalAsync`, or `UpdateImagePathsAsync` on a rejected upload; validation runs before any write; and a storage write failure *after* a valid upload still never triggers the destructive delete.

Closes RECEIPTS-762, RECEIPTS-773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
