### PR TITLE
fix(client): gate securitylog audit queries on admin role

### DIFF
--- a/src/client/src/hooks/useAuthAudit.test.ts
+++ b/src/client/src/hooks/useAuthAudit.test.ts
@@ -127,6 +127,16 @@ describe("useRecentAuthAuditLogs", () => {
       },
     });
   });
+
+  it("does not fetch when enabled is false", () => {
+    const { result } = renderHook(
+      () => useRecentAuthAuditLogs(0, 50, undefined, undefined, { enabled: false }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.GET).not.toHaveBeenCalled();
+  });
 });
 
 describe("useFailedAuthAttempts", () => {
@@ -197,5 +207,15 @@ describe("useFailedAuthAttempts", () => {
         },
       },
     });
+  });
+
+  it("does not fetch when enabled is false", () => {
+    const { result } = renderHook(
+      () => useFailedAuthAttempts(0, 50, undefined, undefined, { enabled: false }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.GET).not.toHaveBeenCalled();
   });
 });

--- a/src/client/src/hooks/useAuthAudit.ts
+++ b/src/client/src/hooks/useAuthAudit.ts
@@ -35,9 +35,12 @@ export function useRecentAuthAuditLogs(
   limit = 50,
   sortBy?: string | null,
   sortDirection?: string | null,
+  options: { enabled?: boolean } = {},
 ) {
+  const { enabled = true } = options;
   const query = useQuery({
     queryKey: ["auth-audit", "recent", offset, limit, sortBy, sortDirection],
+    enabled,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/auth/audit/recent", {
         params: {
@@ -62,9 +65,12 @@ export function useFailedAuthAttempts(
   limit = 50,
   sortBy?: string | null,
   sortDirection?: string | null,
+  options: { enabled?: boolean } = {},
 ) {
+  const { enabled = true } = options;
   const query = useQuery({
     queryKey: ["auth-audit", "failed", offset, limit, sortBy, sortDirection],
+    enabled,
     queryFn: async () => {
       const { data, error } = await client.GET("/api/auth/audit/failed", {
         params: {

--- a/src/client/src/pages/SecurityLog.test.tsx
+++ b/src/client/src/pages/SecurityLog.test.tsx
@@ -121,4 +121,54 @@ describe("SecurityLog", () => {
       screen.queryByRole("tab", { name: /failed logins/i }),
     ).not.toBeInTheDocument();
   });
+
+  it("passes enabled=false to the admin-only audit hooks when not admin (no 403 storm)", async () => {
+    const { usePermission } = await import("@/hooks/usePermission");
+    vi.mocked(usePermission).mockReturnValue(mockQueryResult({
+      isAdmin: () => false,
+    }));
+    const { useRecentAuthAuditLogs, useFailedAuthAttempts } = await import(
+      "@/hooks/useAuthAudit"
+    );
+
+    renderWithProviders(<SecurityLog />);
+
+    expect(vi.mocked(useRecentAuthAuditLogs)).toHaveBeenCalledWith(
+      0,
+      50,
+      "timestamp",
+      "desc",
+      { enabled: false },
+    );
+    expect(vi.mocked(useFailedAuthAttempts)).toHaveBeenCalledWith(
+      0,
+      50,
+      "timestamp",
+      "desc",
+      { enabled: false },
+    );
+  });
+
+  it("passes enabled=true to the admin-only audit hooks when admin", async () => {
+    const { useRecentAuthAuditLogs, useFailedAuthAttempts } = await import(
+      "@/hooks/useAuthAudit"
+    );
+
+    renderWithProviders(<SecurityLog />);
+
+    expect(vi.mocked(useRecentAuthAuditLogs)).toHaveBeenCalledWith(
+      0,
+      50,
+      "timestamp",
+      "desc",
+      { enabled: true },
+    );
+    expect(vi.mocked(useFailedAuthAttempts)).toHaveBeenCalledWith(
+      0,
+      50,
+      "timestamp",
+      "desc",
+      { enabled: true },
+    );
+  });
 });

--- a/src/client/src/pages/SecurityLog.tsx
+++ b/src/client/src/pages/SecurityLog.tsx
@@ -30,8 +30,8 @@ function SecurityLog() {
   const { resetPage: resetFailedPage } = failedPagination;
 
   const myLogs = useMyAuthAuditLog(myPagination.offset, myPagination.limit, sortBy, sortDirection);
-  const recentLogs = useRecentAuthAuditLogs(recentPagination.offset, recentPagination.limit, sortBy, sortDirection);
-  const failedLogs = useFailedAuthAttempts(failedPagination.offset, failedPagination.limit, sortBy, sortDirection);
+  const recentLogs = useRecentAuthAuditLogs(recentPagination.offset, recentPagination.limit, sortBy, sortDirection, { enabled: isAdmin() });
+  const failedLogs = useFailedAuthAttempts(failedPagination.offset, failedPagination.limit, sortBy, sortDirection, { enabled: isAdmin() });
 
   const handleSort = useCallback((column: string) => {
     toggleSort(column);


### PR DESCRIPTION
## Summary
- Non-admins visiting `/security` unconditionally fired `useRecentAuthAuditLogs` and `useFailedAuthAttempts` on mount, which hit the now admin-gated (RECEIPTS-758) `/api/auth/audit/recent` and `/failed` endpoints — two wasted 403s per visit, doubled by react-query retry.
- Both hooks now accept an `options: { enabled?: boolean }` param (matching the existing pattern used by `useUsers`/`useCards`/`useCategories`/etc.), and `SecurityLog.tsx` gates them with `{ enabled: isAdmin() }`. Admin behavior is unchanged; non-admins now fire zero requests to those two endpoints.

## Test plan
- [x] Added `useAuthAudit.test.ts` cases: "does not fetch when enabled is false" for both `useRecentAuthAuditLogs` and `useFailedAuthAttempts`.
- [x] Added `SecurityLog.test.tsx` cases asserting the hooks are called with `{ enabled: false }` when not admin and `{ enabled: true }` when admin.
- [x] `npm run test -- --run useAuthAudit SecurityLog` — 15/15 passing.
- [x] `npm run lint` — 0 errors (2 pre-existing unrelated warnings).
- [x] `npx tsc -b` — clean.
- [x] Full pre-commit hook (build + full client/unit test suite) passed.

Closes RECEIPTS-799.