### PR TITLE
fix(infrastructure): return 409 on restore conflict, make migrations symmetric and replayable, per-consumer signal, robust notifier flush

### DIFF
--- a/src/Application/Interfaces/Services/IDescriptionChangeSignal.cs
+++ b/src/Application/Interfaces/Services/IDescriptionChangeSignal.cs
@@ -2,8 +2,25 @@ using System.Threading.Channels;
 
 namespace Application.Interfaces.Services;
 
+/// <summary>
+/// Broadcasts "descriptions may have changed" hints from write paths (SaveChanges,
+/// manual refresh) to every background consumer that reacts to them.
+/// </summary>
+/// <remarks>
+/// Each consumer calls <see cref="Subscribe"/> exactly once to obtain its OWN wake-up
+/// channel; <see cref="NotifyDirty"/> fans a signal out to all subscribers so a single
+/// notification reaches every consumer. This replaces the earlier single shared channel,
+/// where whichever consumer read first "stole" the wake-up and the others could miss a
+/// signal — including a manual-refresh request (RECEIPTS-790).
+/// </remarks>
 public interface IDescriptionChangeSignal
 {
+	/// <summary>Signals every subscriber that description-related state may have changed.</summary>
 	void NotifyDirty();
-	ChannelReader<bool> Reader { get; }
+
+	/// <summary>
+	/// Registers a new consumer and returns its private wake-up reader. Bursts coalesce into a
+	/// single pending token per consumer, and <see cref="NotifyDirty"/> never blocks.
+	/// </summary>
+	ChannelReader<bool> Subscribe();
 }

--- a/src/Infrastructure/Interfaces/Repositories/ICategoryRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/ICategoryRepository.cs
@@ -15,6 +15,7 @@ public interface ICategoryRepository
 	Task<int> GetCountAsync(CancellationToken cancellationToken, bool? isActive = null);
 	Task DeleteAsync(List<Guid> ids, CancellationToken cancellationToken);
 	Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken);
+	Task<string?> GetRestoreConflictNameAsync(Guid id, CancellationToken cancellationToken);
 	Task<int> GetSubcategoryCountAsync(Guid categoryId, CancellationToken cancellationToken);
 	Task<int> GetReceiptItemCountByCategoryNameAsync(string categoryName, CancellationToken cancellationToken);
 	Task<List<string>> GetSubcategoryNamesAsync(Guid categoryId, CancellationToken cancellationToken);

--- a/src/Infrastructure/Interfaces/Repositories/IItemTemplateRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/IItemTemplateRepository.cs
@@ -15,4 +15,5 @@ public interface IItemTemplateRepository
 	Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken);
 	Task<int> GetCountAsync(CancellationToken cancellationToken);
 	Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken);
+	Task<string?> GetRestoreConflictNameAsync(Guid id, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Interfaces/Repositories/ISubcategoryRepository.cs
+++ b/src/Infrastructure/Interfaces/Repositories/ISubcategoryRepository.cs
@@ -17,6 +17,7 @@ public interface ISubcategoryRepository
 	Task<int> GetCountAsync(CancellationToken cancellationToken, bool? isActive = null);
 	Task DeleteAsync(List<Guid> ids, CancellationToken cancellationToken);
 	Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken);
