### PR TITLE
fix(api): account lockout, hashed refresh tokens, refresh-race handling, timing-safe login

### DIFF
--- a/src/Application/Interfaces/Services/IUserService.cs
+++ b/src/Application/Interfaces/Services/IUserService.cs
@@ -16,4 +16,11 @@ public interface IUserService
 {
 	Task<PagedResult<UserSummary>> ListUsersAsync(int offset, int limit, SortParams sort, CancellationToken cancellationToken = default);
 	Task<string?> FindUserIdByRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Computes the SHA-256 hash (lowercase hex) of a refresh token. Only this hash is persisted on the
+	/// user row; the plaintext token is returned to the client exactly once at issue time. Mirrors the
+	/// hashing used for API keys so a leaked database or backup does not expose usable refresh tokens.
+	/// </summary>
+	string HashRefreshToken(string refreshToken);
 }

--- a/src/Infrastructure/Services/InfrastructureService.cs
+++ b/src/Infrastructure/Services/InfrastructureService.cs
@@ -104,7 +104,16 @@ public static class InfrastructureService
 		services.TryAddSingleton<ICurrentUserAccessor, NullCurrentUserAccessor>();
 
 		services
-			.AddIdentityCore<ApplicationUser>()
+			.AddIdentityCore<ApplicationUser>(options =>
+			{
+				// Account-lockout policy (RECEIPTS auth-hardening). AllowedForNewUsers makes CreateAsync
+				// stamp LockoutEnabled=true so the failed-login counter can actually engage; the login
+				// endpoint increments it via AccessFailedAsync and locks the account for the timespan
+				// below once MaxFailedAccessAttempts consecutive failures are reached.
+				options.Lockout.AllowedForNewUsers = true;
+				options.Lockout.MaxFailedAccessAttempts = 5;
+				options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(15);
+			})
 			.AddRoles<IdentityRole>()
 			.AddEntityFrameworkStores<ApplicationDbContext>();
 

--- a/src/Infrastructure/Services/UserService.cs
+++ b/src/Infrastructure/Services/UserService.cs
@@ -1,4 +1,6 @@
 using System.Linq.Expressions;
+using System.Security.Cryptography;
+using System.Text;
 using Application.Interfaces.Services;
 using Application.Models;
 using Infrastructure.Entities;
@@ -62,9 +64,22 @@ public class UserService(ApplicationDbContext dbContext) : IUserService
 
 	public async Task<string?> FindUserIdByRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default)
 	{
+		if (string.IsNullOrEmpty(refreshToken))
+		{
+			return null;
+		}
+
+		// Refresh tokens are stored hashed, so hash the incoming plaintext and compare hash-to-hash.
+		string tokenHash = HashRefreshToken(refreshToken);
 		return await dbContext.Users
-			.Where(u => u.RefreshToken == refreshToken)
+			.Where(u => u.RefreshToken == tokenHash)
 			.Select(u => u.Id)
 			.FirstOrDefaultAsync(cancellationToken);
+	}
+
+	public string HashRefreshToken(string refreshToken)
+	{
+		byte[] bytes = SHA256.HashData(Encoding.UTF8.GetBytes(refreshToken));
+		return Convert.ToHexString(bytes).ToLowerInvariant();
 	}
 }

--- a/src/Presentation/API/Controllers/AuthController.cs
+++ b/src/Presentation/API/Controllers/AuthController.cs
@@ -31,25 +31,40 @@ public class AuthController(
 	public async Task<Results<Ok<TokenResponse>, JsonHttpResult<OAuthErrorResponse>>> Login([FromBody] LoginRequest request)
 	{
 		ApplicationUser? user = await userManager.FindByEmailAsync(request.Email);
-		if (user is null || !await userManager.CheckPasswordAsync(user, request.Password))
+		if (user is null)
 		{
-			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user?.Id, request.Email, false, "Invalid credentials");
-			return TypedResults.Json(new OAuthErrorResponse
-			{
-				Error = OAuthErrorResponseError.Invalid_grant,
-				Error_description = "Invalid email or password",
-			}, statusCode: StatusCodes.Status401Unauthorized);
+			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), null, request.Email, false, "Invalid credentials");
+			return InvalidCredentialsResponse();
 		}
 
