### PR TITLE
fix(infrastructure): widen quantity precision, de-quadratic soft-delete cascade, batch description reconcile

### DIFF
--- a/docs/migrations/20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision.md
+++ b/docs/migrations/20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision.md
@@ -1,4 +1,4 @@
-# Migration: WidenReceiptItemQuantityAndUnitPricePrecision (RECEIPTS-770)
+# Migration: WidenReceiptItemQuantityAndUnitPricePrecision (RECEIPTS-765)
 
 **Migration id:** `20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision`
 **Date:** 2026-07-11
@@ -29,7 +29,7 @@ backfill or data migration is required.
 `Down` narrows both columns back to `numeric(18,2)` — the exact inverse of `Up`. Note this is
 lossy *by nature* of narrowing scale: any `Quantity`/`UnitPrice` value that was written with 3-4
 fractional digits after this migration applied would be rounded to 2 places on rollback. That is
-the correct symmetric restore of the prior type; pair a rollback with reverting the RECEIPTS-770
+the correct symmetric restore of the prior type; pair a rollback with reverting the RECEIPTS-765
 code change so the model and schema stay in sync.
 
 ## Related code

--- a/docs/migrations/20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision.md
+++ b/docs/migrations/20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision.md
@@ -1,0 +1,46 @@
+# Migration: WidenReceiptItemQuantityAndUnitPricePrecision (RECEIPTS-770)
+
+**Migration id:** `20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision`
+**Date:** 2026-07-11
+
+## What it does
+
+Widens two `receipts.ReceiptItems` columns from the money type `numeric(18,2)` to
+`numeric(18,4)`:
+
+| Column | Old type | New type | Why |
+|---|---|---|---|
+| `Quantity` | `numeric(18,2)` | `numeric(18,4)` | Quantity is a count/weight, not money. Under scale 2 Postgres silently rounded fractional quantities (e.g. `1.125` kg, `2.5` dozen) on insert. |
+| `UnitPrice` | `numeric(18,2)` | `numeric(18,4)` | Unit prices legitimately need sub-cent precision (e.g. fuel at `3.459`/gal, per-gram produce). Scale 2 corrupted them on insert. |
+
+`ApplicationDbContext.PrepareEntityTypesInModelBuilder` maps every `decimal` property to the
+money type `decimal(18,2)`. That default is wrong for these two non-money / sub-cent columns. The
+override lives in `ReceiptItemEntityConfiguration` (applied *after* `PrepareEntityTypesInModelBuilder`,
+so it wins). `TotalAmount` and all other money columns are intentionally left at `decimal(18,2)`.
+
+## Why it is safe
+
+Widening scale `2 -> 4` is non-lossy: existing values have at most 2 fractional digits, and
+`numeric(18,4)` preserves them exactly (precision 18 is unchanged, so no integer-digit loss). No
+backfill or data migration is required.
+
+## Rollback
+
+`Down` narrows both columns back to `numeric(18,2)` — the exact inverse of `Up`. Note this is
+lossy *by nature* of narrowing scale: any `Quantity`/`UnitPrice` value that was written with 3-4
+fractional digits after this migration applied would be rounded to 2 places on rollback. That is
+the correct symmetric restore of the prior type; pair a rollback with reverting the RECEIPTS-770
+code change so the model and schema stay in sync.
+
+## Related code
+
+- Column-type override: `Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs`.
+- Root cause (money-type default for all decimals): `ApplicationDbContext.PrepareEntityTypesInModelBuilder`.
+
+## Validation
+
+Applied by the Testcontainers integration suite (`tests/Infrastructure.IntegrationTests`,
+`Category=Integration`), which migrates a real PostgreSQL instance to HEAD before every test.
+`ColumnTypeMappingTests.ReceiptItemEntity_FractionalQuantityAndSubCentUnitPrice_RoundTripWithoutTruncation`
+inserts `Quantity = 1.125`, `UnitPrice = 3.4599` and asserts they round-trip exactly. CI does not
+run integration tests, so this is validated locally against Docker Postgres.

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -244,95 +244,174 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
 	private void HandleSoftDelete()
 	{
-		List<EntityEntry<ISoftDeletable>> entries = ChangeTracker
-			.Entries<ISoftDeletable>()
-			.Where(e => e.State == EntityState.Deleted)
-			.ToList();
-
-		if (entries.Count == 0)
+		// Discover the cascade from a SINGLE snapshot of the change tracker.
+		// Previously CollectOwnedChildren re-enumerated ChangeTracker.Entries() for every
+		// (deleted parent × owned-child type) pair, and — with auto-detect on — each of those
+		// enumerations triggered a full DetectChanges pass over every tracked property. That is
+		// O(parents × childTypes × trackedEntities). Here we DetectChanges() once (which also
+		// lets EF mark cascade-deleted children as Deleted), disable auto-detect for the
+		// duration so the reads below are cheap, bucket the tracker once, and drive the cascade
+		// from dictionary lookups. The flag is restored in the finally so base.SaveChangesAsync
+		// still runs its normal DetectChanges.
+		bool autoDetectChanges = ChangeTracker.AutoDetectChangesEnabled;
+		ChangeTracker.DetectChanges();
+		ChangeTracker.AutoDetectChangesEnabled = false;
+		try
 		{
-			return;
-		}
-
-		// Snapshot entities that were already soft-deleted before this save.
-		// EF Core cascade-delete marks ALL tracked children as Deleted — even
-		// those that were independently soft-deleted earlier. We must not tag
-		// those with CascadeDeletedByParentId.
-		HashSet<ISoftDeletable> alreadySoftDeleted = new(
-			entries
-				.Where(e => e.Entity.DeletedAt is not null)
-				.Select(e => e.Entity));
-
-		// Identify cascade targets BEFORE changing any states, so the
-		// collection does not depend on the iteration order of entries.
-		List<(ISoftDeletable Target, Guid ParentId)> cascadeTargets = [];
-
-		foreach (EntityEntry<ISoftDeletable> entry in entries)
-		{
-			Type parentType = entry.Entity.GetType();
-			if (OwnedChildrenMapProvider.Map.TryGetValue(parentType, out OwnedChildrenMapProvider.ParentEntry? parentEntry))
-			{
-				Guid parentId = (Guid)parentEntry.IdProperty.GetValue(entry.Entity)!;
-				CollectOwnedChildren(parentId, parentEntry.Children, cascadeTargets);
-			}
-		}
-
-		HashSet<ISoftDeletable> cascadeSet = new(cascadeTargets.Select(t => t.Target));
-
-		// Soft-delete all directly-deleted entries.
-		foreach (EntityEntry<ISoftDeletable> entry in entries)
-		{
-			// Cascade targets are handled below.
-			if (cascadeSet.Contains(entry.Entity))
-			{
-				continue;
-			}
-
-			entry.State = EntityState.Modified;
-			entry.Entity.DeletedAt = DateTimeOffset.UtcNow;
-			entry.Entity.DeletedByUserId = _currentUserAccessor?.UserId;
-			entry.Entity.DeletedByApiKeyId = _currentUserAccessor?.ApiKeyId;
-		}
-
-		// Soft-delete cascade targets and tag them with the parent ID.
-		foreach ((ISoftDeletable target, Guid parentId) in cascadeTargets)
-		{
-			// Skip children that were independently soft-deleted before this save.
-			if (alreadySoftDeleted.Contains(target))
-			{
-				Entry(target).State = EntityState.Modified;
-				continue;
-			}
-
-			target.DeletedAt = DateTimeOffset.UtcNow;
-			target.DeletedByUserId = _currentUserAccessor?.UserId;
-			target.DeletedByApiKeyId = _currentUserAccessor?.ApiKeyId;
-			target.CascadeDeletedByParentId = parentId;
-			Entry(target).State = EntityState.Modified;
-		}
-	}
-
-	private void CollectOwnedChildren(
-		Guid parentId,
-		List<OwnedChildrenMapProvider.OwnedChildEntry> children,
-		List<(ISoftDeletable Target, Guid ParentId)> targets)
-	{
-		foreach (OwnedChildrenMapProvider.OwnedChildEntry child in children)
-		{
+			// Single enumeration: bucket every non-detached entry by runtime type and collect
+			// the directly-/cascade-deleted soft-deletables (in tracker order, preserving the
+			// exact ordering the old nested scan produced).
+			List<EntityEntry> deletedSoftDeletables = [];
+			Dictionary<Type, List<EntityEntry>> entriesByType = [];
 			foreach (EntityEntry entry in ChangeTracker.Entries())
 			{
-				if (entry.Entity.GetType() != child.ChildType || entry.State == EntityState.Detached)
+				if (entry.State == EntityState.Detached)
 				{
 					continue;
 				}
 
-				Guid fkValue = (Guid)child.FkProperty.GetValue(entry.Entity)!;
-				if (fkValue == parentId && entry.Entity is ISoftDeletable softDeletable)
+				Type type = entry.Entity.GetType();
+				if (!entriesByType.TryGetValue(type, out List<EntityEntry>? bucket))
 				{
-					targets.Add((softDeletable, parentId));
+					bucket = [];
+					entriesByType[type] = bucket;
+				}
+				bucket.Add(entry);
+
+				if (entry.State == EntityState.Deleted && entry.Entity is ISoftDeletable)
+				{
+					deletedSoftDeletables.Add(entry);
 				}
 			}
+
+			if (deletedSoftDeletables.Count == 0)
+			{
+				return;
+			}
+
+			// Snapshot entities that were already soft-deleted before this save.
+			// EF Core cascade-delete marks ALL tracked children as Deleted — even
+			// those that were independently soft-deleted earlier. We must not tag
+			// those with CascadeDeletedByParentId.
+			HashSet<ISoftDeletable> alreadySoftDeleted = new(
+				deletedSoftDeletables
+					.Select(e => (ISoftDeletable)e.Entity)
+					.Where(e => e.DeletedAt is not null));
+
+			// Build a per-owned-child FK index over the single snapshot: for each owned-child
+			// relationship, group its tracked entries by FK value. The cascade then resolves
+			// each parent's children with two dictionary lookups instead of a full re-scan.
+			Dictionary<OwnedChildrenMapProvider.OwnedChildEntry, Dictionary<Guid, List<ISoftDeletable>>> childFkIndex =
+				BuildOwnedChildFkIndex(entriesByType);
+
+			// Identify cascade targets BEFORE changing any states, so the
+			// collection does not depend on the iteration order of entries.
+			List<(ISoftDeletable Target, Guid ParentId)> cascadeTargets = [];
+
+			foreach (EntityEntry entry in deletedSoftDeletables)
+			{
+				Type parentType = entry.Entity.GetType();
+				if (OwnedChildrenMapProvider.Map.TryGetValue(parentType, out OwnedChildrenMapProvider.ParentEntry? parentEntry))
+				{
+					Guid parentId = (Guid)parentEntry.IdProperty.GetValue(entry.Entity)!;
+					foreach (OwnedChildrenMapProvider.OwnedChildEntry child in parentEntry.Children)
+					{
+						if (childFkIndex.TryGetValue(child, out Dictionary<Guid, List<ISoftDeletable>>? byFk)
+							&& byFk.TryGetValue(parentId, out List<ISoftDeletable>? matches))
+						{
+							foreach (ISoftDeletable match in matches)
+							{
+								cascadeTargets.Add((match, parentId));
+							}
+						}
+					}
+				}
+			}
+
+			HashSet<ISoftDeletable> cascadeSet = new(cascadeTargets.Select(t => t.Target));
+
+			// Soft-delete all directly-deleted entries.
+			foreach (EntityEntry entry in deletedSoftDeletables)
+			{
+				ISoftDeletable entity = (ISoftDeletable)entry.Entity;
+
+				// Cascade targets are handled below.
+				if (cascadeSet.Contains(entity))
+				{
+					continue;
+				}
+
+				entry.State = EntityState.Modified;
+				entity.DeletedAt = DateTimeOffset.UtcNow;
+				entity.DeletedByUserId = _currentUserAccessor?.UserId;
+				entity.DeletedByApiKeyId = _currentUserAccessor?.ApiKeyId;
+			}
+
+			// Soft-delete cascade targets and tag them with the parent ID.
+			foreach ((ISoftDeletable target, Guid parentId) in cascadeTargets)
+			{
+				// Skip children that were independently soft-deleted before this save.
+				if (alreadySoftDeleted.Contains(target))
+				{
+					Entry(target).State = EntityState.Modified;
+					continue;
+				}
+
+				target.DeletedAt = DateTimeOffset.UtcNow;
+				target.DeletedByUserId = _currentUserAccessor?.UserId;
+				target.DeletedByApiKeyId = _currentUserAccessor?.ApiKeyId;
+				target.CascadeDeletedByParentId = parentId;
+				Entry(target).State = EntityState.Modified;
+			}
 		}
+		finally
+		{
+			ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+		}
+	}
+
+	/// <summary>
+	/// Groups the tracked entries of every owned-child relationship by FK value, from a single
+	/// pre-bucketed snapshot of the change tracker. Keyed by <see cref="OwnedChildrenMapProvider.OwnedChildEntry"/>
+	/// so a child type owned by multiple parents (via distinct FK columns) is indexed per relationship.
+	/// Only <see cref="ISoftDeletable"/> entries are indexed — matching the original cascade filter.
+	/// </summary>
+	private static Dictionary<OwnedChildrenMapProvider.OwnedChildEntry, Dictionary<Guid, List<ISoftDeletable>>> BuildOwnedChildFkIndex(
+		Dictionary<Type, List<EntityEntry>> entriesByType)
+	{
+		Dictionary<OwnedChildrenMapProvider.OwnedChildEntry, Dictionary<Guid, List<ISoftDeletable>>> index = [];
+
+		foreach (OwnedChildrenMapProvider.ParentEntry parentEntry in OwnedChildrenMapProvider.Map.Values)
+		{
+			foreach (OwnedChildrenMapProvider.OwnedChildEntry child in parentEntry.Children)
+			{
+				if (index.ContainsKey(child) || !entriesByType.TryGetValue(child.ChildType, out List<EntityEntry>? bucket))
+				{
+					continue;
+				}
+
+				Dictionary<Guid, List<ISoftDeletable>> byFk = [];
+				foreach (EntityEntry entry in bucket)
+				{
+					if (entry.Entity is not ISoftDeletable softDeletable)
+					{
+						continue;
+					}
+
+					Guid fkValue = (Guid)child.FkProperty.GetValue(entry.Entity)!;
+					if (!byFk.TryGetValue(fkValue, out List<ISoftDeletable>? matches))
+					{
+						matches = [];
+						byFk[fkValue] = matches;
+					}
+					matches.Add(softDeletable);
+				}
+
+				index[child] = byFk;
+			}
+		}
+
+		return index;
 	}
 
 	private List<AuditEntry> CollectAuditEntries()

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -163,27 +163,48 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 		HashSet<string> touched = [];
 		foreach (EntityEntry<ReceiptItemEntity> entry in ChangeTracker.Entries<ReceiptItemEntity>())
 		{
-			if (entry.State is not (EntityState.Added or EntityState.Modified or EntityState.Deleted))
+			switch (entry.State)
 			{
-				continue;
-			}
+				case EntityState.Added:
+				case EntityState.Deleted:
+					// A brand-new active item, or an item leaving the tracker outright, changes
+					// the active-item membership for its current description.
+					AddIfPresent(touched, entry.Entity.Description);
+					break;
 
-			string? current = entry.Entity.Description;
-			if (!string.IsNullOrEmpty(current))
-			{
-				touched.Add(current);
-			}
+				case EntityState.Modified:
+					// Only reconcile a Modified item when it can actually affect the active-item
+					// set for some description: either the Description text changed, or the item's
+					// active state flipped (soft-delete / restore — DeletedAt gained or lost a
+					// value). A metadata-only edit (e.g. Quantity/UnitPrice) leaves membership
+					// unchanged, so reconciling it would be a pair of wasted round trips.
+					string? originalDescription = entry.OriginalValues[nameof(ReceiptItemEntity.Description)] as string;
+					string? currentDescription = entry.Entity.Description;
+					bool descriptionChanged = !string.Equals(originalDescription, currentDescription, StringComparison.Ordinal);
 
-			if (entry.State == EntityState.Modified)
-			{
-				string? original = entry.OriginalValues[nameof(ReceiptItemEntity.Description)] as string;
-				if (!string.IsNullOrEmpty(original))
-				{
-					touched.Add(original);
-				}
+					DateTimeOffset? originalDeletedAt = entry.OriginalValues[nameof(ReceiptItemEntity.DeletedAt)] as DateTimeOffset?;
+					bool activeStateChanged = (originalDeletedAt is null) != (entry.Entity.DeletedAt is null);
+
+					if (descriptionChanged || activeStateChanged)
+					{
+						AddIfPresent(touched, currentDescription);
+						AddIfPresent(touched, originalDescription);
+					}
+					break;
+
+				default:
+					break;
 			}
 		}
 		return touched;