+	Task<string?> GetRestoreConflictNameAsync(Guid id, CancellationToken cancellationToken);
 	Task<int> GetReceiptItemCountBySubcategoryNameAsync(string subcategoryName, CancellationToken cancellationToken);
 	Task<List<(Guid ReceiptId, DateOnly Date, string Location)>> GetAffectedReceiptsBySubcategoryNameAsync(string subcategoryName, int limit, CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Migrations/20260327115645_CleanUpInvalidCategories.cs
+++ b/src/Infrastructure/Migrations/20260327115645_CleanUpInvalidCategories.cs
@@ -27,11 +27,15 @@ public partial class CleanUpInvalidCategories : Migration
 	/// <inheritdoc />
 	protected override void Up(MigrationBuilder migrationBuilder)
 	{
-		// 1. Insert the "Uncategorized" seed category (EF Core HasData).
-		migrationBuilder.InsertData(
-			table: "Categories",
-			columns: ["Id", "Description", "Name"],
-			values: [new Guid("f0e7a123-9b56-4d3a-8c1e-2a5b7d9f4e6c"), "Default category for items without a valid category", "Uncategorized"]);
+		// 1. Insert the "Uncategorized" seed category. Guarded with ON CONFLICT DO NOTHING so
+		//    the migration is replayable: re-running Up after a Down (which intentionally keeps
+		//    the seed row), or applying it to a database that already contains an "Uncategorized"
+		//    category (by PK or by the unique Name index), no-ops instead of throwing a unique
+		//    violation (RECEIPTS-788). A bare INSERT would fail in both cases.
+		migrationBuilder.Sql(
+			"INSERT INTO \"Categories\" (\"Id\", \"Description\", \"Name\")" +
+			" VALUES ('f0e7a123-9b56-4d3a-8c1e-2a5b7d9f4e6c', 'Default category for items without a valid category', 'Uncategorized')" +
+			" ON CONFLICT DO NOTHING;");
 
 		string validList = string.Join(", ", Array.ConvertAll(ValidCategoryNames, n => $"'{n.Replace("'", "''")}'"));
 

--- a/src/Infrastructure/Migrations/20260406141455_AddFilterToYnabSyncRecordUniqueIndex.cs
+++ b/src/Infrastructure/Migrations/20260406141455_AddFilterToYnabSyncRecordUniqueIndex.cs
@@ -25,6 +25,12 @@ public partial class AddFilterToYnabSyncRecordUniqueIndex : Migration
 	/// <inheritdoc />
 	protected override void Down(MigrationBuilder migrationBuilder)
 	{
+		// This migration's Up() only re-creates the already-filtered index (the filter was
+		// added by the prior migration, AddSoftDeleteFilterToYnabSyncRecordIndex), so its
+		// Down() must restore that SAME filtered state — not an unfiltered index. Recreating
+		// the index WITHOUT "DeletedAt" IS NULL would fail with a unique violation on exactly
+		// the soft-deleted-duplicate rows the filter exists to permit, permanently blocking
+		// rollback (RECEIPTS-768).
 		migrationBuilder.DropIndex(
 			name: "IX_YnabSyncRecords_LocalTransactionId_SyncType",
 			table: "YnabSyncRecords");
@@ -33,6 +39,7 @@ public partial class AddFilterToYnabSyncRecordUniqueIndex : Migration
 			name: "IX_YnabSyncRecords_LocalTransactionId_SyncType",
 			table: "YnabSyncRecords",
 			columns: new[] { "LocalTransactionId", "SyncType" },
-			unique: true);
+			unique: true,
+			filter: "\"DeletedAt\" IS NULL");
 	}
 }

--- a/src/Infrastructure/Repositories/CategoryRepository.cs
+++ b/src/Infrastructure/Repositories/CategoryRepository.cs
@@ -144,6 +144,30 @@ public class CategoryRepository(IDbContextFactory<ApplicationDbContext> contextF
 		return true;
 	}
 
+	public async Task<string?> GetRestoreConflictNameAsync(Guid id, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		// The soft-deleted row the caller intends to restore.
+		CategoryEntity? deleted = await context.Categories
+			.IncludeDeleted()
+			.FirstOrDefaultAsync(e => e.Id == id && e.DeletedAt != null, cancellationToken);
+
+		if (deleted is null)
+		{
+			// Nothing to restore (absent or already active) — no conflict to report.
+			return null;
+		}
+
+		// context.Categories is filtered to active rows (DeletedAt == null). A match means an
+		// active category already owns this name, so restoring would violate the filtered
+		// unique index on Name. Return the colliding name so the caller can surface a 409.
+		bool conflict = await context.Categories
+			.AnyAsync(e => e.Name == deleted.Name, cancellationToken);
+
+		return conflict ? deleted.Name : null;
+	}
+
 	public async Task<int> GetSubcategoryCountAsync(Guid categoryId, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();

--- a/src/Infrastructure/Repositories/ItemTemplateRepository.cs
+++ b/src/Infrastructure/Repositories/ItemTemplateRepository.cs
@@ -117,4 +117,28 @@ public class ItemTemplateRepository(IDbContextFactory<ApplicationDbContext> cont
 		await context.SaveChangesAsync(cancellationToken);
 		return true;
 	}
+
+	public async Task<string?> GetRestoreConflictNameAsync(Guid id, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		// The soft-deleted row the caller intends to restore.
+		ItemTemplateEntity? deleted = await context.ItemTemplates
+			.IncludeDeleted()
+			.FirstOrDefaultAsync(e => e.Id == id && e.DeletedAt != null, cancellationToken);
+
+		if (deleted is null)
+		{
+			// Nothing to restore (absent or already active) — no conflict to report.
+			return null;
+		}
+
+		// context.ItemTemplates is filtered to active rows (DeletedAt == null). A match means an
+		// active template already owns this name, so restoring would violate the filtered unique
+		// index on Name. Return the colliding name so the caller can surface a 409.
+		bool conflict = await context.ItemTemplates
+			.AnyAsync(e => e.Name == deleted.Name, cancellationToken);
+
+		return conflict ? deleted.Name : null;
+	}
 }

--- a/src/Infrastructure/Repositories/SubcategoryRepository.cs
+++ b/src/Infrastructure/Repositories/SubcategoryRepository.cs
@@ -170,6 +170,30 @@ public class SubcategoryRepository(IDbContextFactory<ApplicationDbContext> conte
 		return true;
 	}
 
+	public async Task<string?> GetRestoreConflictNameAsync(Guid id, CancellationToken cancellationToken)
+	{
+		using ApplicationDbContext context = contextFactory.CreateDbContext();
+
+		// The soft-deleted row the caller intends to restore.
+		SubcategoryEntity? deleted = await context.Subcategories
+			.IncludeDeleted()
+			.FirstOrDefaultAsync(e => e.Id == id && e.DeletedAt != null, cancellationToken);
+
+		if (deleted is null)
+		{
+			// Nothing to restore (absent or already active) — no conflict to report.
+			return null;
+		}
+
+		// context.Subcategories is filtered to active rows (DeletedAt == null). A match on the
+		// natural key (CategoryId, Name) means an active subcategory already occupies it, so
+		// restoring would violate the filtered unique index. Return the colliding name.
+		bool conflict = await context.Subcategories
+			.AnyAsync(e => e.CategoryId == deleted.CategoryId && e.Name == deleted.Name, cancellationToken);
+
+		return conflict ? deleted.Name : null;
+	}
+
 	public async Task<int> GetReceiptItemCountBySubcategoryNameAsync(string subcategoryName, CancellationToken cancellationToken)
 	{
 		using ApplicationDbContext context = contextFactory.CreateDbContext();

--- a/src/Infrastructure/Services/CategoryService.cs
+++ b/src/Infrastructure/Services/CategoryService.cs
@@ -79,7 +79,28 @@ public class CategoryService(ICategoryRepository repository, CategoryMapper mapp
 
 	public async Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken)
 	{
-		return await repository.RestoreAsync(id, cancellationToken);
+		// The unique index on Name is filtered to DeletedAt IS NULL, so a name freed by
+		// soft-delete can be reused by a new active category. Pre-check for that collision and
+		// surface a clean 409 (via DuplicateEntityException → GlobalExceptionHandlerMiddleware)
+		// instead of the raw unique-violation 500 that would otherwise block restore forever
+		// (RECEIPTS-772).
+		string? conflictingName = await repository.GetRestoreConflictNameAsync(id, cancellationToken);
+		if (conflictingName is not null)
+		{
+			throw new DuplicateEntityException(
+				$"Cannot restore this category because an active category named '{conflictingName}' already exists.");
+		}
+
+		try
+		{
+			return await repository.RestoreAsync(id, cancellationToken);
+		}
+		catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
+		{
+			// Lost a race: an active row with the same name appeared between the pre-check and
+			// SaveChanges. Still map to 409 rather than letting a 500 escape.
+			throw new DuplicateEntityException("A category with this name already exists.", ex);
+		}
 	}
 
 	public async Task<int> GetSubcategoryCountAsync(Guid categoryId, CancellationToken cancellationToken)

--- a/src/Infrastructure/Services/DescriptionChangeSignal.cs
+++ b/src/Infrastructure/Services/DescriptionChangeSignal.cs
@@ -3,12 +3,41 @@ using Application.Interfaces.Services;
 
 namespace Infrastructure.Services;
 
+// Fan-out implementation of IDescriptionChangeSignal. Previously a single shared capacity-1
+// channel meant the two consumers (NormalizedDescriptionResolutionService and
+// ItemSimilarityEdgeRefresher) competed for one wake-up token — whichever read first stole
+// it, so the other could miss a signal (including a manual refresh) and stall until its own
+// safety timer. Now every consumer Subscribe()s once and gets its OWN capacity-1 channel, and
+// NotifyDirty writes to all of them, so a single signal reaches both (RECEIPTS-790).
 public class DescriptionChangeSignal : IDescriptionChangeSignal
 {
-	private readonly Channel<bool> _channel = Channel.CreateBounded<bool>(
-		new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropWrite });
+	private readonly object _gate = new();
+	private readonly List<Channel<bool>> _subscribers = [];
 
-	public void NotifyDirty() => _channel.Writer.TryWrite(true);
+	public ChannelReader<bool> Subscribe()
+	{
+		// Capacity-1 + DropWrite: a burst of NotifyDirty calls coalesces into a single pending
+		// token per consumer, and NotifyDirty never blocks even while a consumer is mid-cycle.
+		Channel<bool> channel = Channel.CreateBounded<bool>(
+			new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropWrite });
 
-	public ChannelReader<bool> Reader => _channel.Reader;
+		lock (_gate)
+		{
+			_subscribers.Add(channel);
+		}
+
+		return channel.Reader;
+	}
+
+	public void NotifyDirty()
+	{
+		lock (_gate)
+		{
+			foreach (Channel<bool> channel in _subscribers)
+			{
+				// Non-blocking; DropWrite means an already-pending token is simply kept.
+				channel.Writer.TryWrite(true);
+			}
+		}
+	}
 }