+		// Reject a locked-out account BEFORE verifying the password. A locked account (whether tripped by
+		// failed-login lockout or disabled by an admin via LockoutEnd) gets a clear 401 — never a 500 —
+		// and repeated attempts during the window don't spend time hashing.
 		if (await userManager.IsLockedOutAsync(user))
 		{
-			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user.Id, request.Email, false, "Account disabled");
-			return TypedResults.Json(new OAuthErrorResponse
-			{
-				Error = OAuthErrorResponseError.Invalid_grant,
-				Error_description = "Account is disabled",
-			}, statusCode: StatusCodes.Status401Unauthorized);
+			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user.Id, request.Email, false, "Account locked");
+			return AccountLockedResponse();
 		}
+
+		if (!await userManager.CheckPasswordAsync(user, request.Password))
+		{
+			// CheckPasswordAsync only verifies the hash — it never touches AccessFailedCount. Increment it
+			// so password brute force actually trips the lockout after MaxFailedAccessAttempts.
+			await userManager.AccessFailedAsync(user);
+
+			// If this failure just crossed the threshold, say so plainly instead of a bare "invalid".
+			if (await userManager.IsLockedOutAsync(user))
+			{
+				await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user.Id, request.Email, false, "Account locked");
+				return AccountLockedResponse();
+			}
+
+			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user.Id, request.Email, false, "Invalid credentials");
+			return InvalidCredentialsResponse();
+		}
+
+		// Correct password — clear any accumulated failed-attempt count.
+		await userManager.ResetAccessFailedCountAsync(user);
 
 		IList<string> roles = await userManager.GetRolesAsync(user);
 		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword);
@@ -67,11 +82,7 @@ public class AuthController(
 			// The session (refresh token) was not persisted — e.g. a concurrency-stamp mismatch. Fail
 			// closed with a generic 401 rather than handing back a token the database never stored.
 			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user.Id, request.Email, false, "Failed to persist session");
-			return TypedResults.Json(new OAuthErrorResponse
-			{
-				Error = OAuthErrorResponseError.Invalid_grant,
-				Error_description = "Invalid email or password",
-			}, statusCode: StatusCodes.Status401Unauthorized);
+			return InvalidCredentialsResponse();
 		}
 
 		await LogAuthEventAsync(nameof(AuthEventType.Login), user.Id, user.Email, true);
@@ -283,6 +294,24 @@ public class AuthController(
 
 		return TypedResults.Ok();
 	}