+
+		static void AddIfPresent(HashSet<string> set, string? value)
+		{
+			if (!string.IsNullOrEmpty(value))
+			{
+				set.Add(value);
+			}
+		}
 	}
 
 	private async Task ReconcileDistinctDescriptionsAsync(HashSet<string> descriptions, CancellationToken cancellationToken)
@@ -194,43 +215,41 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 			return;
 		}
 
-		// Use raw SQL for both insert and delete so the reconciliation is atomic per description
-		// and idempotent under concurrent saves. An EF check-then-write pattern here would race
-		// on the PK (two concurrent adds of the same new description → second INSERT hits 23505).
-		bool signalDirty = false;
-		foreach (string desc in descriptions)
-		{
-			// INSERT when there is at least one active ReceiptItem with this description.
-			// DELETE when there are no active ReceiptItems (descriptive cascade wipes any edges).
-			// The NOT EXISTS guard on DELETE makes it race-safe: if a concurrent insert is adding
-			// a receipt item with this description, the subquery will find it and the DELETE
-			// becomes a no-op.
-			int rowsInserted = await Database.ExecuteSqlRawAsync(
-				"""
-				INSERT INTO "matching"."DistinctDescriptions" ("Description", "ProcessedAt")
-				SELECT {0}, NULL
-				WHERE EXISTS (SELECT 1 FROM "receipts"."ReceiptItems" WHERE "Description" = {0} AND "DeletedAt" IS NULL)
-				ON CONFLICT ("Description") DO NOTHING;
-				""",
-				[desc],
-				cancellationToken);
+		// Reconcile the ENTIRE touched set in two set-based round trips (one INSERT, one DELETE)
+		// instead of a pair of round trips per description. Raw SQL keeps the reconciliation
+		// atomic and idempotent under concurrent saves: the INSERT's ON CONFLICT DO NOTHING and
+		// the DELETE's NOT EXISTS guard both race-safely converge on the invariant "a
+		// DistinctDescriptions row exists iff an active ReceiptItem with that description exists".
+		// The touched descriptions are passed as a single text[] parameter and expanded with
+		// unnest / = ANY, so the number of round trips is constant regardless of set size.
+		string[] descriptionArray = [.. descriptions];
 
-			int rowsDeleted = await Database.ExecuteSqlRawAsync(
-				"""
-				DELETE FROM "matching"."DistinctDescriptions"
-				WHERE "Description" = {0}
-				  AND NOT EXISTS (SELECT 1 FROM "receipts"."ReceiptItems" WHERE "Description" = {0} AND "DeletedAt" IS NULL);
-				""",
-				[desc],
-				cancellationToken);
+		// INSERT a row for every touched description that still has at least one active
+		// ReceiptItem. ON CONFLICT keeps it idempotent (and race-safe on the PK).
+		int rowsInserted = await Database.ExecuteSqlRawAsync(
+			"""
+			INSERT INTO "matching"."DistinctDescriptions" ("Description", "ProcessedAt")
+			SELECT d, NULL
+			FROM unnest({0}::text[]) AS d
+			WHERE EXISTS (SELECT 1 FROM "receipts"."ReceiptItems" AS ri WHERE ri."Description" = d AND ri."DeletedAt" IS NULL)
+			ON CONFLICT ("Description") DO NOTHING;
+			""",
+			[descriptionArray],
+			cancellationToken);
 
-			if (rowsInserted > 0 || rowsDeleted > 0)
-			{
-				signalDirty = true;
-			}
-		}
+		// DELETE any touched description that no longer has an active ReceiptItem. The NOT EXISTS
+		// guard makes it race-safe: a concurrent insert of a receipt item with that description
+		// leaves the subquery non-empty, so the DELETE becomes a no-op for that row.
+		int rowsDeleted = await Database.ExecuteSqlRawAsync(
+			"""
+			DELETE FROM "matching"."DistinctDescriptions" AS dd
+			WHERE dd."Description" = ANY({0}::text[])
+			  AND NOT EXISTS (SELECT 1 FROM "receipts"."ReceiptItems" AS ri WHERE ri."Description" = dd."Description" AND ri."DeletedAt" IS NULL);
+			""",
+			[descriptionArray],
+			cancellationToken);
 