--- a/src/Infrastructure/Services/ItemSimilarityEdgeRefresher.cs
+++ b/src/Infrastructure/Services/ItemSimilarityEdgeRefresher.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading.Channels;
 using Application.Interfaces.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,7 +11,7 @@ namespace Infrastructure.Services;
 public class ItemSimilarityEdgeRefresher : BackgroundService
 {
 	private readonly IServiceScopeFactory _scopeFactory;
-	private readonly IDescriptionChangeSignal _signal;
+	private readonly ChannelReader<bool> _signalReader;
 	private readonly ILogger<ItemSimilarityEdgeRefresher> _logger;
 	private readonly TimeProvider _timeProvider;
 
@@ -41,7 +42,9 @@ public class ItemSimilarityEdgeRefresher : BackgroundService
 		TimeProvider? timeProvider = null)
 	{
 		_scopeFactory = scopeFactory;
-		_signal = signal;
+		// Subscribe once for this refresher's own wake-up channel so a signal is never stolen
+		// by the other consumer (NormalizedDescriptionResolutionService) — RECEIPTS-790.
+		_signalReader = signal.Subscribe();
 		_logger = logger;
 		_timeProvider = timeProvider ?? TimeProvider.System;
 	}
@@ -76,7 +79,7 @@ public class ItemSimilarityEdgeRefresher : BackgroundService
 				waitCts.CancelAfter(MaxIdleInterval);
 				try
 				{
-					await _signal.Reader.ReadAsync(waitCts.Token);
+					await _signalReader.ReadAsync(waitCts.Token);
 				}
 				catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
 				{
@@ -98,7 +101,7 @@ public class ItemSimilarityEdgeRefresher : BackgroundService
 			}
 
 			// Drain any additional dirty signals that arrived during the debounce window.
-			while (_signal.Reader.TryRead(out _))
+			while (_signalReader.TryRead(out _))
 			{
 			}
 

--- a/src/Infrastructure/Services/ItemTemplateService.cs
+++ b/src/Infrastructure/Services/ItemTemplateService.cs
@@ -1,9 +1,12 @@
+using Application.Exceptions;
 using Application.Interfaces.Services;
 using Application.Models;
 using Domain.Core;
 using Infrastructure.Entities.Core;
 using Infrastructure.Interfaces.Repositories;
 using Infrastructure.Mapping;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace Infrastructure.Services;
 
@@ -61,6 +64,27 @@ public class ItemTemplateService(IItemTemplateRepository repository, ItemTemplat
 
 	public async Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken)
 	{
-		return await repository.RestoreAsync(id, cancellationToken);
+		// The unique index on Name is filtered to DeletedAt IS NULL, so a name freed by
+		// soft-delete can be reused by a new active template. Pre-check for that collision and
+		// surface a clean 409 (via DuplicateEntityException → GlobalExceptionHandlerMiddleware)
+		// instead of the raw unique-violation 500 that would otherwise block restore forever
+		// (RECEIPTS-772).
+		string? conflictingName = await repository.GetRestoreConflictNameAsync(id, cancellationToken);
+		if (conflictingName is not null)
+		{
+			throw new DuplicateEntityException(
+				$"Cannot restore this item template because an active template named '{conflictingName}' already exists.");
+		}
+
+		try
+		{
+			return await repository.RestoreAsync(id, cancellationToken);
+		}
+		catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
+		{
+			// Lost a race: an active row with the same name appeared between the pre-check and
+			// SaveChanges. Still map to 409 rather than letting a 500 escape.
+			throw new DuplicateEntityException("An item template with this name already exists.", ex);
+		}
 	}
 }

--- a/src/Infrastructure/Services/NormalizedDescriptionResolutionService.cs
+++ b/src/Infrastructure/Services/NormalizedDescriptionResolutionService.cs
@@ -1,3 +1,4 @@
+using System.Threading.Channels;
 using Application.Interfaces.Services;
 using Application.Models.NormalizedDescriptions;
 using Domain.NormalizedDescriptions;
@@ -16,9 +17,10 @@ namespace Infrastructure.Services;
 // NormalizedDescriptionService.GetOrCreateAsync exactly once and its (Id, MatchScore) is
 // written onto every row in the group.
 //
-// Signal-driven via IDescriptionChangeSignal — the same channel that dirties
+// Signal-driven via IDescriptionChangeSignal — the same broadcast that dirties
 // ItemSimilarityEdgeRefresher also hints that new ReceiptItems may need normalization.
-// Both consumers are idempotent, so reusing the signal is safe.
+// Both consumers are idempotent. This service Subscribe()s once for its OWN wake-up channel
+// so a signal can never be "stolen" by the other consumer (RECEIPTS-790).
 //
 // Errors are logged and the cycle retries next tick — we never surface exceptions past the
 // hosted-service boundary because a resolver crash would otherwise cascade into the host