+
+	// Identical generic response for the unknown-email and wrong-password paths so neither timing nor
+	// wording reveals which one failed (user-enumeration defense).
+	private static JsonHttpResult<OAuthErrorResponse> InvalidCredentialsResponse() =>
+		TypedResults.Json(new OAuthErrorResponse
+		{
+			Error = OAuthErrorResponseError.Invalid_grant,
+			Error_description = "Invalid email or password",
+		}, statusCode: StatusCodes.Status401Unauthorized);
+
+	// Distinct, clear response for a locked/disabled account (covers both failed-login lockout and
+	// admin disable). Still a 401 so the OAuth error contract and client handling are unchanged.
+	private static JsonHttpResult<OAuthErrorResponse> AccountLockedResponse() =>
+		TypedResults.Json(new OAuthErrorResponse
+		{
+			Error = OAuthErrorResponseError.Invalid_grant,
+			Error_description = "Account is locked. Try again later or contact an administrator.",
+		}, statusCode: StatusCodes.Status401Unauthorized);
 
 	private async Task LogAuthEventAsync(string eventType, string? userId, string? username, bool success, string? failureReason = null)
 	{

--- a/src/Presentation/API/Controllers/AuthController.cs
+++ b/src/Presentation/API/Controllers/AuthController.cs
@@ -55,7 +55,9 @@ public class AuthController(
 		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword);
 		string refreshToken = tokenService.GenerateRefreshToken();
 
-		user.RefreshToken = refreshToken;
+		// Persist only the hash of the refresh token; the plaintext is returned to the client below and
+		// never stored, so a leaked database/backup cannot yield a usable token.
+		user.RefreshToken = userService.HashRefreshToken(refreshToken);
 		user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
 		user.LastLoginAt = DateTimeOffset.UtcNow;
 		await userManager.UpdateAsync(user);
@@ -93,7 +95,7 @@ public class AuthController(
 		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword);
 		string newRefreshToken = tokenService.GenerateRefreshToken();
 
-		user.RefreshToken = newRefreshToken;
+		user.RefreshToken = userService.HashRefreshToken(newRefreshToken);
 		user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
 		await userManager.UpdateAsync(user);
 
@@ -167,7 +169,7 @@ public class AuthController(
 		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, false);
 		string refreshToken = tokenService.GenerateRefreshToken();
 
-		user.RefreshToken = refreshToken;
+		user.RefreshToken = userService.HashRefreshToken(refreshToken);
 		user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
 		await userManager.UpdateAsync(user);
 

--- a/src/Presentation/API/Controllers/AuthController.cs
+++ b/src/Presentation/API/Controllers/AuthController.cs
@@ -24,6 +24,13 @@ public class AuthController(
 	IAuthAuditService authAuditService,
 	ILogger<AuthController> logger) : ControllerBase
 {
+	// A throwaway user and a precomputed, valid PHC-format hash whose PBKDF2 work factor matches a
+	// freshly-hashed password from the default hasher. Verifying a supplied password against this runs
+	// the full PBKDF2 cost, so the unknown-email login path is not measurably faster than a real one.
+	private static readonly ApplicationUser DummyUser = new();
+	private static readonly string DummyPasswordHash =
+		new PasswordHasher<ApplicationUser>().HashPassword(DummyUser, "timing-safe-dummy-password-value");
+
 	[HttpPost("login")]
 	[AllowAnonymous]
 	[EndpointSummary("Login with email and password")]
@@ -33,6 +40,10 @@ public class AuthController(
 		ApplicationUser? user = await userManager.FindByEmailAsync(request.Email);
 		if (user is null)
 		{
+			// User-enumeration defense: when the email is unknown, run a real PBKDF2 verification against a
+			// throwaway hash so this path costs about the same as a wrong-password path. Without it the
+			// missing-user branch returns measurably faster and leaks which emails are registered.
+			VerifyDummyPassword(request.Password);
 			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), null, request.Email, false, "Invalid credentials");
 			return InvalidCredentialsResponse();
 		}
@@ -294,6 +305,11 @@ public class AuthController(
 
 		return TypedResults.Ok();
 	}
+
+	// Runs a full PBKDF2 verification against a throwaway hash purely to equalize timing on the
+	// unknown-user path. The result is intentionally discarded.
+	private void VerifyDummyPassword(string password) =>
+		_ = userManager.PasswordHasher.VerifyHashedPassword(DummyUser, DummyPasswordHash, password);
 
 	// Identical generic response for the unknown-email and wrong-password paths so neither timing nor
 	// wording reveals which one failed (user-enumeration defense).

--- a/src/Presentation/API/Controllers/AuthController.cs
+++ b/src/Presentation/API/Controllers/AuthController.cs
@@ -60,7 +60,19 @@ public class AuthController(
 		user.RefreshToken = userService.HashRefreshToken(refreshToken);
 		user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
 		user.LastLoginAt = DateTimeOffset.UtcNow;
-		await userManager.UpdateAsync(user);
+
+		IdentityResult updateResult = await userManager.UpdateAsync(user);
+		if (!updateResult.Succeeded)
+		{
+			// The session (refresh token) was not persisted — e.g. a concurrency-stamp mismatch. Fail
+			// closed with a generic 401 rather than handing back a token the database never stored.
+			await LogAuthEventAsync(nameof(AuthEventType.LoginFailed), user.Id, request.Email, false, "Failed to persist session");
+			return TypedResults.Json(new OAuthErrorResponse
+			{
+				Error = OAuthErrorResponseError.Invalid_grant,
+				Error_description = "Invalid email or password",
+			}, statusCode: StatusCodes.Status401Unauthorized);
+		}
 
 		await LogAuthEventAsync(nameof(AuthEventType.Login), user.Id, user.Email, true);
 
@@ -97,7 +109,15 @@ public class AuthController(
 
 		user.RefreshToken = userService.HashRefreshToken(newRefreshToken);
 		user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
-		await userManager.UpdateAsync(user);
+
+		IdentityResult updateResult = await userManager.UpdateAsync(user);
+		if (!updateResult.Succeeded)
+		{
+			// Two refresh requests raced: the stored ConcurrencyStamp changed under us, so this rotation
+			// was NOT persisted. Returning the new token would hand back one the database never saved.
+			// Fail closed (invalid_grant) so the loser retries with a fresh, valid token.
+			return TypedResults.Unauthorized();
+		}
 
 		return TypedResults.Ok(new TokenResponse
 		{
@@ -171,7 +191,14 @@ public class AuthController(
 
 		user.RefreshToken = userService.HashRefreshToken(refreshToken);
 		user.RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30);
-		await userManager.UpdateAsync(user);
+
+		IdentityResult sessionUpdateResult = await userManager.UpdateAsync(user);
+		if (!sessionUpdateResult.Succeeded)
+		{
+			// The password change itself already persisted; only the new session failed to save (e.g. a
+			// concurrency-stamp mismatch). Fail closed so the caller re-authenticates with the new password.
+			return TypedResults.Unauthorized();
+		}
 
 		await LogAuthEventAsync(nameof(AuthEventType.PasswordChanged), user.Id, user.Email, true);
 

--- a/src/Presentation/API/Controllers/UsersController.cs
+++ b/src/Presentation/API/Controllers/UsersController.cs
@@ -163,16 +163,12 @@ public class UsersController(
 		user.FirstName = request.FirstName;
 		user.LastName = request.LastName;
 
-		if (request.IsDisabled)
-		{
-			user.LockoutEnabled = true;
-			user.LockoutEnd = DateTimeOffset.MaxValue;
-		}
-		else
-		{
-			user.LockoutEnabled = false;
-			user.LockoutEnd = null;
-		}
+		// Disabled/enabled is signalled by LockoutEnd (MaxValue = disabled, null = enabled), never by
+		// LockoutEnabled. LockoutEnabled must stay true so failed-login lockout keeps working — setting it
+		// false here would permanently disable brute-force protection for the user, since IsLockedOutAsync
+		// short-circuits to false when LockoutEnabled is false (RECEIPTS-776).
+		user.LockoutEnabled = true;
+		user.LockoutEnd = request.IsDisabled ? DateTimeOffset.MaxValue : null;
 
 		IdentityResult updateResult = await userManager.UpdateAsync(user);
 		if (!updateResult.Succeeded)

--- a/tests/Infrastructure.Tests/Services/UserServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/UserServiceTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Infrastructure.Entities;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Tests.Services;
+
+public class UserServiceTests
+{
+	private static ApplicationDbContext CreateContext() =>
+		new(new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase($"UserServiceTests_{Guid.NewGuid()}")
+			.Options);
+
+	[Fact]
+	public void HashRefreshToken_ProducesSha256Hex_ThatDiffersFromPlaintext()
+	{
+		using ApplicationDbContext context = CreateContext();
+		UserService service = new(context);
+
+		const string token = "some-random-refresh-token";
+		string hash = service.HashRefreshToken(token);
+
+		hash.Should().NotBe(token);
+		hash.Should().HaveLength(64); // SHA-256 = 32 bytes = 64 lowercase hex chars
+		hash.Should().MatchRegex("^[0-9a-f]{64}$");
+		service.HashRefreshToken(token).Should().Be(hash); // deterministic
+	}
+
+	[Fact]
+	public async Task FindUserIdByRefreshTokenAsync_MatchesOnHash_WhenStoredValueIsHashed()
+	{
+		using ApplicationDbContext context = CreateContext();
+		UserService service = new(context);
+
+		const string plaintext = "the-plaintext-refresh-token";
+		context.Users.Add(new ApplicationUser
+		{
+			Id = "user-1",
+			Email = "u@example.com",
+			UserName = "u@example.com",
+			// Stored hashed, exactly as AuthController persists it.
+			RefreshToken = service.HashRefreshToken(plaintext),
+			RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30),
+		});
+		await context.SaveChangesAsync();
+
+		// A valid plaintext token still resolves to its user (hashed internally before comparison).
+		string? foundId = await service.FindUserIdByRefreshTokenAsync(plaintext);
+		foundId.Should().Be("user-1");
+	}
+
+	[Fact]
+	public async Task FindUserIdByRefreshTokenAsync_DoesNotMatchStoredPlaintext()
+	{
+		using ApplicationDbContext context = CreateContext();
+		UserService service = new(context);
+
+		const string plaintext = "leaked-plaintext-token";
+		// A legacy/attacker row that stored the raw token must NOT be found via the hashed lookup.
+		context.Users.Add(new ApplicationUser
+		{
+			Id = "user-2",
+			Email = "v@example.com",
+			UserName = "v@example.com",
+			RefreshToken = plaintext,
+			RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30),
+		});
+		await context.SaveChangesAsync();
+
+		string? foundId = await service.FindUserIdByRefreshTokenAsync(plaintext);
+		foundId.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task FindUserIdByRefreshTokenAsync_ReturnsNull_ForEmptyToken()
+	{
+		using ApplicationDbContext context = CreateContext();
+		UserService service = new(context);
+
+		string? foundId = await service.FindUserIdByRefreshTokenAsync("");
+		foundId.Should().BeNull();
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
@@ -17,6 +17,7 @@ namespace Presentation.API.Tests.Controllers;
 public class AuthControllerTests
 {
 	private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+	private readonly Mock<IPasswordHasher<ApplicationUser>> _passwordHasherMock;
 	private readonly Mock<ITokenService> _tokenServiceMock;
 	private readonly Mock<IUserService> _userServiceMock;
 	private readonly Mock<IAuthAuditService> _authAuditServiceMock;
@@ -25,10 +26,11 @@ public class AuthControllerTests
 	public AuthControllerTests()
 	{
 		Mock<IUserStore<ApplicationUser>> userStoreMock = new();
+		_passwordHasherMock = new Mock<IPasswordHasher<ApplicationUser>>();
 		_userManagerMock = new Mock<UserManager<ApplicationUser>>(
 			userStoreMock.Object,
 			new Mock<IOptions<IdentityOptions>>().Object,
-			new Mock<IPasswordHasher<ApplicationUser>>().Object,
+			_passwordHasherMock.Object,
 			Array.Empty<IUserValidator<ApplicationUser>>(),
 			Array.Empty<IPasswordValidator<ApplicationUser>>(),
 			new Mock<ILookupNormalizer>().Object,
@@ -117,6 +119,26 @@ public class AuthControllerTests
 		Results<Ok<TokenResponse>, JsonHttpResult<OAuthErrorResponse>> result = await _controller.Login(new LoginRequest { Email = "test@example.com", Password = "wrong" });
 
 		// Assert
+		JsonHttpResult<OAuthErrorResponse> errorResult = Assert.IsType<JsonHttpResult<OAuthErrorResponse>>(result.Result);
+		errorResult.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+		errorResult.Value!.Error.Should().Be(OAuthErrorResponseError.Invalid_grant);
+		errorResult.Value!.Error_description.Should().Be("Invalid email or password");
+	}
+
+	[Fact]
+	public async Task Login_UnknownEmail_PerformsDummyHash_AndReturnsGenericError()
+	{
+		// Arrange — no user with this email.
+		_userManagerMock.Setup(m => m.FindByEmailAsync("ghost@example.com")).ReturnsAsync((ApplicationUser?)null);
+
+		// Act
+		Results<Ok<TokenResponse>, JsonHttpResult<OAuthErrorResponse>> result = await _controller.Login(new LoginRequest { Email = "ghost@example.com", Password = "whatever" });
+
+		// Assert — a password verification still runs (timing-safe), and the response is the same generic
+		// error the wrong-password path returns, so neither timing nor wording reveals the email is unknown.
+		_passwordHasherMock.Verify(
+			h => h.VerifyHashedPassword(It.IsAny<ApplicationUser>(), It.IsAny<string>(), "whatever"),
+			Times.Once);
 		JsonHttpResult<OAuthErrorResponse> errorResult = Assert.IsType<JsonHttpResult<OAuthErrorResponse>>(result.Result);
 		errorResult.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
 		errorResult.Value!.Error.Should().Be(OAuthErrorResponseError.Invalid_grant);

--- a/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
@@ -38,6 +38,9 @@ public class AuthControllerTests
 
 		_tokenServiceMock = new Mock<ITokenService>();
 		_userServiceMock = new Mock<IUserService>();
+		// Refresh tokens are persisted hashed. Model the hash deterministically so tests can assert the
+		// stored value differs from the plaintext returned to the client.
+		_userServiceMock.Setup(s => s.HashRefreshToken(It.IsAny<string>())).Returns<string>(t => "hashed:" + t);
 		_authAuditServiceMock = new Mock<IAuthAuditService>();
 		Mock<ILogger<AuthController>> loggerMock = ControllerTestHelpers.GetLoggerMock<AuthController>();
 
@@ -136,6 +139,29 @@ public class AuthControllerTests
 		errorResult.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
 		errorResult.Value!.Error.Should().Be(OAuthErrorResponseError.Invalid_grant);
 		errorResult.Value!.Error_description.Should().Be("Account is disabled");
+	}
+
+	[Fact]
+	public async Task Login_StoresHashedRefreshToken_NotPlaintext()
+	{
+		// Arrange
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByEmailAsync("test@example.com")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.CheckPasswordAsync(user, "password")).ReturnsAsync(true);
+		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("access-token");
+		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("plaintext-refresh");
+
+		// Act
+		Results<Ok<TokenResponse>, JsonHttpResult<OAuthErrorResponse>> result = await _controller.Login(new LoginRequest { Email = "test@example.com", Password = "password" });
+
+		// Assert — the client receives the plaintext token, but only the hash is persisted.
+		Ok<TokenResponse> okResult = Assert.IsType<Ok<TokenResponse>>(result.Result);
+		okResult.Value!.RefreshToken.Should().Be("plaintext-refresh");
+		user.RefreshToken.Should().Be("hashed:plaintext-refresh");
+		user.RefreshToken.Should().NotBe("plaintext-refresh");
 	}
 
 	// ── Refresh ──────────────────────────────────────────────

--- a/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
@@ -126,10 +126,9 @@ public class AuthControllerTests
 	[Fact]
 	public async Task Login_LockedOut_ReturnsOAuthErrorResponse()
 	{
-		// Arrange
+		// Arrange — a locked/disabled account is rejected before the password is even checked.
 		ApplicationUser user = CreateTestUser();
 		_userManagerMock.Setup(m => m.FindByEmailAsync("test@example.com")).ReturnsAsync(user);
-		_userManagerMock.Setup(m => m.CheckPasswordAsync(user, "password")).ReturnsAsync(true);
 		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(true);
 
 		// Act
@@ -139,7 +138,73 @@ public class AuthControllerTests
 		JsonHttpResult<OAuthErrorResponse> errorResult = Assert.IsType<JsonHttpResult<OAuthErrorResponse>>(result.Result);
 		errorResult.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
 		errorResult.Value!.Error.Should().Be(OAuthErrorResponseError.Invalid_grant);
-		errorResult.Value!.Error_description.Should().Be("Account is disabled");
+		errorResult.Value!.Error_description.Should().Be("Account is locked. Try again later or contact an administrator.");
+		// The password is never verified for a locked account.
+		_userManagerMock.Verify(m => m.CheckPasswordAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task Login_WrongPassword_IncrementsAccessFailedCount()
+	{
+		// Arrange
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByEmailAsync("test@example.com")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
+		_userManagerMock.Setup(m => m.CheckPasswordAsync(user, "wrong")).ReturnsAsync(false);
+		_userManagerMock.Setup(m => m.AccessFailedAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+		// Act
+		Results<Ok<TokenResponse>, JsonHttpResult<OAuthErrorResponse>> result = await _controller.Login(new LoginRequest { Email = "test@example.com", Password = "wrong" });
+
+		// Assert — generic error, and the failed-attempt counter was incremented (this is what engages lockout).
+		JsonHttpResult<OAuthErrorResponse> errorResult = Assert.IsType<JsonHttpResult<OAuthErrorResponse>>(result.Result);
+		errorResult.Value!.Error_description.Should().Be("Invalid email or password");
+		_userManagerMock.Verify(m => m.AccessFailedAsync(user), Times.Once);
+	}
+
+	[Fact]
+	public async Task Login_WrongPassword_WhenThresholdReached_ReturnsLocked()
+	{
+		// Arrange — the account is not locked before this attempt, but AccessFailedAsync trips the lockout.
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByEmailAsync("test@example.com")).ReturnsAsync(user);
+		_userManagerMock.SetupSequence(m => m.IsLockedOutAsync(user))
+			.ReturnsAsync(false)  // pre-check before verifying the password
+			.ReturnsAsync(true);  // post-check after AccessFailedAsync crosses the threshold
+		_userManagerMock.Setup(m => m.CheckPasswordAsync(user, "wrong")).ReturnsAsync(false);
+		_userManagerMock.Setup(m => m.AccessFailedAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+		// Act
+		Results<Ok<TokenResponse>, JsonHttpResult<OAuthErrorResponse>> result = await _controller.Login(new LoginRequest { Email = "test@example.com", Password = "wrong" });
+
+		// Assert
+		JsonHttpResult<OAuthErrorResponse> errorResult = Assert.IsType<JsonHttpResult<OAuthErrorResponse>>(result.Result);
+		errorResult.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+		errorResult.Value!.Error_description.Should().Be("Account is locked. Try again later or contact an administrator.");
+		_userManagerMock.Verify(m => m.AccessFailedAsync(user), Times.Once);
+	}
+
+	[Fact]
+	public async Task Login_Success_ResetsAccessFailedCount()
+	{
+		// Arrange
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByEmailAsync("test@example.com")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
+		_userManagerMock.Setup(m => m.CheckPasswordAsync(user, "password")).ReturnsAsync(true);
+		_userManagerMock.Setup(m => m.ResetAccessFailedCountAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("access-token");
+		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("refresh-token");
+
+		// Act
+		Results<Ok<TokenResponse>, JsonHttpResult<OAuthErrorResponse>> result = await _controller.Login(new LoginRequest { Email = "test@example.com", Password = "password" });
+
+		// Assert
+		Assert.IsType<Ok<TokenResponse>>(result.Result);
+		_userManagerMock.Verify(m => m.ResetAccessFailedCountAsync(user), Times.Once);
+		_userManagerMock.Verify(m => m.AccessFailedAsync(It.IsAny<ApplicationUser>()), Times.Never);
 	}
 
 	[Fact]

--- a/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
@@ -90,6 +90,7 @@ public class AuthControllerTests
 		_userManagerMock.Setup(m => m.CheckPasswordAsync(user, "password")).ReturnsAsync(true);
 		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
 		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin", "User" });
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
 		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("access-token");
 		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("refresh-token");
 
@@ -174,6 +175,7 @@ public class AuthControllerTests
 		_userServiceMock.Setup(s => s.FindUserIdByRefreshTokenAsync("valid-refresh-token", It.IsAny<CancellationToken>())).ReturnsAsync(user.Id);
 		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
 		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
 		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("new-access-token");
 		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("new-refresh-token");
 
@@ -187,6 +189,26 @@ public class AuthControllerTests
 		response.Scope.Should().Be("User");
 	}
 
+	[Fact]
+	public async Task RefreshToken_ConcurrencyFailure_ReturnsUnauthorized()
+	{
+		// Arrange — two refresh requests race; this one loses the ConcurrencyStamp check on UpdateAsync.
+		ApplicationUser user = CreateTestUser();
+		_userServiceMock.Setup(s => s.FindUserIdByRefreshTokenAsync("valid-refresh-token", It.IsAny<CancellationToken>())).ReturnsAsync(user.Id);
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("new-access-token");
+		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("new-refresh-token");
+		_userManagerMock.Setup(m => m.UpdateAsync(user))
+			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "ConcurrencyFailure", Description = "Optimistic concurrency failure." }));
+
+		// Act
+		Results<Ok<TokenResponse>, UnauthorizedHttpResult> result = await _controller.RefreshToken(new RefreshTokenRequest { RefreshToken = "valid-refresh-token" }, CancellationToken.None);
+
+		// Assert — the caller must NOT receive a token that was never persisted.
+		Assert.IsType<UnauthorizedHttpResult>(result.Result);
+	}
+
 	// ── ChangePassword ───────────────────────────────────────
 
 	[Fact]
@@ -198,6 +220,7 @@ public class AuthControllerTests
 		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
 		_userManagerMock.Setup(m => m.ChangePasswordAsync(user, "old", "new")).ReturnsAsync(IdentityResult.Success);
 		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin" });
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
 		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("access-token");
 		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("refresh-token");
 

--- a/tests/Presentation.API.Tests/Controllers/UsersControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/UsersControllerTests.cs
@@ -248,6 +248,54 @@ public class UsersControllerTests
 	}
 
 	[Fact]
+	public async Task UpdateUser_KeepsLockoutEnabledTrue_WhenEnabling_SoFailedLoginLockoutStillWorks()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		// Previously disabled: enabling must NOT turn off the lockout machinery.
+		user.LockoutEnabled = true;
+		user.LockoutEnd = DateTimeOffset.MaxValue;
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.RemoveFromRolesAsync(user, It.IsAny<IEnumerable<string>>())).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(user, "User")).ReturnsAsync(IdentityResult.Success);
+
+		Results<NoContent, NotFound, BadRequest<string>, BadRequest<IEnumerable<string>>> result = await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "User", IsDisabled = false });
+
+		Assert.IsType<NoContent>(result.Result);
+		// LockoutEnabled stays true, so AccessFailedAsync/IsLockedOutAsync can still lock this account on
+		// failed logins. Enable is signalled purely by clearing LockoutEnd.
+		user.LockoutEnabled.Should().BeTrue();
+		user.LockoutEnd.Should().BeNull();
+		// IsDisabled invariant: an enabled user (LockoutEnd null) reads as not disabled.
+		(user.LockoutEnabled && user.LockoutEnd > DateTimeOffset.UtcNow).Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task UpdateUser_Disable_SetsLockoutEndToMaxValue_AndKeepsLockoutEnabled()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.RemoveFromRolesAsync(user, It.IsAny<IEnumerable<string>>())).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(user, "User")).ReturnsAsync(IdentityResult.Success);
+
+		await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "User", IsDisabled = true });
+
+		user.LockoutEnabled.Should().BeTrue();
+		user.LockoutEnd.Should().Be(DateTimeOffset.MaxValue);
+		// IsDisabled invariant: a disabled user (LockoutEnd = MaxValue) reads as disabled.
+		(user.LockoutEnabled && user.LockoutEnd > DateTimeOffset.UtcNow).Should().BeTrue();
+	}
+
+	[Fact]
 	public async Task UpdateUser_ReturnsNotFound_WhenUserDoesNotExist()
 	{
 		SetupUserClaims("admin-1");


### PR DESCRIPTION
## Summary

Four confirmed authentication-hardening findings in `AuthController` + `UserService`, one logical commit each. No schema/migration change and no generated-file/spec change.

### 1. Account lockout on failed login (RECEIPTS-776)
`Login` used `UserManager.CheckPasswordAsync`, which verifies the hash but never touches `AccessFailedCount`, so brute force was only IP-rate-limited. Now: locked-out users are rejected **before** the password check (clear 401, never a 500); a bad password calls `AccessFailedAsync`; a correct password calls `ResetAccessFailedCountAsync`. Lockout policy configured where Identity is registered (`InfrastructureService`): `AllowedForNewUsers=true` (so `CreateAsync` stamps `LockoutEnabled=true` and the counter can actually engage), `MaxFailedAccessAttempts=5`, `DefaultLockoutTimeSpan=15 min`. Combined with RECEIPTS-757 (API-key handler already rejects locked-out users), lockout now protects both surfaces.

### 2. Timing-safe login / user-enumeration (RECEIPTS-792)
When the email did not exist, no PBKDF2 verification ran, so the unknown-user response was measurably faster. Now the unknown-user path runs a real PBKDF2 verification against a precomputed throwaway hash, and both the unknown-email and wrong-password paths return the identical generic `Invalid email or password` 401.

### 3. Refresh ignores IdentityResult / concurrency race (RECEIPTS-777)
`RefreshToken` rotated the stored token and called `UpdateAsync` without checking the result; when two refreshes race, the loser got a `ConcurrencyFailure` but the code returned a token that was never persisted. Now `RefreshToken`, `Login`, and `ChangePassword` capture the `IdentityResult` and fail closed (401) on failure instead of returning a stale/unsaved token.

### 4. Refresh token stored in plaintext (RECEIPTS-774)
The 30-day rolling refresh token was stored verbatim and looked up by raw string equality. Now only the SHA-256 hash (lowercase hex, mirroring `ApiKeyService.HashKey`) is stored; lookup hashes the incoming token and compares hash-to-hash. The plaintext token is still returned to the client once at issue time. The `RefreshToken` column is `text`, so the 64-char hash fits with **no schema change / no migration**. Existing stored plaintext tokens no longer match after deploy, so users re-login once (acceptable).

## Tests
Added to `AuthControllerTests` and a new `UserServiceTests`:
- lockout: locked-out user rejected before password check; bad password increments `AccessFailedAsync`; failure that crosses the threshold returns the locked response; success resets the counter.
- timing-safe: unknown email still performs a password verification and returns the same generic error.
- refresh race: a `ConcurrencyFailure` on `UpdateAsync` returns 401, not a stale token.
- hashing: login stores the hashed value (not the plaintext returned to the client); `FindUserIdByRefreshTokenAsync` matches a valid plaintext token via its hash and does not match a stored raw token.

Validated with the CI coverage command: `Presentation.API.Tests` 1016 passed, `Infrastructure.Tests` 659 passed (both `--collect:"XPlat Code Coverage" --settings scripts/tests/coverlet.runsettings`, exit 0). Full pre-commit gate (solution build warnings-as-errors, full .NET test suite, vitest 2152, tsc, eslint) green.

Closes RECEIPTS-776, RECEIPTS-792, RECEIPTS-777, RECEIPTS-774

🤖 Generated with [Claude Code](https://claude.com/claude-code)