-		if (signalDirty)
+		if (rowsInserted > 0 || rowsDeleted > 0)
 		{
 			_descriptionChangeSignal?.NotifyDirty();
 		}

--- a/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
@@ -16,6 +16,21 @@ public class ReceiptItemEntityConfiguration : IEntityTypeConfiguration<ReceiptIt
 			.IsRequired()
 			.ValueGeneratedOnAdd();
 
+		// RECEIPTS-770: ApplicationDbContext.PrepareEntityTypesInModelBuilder maps EVERY decimal
+		// property to the money type decimal(18,2). That is wrong for Quantity and UnitPrice:
+		//   - Quantity is a count/weight, not money. Postgres silently rounds fractional
+		//     quantities (e.g. 2.5 kg, 1.125 dozen) to scale 2 on insert.
+		//   - UnitPrice legitimately needs sub-cent precision (e.g. fuel at 3.459/gal, or
+		//     per-gram produce). Rounding it to scale 2 corrupts the value on insert.
+		// TotalAmount stays decimal(18,2): it is the reconciled money amount that must land on
+		// whole cents. This configuration runs AFTER PrepareEntityTypesInModelBuilder, so these
+		// explicit overrides win. Widening scale 2 -> 4 is non-lossy for existing data.
+		builder.Property(e => e.Quantity)
+			.HasColumnType("decimal(18,4)");
+
+		builder.Property(e => e.UnitPrice)
+			.HasColumnType("decimal(18,4)");
+
 		builder.Navigation(e => e.Receipt)
 			.AutoInclude();
 