@@ -32,6 +34,10 @@ public class NormalizedDescriptionResolutionService(
 	internal const int MinDescriptionLength = 2;
 	internal static readonly TimeSpan Interval = TimeSpan.FromSeconds(30);
 	internal static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(10);
+
+	// Subscribed at construction (before any NotifyDirty this instance should react to) so a
+	// wake-up fired during startup is buffered rather than lost.
+	private readonly ChannelReader<bool> _signalReader = signal.Subscribe();
 
 	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 	{
@@ -65,7 +71,7 @@ public class NormalizedDescriptionResolutionService(
 
 			// Drain any dirty signals that arrived while we were processing. We only care
 			// that at least one signal exists to wake us early; excess reads are harmless.
-			while (signal.Reader.TryRead(out _))
+			while (_signalReader.TryRead(out _))
 			{
 			}
 
@@ -78,7 +84,7 @@ public class NormalizedDescriptionResolutionService(
 				waitCts.CancelAfter(Interval);
 				try
 				{
-					await signal.Reader.ReadAsync(waitCts.Token);
+					await _signalReader.ReadAsync(waitCts.Token);
 				}
 				catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
 				{

--- a/src/Infrastructure/Services/SubcategoryService.cs
+++ b/src/Infrastructure/Services/SubcategoryService.cs
@@ -95,7 +95,28 @@ public class SubcategoryService(ISubcategoryRepository repository, SubcategoryMa
 
 	public async Task<bool> RestoreAsync(Guid id, CancellationToken cancellationToken)
 	{
-		return await repository.RestoreAsync(id, cancellationToken);
+		// The unique index on (CategoryId, Name) is filtered to DeletedAt IS NULL, so a name
+		// freed by soft-delete can be reused by a new active subcategory. Pre-check for that
+		// collision and surface a clean 409 (via DuplicateEntityException →
+		// GlobalExceptionHandlerMiddleware) instead of the raw unique-violation 500 that would
+		// otherwise block restore forever (RECEIPTS-772).
+		string? conflictingName = await repository.GetRestoreConflictNameAsync(id, cancellationToken);
+		if (conflictingName is not null)
+		{
+			throw new DuplicateEntityException(
+				$"Cannot restore this subcategory because an active subcategory named '{conflictingName}' already exists in this category.");
+		}
+
+		try
+		{
+			return await repository.RestoreAsync(id, cancellationToken);
+		}
+		catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
+		{
+			// Lost a race: an active row with the same natural key appeared between the
+			// pre-check and SaveChanges. Still map to 409 rather than letting a 500 escape.
+			throw new DuplicateEntityException("A subcategory with this name already exists in this category.", ex);
+		}
 	}
 
 	public async Task<int> GetReceiptItemCountBySubcategoryNameAsync(string subcategoryName, CancellationToken cancellationToken)

--- a/src/Presentation/API/Services/EntityChangeNotifier.cs
+++ b/src/Presentation/API/Services/EntityChangeNotifier.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using API.Authentication;
 using API.Hubs;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace API.Services;
 
@@ -10,22 +11,26 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 {
 	private readonly IHubContext<EntityHub, IEntityHubClient> _hubContext;
 	private readonly IHttpContextAccessor _httpContextAccessor;
+	private readonly ILogger<EntityChangeNotifier> _logger;
 	private readonly ConcurrentDictionary<(string EntityType, string ChangeType, string? UserId, string? AuthMethod, string? ConnectionId), NotificationBucket> _pending = new();
 	private readonly Timer _flushTimer;
 	private readonly TimeSpan _flushInterval;
 	private int _disposed;
 
-	public EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor)
-		: this(hubContext, httpContextAccessor, TimeSpan.FromSeconds(1))
+	public EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor, ILogger<EntityChangeNotifier> logger)
+		: this(hubContext, httpContextAccessor, TimeSpan.FromSeconds(1), logger)
 	{
 	}
 
-	internal EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor, TimeSpan flushInterval)
+	internal EntityChangeNotifier(IHubContext<EntityHub, IEntityHubClient> hubContext, IHttpContextAccessor httpContextAccessor, TimeSpan flushInterval, ILogger<EntityChangeNotifier>? logger = null)
 	{
 		_hubContext = hubContext;
 		_httpContextAccessor = httpContextAccessor;
+		_logger = logger ?? NullLogger<EntityChangeNotifier>.Instance;
 		_flushInterval = flushInterval;
-		_flushTimer = new Timer(_ => _ = FlushAsync(), null, _flushInterval, _flushInterval);
+		// Route the timer through TimerFlushAsync so a throw can never fault the callback or
+		// surface as an unobserved task exception — the timer must keep firing (RECEIPTS-794).
+		_flushTimer = new Timer(static state => _ = ((EntityChangeNotifier)state!).TimerFlushAsync(), this, _flushInterval, _flushInterval);
 	}
 
 	public Task NotifyCreated(string entityType, Guid id)
@@ -97,9 +102,24 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 		return new NotificationOrigin(userId, authMethod, connectionId);
 	}
 
+	private async Task TimerFlushAsync()
+	{
+		try
+		{
+			await FlushAsync();
+		}
+		catch (Exception ex)
+		{
+			// FlushAsync already handles per-send failures; this is a last-resort guard so an
+			// unexpected throw can never fault the timer callback or become an unobserved
+			// exception. The timer keeps firing on its interval regardless.
+			_logger.LogError(ex, "Unexpected error in entity-change notifier flush timer.");
+		}
+	}
+
 	internal async Task FlushAsync()
 	{
-		// Snapshot and remove all pending buckets atomically per key
+		// Snapshot and remove all pending buckets atomically per key.
 		List<(string EntityType, string ChangeType, string? UserId, string? AuthMethod, string? ConnectionId, int Count)> toSend = [];
 		foreach (var key in _pending.Keys)
 		{
@@ -109,11 +129,48 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 			}
 		}
 
-		foreach (var (entityType, changeType, userId, authMethod, connectionId, count) in toSend)
+		for (int i = 0; i < toSend.Count; i++)
 		{
-			await _hubContext.Clients.All.EntityChanged(
-				new EntityChangeNotification(entityType, changeType, null, count, userId, authMethod, connectionId));
+			var (entityType, changeType, userId, authMethod, connectionId, count) = toSend[i];
+			try
+			{
+				await _hubContext.Clients.All.EntityChanged(
+					new EntityChangeNotification(entityType, changeType, null, count, userId, authMethod, connectionId));
+			}
+			catch (Exception ex)
+			{
+				// A hub/transport failure mid-flush must not permanently drop notifications we
+				// already dequeued. Re-enqueue this bucket and every one not yet sent so the
+				// next timer tick (or Dispose) retries them, then log and stop (RECEIPTS-794).
+				int requeued = 0;
+				for (int j = i; j < toSend.Count; j++)
+				{
+					Requeue(toSend[j]);
+					requeued++;
+				}
+
+				_logger.LogError(
+					ex,
+					"Failed to flush entity-change notifications; re-enqueued {Requeued} batch(es) for retry.",
+					requeued);
+				return;
+			}
 		}
+	}
+
+	private void Requeue((string EntityType, string ChangeType, string? UserId, string? AuthMethod, string? ConnectionId, int Count) item)
+	{
+		var key = (item.EntityType, item.ChangeType, item.UserId, item.AuthMethod, item.ConnectionId);
+		_pending.AddOrUpdate(
+			key,
+			_ => new NotificationBucket(item.Count),
+			(_, existing) =>
+			{
+				// A fresh bucket may have accumulated for this key since we dequeued; merge the
+				// un-sent count into it so nothing is lost and nothing is double-counted.
+				existing.Add(item.Count);
+				return existing;
+			});
 	}
 
 	public void Dispose()
@@ -121,7 +178,8 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 		if (Interlocked.Exchange(ref _disposed, 1) == 0)
 		{
 			_flushTimer.Dispose();
-			// Fire one last flush synchronously to drain pending notifications
+			// Fire one last flush synchronously to drain pending notifications. FlushAsync
+			// swallows and logs its own send failures, so this cannot throw during teardown.
 			FlushAsync().GetAwaiter().GetResult();
 		}
 	}
@@ -138,12 +196,19 @@ public sealed class EntityChangeNotifier : IEntityChangeNotifier, IDisposable
 			_count = 1;
 		}
 
