### PR TITLE
fix(client): gate command-palette queries on input and hoist recyclebin restore mutations

### DIFF
--- a/src/client/src/hooks/useAccounts.ts
+++ b/src/client/src/hooks/useAccounts.ts
@@ -4,9 +4,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
 
-export function useAccounts(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, isActive?: boolean | null) {
+export function useAccounts(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, isActive?: boolean | null, options: { enabled?: boolean } = {}) {
+  const { enabled = true } = options;
   const query = useQuery({
     queryKey: ["accounts", "list", offset, limit, sortBy, sortDirection, isActive],
+    enabled,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/accounts", {
         params: { query: { offset, limit, sortBy: sortBy ?? undefined, sortDirection: (sortDirection ?? undefined) as "asc" | "desc" | undefined, isActive: isActive ?? undefined } },

--- a/src/client/src/hooks/useCards.ts
+++ b/src/client/src/hooks/useCards.ts
@@ -6,9 +6,11 @@ import { toast } from "sonner";
 
 // Note: Cards are hard-delete entities (no soft-delete/restore).
 
-export function useCards(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, isActive?: boolean | null) {
+export function useCards(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, isActive?: boolean | null, options: { enabled?: boolean } = {}) {
+  const { enabled = true } = options;
   const query = useQuery({
     queryKey: ["cards", "list", offset, limit, sortBy, sortDirection, isActive],
+    enabled,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/cards", {
         params: { query: { offset, limit, sortBy: sortBy ?? undefined, sortDirection: (sortDirection ?? undefined) as "asc" | "desc" | undefined, isActive: isActive ?? undefined } },

--- a/src/client/src/hooks/useCategories.ts
+++ b/src/client/src/hooks/useCategories.ts
@@ -4,9 +4,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
 
-export function useCategories(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, isActive?: boolean | null) {
+export function useCategories(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, isActive?: boolean | null, options: { enabled?: boolean } = {}) {
+  const { enabled = true } = options;
   const query = useQuery({
     queryKey: ["categories", "list", offset, limit, sortBy, sortDirection, isActive],
+    enabled,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/categories", {
         params: { query: { offset, limit, sortBy: sortBy ?? undefined, sortDirection: (sortDirection ?? undefined) as "asc" | "desc" | undefined, isActive: isActive ?? undefined } },

--- a/src/client/src/hooks/useItemTemplates.ts
+++ b/src/client/src/hooks/useItemTemplates.ts
@@ -4,9 +4,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
 
-export function useItemTemplates(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null) {
+export function useItemTemplates(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, options: { enabled?: boolean } = {}) {
+  const { enabled = true } = options;
   const query = useQuery({
     queryKey: ["itemTemplates", "list", offset, limit, sortBy, sortDirection],
+    enabled,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/item-templates", {
         params: { query: { offset, limit, sortBy: sortBy ?? undefined, sortDirection: (sortDirection ?? undefined) as "asc" | "desc" | undefined } },

--- a/src/client/src/hooks/useReceiptItems.ts
+++ b/src/client/src/hooks/useReceiptItems.ts
@@ -4,10 +4,12 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
 
-export function useReceiptItems(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, q?: string | null) {
+export function useReceiptItems(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, q?: string | null, options: { enabled?: boolean } = {}) {
+  const { enabled = true } = options;
   const trimmedQ = q?.trim() || undefined;
   const query = useQuery({
     queryKey: ["receipt-items", "list", offset, limit, sortBy, sortDirection, trimmedQ],
+    enabled,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/receipt-items", {
         params: { query: { offset, limit, sortBy: sortBy ?? undefined, sortDirection: (sortDirection ?? undefined) as "asc" | "desc" | undefined, q: trimmedQ } },

--- a/src/client/src/hooks/useReceipts.ts
+++ b/src/client/src/hooks/useReceipts.ts
@@ -12,10 +12,13 @@ export function useReceipts(
   accountId?: string | null,
   cardId?: string | null,
   q?: string | null,
+  options: { enabled?: boolean } = {},
 ) {
+  const { enabled = true } = options;
   const trimmedQ = q?.trim() || undefined;
   const query = useQuery({
     queryKey: ["receipts", "list", offset, limit, sortBy, sortDirection, accountId, cardId, trimmedQ],
+    enabled,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/receipts", {
         params: {

--- a/src/client/src/hooks/useSubcategories.ts
+++ b/src/client/src/hooks/useSubcategories.ts
@@ -4,9 +4,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import client from "@/lib/api-client";
 import { toast } from "sonner";
 
-export function useSubcategories(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, isActive?: boolean | null) {
+export function useSubcategories(offset = 0, limit = 50, sortBy?: string | null, sortDirection?: string | null, isActive?: boolean | null, options: { enabled?: boolean } = {}) {
+  const { enabled = true } = options;
   const query = useQuery({
     queryKey: ["subcategories", "list", offset, limit, sortBy, sortDirection, isActive],
+    enabled,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/subcategories", {
         params: { query: { offset, limit, sortBy: sortBy ?? undefined, sortDirection: (sortDirection ?? undefined) as "asc" | "desc" | undefined, isActive: isActive ?? undefined } },

--- a/src/client/src/lib/command-palette/entity-results.test.tsx
+++ b/src/client/src/lib/command-palette/entity-results.test.tsx
@@ -114,9 +114,21 @@ describe("useEntityResults", () => {
     );
   });
 
-  it("passes enabled=true to useUsers when admin", async () => {
+  it("passes enabled=false to useUsers when admin but query is empty", async () => {
     const { useUsers } = await import("@/hooks/useUsers");
     renderHook(() => useEntityResults({ isAdmin: true }));
+    expect(vi.mocked(useUsers)).toHaveBeenCalledWith(
+      0,
+      expect.any(Number),
+      undefined,
+      undefined,
+      { enabled: false },
+    );
+  });
+
+  it("passes enabled=true to useUsers when admin and query is non-empty", async () => {
+    const { useUsers } = await import("@/hooks/useUsers");
+    renderHook(() => useEntityResults({ isAdmin: true, query: "bob" }));
     expect(vi.mocked(useUsers)).toHaveBeenCalledWith(
       0,
       expect.any(Number),
@@ -154,6 +166,7 @@ describe("useEntityResults", () => {
       null,
       null,
       undefined,
+      { enabled: false },
     );
     expect(vi.mocked(useReceiptItems)).toHaveBeenCalledWith(
       0,
@@ -161,6 +174,7 @@ describe("useEntityResults", () => {
       null,
       null,
       undefined,
+      { enabled: false },
     );
   });
 
@@ -182,10 +196,58 @@ describe("useEntityResults", () => {
 
       const receiptsCalls = vi.mocked(useReceipts).mock.calls;
       const receiptItemsCalls = vi.mocked(useReceiptItems).mock.calls;
-      expect(receiptsCalls.at(-1)).toEqual([0, expect.any(Number), null, null, null, null, "Walmart"]);
-      expect(receiptItemsCalls.at(-1)).toEqual([0, expect.any(Number), null, null, "Walmart"]);
+      expect(receiptsCalls.at(-1)).toEqual([0, expect.any(Number), null, null, null, null, "Walmart", { enabled: true }]);
+      expect(receiptItemsCalls.at(-1)).toEqual([0, expect.any(Number), null, null, "Walmart", { enabled: true }]);
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("does not enable any entity hook when the palette input is empty", async () => {
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    const { useCards } = await import("@/hooks/useCards");
+    const { useCategories } = await import("@/hooks/useCategories");
+    const { useSubcategories } = await import("@/hooks/useSubcategories");
+    const { useItemTemplates } = await import("@/hooks/useItemTemplates");
+    const { useReceipts } = await import("@/hooks/useReceipts");
+    const { useReceiptItems } = await import("@/hooks/useReceiptItems");
+    const { useUsers } = await import("@/hooks/useUsers");
+
+    renderHook(() => useEntityResults({ isAdmin: true, query: "" }));
+
+    for (const mock of [
+      useAccounts,
+      useCards,
+      useCategories,
+      useSubcategories,
+      useItemTemplates,
+      useReceipts,
+      useReceiptItems,
+      useUsers,
+    ]) {
+      const lastCall = vi.mocked(mock).mock.calls.at(-1);
+      expect(lastCall?.at(-1)).toEqual({ enabled: false });
+    }
+  });
+
+  it("enables the reference-list entity hooks once the palette input is non-empty", async () => {
+    const { useAccounts } = await import("@/hooks/useAccounts");
+    const { useCards } = await import("@/hooks/useCards");
+    const { useCategories } = await import("@/hooks/useCategories");
+    const { useSubcategories } = await import("@/hooks/useSubcategories");
+    const { useItemTemplates } = await import("@/hooks/useItemTemplates");
+
+    renderHook(() => useEntityResults({ isAdmin: false, query: "wal" }));
+
+    for (const mock of [
+      useAccounts,
+      useCards,
+      useCategories,
+      useSubcategories,
+      useItemTemplates,
+    ]) {
+      const lastCall = vi.mocked(mock).mock.calls.at(-1);
+      expect(lastCall?.at(-1)).toEqual({ enabled: true });
     }
   });
 });

--- a/src/client/src/lib/command-palette/entity-results.ts
+++ b/src/client/src/lib/command-palette/entity-results.ts
@@ -71,14 +71,20 @@ export function useEntityResults({
 }): EntityResultGroup[] {
   const debouncedQuery = useDebouncedValue(query, 200);
   const entitySearch = debouncedQuery.trim() || undefined;
-  const accounts = useAccounts(0, SMALL_LIMIT);
-  const cards = useCards(0, SMALL_LIMIT);
-  const categories = useCategories(0, SMALL_LIMIT);
-  const subcategories = useSubcategories(0, SMALL_LIMIT);
-  const itemTemplates = useItemTemplates(0, SMALL_LIMIT);
-  const receipts = useReceipts(0, LARGE_LIMIT, null, null, null, null, entitySearch);
-  const receiptItems = useReceiptItems(0, LARGE_LIMIT, null, null, entitySearch);
-  const users = useUsers(0, SMALL_LIMIT, undefined, undefined, { enabled: isAdmin });
+  // Nothing renders until the user types (CommandPalette only shows entity
+  // groups once `query` is non-empty), so mounting these on palette open
+  // would fire 7-8 list queries the UI never displays. Gate on the raw
+  // (non-debounced) input so the fetch starts on the very first keystroke
+  // rather than waiting out the debounce window.
+  const hasQuery = query.trim().length > 0;
+  const accounts = useAccounts(0, SMALL_LIMIT, undefined, undefined, undefined, { enabled: hasQuery });
+  const cards = useCards(0, SMALL_LIMIT, undefined, undefined, undefined, { enabled: hasQuery });
+  const categories = useCategories(0, SMALL_LIMIT, undefined, undefined, undefined, { enabled: hasQuery });
+  const subcategories = useSubcategories(0, SMALL_LIMIT, undefined, undefined, undefined, { enabled: hasQuery });
+  const itemTemplates = useItemTemplates(0, SMALL_LIMIT, undefined, undefined, { enabled: hasQuery });
+  const receipts = useReceipts(0, LARGE_LIMIT, null, null, null, null, entitySearch, { enabled: hasQuery });
+  const receiptItems = useReceiptItems(0, LARGE_LIMIT, null, null, entitySearch, { enabled: hasQuery });
+  const users = useUsers(0, SMALL_LIMIT, undefined, undefined, { enabled: isAdmin && hasQuery });
 
   return useMemo<EntityResultGroup[]>(() => {
     const groups: EntityResultGroup[] = [];

--- a/src/client/src/pages/RecycleBin.test.tsx
+++ b/src/client/src/pages/RecycleBin.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { mockQueryResult, mockMutationResult } from "@/test/mock-hooks";
 import RecycleBin from "./RecycleBin";
@@ -172,6 +172,72 @@ describe("RecycleBin", () => {
     await user.click(restoreButtons[0]);
 
     expect(mockMutate).toHaveBeenCalledWith("t1");
+  });
+
+  it("calls restoreCategory.mutate when Restore is clicked on a category (hoisted mutation map)", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useDeletedCategories, useRestoreCategory } = await import("@/hooks/useCategories");
+    vi.mocked(useDeletedCategories).mockReturnValue(mockQueryResult({
+      data: [{ id: "c1", name: "Groceries" }],
+      total: 1,
+      isLoading: false,
+    }));
+    vi.mocked(useRestoreCategory).mockReturnValue(mockMutationResult({ mutate: mockMutate }));
+
+    renderWithProviders(<RecycleBin />);
+    // Scope to the category's own row rather than assuming button ordinal
+    // position — other entity types' mocks retain data from earlier tests in
+    // this file (they're only reset when a test explicitly overrides them),
+    // so the "All" tab can contain more than just this one row.
+    const row = screen.getByText("Groceries").closest("tr") as HTMLElement;
+    await user.click(within(row).getByRole("button", { name: /restore/i }));
+
+    expect(mockMutate).toHaveBeenCalledWith("c1");
+  });
+
+  it("calls restoreReceiptItem.mutate when Restore is clicked on a receipt item", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const mockMutate = vi.fn();
+    const { useDeletedReceiptItems, useRestoreReceiptItem } = await import("@/hooks/useReceiptItems");
+    vi.mocked(useDeletedReceiptItems).mockReturnValue(mockQueryResult({
+      data: [{ id: "ri1", description: "Widget", receiptItemCode: "W-001" }],
+      total: 1,
+      isLoading: false,
+    }));
+    vi.mocked(useRestoreReceiptItem).mockReturnValue(mockMutationResult({ mutate: mockMutate }));
+
+    renderWithProviders(<RecycleBin />);
+    const row = screen.getByText("Widget (W-001)").closest("tr") as HTMLElement;
+    await user.click(within(row).getByRole("button", { name: /restore/i }));
+
+    expect(mockMutate).toHaveBeenCalledWith("ri1");
+  });
+
+  it("shows the pending state only on the row whose entity type mutation is pending", async () => {
+    const { useDeletedReceipts } = await import("@/hooks/useReceipts");
+    const { useDeletedTransactions, useRestoreTransaction } = await import("@/hooks/useTransactions");
+    vi.mocked(useDeletedReceipts).mockReturnValue(mockQueryResult({
+      data: [{ id: "r1", location: "Store", date: "2026-01-01" }],
+      total: 1,
+      isLoading: false,
+    }));
+    vi.mocked(useDeletedTransactions).mockReturnValue(mockQueryResult({
+      data: [{ id: "t1", amount: 10, date: "2026-01-02" }],
+      total: 1,
+      isLoading: false,
+    }));
+    // Only the Transaction restore mutation is pending — resolved once in
+    // RecycleBin and threaded down via the entityType -> mutation map, so
+    // the Receipt row (a different mutation instance) must stay unaffected.
+    vi.mocked(useRestoreTransaction).mockReturnValue(mockMutationResult({ isPending: true }));
+
+    renderWithProviders(<RecycleBin />);
+
+    const receiptRow = screen.getByText("Store - 2026-01-01").closest("tr") as HTMLElement;
+    const transactionRow = screen.getByText("$10.00 - 2026-01-02").closest("tr") as HTMLElement;
+    expect(within(transactionRow).getByText("Restoring...")).toBeInTheDocument();
+    expect(within(receiptRow).getByRole("button", { name: /^restore$/i })).toBeInTheDocument();
   });
 
   it("calls purgeTrash.mutate when Empty Trash is confirmed", async () => {

--- a/src/client/src/pages/RecycleBin.tsx
+++ b/src/client/src/pages/RecycleBin.tsx
@@ -63,33 +63,21 @@ interface DeletedItem {
   label: string;
 }
 
+interface RestoreMutation {
+  mutate: (id: string) => void;
+  isPending: boolean;
+}
+
+/** entityType -> resolved restore mutation, built once in RecycleBin and threaded down to rows. */
+type RestoreMutationMap = Record<string, RestoreMutation>;
+
 function RestoreButton({
-  entityType,
   entityId,
+  mutation,
 }: {
-  entityType: string;
   entityId: string;
+  mutation?: RestoreMutation;
 }) {
-  const restoreReceipt = useRestoreReceipt();
-  const restoreReceiptItem = useRestoreReceiptItem();
-  const restoreTransaction = useRestoreTransaction();
-  const restoreItemTemplate = useRestoreItemTemplate();
-  const restoreCategory = useRestoreCategory();
-  const restoreSubcategory = useRestoreSubcategory();
-
-  const mutations: Record<
-    string,
-    { mutate: (id: string) => void; isPending: boolean }
-  > = {
-    Receipt: restoreReceipt,
-    ReceiptItem: restoreReceiptItem,
-    Transaction: restoreTransaction,
-    ItemTemplate: restoreItemTemplate,
-    Category: restoreCategory,
-    Subcategory: restoreSubcategory,
-  };
-
-  const mutation = mutations[entityType];
   if (!mutation) return null;
 
   return (
@@ -107,6 +95,7 @@ function RestoreButton({
 
 function DeletedItemsTable({
   items,
+  restoreMutations,
   focusedKey,
   tableRef,
   onRowClick,
@@ -114,6 +103,7 @@ function DeletedItemsTable({
   getRowProps,
 }: {
   items: DeletedItem[];
+  restoreMutations: RestoreMutationMap;
   focusedKey?: string | null;
   tableRef?: React.RefObject<HTMLDivElement | null>;
   onRowClick?: (index: number) => void;
@@ -176,8 +166,8 @@ function DeletedItemsTable({
                 </TableCell>
                 <TableCell>
                   <RestoreButton
-                    entityType={item.entityType}
                     entityId={item.id}
+                    mutation={restoreMutations[item.entityType]}
                   />
                 </TableCell>
               </TableRow>
@@ -198,6 +188,43 @@ function RecycleBin() {
   const categories = useDeletedCategories();
   const subcategories = useDeletedSubcategories();
   const purgeTrash = usePurgeTrash();
+
+  // Hoisted once here (not per row) — each of these mutation hooks registers
+  // its own MutationObserver on the shared query cache, so instantiating them
+  // per row (hundreds of times on the "All" tab) multiplied observer count
+  // for no benefit. Resolve them into a single entityType -> mutation map and
+  // pass the map down so each row only touches its one mutation.
+  const restoreReceipt = useRestoreReceipt();
+  const restoreReceiptItem = useRestoreReceiptItem();
+  const restoreTransaction = useRestoreTransaction();
+  const restoreItemTemplate = useRestoreItemTemplate();
+  const restoreCategory = useRestoreCategory();
+  const restoreSubcategory = useRestoreSubcategory();
+
+  const restoreMutations = useMemo<RestoreMutationMap>(
+    () => ({
+      Receipt: { mutate: restoreReceipt.mutate, isPending: restoreReceipt.isPending },
+      ReceiptItem: { mutate: restoreReceiptItem.mutate, isPending: restoreReceiptItem.isPending },
+      Transaction: { mutate: restoreTransaction.mutate, isPending: restoreTransaction.isPending },
+      ItemTemplate: { mutate: restoreItemTemplate.mutate, isPending: restoreItemTemplate.isPending },
+      Category: { mutate: restoreCategory.mutate, isPending: restoreCategory.isPending },
+      Subcategory: { mutate: restoreSubcategory.mutate, isPending: restoreSubcategory.isPending },
+    }),
+    [
+      restoreReceipt.mutate,
+      restoreReceipt.isPending,
+      restoreReceiptItem.mutate,
+      restoreReceiptItem.isPending,
+      restoreTransaction.mutate,
+      restoreTransaction.isPending,
+      restoreItemTemplate.mutate,
+      restoreItemTemplate.isPending,
+      restoreCategory.mutate,
+      restoreCategory.isPending,
+      restoreSubcategory.mutate,
+      restoreSubcategory.isPending,
+    ],
+  );
 
   const isLoading =
     receipts.isLoading ||
@@ -408,6 +435,7 @@ function RecycleBin() {
         <TabsContent value="all">
           <DeletedItemsTable
             items={allItems}
+            restoreMutations={restoreMutations}
             focusedKey={focusedId}
             tableRef={tableRef}
             onRowClick={setFocusedIndex}
@@ -418,7 +446,7 @@ function RecycleBin() {
 
         {Object.entries(byType).map(([type, items]) => (
           <TabsContent key={type} value={type}>
-            <DeletedItemsTable items={items} />
+            <DeletedItemsTable items={items} restoreMutations={restoreMutations} />
           </TabsContent>
         ))}
       </Tabs>


### PR DESCRIPTION
Two client-side performance fixes. Both are "gate/hoist to stop redundant work."

## Fix 1 — RECEIPTS-795: command palette over-fetches on every open
`useEntityResults` mounted all eight entity list hooks (five reference lists at limit 1000, receipts + receipt-items at 200, users at 1000) unconditionally on palette open, firing ~7-8 list queries (~3,400-4,600 rows) before the user typed anything. Entity groups only render once the user types (`query.trim().length > 0`), so none of that data was ever shown.

- Added an `enabled` option (matching the existing `useUsers` pattern) to `useAccounts`, `useCards`, `useCategories`, `useSubcategories`, `useItemTemplates`, `useReceipts`, and `useReceiptItems`. The new trailing param is optional and defaults to enabled, so all existing callers are unaffected.
- `useEntityResults` now gates every entity query on the raw (non-debounced) palette input: `enabled: query.trim().length > 0`. Users additionally require `isAdmin`. Gating on the raw input means the fetch starts on the first keystroke rather than after the debounce window; the debounced value is still what's sent as the `q=` server filter for receipts/receipt-items.
- No reference lists are kept as an open-time prefetch — nothing renders before typing, so all eight are gated.

## Fix 2 — RECEIPTS-797: RecycleBin instantiates six mutation hooks per row
`RestoreButton` was rendered once per deleted item and unconditionally called all six restore mutation hooks, though each row uses only one. Each `useMutation` registers a `MutationObserver` on the shared cache, so the "All" tab with hundreds of rows created ~1,800 observer instances.

- Hoisted the six restore mutation hooks into `RecycleBin` once, built an `entityType -> { mutate, isPending }` map there (memoized on the stable `mutate` refs + `isPending` flags), and threaded it down through `DeletedItemsTable` to each row.
- `RestoreButton` now receives only its resolved mutation as a prop and instantiates no hooks — per-row cost is constant. Restore behavior and per-row pending state are unchanged.

## Validation (from `src/client`)
- `npx tsc -b` — clean
- `npm run lint` — clean (0 errors; 2 pre-existing warnings unrelated to this change)
- `npx vitest run` — all pass (190 files, 2158 tests)

## Tests
- `entity-results.test.tsx`: updated the existing empty-query and debounced-query assertions to expect the new `{ enabled }` arg; added a test that no entity hook is enabled with empty input and one that reference-list hooks become enabled once input is typed; updated the users-when-admin test to require non-empty input.
- `CommandPalette.test.tsx`: existing behavior tests (no entity groups on empty query, results render once typed) still pass unchanged.
- `RecycleBin.test.tsx`: added tests that a category and a receipt-item row each call the correct hoisted mutation, plus a test that a pending mutation shows the pending state only on its own entity-type row (not other rows). Scoped row lookups with `within(...)` since the shared mocks retain data across tests.

Closes RECEIPTS-795, RECEIPTS-797