--- a/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
+++ b/src/Infrastructure/Configurations/ReceiptItemEntityConfiguration.cs
@@ -16,7 +16,7 @@ public class ReceiptItemEntityConfiguration : IEntityTypeConfiguration<ReceiptIt
 			.IsRequired()
 			.ValueGeneratedOnAdd();
 
-		// RECEIPTS-770: ApplicationDbContext.PrepareEntityTypesInModelBuilder maps EVERY decimal
+		// RECEIPTS-765: ApplicationDbContext.PrepareEntityTypesInModelBuilder maps EVERY decimal
 		// property to the money type decimal(18,2). That is wrong for Quantity and UnitPrice:
 		//   - Quantity is a count/weight, not money. Postgres silently rounds fractional
 		//     quantities (e.g. 2.5 kg, 1.125 dozen) to scale 2 on insert.

--- a/src/Infrastructure/Migrations/20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision.Designer.cs
+++ b/src/Infrastructure/Migrations/20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision")]
+    partial class WidenReceiptItemQuantityAndUnitPricePrecision
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision.cs
+++ b/src/Infrastructure/Migrations/20260711221607_WidenReceiptItemQuantityAndUnitPricePrecision.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class WidenReceiptItemQuantityAndUnitPricePrecision : Migration
+{
+	/// <inheritdoc />
+	protected override void Up(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AlterColumn<decimal>(
+			name: "UnitPrice",
+			schema: "receipts",
+			table: "ReceiptItems",
+			type: "numeric(18,4)",
+			nullable: false,
+			oldClrType: typeof(decimal),
+			oldType: "numeric(18,2)");
+
+		migrationBuilder.AlterColumn<decimal>(
+			name: "Quantity",
+			schema: "receipts",
+			table: "ReceiptItems",
+			type: "numeric(18,4)",
+			nullable: false,
+			oldClrType: typeof(decimal),
+			oldType: "numeric(18,2)");
+	}
+
+	/// <inheritdoc />
+	protected override void Down(MigrationBuilder migrationBuilder)
+	{
+		migrationBuilder.AlterColumn<decimal>(
+			name: "UnitPrice",
+			schema: "receipts",
+			table: "ReceiptItems",
+			type: "numeric(18,2)",
+			nullable: false,
+			oldClrType: typeof(decimal),
+			oldType: "numeric(18,4)");
+
+		migrationBuilder.AlterColumn<decimal>(
+			name: "Quantity",
+			schema: "receipts",
+			table: "ReceiptItems",
+			type: "numeric(18,2)",
+			nullable: false,
+			oldClrType: typeof(decimal),
+			oldType: "numeric(18,4)");
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
+++ b/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
@@ -128,6 +128,37 @@ public class ColumnTypeMappingTests(PostgresFixture fixture)
 	}
 
 	[Fact]
+	public async Task ReceiptItemEntity_FractionalQuantityAndSubCentUnitPrice_RoundTripWithoutTruncation()
+	{
+		// RECEIPTS-770: Quantity and UnitPrice were mapped to the money type decimal(18,2),
+		// which silently rounds fractional quantities and sub-cent unit prices on insert.
+		// With numeric(18,4) they must round-trip exactly. The chosen values have scale > 2,
+		// so under the old (18,2) mapping this assertion would fail (rounded to 2 places).
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
+		item.Quantity = 1.125m;    // scale 3 — a fractional quantity (e.g. 1.125 kg)
+		item.UnitPrice = 3.4599m;  // scale 4 — a sub-cent unit price (e.g. fuel per gallon)
+		item.TotalAmount = 3.89m;  // money stays scale 2
+
+		// Act
+		context.ReceiptItems.Add(item);
+		await context.SaveChangesAsync();
+
+		// Assert — read on a fresh context so the values come back from Postgres, not the tracker
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		ReceiptItemEntity? loaded = await readContext.ReceiptItems.FirstOrDefaultAsync(i => i.Id == item.Id);
+
+		loaded.Should().NotBeNull();
+		loaded!.Quantity.Should().Be(1.125m, "numeric(18,4) must preserve a fractional quantity without rounding to scale 2");
+		loaded.UnitPrice.Should().Be(3.4599m, "numeric(18,4) must preserve a sub-cent unit price without rounding to scale 2");
+		loaded.TotalAmount.Should().Be(3.89m, "TotalAmount remains money at decimal(18,2)");
+	}
+
+	[Fact]
 	public async Task AdjustmentEntity_RoundTrips_WithEnumToStringConversion()
 	{
 		// Arrange — AdjustmentType enum stored as text

--- a/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
+++ b/tests/Infrastructure.IntegrationTests/ColumnTypeMappingTests.cs
@@ -130,7 +130,7 @@ public class ColumnTypeMappingTests(PostgresFixture fixture)
 	[Fact]
 	public async Task ReceiptItemEntity_FractionalQuantityAndSubCentUnitPrice_RoundTripWithoutTruncation()
 	{
-		// RECEIPTS-770: Quantity and UnitPrice were mapped to the money type decimal(18,2),
+		// RECEIPTS-765: Quantity and UnitPrice were mapped to the money type decimal(18,2),
 		// which silently rounds fractional quantities and sub-cent unit prices on insert.
 		// With numeric(18,4) they must round-trip exactly. The chosen values have scale > 2,
 		// so under the old (18,2) mapping this assertion would fail (rounded to 2 places).

--- a/tests/Infrastructure.IntegrationTests/DistinctDescriptionReconcileTests.cs
+++ b/tests/Infrastructure.IntegrationTests/DistinctDescriptionReconcileTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests;
+
+/// <summary>
+/// SaveChangesAsync reconciles the matching.DistinctDescriptions table so a row exists iff at
+/// least one active ReceiptItem carries that description. These tests pin the reconcile semantics
+/// against a real Postgres instance: the batched set-based reconcile must leave the table in the
+/// same state as the old per-description loop, and it must NOT reconcile a description whose
+/// active-item membership did not change (a metadata-only edit).
+/// Descriptions are made unique per test so the shared fixture container does not cross-contaminate.
+/// </summary>
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class DistinctDescriptionReconcileTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task Reconcile_AddingActiveReceiptItem_InsertsDistinctDescription()
+	{
+		string description = $"Widget_{Guid.NewGuid():N}";
+
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
+		item.Description = description;
+
+		// Act
+		context.ReceiptItems.Add(item);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		bool exists = await readContext.DistinctDescriptions.AnyAsync(d => d.Description == description);
+		exists.Should().BeTrue("a DistinctDescriptions row is created when an active ReceiptItem uses the description");
+	}
+
+	[Fact]
+	public async Task Reconcile_ChangingDescription_MovesDistinctDescriptionRow()
+	{
+		string oldDescription = $"Widget_{Guid.NewGuid():N}";
+		string newDescription = $"Gadget_{Guid.NewGuid():N}";
+
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
+		item.Description = oldDescription;
+		context.ReceiptItems.Add(item);
+		await context.SaveChangesAsync();
+
+		// Act — rename the only item carrying oldDescription
+		item.Description = newDescription;
+		await context.SaveChangesAsync();
+
+		// Assert — old description has no active items left, new one gained one
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		bool oldExists = await readContext.DistinctDescriptions.AnyAsync(d => d.Description == oldDescription);
+		bool newExists = await readContext.DistinctDescriptions.AnyAsync(d => d.Description == newDescription);
+
+		oldExists.Should().BeFalse("the old description no longer has any active ReceiptItem");
+		newExists.Should().BeTrue("the new description now has an active ReceiptItem");
+	}
+
+	[Fact]
+	public async Task Reconcile_SoftDeletingItem_RemovesDistinctDescription()
+	{
+		// Guards the DeletedAt-change branch: soft-deleting the last active item for a description
+		// flips its active state, so the reconcile must still run and drop the row.
+		string description = $"Widget_{Guid.NewGuid():N}";
+
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
+		item.Description = description;
+		context.ReceiptItems.Add(item);
+		await context.SaveChangesAsync();
+
+		// Sanity — the row exists before the soft delete
+		(await context.DistinctDescriptions.AnyAsync(d => d.Description == description)).Should().BeTrue();
+
+		// Act — soft-delete the item (goes through HandleSoftDelete -> Modified with DeletedAt set)
+		context.ReceiptItems.Remove(item);
+		await context.SaveChangesAsync();
+
+		// Assert
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		bool exists = await readContext.DistinctDescriptions.AnyAsync(d => d.Description == description);
+		exists.Should().BeFalse("soft-deleting the last active item must drop its DistinctDescriptions row");
+	}
+
+	[Fact]
+	public async Task Reconcile_MetadataOnlyChange_DoesNotReconcileUnchangedDescription()
+	{
+		// Proves the waste-elimination: a Modified item whose Description and active state are
+		// unchanged (only Quantity edited) must NOT trigger a reconcile for that description.
+		// We first delete the DistinctDescriptions row out from under an active item; if the edit
+		// reconciled the unchanged description (old behaviour), the row would be re-inserted.
+		string description = $"Widget_{Guid.NewGuid():N}";
+
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		context.Receipts.Add(receipt);
+		await context.SaveChangesAsync();
+
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receipt.Id);
+		item.Description = description;
+		context.ReceiptItems.Add(item);
+		await context.SaveChangesAsync();
+
+		// The active item created the row; delete it directly to detect any spurious reconcile.
+		await context.Database.ExecuteSqlRawAsync(
+			"""DELETE FROM "matching"."DistinctDescriptions" WHERE "Description" = {0};""",
+			description);
+		(await context.DistinctDescriptions.AnyAsync(d => d.Description == description)).Should().BeFalse();
+
+		// Act — change ONLY the quantity; description and active state are unchanged
+		item.Quantity = 7.5m;
+		await context.SaveChangesAsync();
+
+		// Assert — the row stays absent, proving the unchanged description was not reconciled
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+		bool exists = await readContext.DistinctDescriptions.AnyAsync(d => d.Description == description);
+		exists.Should().BeFalse("a metadata-only edit must not reconcile a description whose active membership did not change");
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/SoftDeleteTests.cs
+++ b/tests/Infrastructure.IntegrationTests/SoftDeleteTests.cs
@@ -284,6 +284,91 @@ public class SoftDeleteTests(PostgresFixture fixture)
 	}
 
 	[Fact]
+	public async Task SoftDelete_Receipt_CascadesToAllOwnedChildrenAndGrandchildren_InOneSave()
+	{
+		// Regression for the de-quadratic soft-delete cascade rewrite (the cascade is the
+		// correctness path RECEIPTS-755 depends on): deleting a single receipt that owns multiple
+		// children of every owned type — plus a grandchild owned by one of those children
+		// (Transaction -> YnabSyncRecord) — must still soft-delete the entire graph in one save
+		// and stamp each cascade target with its DIRECT parent id.
+		Guid receiptId;
+		Guid[] itemIds;
+		Guid transactionId;
+		Guid adjustmentId;
+		Guid syncRecordId;
+		{
+			await using ApplicationDbContext setupContext = fixture.CreateDbContext();
+			ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+			AccountEntity account = AccountEntityGenerator.Generate();
+			CardEntity card = CardEntityGenerator.Generate();
+			card.AccountId = account.Id;
+			setupContext.Receipts.Add(receipt);
+			setupContext.Accounts.Add(account);
+			setupContext.Cards.Add(card);
+			await setupContext.SaveChangesAsync();
+
+			ReceiptItemEntity item1 = ReceiptItemEntityGenerator.Generate(receipt.Id);
+			ReceiptItemEntity item2 = ReceiptItemEntityGenerator.Generate(receipt.Id);
+			TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, account.Id, card.Id);
+			AdjustmentEntity adjustment = AdjustmentEntityGenerator.Generate();
+			adjustment.ReceiptId = receipt.Id;
+			setupContext.ReceiptItems.AddRange(item1, item2);
+			setupContext.Transactions.Add(transaction);
+			setupContext.Adjustments.Add(adjustment);
+			await setupContext.SaveChangesAsync();
+
+			YnabSyncRecordEntity syncRecord = YnabSyncRecordEntityGenerator.Generate(localTransactionId: transaction.Id);
+			setupContext.YnabSyncRecords.Add(syncRecord);
+			await setupContext.SaveChangesAsync();
+
+			receiptId = receipt.Id;
+			itemIds = [item1.Id, item2.Id];
+			transactionId = transaction.Id;
+			adjustmentId = adjustment.Id;
+			syncRecordId = syncRecord.Id;
+		}
+
+		// Act — load the whole owned graph into the tracker, then remove only the receipt.
+		{
+			await using ApplicationDbContext deleteContext = fixture.CreateDbContext();
+			ReceiptEntity receiptToDelete = await deleteContext.Receipts.FirstAsync(r => r.Id == receiptId);
+			await deleteContext.ReceiptItems.IgnoreAutoIncludes().Where(i => i.ReceiptId == receiptId).LoadAsync();
+			await deleteContext.Adjustments.IgnoreAutoIncludes().Where(a => a.ReceiptId == receiptId).LoadAsync();
+			await deleteContext.Transactions.IgnoreAutoIncludes().Where(t => t.ReceiptId == receiptId).LoadAsync();
+			await deleteContext.YnabSyncRecords.IgnoreAutoIncludes().Where(s => s.LocalTransactionId == transactionId).LoadAsync();
+			deleteContext.Receipts.Remove(receiptToDelete);
+			await deleteContext.SaveChangesAsync();
+		}
+
+		// Assert — every child and the grandchild is soft-deleted, stamped with its DIRECT parent.
+		await using ApplicationDbContext readContext = fixture.CreateDbContext();
+
+		foreach (Guid itemId in itemIds)
+		{
+			ReceiptItemEntity? item = await readContext.ReceiptItems.IgnoreQueryFilters().FirstOrDefaultAsync(i => i.Id == itemId);
+			item.Should().NotBeNull();
+			item!.DeletedAt.Should().NotBeNull();
+			item.CascadeDeletedByParentId.Should().Be(receiptId);
+		}
+
+		AdjustmentEntity? adj = await readContext.Adjustments.IgnoreQueryFilters().FirstOrDefaultAsync(a => a.Id == adjustmentId);
+		adj.Should().NotBeNull();
+		adj!.DeletedAt.Should().NotBeNull();
+		adj.CascadeDeletedByParentId.Should().Be(receiptId);
+
+		TransactionEntity? tx = await readContext.Transactions.IgnoreQueryFilters().FirstOrDefaultAsync(t => t.Id == transactionId);
+		tx.Should().NotBeNull();
+		tx!.DeletedAt.Should().NotBeNull();
+		tx.CascadeDeletedByParentId.Should().Be(receiptId);
+
+		// Grandchild: owned by the Transaction, so its parent stamp is the transaction id.
+		YnabSyncRecordEntity? sync = await readContext.YnabSyncRecords.IgnoreQueryFilters().FirstOrDefaultAsync(s => s.Id == syncRecordId);
+		sync.Should().NotBeNull();
+		sync!.DeletedAt.Should().NotBeNull();
+		sync.CascadeDeletedByParentId.Should().Be(transactionId);
+	}
+
+	[Fact]
 	public async Task SoftDelete_YnabSyncRecord_AllowsReCreationAfterSoftDelete()
 	{
 		// Arrange — this test validates the filtered unique index on (LocalTransactionId, SyncType)


### PR DESCRIPTION
## Summary

Three confirmed findings in `src/Infrastructure/ApplicationDbContext.cs`, one commit per fix (plus a small commit correcting an issue-reference placeholder).

Closes RECEIPTS-765, RECEIPTS-766, RECEIPTS-786.

## Fix 1 — decimal precision loss (RECEIPTS-765)

`PrepareEntityTypesInModelBuilder` maps **every** `decimal` to the money type `decimal(18,2)`, including `ReceiptItemEntity.Quantity` (a count/weight) and `UnitPrice` (which legitimately needs sub-cent precision, e.g. fuel per gallon). Postgres silently rounded both to scale 2 on insert.

**Decision:** widen **both** `Quantity` and `UnitPrice` to `numeric(18,4)` — the least-disruptive correct option. Adding scale-2 validation at the API boundary was rejected because it would *reject* legitimate sub-cent unit prices rather than store them. Money columns that must land on whole cents (`TotalAmount` and all other money columns) intentionally stay `decimal(18,2)`. The override lives in `ReceiptItemEntityConfiguration`, which runs *after* the money-type default and therefore wins.

Widening scale `2 -> 4` is **non-lossy** on existing data (values had ≤2 fractional digits; precision 18 is unchanged). The migration is surgical (only the two columns) with a **symmetric** `Down`, and the snapshot diff is limited to those two columns (RECEIPTS-749 discipline).

<details><summary>Migration Up / Down</summary>

```csharp
// Up  — widen both columns
migrationBuilder.AlterColumn<decimal>(name: "UnitPrice", schema: "receipts", table: "ReceiptItems",
    type: "numeric(18,4)", nullable: false, oldClrType: typeof(decimal), oldType: "numeric(18,2)");
migrationBuilder.AlterColumn<decimal>(name: "Quantity",  schema: "receipts", table: "ReceiptItems",
    type: "numeric(18,4)", nullable: false, oldClrType: typeof(decimal), oldType: "numeric(18,2)");

// Down — restore the prior type (numeric(18,2))
migrationBuilder.AlterColumn<decimal>(name: "UnitPrice", schema: "receipts", table: "ReceiptItems",
    type: "numeric(18,2)", nullable: false, oldClrType: typeof(decimal), oldType: "numeric(18,4)");
migrationBuilder.AlterColumn<decimal>(name: "Quantity",  schema: "receipts", table: "ReceiptItems",
    type: "numeric(18,2)", nullable: false, oldClrType: typeof(decimal), oldType: "numeric(18,4)");
```
</details>

## Fix 2 — quadratic cascade discovery (RECEIPTS-766)

`HandleSoftDelete` called `CollectOwnedChildren` once per deleted parent, and `CollectOwnedChildren` re-enumerated `ChangeTracker.Entries()` for every owned-child type — with auto-detect on, each enumeration triggered a full `DetectChanges` over every tracked entity's every property. That is **O(parents × childTypes × trackedEntities)** on a hot save path.

Now discovered from a **single snapshot**: `DetectChanges()` once (which still lets EF mark cascade-deleted children as `Deleted`), then `AutoDetectChangesEnabled = false` for the duration (restored in a `finally`, so `base.SaveChangesAsync` runs its normal detection). The tracker is bucketed once by runtime type, a per-owned-child FK index is built (`Dictionary<OwnedChildEntry, Dictionary<fkValue, children>>`), and each parent's children are resolved with two dictionary lookups.

**Behavior is preserved exactly:** deleted entries are iterated in tracker order and children in relationship-definition order, so `cascadeTargets`, the `CascadeDeletedByParentId` stamping, the already-soft-deleted skip, and multi-level recursion (Receipt → Transaction → YnabSyncRecord) are identical — only the discovery mechanism changed.

## Fix 3 — reconcile N+1 (RECEIPTS-786)

`ReconcileDistinctDescriptionsAsync` ran two sequential raw-SQL round trips (INSERT…ON CONFLICT + DELETE…NOT EXISTS) **per touched description** after every `SaveChangesAsync` touching ReceiptItems — including for `Modified` entries whose `Description` never actually changed.

- `CollectTouchedReceiptItemDescriptions` now includes a `Modified` item only when it can affect the active-description set: the `Description` text changed **or** its active state flipped (`DeletedAt` gained/lost a value — soft-delete/restore). Metadata-only edits (e.g. `Quantity`) are skipped. (The `DeletedAt` condition preserves the pre-existing soft-delete reconcile behavior — a naive "description changed only" check would have regressed it.)
- The reconcile is now **set-based**: the whole touched set is passed as one `text[]` parameter and expanded with `unnest` / `= ANY`, giving **one INSERT and one DELETE** regardless of set size. `ON CONFLICT DO NOTHING` and the `NOT EXISTS` guard keep it idempotent/race-safe, so `DistinctDescriptions` converges on the same state as the old loop.

## Test strategy (RECEIPTS-763 CI-crash avoidance)

No new InMemory-database unit tests were added for cascade/reconcile/column-type behavior — those live in `tests/Infrastructure.IntegrationTests` (real Postgres, `Category=Integration`), the correct home. Existing InMemory unit tests were preserved and stay green.

**Tests added (all integration):**
- `ColumnTypeMappingTests.ReceiptItemEntity_FractionalQuantityAndSubCentUnitPrice_RoundTripWithoutTruncation` — `Quantity = 1.125`, `UnitPrice = 3.4599` round-trip exactly.
- `SoftDeleteTests.SoftDelete_Receipt_CascadesToAllOwnedChildrenAndGrandchildren_InOneSave` — one receipt owning items + transaction + adjustment + a transaction-owned grandchild soft-deletes the whole graph, each stamped with its direct parent.
- `DistinctDescriptionReconcileTests` (4) — insert on add; move row on description change; drop row on soft-delete (guards the `DeletedAt` branch); and a deterministic *does-not-reconcile-unchanged-description* test (delete the row out from under an active item, edit only `Quantity`, assert the row stays absent).

## Validation

- `dotnet build Receipts.slnx` clean; warnings-as-errors build clean (only pre-existing NU* package advisories).
- **Exact CI coverage command** completed with a real total, no crash: `dotnet test tests/Infrastructure.Tests --filter "Category!=Integration" --collect:"XPlat Code Coverage" --settings scripts/tests/coverlet.runsettings` → **Passed 660, Failed 0, Total 660, exit 0**.
- Full `Infrastructure.IntegrationTests` suite against Docker Postgres (Testcontainers migrates to HEAD, so the migration is exercised): **50 passed, 0 failed**.
- Pre-commit hook (format verify, warnings-as-errors build, .NET + frontend tests) passed on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