-		public int Count => _count;
+		public NotificationBucket(int initialCount)
+		{
+			_count = initialCount;
+		}
+
+		public int Count => Volatile.Read(ref _count);
 
 		public void Add(Guid? id)
 		{
 			_ = id;
 			Interlocked.Increment(ref _count);
 		}
+
+		public void Add(int delta) => Interlocked.Add(ref _count, delta);
 	}
 }

--- a/tests/Infrastructure.IntegrationTests/MigrationReplayTests.cs
+++ b/tests/Infrastructure.IntegrationTests/MigrationReplayTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Infrastructure.IntegrationTests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.IntegrationTests;
+
+// RECEIPTS-788: CleanUpInvalidCategories' seed INSERT must be replayable — re-running Up after
+// a Down (which intentionally keeps the "Uncategorized" row) must no-op instead of throwing a
+// unique violation. This exercises the migration's exact guarded INSERT against real Postgres
+// twice, mirroring a replay. The fresh-DB insert path is already covered by the fixture applying
+// the (modified) migration at startup.
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class MigrationReplayTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task CleanUpInvalidCategories_SeedInsert_IsIdempotentOnReplay()
+	{
+		// The exact SQL the migration now runs. Unqualified "Categories" resolves via the
+		// fixture search_path to the table's current schema (library).
+		const string seedSql =
+			"INSERT INTO \"Categories\" (\"Id\", \"Description\", \"Name\")" +
+			" VALUES ('f0e7a123-9b56-4d3a-8c1e-2a5b7d9f4e6c', 'Default category for items without a valid category', 'Uncategorized')" +
+			" ON CONFLICT DO NOTHING;";
+
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+
+		// Run it twice — the second run simulates replay after a Down that kept the row. A bare
+		// INSERT would throw a unique violation here; ON CONFLICT DO NOTHING must no-op.
+		Func<Task> act = async () =>
+		{
+			await context.Database.ExecuteSqlRawAsync(seedSql);
+			await context.Database.ExecuteSqlRawAsync(seedSql);
+		};
+
+		await act.Should().NotThrowAsync();
+
+		// Exactly one "Uncategorized" category remains — no duplicate, no error.
+		int count = await context.Categories
+			.IgnoreQueryFilters()
+			.CountAsync(c => c.Name == "Uncategorized");
+		count.Should().Be(1);
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/RestoreConflictTests.cs
+++ b/tests/Infrastructure.IntegrationTests/RestoreConflictTests.cs
@@ -1,0 +1,100 @@
+using Application.Exceptions;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Infrastructure.Mapping;
+using Infrastructure.Repositories;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.IntegrationTests;
+
+// RECEIPTS-772: the unique indexes on Categories.Name / Subcategories(CategoryId, Name) /
+// ItemTemplates.Name are filtered on DeletedAt IS NULL, so a name can be re-created after the
+// original is soft-deleted. Restoring the original must then fail cleanly (409 via
+// DuplicateEntityException) rather than throwing a raw unique-violation (500). These tests run
+// against real PostgreSQL, where the filtered unique index is actually enforced.
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class RestoreConflictTests(PostgresFixture fixture)
+{
+	private sealed class FixtureContextFactory(PostgresFixture fixture) : IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => fixture.CreateDbContext();
+	}
+
+	private CategoryService CreateCategoryService() =>
+		new(new CategoryRepository(new FixtureContextFactory(fixture)), new CategoryMapper());
+
+	[Fact]
+	public async Task RestoreCategory_WhenActiveNameWasReCreated_ThrowsDuplicateEntityException_NotDbUpdateException()
+	{
+		// Arrange — unique name so we never collide with seed data or other tests.
+		string name = $"RestoreConflict-{Guid.NewGuid()}";
+		Guid deletedId;
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			CategoryEntity original = new() { Id = Guid.NewGuid(), Name = name, Description = "original", IsActive = true };
+			setup.Categories.Add(original);
+			await setup.SaveChangesAsync();
+			deletedId = original.Id;
+
+			// Soft-delete the original, freeing the name.
+			setup.Categories.Remove(original);
+			await setup.SaveChangesAsync();
+
+			// Re-create an ACTIVE category with the same name (allowed by the filtered index).
+			setup.Categories.Add(new CategoryEntity { Id = Guid.NewGuid(), Name = name, Description = "re-created", IsActive = true });
+			await setup.SaveChangesAsync();
+		}
+
+		CategoryService service = CreateCategoryService();
+
+		// Act
+		Func<Task> act = async () => await service.RestoreAsync(deletedId, CancellationToken.None);
+
+		// Assert — surfaced as a 409-mapped conflict carrying the conflicting name, not a 500.
+		(await act.Should().ThrowAsync<DuplicateEntityException>())
+			.Which.Message.Should().Contain(name);
+
+		// The soft-deleted row must remain deleted since the restore was rejected.
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+		CategoryEntity? stillDeleted = await verify.Categories
+			.IgnoreQueryFilters()
+			.SingleAsync(c => c.Id == deletedId);
+		stillDeleted.DeletedAt.Should().NotBeNull("a rejected restore must not clear DeletedAt");
+	}
+
+	[Fact]
+	public async Task RestoreCategory_WhenNoActiveNameConflict_Succeeds()
+	{
+		// Arrange — soft-delete a category whose name is NOT taken by any active row.
+		string name = $"RestoreOk-{Guid.NewGuid()}";
+		Guid deletedId;
+
+		await using (ApplicationDbContext setup = fixture.CreateDbContext())
+		{
+			CategoryEntity original = new() { Id = Guid.NewGuid(), Name = name, Description = "original", IsActive = true };
+			setup.Categories.Add(original);
+			await setup.SaveChangesAsync();
+			deletedId = original.Id;
+
+			setup.Categories.Remove(original);
+			await setup.SaveChangesAsync();
+		}
+
+		CategoryService service = CreateCategoryService();
+
+		// Act
+		bool restored = await service.RestoreAsync(deletedId, CancellationToken.None);
+
+		// Assert
+		restored.Should().BeTrue();
+
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+		CategoryEntity? active = await verify.Categories.SingleOrDefaultAsync(c => c.Id == deletedId);
+		active.Should().NotBeNull("the category should be visible again after a conflict-free restore");
+		active!.DeletedAt.Should().BeNull();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/CategoryServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/CategoryServiceTests.cs
@@ -1,0 +1,76 @@
+using Application.Exceptions;
+using FluentAssertions;
+using Infrastructure.Interfaces.Repositories;
+using Infrastructure.Mapping;
+using Infrastructure.Services;
+using Moq;
+
+namespace Infrastructure.Tests.Services;
+
+public class CategoryServiceTests
+{
+	private readonly Mock<ICategoryRepository> _mockRepository = new();
+	private readonly CategoryService _service;
+
+	public CategoryServiceTests()
+	{
+		_service = new CategoryService(_mockRepository.Object, new CategoryMapper());
+	}
+
+	[Fact]
+	public async Task RestoreAsync_WhenActiveNameConflict_ThrowsDuplicateEntityException_AndDoesNotRestore()
+	{
+		// Arrange — an active category already owns the trashed row's name (RECEIPTS-772).
+		Guid id = Guid.NewGuid();
+		_mockRepository
+			.Setup(r => r.GetRestoreConflictNameAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync("Groceries");
+
+		// Act
+		Func<Task> act = async () => await _service.RestoreAsync(id, CancellationToken.None);
+
+		// Assert — maps to a 409-mapped exception with the conflicting name, and never restores.
+		(await act.Should().ThrowAsync<DuplicateEntityException>())
+			.Which.Message.Should().Contain("Groceries");
+		_mockRepository.Verify(r => r.RestoreAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task RestoreAsync_WhenNoConflict_DelegatesToRepository_ReturnsTrue()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		_mockRepository
+			.Setup(r => r.GetRestoreConflictNameAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((string?)null);
+		_mockRepository
+			.Setup(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		// Act
+		bool actual = await _service.RestoreAsync(id, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeTrue();
+		_mockRepository.Verify(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task RestoreAsync_WhenNoConflictAndNotFound_ReturnsFalse()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		_mockRepository
+			.Setup(r => r.GetRestoreConflictNameAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((string?)null);
+		_mockRepository
+			.Setup(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		// Act
+		bool actual = await _service.RestoreAsync(id, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeFalse();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/DescriptionChangeSignalTests.cs
+++ b/tests/Infrastructure.Tests/Services/DescriptionChangeSignalTests.cs
@@ -1,0 +1,65 @@
+using System.Threading.Channels;
+using FluentAssertions;
+using Infrastructure.Services;
+
+namespace Infrastructure.Tests.Services;
+
+// RECEIPTS-790: a single shared capacity-1 channel let whichever background consumer read
+// first "steal" the wake-up, so the other could miss a signal and stall until its safety
+// timer. These tests pin the per-consumer fan-out behavior that replaced it.
+public class DescriptionChangeSignalTests
+{
+	[Fact]
+	public void NotifyDirty_ReachesEverySubscriber()
+	{
+		DescriptionChangeSignal signal = new();
+		ChannelReader<bool> resolver = signal.Subscribe();
+		ChannelReader<bool> refresher = signal.Subscribe();
+
+		signal.NotifyDirty();
+
+		resolver.TryRead(out _).Should().BeTrue("the first consumer must receive its own copy of the signal");
+		refresher.TryRead(out _).Should().BeTrue("the second consumer must receive its own copy of the signal");
+	}
+
+	[Fact]
+	public void NotifyDirty_OneConsumerDraining_DoesNotStealTheOthersWakeUp()
+	{
+		DescriptionChangeSignal signal = new();
+		ChannelReader<bool> resolver = signal.Subscribe();
+		ChannelReader<bool> refresher = signal.Subscribe();
+
+		signal.NotifyDirty();
+
+		// First consumer fully drains its own channel...
+		resolver.TryRead(out _).Should().BeTrue();
+		resolver.TryRead(out _).Should().BeFalse("its single pending token is consumed");
+
+		// ...and the second consumer's token is still waiting for it.
+		refresher.TryRead(out _).Should().BeTrue("the other consumer's wake-up must not have been stolen");
+	}
+
+	[Fact]
+	public void NotifyDirty_Burst_CoalescesToOnePendingTokenPerConsumer()
+	{
+		DescriptionChangeSignal signal = new();
+		ChannelReader<bool> reader = signal.Subscribe();
+
+		signal.NotifyDirty();
+		signal.NotifyDirty();
+		signal.NotifyDirty();
+
+		reader.TryRead(out _).Should().BeTrue();
+		reader.TryRead(out _).Should().BeFalse("capacity-1 DropWrite coalesces a burst into a single pending token");
+	}
+
+	[Fact]
+	public void NotifyDirty_WithNoSubscribers_DoesNotThrow()
+	{
+		DescriptionChangeSignal signal = new();
+
+		Action act = signal.NotifyDirty;
+
+		act.Should().NotThrow();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/ItemTemplateServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/ItemTemplateServiceTests.cs
@@ -1,0 +1,76 @@
+using Application.Exceptions;
+using FluentAssertions;
+using Infrastructure.Interfaces.Repositories;
+using Infrastructure.Mapping;
+using Infrastructure.Services;
+using Moq;
+
+namespace Infrastructure.Tests.Services;
+
+public class ItemTemplateServiceTests
+{
+	private readonly Mock<IItemTemplateRepository> _mockRepository = new();
+	private readonly ItemTemplateService _service;
+
+	public ItemTemplateServiceTests()
+	{
+		_service = new ItemTemplateService(_mockRepository.Object, new ItemTemplateMapper());
+	}
+
+	[Fact]
+	public async Task RestoreAsync_WhenActiveNameConflict_ThrowsDuplicateEntityException_AndDoesNotRestore()
+	{
+		// Arrange — an active template already owns the trashed row's name (RECEIPTS-772).
+		Guid id = Guid.NewGuid();
+		_mockRepository
+			.Setup(r => r.GetRestoreConflictNameAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync("Gallon of Milk");
+
+		// Act
+		Func<Task> act = async () => await _service.RestoreAsync(id, CancellationToken.None);
+
+		// Assert
+		(await act.Should().ThrowAsync<DuplicateEntityException>())
+			.Which.Message.Should().Contain("Gallon of Milk");
+		_mockRepository.Verify(r => r.RestoreAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task RestoreAsync_WhenNoConflict_DelegatesToRepository_ReturnsTrue()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		_mockRepository
+			.Setup(r => r.GetRestoreConflictNameAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((string?)null);
+		_mockRepository
+			.Setup(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		// Act
+		bool actual = await _service.RestoreAsync(id, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeTrue();
+		_mockRepository.Verify(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task RestoreAsync_WhenNoConflictAndNotFound_ReturnsFalse()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		_mockRepository
+			.Setup(r => r.GetRestoreConflictNameAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((string?)null);
+		_mockRepository
+			.Setup(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		// Act
+		bool actual = await _service.RestoreAsync(id, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeFalse();
+	}
+}

--- a/tests/Infrastructure.Tests/Services/NormalizedDescriptionResolutionServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/NormalizedDescriptionResolutionServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Channels;
 using Application.Interfaces.Services;
 using Application.Models.NormalizedDescriptions;
 using Domain.NormalizedDescriptions;
@@ -29,6 +30,10 @@ public class NormalizedDescriptionResolutionServiceTests
 		_embeddingServiceMock = new Mock<IEmbeddingService>();
 		_normalizedServiceMock = new Mock<INormalizedDescriptionService>();
 		_signalMock = new Mock<IDescriptionChangeSignal>();
+		// The service Subscribe()s once at construction for its own wake-up reader.
+		_signalMock
+			.Setup(s => s.Subscribe())
+			.Returns(Channel.CreateBounded<bool>(1).Reader);
 		_loggerMock = new Mock<ILogger<NormalizedDescriptionResolutionService>>();
 		_scopeFactoryMock = new Mock<IServiceScopeFactory>();
 		_scopeMock = new Mock<IServiceScope>();

--- a/tests/Infrastructure.Tests/Services/SubcategoryServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/SubcategoryServiceTests.cs
@@ -1,0 +1,77 @@
+using Application.Exceptions;
+using FluentAssertions;
+using Infrastructure.Interfaces.Repositories;
+using Infrastructure.Mapping;
+using Infrastructure.Services;
+using Moq;
+
+namespace Infrastructure.Tests.Services;
+
+public class SubcategoryServiceTests
+{
+	private readonly Mock<ISubcategoryRepository> _mockRepository = new();
+	private readonly SubcategoryService _service;
+
+	public SubcategoryServiceTests()
+	{
+		_service = new SubcategoryService(_mockRepository.Object, new SubcategoryMapper());
+	}
+
+	[Fact]
+	public async Task RestoreAsync_WhenActiveNameConflict_ThrowsDuplicateEntityException_AndDoesNotRestore()
+	{
+		// Arrange — an active subcategory already owns the trashed row's (CategoryId, Name)
+		// natural key (RECEIPTS-772).
+		Guid id = Guid.NewGuid();
+		_mockRepository
+			.Setup(r => r.GetRestoreConflictNameAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync("Produce");
+
+		// Act
+		Func<Task> act = async () => await _service.RestoreAsync(id, CancellationToken.None);
+
+		// Assert
+		(await act.Should().ThrowAsync<DuplicateEntityException>())
+			.Which.Message.Should().Contain("Produce");
+		_mockRepository.Verify(r => r.RestoreAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task RestoreAsync_WhenNoConflict_DelegatesToRepository_ReturnsTrue()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		_mockRepository
+			.Setup(r => r.GetRestoreConflictNameAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((string?)null);
+		_mockRepository
+			.Setup(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+
+		// Act
+		bool actual = await _service.RestoreAsync(id, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeTrue();
+		_mockRepository.Verify(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task RestoreAsync_WhenNoConflictAndNotFound_ReturnsFalse()
+	{
+		// Arrange
+		Guid id = Guid.NewGuid();
+		_mockRepository
+			.Setup(r => r.GetRestoreConflictNameAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync((string?)null);
+		_mockRepository
+			.Setup(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+
+		// Act
+		bool actual = await _service.RestoreAsync(id, CancellationToken.None);
+
+		// Assert
+		actual.Should().BeFalse();
+	}
+}

--- a/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
+++ b/tests/Presentation.API.Tests/Services/EntityChangeNotifierTests.cs
@@ -5,6 +5,7 @@ using API.Services;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Presentation.API.Tests.Services;
@@ -325,6 +326,111 @@ public class EntityChangeNotifierTests : IDisposable
 				n.UserId == null &&
 				n.AuthMethod == null)),
 			Times.Once);
+	}
+
+	// RECEIPTS-794: a send failure mid-flush must be logged and must NOT permanently drop
+	// notifications that were already dequeued.
+	private static (Mock<IHubContext<EntityHub, IEntityHubClient>> HubContext, List<EntityChangeNotification> Delivered) BuildFailableHub(Func<bool> shouldFail)
+	{
+		List<EntityChangeNotification> delivered = [];
+		var clientMock = new Mock<IEntityHubClient>();
+		clientMock
+			.Setup(c => c.EntityChanged(It.IsAny<EntityChangeNotification>()))
+			.Returns((EntityChangeNotification n) =>
+			{
+				if (shouldFail())
+				{
+					return Task.FromException(new InvalidOperationException("hub transport failure"));
+				}
+
+				delivered.Add(n);
+				return Task.CompletedTask;
+			});
+
+		Mock<IHubClients<IEntityHubClient>> hubClientsMock = new();
+		hubClientsMock.Setup(c => c.All).Returns(clientMock.Object);
+		Mock<IHubContext<EntityHub, IEntityHubClient>> hubContextMock = new();
+		hubContextMock.Setup(h => h.Clients).Returns(hubClientsMock.Object);
+
+		return (hubContextMock, delivered);
+	}
+
+	private EntityChangeNotifier CreateNotifier(Mock<IHubContext<EntityHub, IEntityHubClient>> hubContext, Mock<ILogger<EntityChangeNotifier>> logger)
+	{
+		// Very long flush interval so the timer never fires; tests drive FlushAsync directly.
+		return new EntityChangeNotifier(hubContext.Object, _httpContextAccessorMock.Object, TimeSpan.FromHours(1), logger.Object);
+	}
+
+	[Fact]
+	public async Task FlushAsync_WhenSendThrows_LogsErrorAndDoesNotThrow()
+	{
+		// Arrange
+		bool fail = true;
+		var (hubContext, _) = BuildFailableHub(() => fail);
+		var loggerMock = new Mock<ILogger<EntityChangeNotifier>>();
+		using EntityChangeNotifier notifier = CreateNotifier(hubContext, loggerMock);
+		await notifier.NotifyCreated("receipt", Guid.NewGuid());
+
+		// Act — the hub throws while sending; FlushAsync must swallow and log, not propagate.
+		Func<Task> act = notifier.FlushAsync;
+
+		// Assert
+		await act.Should().NotThrowAsync();
+		loggerMock.Verify(
+			x => x.Log(
+				LogLevel.Error,
+				It.IsAny<EventId>(),
+				It.IsAny<It.IsAnyType>(),
+				It.IsAny<Exception>(),
+				It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+			Times.AtLeastOnce);
+	}
+
+	[Fact]
+	public async Task FlushAsync_WhenSendThrows_RequeuesSoNotificationIsDeliveredOnRetry()
+	{
+		// Arrange
+		bool fail = true;
+		var (hubContext, delivered) = BuildFailableHub(() => fail);
+		var loggerMock = new Mock<ILogger<EntityChangeNotifier>>();
+		using EntityChangeNotifier notifier = CreateNotifier(hubContext, loggerMock);
+		await notifier.NotifyCreated("receipt", Guid.NewGuid());
+
+		// Act — first flush fails (nothing delivered), then the hub recovers and we flush again.
+		await notifier.FlushAsync();
+		delivered.Should().BeEmpty("the send failed, so nothing was delivered yet");
+
+		fail = false;
+		await notifier.FlushAsync();
+
+		// Assert — the notification was re-enqueued on failure and delivered on the retry,
+		// with its original aggregated count, rather than being permanently dropped.
+		delivered.Should().ContainSingle();
+		delivered[0].EntityType.Should().Be("receipt");
+		delivered[0].ChangeType.Should().Be("created");
+		delivered[0].Count.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task FlushAsync_WhenSendThrows_PreservesNotYetAttemptedBuckets()
+	{
+		// Arrange — two distinct pending notifications; the first send throws.
+		bool fail = true;
+		var (hubContext, delivered) = BuildFailableHub(() => fail);
+		var loggerMock = new Mock<ILogger<EntityChangeNotifier>>();
+		using EntityChangeNotifier notifier = CreateNotifier(hubContext, loggerMock);
+		await notifier.NotifyCreated("receipt", Guid.NewGuid());
+		await notifier.NotifyDeleted("category", Guid.NewGuid());
+
+		// Act — failing flush must re-enqueue BOTH the failed bucket and the one never attempted.
+		await notifier.FlushAsync();
+		fail = false;
+		await notifier.FlushAsync();
+
+		// Assert — both notifications survive and are delivered on retry.
+		delivered.Should().HaveCount(2);
+		delivered.Should().ContainSingle(n => n.EntityType == "receipt" && n.ChangeType == "created");
+		delivered.Should().ContainSingle(n => n.EntityType == "category" && n.ChangeType == "deleted");
 	}
 
 	[Fact]


### PR DESCRIPTION
Fixes the final five confirmed findings. Disjoint files, one logical commit per fix. Scope is mostly `infrastructure`; the notifier fix touches `api`.

## Fixes

1. **RECEIPTS-772 — 409 (not 500) on restore into an active-name conflict.** The unique indexes on `Categories.Name`, `Subcategories(CategoryId, Name)` and `ItemTemplates.Name` are filtered on `DeletedAt IS NULL`, so a name freed by soft-delete can be re-created. Restoring the original then threw an unhandled unique-violation `DbUpdateException` (500), permanently blocking restore. Added `GetRestoreConflictNameAsync` to each repository (pre-check for an active row sharing the trashed row's natural key); the services now throw `DuplicateEntityException` (which `GlobalExceptionHandlerMiddleware` already maps to 409) with the conflicting name, plus a `DbUpdateException` catch as a race backstop. No auto-rename.

2. **RECEIPTS-768 — symmetric `Down()` for `AddFilterToYnabSyncRecordUniqueIndex`.** This migration's `Up()` only re-creates the already-filtered index (the filter was added by the prior migration), but its `Down()` recreated it *without* the `"DeletedAt" IS NULL` filter — failing with a unique violation on the soft-deleted-duplicate rows the filter permits. `Down()` now restores the filtered index. No schema/snapshot change.

3. **RECEIPTS-788 — `CleanUpInvalidCategories` is now replayable.** The unconditional `InsertData("Uncategorized")` threw on replay after a Down (which keeps the row) or on any DB already containing it. Replaced with a raw `INSERT ... ON CONFLICT DO NOTHING`. Fresh-DB behavior unchanged; no snapshot change.

4. **RECEIPTS-790 — per-consumer wake-up for the description-change signal.** `NormalizedDescriptionResolutionService` and `ItemSimilarityEdgeRefresher` both read one shared capacity-1 `Channel`, so whichever read first stole the wake-up and the other could miss a signal (including a manual refresh). `IDescriptionChangeSignal` is now a broadcast: each consumer `Subscribe()`s once for its OWN capacity-1 channel, and `NotifyDirty()` fans out to all of them. Coalesce-to-one-pending-token + non-blocking `TryWrite` semantics preserved; both services subscribe at construction so a startup signal is buffered.

5. **RECEIPTS-794 — robust, non-dropping `EntityChangeNotifier` flush.** The timer flush was fire-and-forget: an exception mid-flush permanently dropped already-dequeued SignalR notifications with no log. The timer now routes through a guarded wrapper; `FlushAsync` wraps each send, logs failures, and re-enqueues the failed bucket plus every bucket not yet sent so a transient hub error retries instead of dropping. Batching/coalescing unchanged. Added an `ILogger` (NullLogger fallback for the internal test ctor).

## Validation

- `dotnet build Receipts.slnx` — clean (0 errors).
- `dotnet format` — verified clean on all changed files.
- CI coverage command, `--filter "Category!=Integration" --collect:"XPlat Code Coverage" --settings scripts/tests/coverlet.runsettings`:
  - `tests/Infrastructure.Tests` — **677 passed, 0 failed**.
  - `tests/Presentation.API.Tests` — **1021 passed, 0 failed**.
- Real-Postgres (Testcontainers) integration tests: `RestoreConflictTests` (2/2) prove restore-into-conflict raises `DuplicateEntityException` (409) not a raw 500, and a conflict-free restore still succeeds; `MigrationReplayTests` (1/1) proves the guarded seed INSERT is idempotent on replay.
- Migration `Down()` symmetry (RECEIPTS-768) verified by inspection against the prior migration and the model snapshot (both confirm the current index is filtered); CI does not run migrations.

## Tests added

- `DescriptionChangeSignalTests` (fan-out, no-steal, burst coalescing, no-subscribers).
- `EntityChangeNotifierTests` — 3 new (send failure logs + does not throw; failed send re-enqueued and delivered on retry; not-yet-attempted buckets preserved).
- `CategoryServiceTests` / `SubcategoryServiceTests` / `ItemTemplateServiceTests` — restore pre-check throws `DuplicateEntityException`; no-conflict delegates.
- `RestoreConflictTests` + `MigrationReplayTests` (Infrastructure.IntegrationTests, real Postgres).

No new EF migration and no model-snapshot change. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)