### PR TITLE
fix(api): revalidate jwt security stamp per request to kill deactivated sessions

### DIFF
--- a/src/Application/Interfaces/Services/ITokenService.cs
+++ b/src/Application/Interfaces/Services/ITokenService.cs
@@ -11,7 +11,7 @@ public record TokenIntrospectionResult(
 
 public interface ITokenService
 {
-	string GenerateAccessToken(string userId, string email, IList<string> roles, bool mustResetPassword);
+	string GenerateAccessToken(string userId, string email, IList<string> roles, bool mustResetPassword, string securityStamp);
 	string GenerateRefreshToken();
 	TokenIntrospectionResult IntrospectAccessToken(string token);
 }

--- a/src/Common/AuthClaimTypes.cs
+++ b/src/Common/AuthClaimTypes.cs
@@ -1,0 +1,15 @@
+namespace Common;
+
+/// <summary>
+/// Custom (non-standard) JWT claim types that the application both issues and validates.
+/// </summary>
+public static class AuthClaimTypes
+{
+	/// <summary>
+	/// Carries the user's ASP.NET Identity <c>SecurityStamp</c> at the moment the access token was issued.
+	/// Every authenticated request re-compares this against the user's live stamp; rotating the stamp
+	/// (on deactivation, disable, or password reset) makes all previously-issued access tokens fail
+	/// revalidation immediately, so a session cannot outlive the state change that should have ended it.
+	/// </summary>
+	public const string SecurityStamp = "security_stamp";
+}

--- a/src/Infrastructure/Services/TokenService.cs
+++ b/src/Infrastructure/Services/TokenService.cs
@@ -11,7 +11,7 @@ namespace Infrastructure.Services;
 
 public class TokenService(IConfiguration configuration) : ITokenService
 {
-	public string GenerateAccessToken(string userId, string email, IList<string> roles, bool mustResetPassword)
+	public string GenerateAccessToken(string userId, string email, IList<string> roles, bool mustResetPassword, string securityStamp)
 	{
 		string key = configuration[ConfigurationVariables.JwtKey] ?? "build-time-placeholder-key-32-chars!!";
 		string issuer = configuration[ConfigurationVariables.JwtIssuer] ?? "receipts-api";
@@ -25,6 +25,9 @@ public class TokenService(IConfiguration configuration) : ITokenService
 			new Claim(ClaimTypes.NameIdentifier, userId),
 			new Claim(ClaimTypes.Email, email),
 			new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+			// Bakes the user's current security stamp into the token so every request can re-check it
+			// against the live value and reject sessions that outlived a deactivation or password reset.
+			new Claim(AuthClaimTypes.SecurityStamp, securityStamp),
 			.. roles.Select(r => new Claim(ClaimTypes.Role, r)),
 		];
 

--- a/src/Presentation/API/Authentication/JwtSecurityStampValidator.cs
+++ b/src/Presentation/API/Authentication/JwtSecurityStampValidator.cs
@@ -1,0 +1,85 @@
+using System.Security.Claims;
+using Common;
+using Infrastructure.Entities;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
+
+namespace API.Authentication;
+
+/// <summary>
+/// Per-request revalidation of a JWT access token against the owning user's live state.
+/// A JWT carries baked-in role claims and, by default, is trusted until it expires — so an access
+/// token issued before a user is deactivated or has their password reset would keep working. This
+/// re-checks the token's <c>security_stamp</c> claim (and lockout state) against the database on
+/// every authenticated request, mirroring the API-key handler's per-request account re-check
+/// (RECEIPTS-757, RECEIPTS-800). Costs one DB read per authenticated request, which is acceptable.
+/// </summary>
+public static class JwtSecurityStampValidator
+{
+	/// <summary>
+	/// <see cref="JwtBearerEvents.OnTokenValidated"/> handler: fails the authentication when the token's
+	/// security stamp no longer matches the user's live stamp (or the account is gone / locked out).
+	/// </summary>
+	public static async Task RevalidateAsync(TokenValidatedContext context)
+	{
+		UserManager<ApplicationUser> userManager = context.HttpContext.RequestServices
+			.GetRequiredService<UserManager<ApplicationUser>>();
+
+		string? userId = context.Principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+		string? tokenStamp = context.Principal?.FindFirst(AuthClaimTypes.SecurityStamp)?.Value;
+
+		SecurityStampRevalidationResult result = await EvaluateAsync(userManager, userId, tokenStamp);
+		if (!result.IsValid)
+		{
+			context.Fail(result.FailureReason!);
+		}
+	}
+
+	/// <summary>
+	/// Core comparison, split out from the event handler so it can be unit-tested with a mocked
+	/// <see cref="UserManager{TUser}"/> without constructing a full HTTP pipeline / token context.
+	/// </summary>
+	public static async Task<SecurityStampRevalidationResult> EvaluateAsync(
+		UserManager<ApplicationUser> userManager,
+		string? userId,
+		string? tokenStamp)
+	{
+		if (string.IsNullOrEmpty(userId))
+		{
+			return SecurityStampRevalidationResult.Invalid("Token is missing the subject (sub) claim.");
+		}
+
+		// Tokens minted before this feature shipped carry no security_stamp claim. Treat an absent stamp
+		// as invalid so those sessions fail closed; the user simply logs in once after deploy (RECEIPTS-800).
+		if (string.IsNullOrEmpty(tokenStamp))
+		{
+			return SecurityStampRevalidationResult.Invalid("Token is missing the security_stamp claim.");
+		}
+
+		ApplicationUser? user = await userManager.FindByIdAsync(userId);
+		if (user is null)
+		{
+			return SecurityStampRevalidationResult.Invalid("Token subject no longer exists.");
+		}
+
+		if (await userManager.IsLockedOutAsync(user))
+		{
+			return SecurityStampRevalidationResult.Invalid("Account is disabled or locked out.");
+		}
+
+		if (!string.Equals(tokenStamp, user.SecurityStamp, StringComparison.Ordinal))
+		{
+			return SecurityStampRevalidationResult.Invalid("Security stamp has changed; token is no longer valid.");
+		}
+
+		return SecurityStampRevalidationResult.Valid;
+	}
+}
+
+/// <summary>Outcome of <see cref="JwtSecurityStampValidator.EvaluateAsync"/>.</summary>
+public sealed record SecurityStampRevalidationResult(bool IsValid, string? FailureReason)
+{
+	public static readonly SecurityStampRevalidationResult Valid = new(true, null);
+
+	public static SecurityStampRevalidationResult Invalid(string reason) => new(false, reason);
+}

--- a/src/Presentation/API/Configuration/AuthConfiguration.cs
+++ b/src/Presentation/API/Configuration/AuthConfiguration.cs
@@ -58,6 +58,12 @@ public static class AuthConfiguration
 
 						return Task.CompletedTask;
 					},
+					// Re-validate the token against the user's live state on every request. A JWT is
+					// otherwise trusted until it expires, so an access token issued before a user was
+					// deactivated or had their password reset would keep working. Rotating the user's
+					// security stamp (see UsersController / AuthController) makes this fail closed
+					// immediately (RECEIPTS-800).
+					OnTokenValidated = JwtSecurityStampValidator.RevalidateAsync,
 					OnAuthenticationFailed = context =>
 					{
 						ILoggerFactory loggerFactory = context.HttpContext.RequestServices

--- a/src/Presentation/API/Controllers/AuthController.cs
+++ b/src/Presentation/API/Controllers/AuthController.cs
@@ -78,7 +78,8 @@ public class AuthController(
 		await userManager.ResetAccessFailedCountAsync(user);
 
 		IList<string> roles = await userManager.GetRolesAsync(user);
-		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword);
+		string securityStamp = await EnsureSecurityStampAsync(user);
+		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword, securityStamp);
 		string refreshToken = tokenService.GenerateRefreshToken();
 
 		// Persist only the hash of the refresh token; the plaintext is returned to the client below and
@@ -126,7 +127,8 @@ public class AuthController(
 		}
 
 		IList<string> roles = await userManager.GetRolesAsync(user);
-		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword);
+		string securityStamp = await EnsureSecurityStampAsync(user);
+		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, user.MustResetPassword, securityStamp);
 		string newRefreshToken = tokenService.GenerateRefreshToken();
 
 		user.RefreshToken = userService.HashRefreshToken(newRefreshToken);
@@ -207,8 +209,11 @@ public class AuthController(
 
 		user.MustResetPassword = false;
 
+		// ChangePasswordAsync already rotated the security stamp, invalidating every access token issued
+		// before this call. The new token below carries the fresh stamp so this session keeps working.
 		IList<string> roles = await userManager.GetRolesAsync(user);
-		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, false);
+		string securityStamp = await EnsureSecurityStampAsync(user);
+		string accessToken = tokenService.GenerateAccessToken(user.Id, user.Email!, roles, false, securityStamp);
 		string refreshToken = tokenService.GenerateRefreshToken();
 
 		user.RefreshToken = userService.HashRefreshToken(refreshToken);
@@ -304,6 +309,20 @@ public class AuthController(
 		}
 
 		return TypedResults.Ok();
+	}
+
+	// Returns the security stamp to bake into the access token. Accounts created before per-request
+	// stamp revalidation shipped may have a null stamp; generate one so the claim is never empty
+	// (an empty/absent stamp claim is rejected on every request). UpdateSecurityStampAsync mutates and
+	// persists user.SecurityStamp in place, so the fresh value is available without a reload.
+	private async Task<string> EnsureSecurityStampAsync(ApplicationUser user)
+	{
+		if (string.IsNullOrEmpty(user.SecurityStamp))
+		{
+			await userManager.UpdateSecurityStampAsync(user);
+		}
+
+		return user.SecurityStamp!;
 	}
 
 	// Runs a full PBKDF2 verification against a throwaway hash purely to equalize timing on the

--- a/src/Presentation/API/Controllers/AuthController.cs
+++ b/src/Presentation/API/Controllers/AuthController.cs
@@ -168,6 +168,13 @@ public class AuthController(
 		ApplicationUser? user = await userManager.FindByIdAsync(userId);
 		if (user is not null)
 		{
+			// Clear the refresh token so the session cannot be renewed. We intentionally do NOT rotate the
+			// security stamp on logout: the stamp is global to the user, so rotating it would invalidate
+			// access tokens on every device and turn a single-device logout into a global sign-out. The
+			// already-issued access token is therefore best-effort here — it stays valid until it expires
+			// (<= 1h), and the cleared refresh token prevents renewal past that. Immediate stamp rotation is
+			// reserved for deactivate/disable/password-reset, where killing all sessions at once is intended
+			// (RECEIPTS-800).
 			user.RefreshToken = null;
 			user.RefreshTokenExpiresAt = null;
 			await userManager.UpdateAsync(user);
@@ -300,6 +307,11 @@ public class AuthController(
 			ApplicationUser? user = await userManager.FindByIdAsync(userId);
 			if (user is not null)
 			{
+				// Revoking the refresh token stops renewal but intentionally does NOT rotate the security
+				// stamp: the stamp is global to the user, so rotating it would sign the user out of every
+				// device. The already-issued access token is best-effort here — valid until it expires
+				// (<= 1h), with renewal blocked by the cleared refresh token. Immediate, all-session
+				// invalidation is reserved for deactivate/disable/password-reset (RECEIPTS-800).
 				user.RefreshToken = null;
 				user.RefreshTokenExpiresAt = null;
 				await userManager.UpdateAsync(user);

--- a/src/Presentation/API/Controllers/UsersController.cs
+++ b/src/Presentation/API/Controllers/UsersController.cs
@@ -181,6 +181,10 @@ public class UsersController(
 			// Disabling an account must also cut off any pre-existing API keys, otherwise
 			// they keep authenticating with the user's roles indefinitely (RECEIPTS-757).
 			await apiKeyService.RevokeAllForUserAsync(user.Id);
+
+			// Rotate the security stamp so any JWT access token issued before this disable fails
+			// per-request revalidation immediately, instead of surviving until it expires (RECEIPTS-800).
+			await userManager.UpdateSecurityStampAsync(user);
 		}
 
 		IList<string> roles = await userManager.GetRolesAsync(user);
@@ -220,6 +224,11 @@ public class UsersController(
 		user.RefreshTokenExpiresAt = null;
 		await userManager.UpdateAsync(user);
 
+		// Rotate the security stamp so any JWT access token issued before deactivation fails per-request
+		// revalidation immediately. Clearing the refresh token alone only stops renewal; without this the
+		// existing access token would keep working until it expires (RECEIPTS-800).
+		await userManager.UpdateSecurityStampAsync(user);
+
 		// Revoke API keys so a deactivated user cannot keep authenticating via a stale key.
 		await apiKeyService.RevokeAllForUserAsync(user.Id);
 
@@ -249,6 +258,11 @@ public class UsersController(
 		user.RefreshToken = null;
 		user.RefreshTokenExpiresAt = null;
 		await userManager.UpdateAsync(user);
+
+		// Rotate the security stamp so JWT access tokens minted under the old password fail per-request
+		// revalidation immediately (explicit and independent of Identity's internal stamp rotation on
+		// password change, RECEIPTS-800).
+		await userManager.UpdateSecurityStampAsync(user);
 
 		// Force-resetting a password invalidates the old credential; revoke API keys too so
 		// they cannot be used to bypass the reset (defense in depth, RECEIPTS-757).

--- a/tests/Infrastructure.Tests/Services/TokenServiceBranchTests.cs
+++ b/tests/Infrastructure.Tests/Services/TokenServiceBranchTests.cs
@@ -18,7 +18,7 @@ public class TokenServiceBranchTests
 		TokenService service = new(configuration);
 
 		// Act — should not throw, falls back to defaults
-		string token = service.GenerateAccessToken("user-1", "a@b.com", new List<string> { "User" }, false);
+		string token = service.GenerateAccessToken("user-1", "a@b.com", new List<string> { "User" }, false, "stamp-1");
 
 		// Assert — token is generated with fallback issuer/audience
 		token.Should().NotBeNullOrEmpty();
@@ -40,7 +40,7 @@ public class TokenServiceBranchTests
 			.Build();
 		TokenService service = new(configuration);
 
-		string token = service.GenerateAccessToken("user-2", "b@c.com", new List<string> { "Admin" }, false);
+		string token = service.GenerateAccessToken("user-2", "b@c.com", new List<string> { "Admin" }, false, "stamp-2");
 
 		// Act
 		TokenIntrospectionResult result = service.IntrospectAccessToken(token);
@@ -66,7 +66,7 @@ public class TokenServiceBranchTests
 		TokenService service = new(configuration);
 
 		// Act
-		string token = service.GenerateAccessToken("user-3", "c@d.com", new List<string> { "User" }, true);
+		string token = service.GenerateAccessToken("user-3", "c@d.com", new List<string> { "User" }, true, "stamp-3");
 
 		// Assert — token is valid and contains the claim
 		TokenIntrospectionResult result = service.IntrospectAccessToken(token);
@@ -89,7 +89,7 @@ public class TokenServiceBranchTests
 		TokenService service = new(configuration);
 
 		// Act
-		string token = service.GenerateAccessToken("user-4", "d@e.com", new List<string> { "User" }, false);
+		string token = service.GenerateAccessToken("user-4", "d@e.com", new List<string> { "User" }, false, "stamp-4");
 
 		// Assert
 		TokenIntrospectionResult result = service.IntrospectAccessToken(token);
@@ -117,7 +117,7 @@ public class TokenServiceBranchTests
 			.Build();
 		TokenService defaultService = new(defaultConfiguration);
 
-		string token = explicitService.GenerateAccessToken("user-5", "e@f.com", new List<string> { "User" }, false);
+		string token = explicitService.GenerateAccessToken("user-5", "e@f.com", new List<string> { "User" }, false, "stamp-5");
 
 		// Act — introspect with different (default) key
 		TokenIntrospectionResult result = defaultService.IntrospectAccessToken(token);

--- a/tests/Infrastructure.Tests/Services/TokenServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/TokenServiceTests.cs
@@ -2,6 +2,7 @@ using Application.Interfaces.Services;
 using FluentAssertions;
 using Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.JsonWebTokens;
 
 namespace Infrastructure.Tests.Services;
 
@@ -29,7 +30,7 @@ public class TokenServiceTests
 	public void IntrospectAccessToken_ValidToken_ReturnsActive()
 	{
 		// Arrange
-		string token = _tokenService.GenerateAccessToken("user-123", "test@example.com", new List<string> { "Admin" }, false);
+		string token = _tokenService.GenerateAccessToken("user-123", "test@example.com", new List<string> { "Admin" }, false, "stamp-abc");
 
 		// Act
 		TokenIntrospectionResult result = _tokenService.IntrospectAccessToken(token);
@@ -72,7 +73,7 @@ public class TokenServiceTests
 			.AddInMemoryCollection(otherConfig)
 			.Build();
 		TokenService otherService = new(otherConfiguration);
-		string token = otherService.GenerateAccessToken("user-123", "test@example.com", new List<string> { "Admin" }, false);
+		string token = otherService.GenerateAccessToken("user-123", "test@example.com", new List<string> { "Admin" }, false, "stamp-abc");
 
 		// Act
 		TokenIntrospectionResult result = _tokenService.IntrospectAccessToken(token);
@@ -85,7 +86,7 @@ public class TokenServiceTests
 	public void IntrospectAccessToken_MultipleRoles_ReturnsSpaceSeparatedScope()
 	{
 		// Arrange
-		string token = _tokenService.GenerateAccessToken("user-123", "test@example.com", new List<string> { "Admin", "User" }, false);
+		string token = _tokenService.GenerateAccessToken("user-123", "test@example.com", new List<string> { "Admin", "User" }, false, "stamp-abc");
 
 		// Act
 		TokenIntrospectionResult result = _tokenService.IntrospectAccessToken(token);
@@ -93,5 +94,17 @@ public class TokenServiceTests
 		// Assert
 		result.Active.Should().BeTrue();
 		result.Scope.Should().Be("Admin User");
+	}
+
+	[Fact]
+	public void GenerateAccessToken_EmbedsSecurityStampClaim()
+	{
+		// Arrange & Act
+		string token = _tokenService.GenerateAccessToken("user-123", "test@example.com", new List<string> { "Admin" }, false, "stamp-xyz-789");
+
+		// Assert — the token carries the security_stamp claim so per-request revalidation can compare it
+		// against the user's live stamp (RECEIPTS-800).
+		JsonWebToken jwt = new JsonWebTokenHandler().ReadJsonWebToken(token);
+		jwt.GetClaim("security_stamp").Value.Should().Be("stamp-xyz-789");
 	}
 }

--- a/tests/Presentation.API.Tests/Authentication/JwtSecurityStampRevalidationEndToEndTests.cs
+++ b/tests/Presentation.API.Tests/Authentication/JwtSecurityStampRevalidationEndToEndTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Net.Http.Headers;
+using API.Configuration;
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Infrastructure.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Presentation.API.Tests.Authentication;
+
+/// <summary>
+/// End-to-end proof that per-request security-stamp revalidation works through the REAL token
+/// pipeline: a token minted by <see cref="TokenService"/> is validated by the actual JwtBearer
+/// handler configured in <see cref="AuthConfiguration.AddAuthServices"/> (same
+/// TokenValidationParameters, same <c>OnTokenValidated</c> handler), so this also proves the
+/// <c>security_stamp</c> and <c>NameIdentifier</c> claims survive JwtBearer's inbound claim mapping —
+/// something the mocked <see cref="JwtSecurityStampValidator.EvaluateAsync"/> unit tests cannot catch.
+/// A stand-alone TestServer host is used (mirroring AuthMiddlewareOrderingTests); there is no shared
+/// WebApplicationFactory in this repo.
+/// </summary>
+public class JwtSecurityStampRevalidationEndToEndTests
+{
+	private static readonly Dictionary<string, string?> JwtConfig = new()
+	{
+		["Jwt:Key"] = "test-signing-key-that-is-at-least-32-chars!!",
+		["Jwt:Issuer"] = "test-issuer",
+		["Jwt:Audience"] = "test-audience",
+	};
+
+	private static IConfiguration BuildConfiguration() =>
+		new ConfigurationBuilder().AddInMemoryCollection(JwtConfig).Build();
+
+	private static string MintToken(string userId, string securityStamp) =>
+		new TokenService(BuildConfiguration())
+			.GenerateAccessToken(userId, "test@example.com", new List<string> { "User" }, false, securityStamp);
+
+	private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+	{
+		Mock<IUserStore<ApplicationUser>> userStoreMock = new();
+		return new Mock<UserManager<ApplicationUser>>(
+			userStoreMock.Object,
+			new Mock<IOptions<IdentityOptions>>().Object,
+			new Mock<IPasswordHasher<ApplicationUser>>().Object,
+			Array.Empty<IUserValidator<ApplicationUser>>(),
+			Array.Empty<IPasswordValidator<ApplicationUser>>(),
+			new Mock<ILookupNormalizer>().Object,
+			new Mock<IdentityErrorDescriber>().Object,
+			new Mock<IServiceProvider>().Object,
+			new Mock<ILogger<UserManager<ApplicationUser>>>().Object);
+	}
+
+	// Builds a minimal host wired with the REAL auth pipeline from AddAuthServices (the same
+	// JwtBearer TokenValidationParameters, OnTokenValidated handler, and default "ApiOrJwt" policy the
+	// app uses) plus a mock UserManager for the OnTokenValidated handler to resolve. The default policy
+	// lists both the JwtBearer and ApiKey schemes, so the ApiKey handler is constructed too — its
+	// collaborators are registered as no-op mocks. A request carrying only a Bearer token makes the
+	// ApiKey handler return NoResult, leaving JwtBearer + security-stamp revalidation to decide the
+	// outcome: a valid token yields 200 and a failed revalidation (context.Fail) yields 401.
+	private static WebApplication BuildHost(UserManager<ApplicationUser> userManager)
+	{
+		WebApplicationBuilder appBuilder = WebApplication.CreateBuilder();
+		appBuilder.WebHost.UseTestServer();
+
+		appBuilder.Services.AddAuthServices(BuildConfiguration());
+		appBuilder.Services.AddScoped(_ => userManager);
+		// Collaborators the ApiKey scheme handler needs to be constructible under the "ApiOrJwt" policy.
+		appBuilder.Services.AddSingleton(Mock.Of<IApiKeyService>());
+		appBuilder.Services.AddSingleton(Mock.Of<IAuthAuditService>());
+
+		WebApplication app = appBuilder.Build();
+
+		app.UseAuthentication();
+		app.UseAuthorization();
+
+		app.MapGet("/secure", () => Results.Ok("authorized")).RequireAuthorization();
+
+		return app;
+	}
+
+	private static async Task<HttpResponseMessage> CallSecureAsync(WebApplication app, string token)
+	{
+		HttpClient client = app.GetTestClient();
+		HttpRequestMessage request = new(HttpMethod.Get, "/secure");
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return await client.SendAsync(request);
+	}
+
+	[Fact]
+	public async Task AuthenticatedRequest_WithMatchingSecurityStamp_Succeeds()
+	{
+		// Arrange — the live user's stamp equals the stamp baked into the token.
+		ApplicationUser user = new() { Id = "user-123", Email = "test@example.com", SecurityStamp = "stamp-current" };
+		Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+		userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
+
+		await using WebApplication app = BuildHost(userManagerMock.Object);
+		await app.StartAsync();
+
+		string token = MintToken("user-123", "stamp-current");
+
+		// Act
+		HttpResponseMessage response = await CallSecureAsync(app, token);
+
+		// Assert — the security_stamp and NameIdentifier claims round-tripped through real JwtBearer
+		// validation and OnTokenValidated accepted the token.
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+
+	[Fact]
+	public async Task AuthenticatedRequest_AfterSecurityStampRotated_Returns401()
+	{
+		// Arrange — the user's stamp was rotated (e.g. deactivation/reset) after the token was issued;
+		// the token still carries the old stamp.
+		ApplicationUser user = new() { Id = "user-123", Email = "test@example.com", SecurityStamp = "stamp-rotated" };
+		Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+		userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
+
+		await using WebApplication app = BuildHost(userManagerMock.Object);
+		await app.StartAsync();
+
+		string token = MintToken("user-123", "stamp-old");
+
+		// Act
+		HttpResponseMessage response = await CallSecureAsync(app, token);
+
+		// Assert — a signature-valid, unexpired token is rejected purely because its stamp no longer matches.
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task AuthenticatedRequest_WhenUserIsLockedOut_Returns401_EvenWithMatchingStamp()
+	{
+		// Arrange — a deactivated/locked account is rejected regardless of the stamp comparison.
+		ApplicationUser user = new() { Id = "user-123", Email = "test@example.com", SecurityStamp = "stamp-current" };
+		Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+		userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(true);
+
+		await using WebApplication app = BuildHost(userManagerMock.Object);
+		await app.StartAsync();
+
+		string token = MintToken("user-123", "stamp-current");
+
+		// Act
+		HttpResponseMessage response = await CallSecureAsync(app, token);
+
+		// Assert
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+}

--- a/tests/Presentation.API.Tests/Authentication/JwtSecurityStampValidatorTests.cs
+++ b/tests/Presentation.API.Tests/Authentication/JwtSecurityStampValidatorTests.cs
@@ -1,0 +1,134 @@
+using API.Authentication;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Presentation.API.Tests.Authentication;
+
+public class JwtSecurityStampValidatorTests
+{
+	private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+
+	public JwtSecurityStampValidatorTests()
+	{
+		Mock<IUserStore<ApplicationUser>> userStoreMock = new();
+		_userManagerMock = new Mock<UserManager<ApplicationUser>>(
+			userStoreMock.Object,
+			new Mock<IOptions<IdentityOptions>>().Object,
+			new Mock<IPasswordHasher<ApplicationUser>>().Object,
+			Array.Empty<IUserValidator<ApplicationUser>>(),
+			Array.Empty<IPasswordValidator<ApplicationUser>>(),
+			new Mock<ILookupNormalizer>().Object,
+			new Mock<IdentityErrorDescriber>().Object,
+			new Mock<IServiceProvider>().Object,
+			new Mock<ILogger<UserManager<ApplicationUser>>>().Object);
+	}
+
+	private static ApplicationUser CreateUser(string id = "user-123", string stamp = "stamp-current")
+	{
+		return new ApplicationUser
+		{
+			Id = id,
+			Email = "test@example.com",
+			UserName = "test@example.com",
+			SecurityStamp = stamp,
+		};
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_MatchingStamp_ReturnsValid()
+	{
+		// Arrange — the token's stamp equals the user's live stamp, and the account is not locked.
+		ApplicationUser user = CreateUser(stamp: "stamp-current");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
+
+		// Act
+		SecurityStampRevalidationResult result = await JwtSecurityStampValidator.EvaluateAsync(
+			_userManagerMock.Object, "user-123", "stamp-current");
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.FailureReason.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_StampNoLongerMatches_ReturnsInvalid()
+	{
+		// Arrange — the user's stamp was rotated (e.g. deactivation/password reset) after the token was issued.
+		ApplicationUser user = CreateUser(stamp: "stamp-rotated");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
+
+		// Act — token still carries the old stamp.
+		SecurityStampRevalidationResult result = await JwtSecurityStampValidator.EvaluateAsync(
+			_userManagerMock.Object, "user-123", "stamp-old");
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.FailureReason.Should().Contain("Security stamp");
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_AbsentStampClaim_ReturnsInvalid()
+	{
+		// Arrange — a token minted before this feature shipped carries no security_stamp claim.
+		// It must fail closed; the user re-logs in once after deploy.
+		SecurityStampRevalidationResult resultNull = await JwtSecurityStampValidator.EvaluateAsync(
+			_userManagerMock.Object, "user-123", null);
+		SecurityStampRevalidationResult resultEmpty = await JwtSecurityStampValidator.EvaluateAsync(
+			_userManagerMock.Object, "user-123", "");
+
+		// Assert — never hits the database; rejected on the missing claim alone.
+		resultNull.IsValid.Should().BeFalse();
+		resultEmpty.IsValid.Should().BeFalse();
+		_userManagerMock.Verify(m => m.FindByIdAsync(It.IsAny<string>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_MissingUserId_ReturnsInvalid()
+	{
+		// Act
+		SecurityStampRevalidationResult result = await JwtSecurityStampValidator.EvaluateAsync(
+			_userManagerMock.Object, null, "stamp-current");
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		_userManagerMock.Verify(m => m.FindByIdAsync(It.IsAny<string>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_UserNoLongerExists_ReturnsInvalid()
+	{
+		// Arrange — the account was hard-deleted after the token was issued.
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync((ApplicationUser?)null);
+
+		// Act
+		SecurityStampRevalidationResult result = await JwtSecurityStampValidator.EvaluateAsync(
+			_userManagerMock.Object, "user-123", "stamp-current");
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.FailureReason.Should().Contain("no longer exists");
+	}
+
+	[Fact]
+	public async Task EvaluateAsync_LockedOutUser_ReturnsInvalid_EvenWhenStampMatches()
+	{
+		// Arrange — a deactivated/locked account is rejected regardless of the stamp comparison.
+		ApplicationUser user = CreateUser(stamp: "stamp-current");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(true);
+
+		// Act
+		SecurityStampRevalidationResult result = await JwtSecurityStampValidator.EvaluateAsync(
+			_userManagerMock.Object, "user-123", "stamp-current");
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.FailureReason.Should().Contain("disabled");
+	}
+}

--- a/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/AuthControllerTests.cs
@@ -78,6 +78,9 @@ public class AuthControllerTests
 			RefreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(30),
 			MustResetPassword = false,
 			CreatedAt = DateTimeOffset.UtcNow,
+			// Non-null so the token-issuing paths embed this stamp directly instead of taking the
+			// backfill branch (which would call UpdateSecurityStampAsync for legacy null-stamp accounts).
+			SecurityStamp = "stamp-1",
 		};
 	}
 
@@ -93,7 +96,7 @@ public class AuthControllerTests
 		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
 		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin", "User" });
 		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
-		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("access-token");
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false, It.IsAny<string>())).Returns("access-token");
 		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("refresh-token");
 
 		// Act
@@ -217,7 +220,7 @@ public class AuthControllerTests
 		_userManagerMock.Setup(m => m.ResetAccessFailedCountAsync(user)).ReturnsAsync(IdentityResult.Success);
 		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
 		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
-		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("access-token");
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false, It.IsAny<string>())).Returns("access-token");
 		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("refresh-token");
 
 		// Act
@@ -239,7 +242,7 @@ public class AuthControllerTests
 		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
 		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
 		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
-		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("access-token");
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false, It.IsAny<string>())).Returns("access-token");
 		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("plaintext-refresh");
 
 		// Act
@@ -250,6 +253,51 @@ public class AuthControllerTests
 		okResult.Value!.RefreshToken.Should().Be("plaintext-refresh");
 		user.RefreshToken.Should().Be("hashed:plaintext-refresh");
 		user.RefreshToken.Should().NotBe("plaintext-refresh");
+	}
+
+	[Fact]
+	public async Task Login_ThreadsSecurityStampIntoAccessToken_WithoutRotating()
+	{
+		// Arrange — the account already has a security stamp.
+		ApplicationUser user = CreateTestUser(); // SecurityStamp = "stamp-1"
+		_userManagerMock.Setup(m => m.FindByEmailAsync("test@example.com")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.CheckPasswordAsync(user, "password")).ReturnsAsync(true);
+		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false, "stamp-1")).Returns("access-token");
+		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("refresh-token");
+
+		// Act
+		Results<Ok<TokenResponse>, JsonHttpResult<OAuthErrorResponse>> result = await _controller.Login(new LoginRequest { Email = "test@example.com", Password = "password" });
+
+		// Assert — the live stamp is baked into the token, and it is NOT needlessly rotated.
+		Assert.IsType<Ok<TokenResponse>>(result.Result);
+		_tokenServiceMock.Verify(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false, "stamp-1"), Times.Once);
+		_userManagerMock.Verify(m => m.UpdateSecurityStampAsync(It.IsAny<ApplicationUser>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task Login_BackfillsSecurityStamp_WhenUserStampIsNull()
+	{
+		// Arrange — a legacy account created before security stamps were populated has a null stamp.
+		ApplicationUser user = CreateTestUser();
+		user.SecurityStamp = null;
+		_userManagerMock.Setup(m => m.FindByEmailAsync("test@example.com")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.CheckPasswordAsync(user, "password")).ReturnsAsync(true);
+		_userManagerMock.Setup(m => m.IsLockedOutAsync(user)).ReturnsAsync(false);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.UpdateSecurityStampAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false, It.IsAny<string>())).Returns("access-token");
+		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("refresh-token");
+
+		// Act
+		Results<Ok<TokenResponse>, JsonHttpResult<OAuthErrorResponse>> result = await _controller.Login(new LoginRequest { Email = "test@example.com", Password = "password" });
+
+		// Assert — the stamp is generated so the emitted claim is never empty.
+		Assert.IsType<Ok<TokenResponse>>(result.Result);
+		_userManagerMock.Verify(m => m.UpdateSecurityStampAsync(user), Times.Once);
 	}
 
 	// ── Refresh ──────────────────────────────────────────────
@@ -263,7 +311,7 @@ public class AuthControllerTests
 		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
 		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
 		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
-		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("new-access-token");
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false, It.IsAny<string>())).Returns("new-access-token");
 		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("new-refresh-token");
 
 		// Act
@@ -284,7 +332,7 @@ public class AuthControllerTests
 		_userServiceMock.Setup(s => s.FindUserIdByRefreshTokenAsync("valid-refresh-token", It.IsAny<CancellationToken>())).ReturnsAsync(user.Id);
 		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
 		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
-		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("new-access-token");
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false, It.IsAny<string>())).Returns("new-access-token");
 		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("new-refresh-token");
 		_userManagerMock.Setup(m => m.UpdateAsync(user))
 			.ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "ConcurrencyFailure", Description = "Optimistic concurrency failure." }));
@@ -308,7 +356,7 @@ public class AuthControllerTests
 		_userManagerMock.Setup(m => m.ChangePasswordAsync(user, "old", "new")).ReturnsAsync(IdentityResult.Success);
 		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "Admin" });
 		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
-		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false)).Returns("access-token");
+		_tokenServiceMock.Setup(t => t.GenerateAccessToken(user.Id, user.Email!, It.IsAny<IList<string>>(), false, It.IsAny<string>())).Returns("access-token");
 		_tokenServiceMock.Setup(t => t.GenerateRefreshToken()).Returns("refresh-token");
 
 		// Act

--- a/tests/Presentation.API.Tests/Controllers/UsersControllerTests.cs
+++ b/tests/Presentation.API.Tests/Controllers/UsersControllerTests.cs
@@ -230,6 +230,44 @@ public class UsersControllerTests
 	}
 
 	[Fact]
+	public async Task UpdateUser_RotatesSecurityStamp_WhenDisabling()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.RemoveFromRolesAsync(user, It.IsAny<IEnumerable<string>>())).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(user, "User")).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.UpdateSecurityStampAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+		await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "User", IsDisabled = true });
+
+		// Rotating the stamp kills any JWT access token issued before the disable (RECEIPTS-800).
+		_userManagerMock.Verify(m => m.UpdateSecurityStampAsync(user), Times.Once);
+	}
+
+	[Fact]
+	public async Task UpdateUser_DoesNotRotateSecurityStamp_WhenNotDisabling()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(new List<string> { "User" });
+		_userManagerMock.Setup(m => m.RemoveFromRolesAsync(user, It.IsAny<IEnumerable<string>>())).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddToRoleAsync(user, "User")).ReturnsAsync(IdentityResult.Success);
+
+		await _controller.UpdateUser(
+			"user-123",
+			new UpdateUserRequest { Email = "a@b.com", FirstName = "A", LastName = "B", Role = "User", IsDisabled = false });
+
+		_userManagerMock.Verify(m => m.UpdateSecurityStampAsync(It.IsAny<ApplicationUser>()), Times.Never);
+	}
+
+	[Fact]
 	public async Task UpdateUser_DoesNotRevokeApiKeys_WhenNotDisabling()
 	{
 		SetupUserClaims("admin-1");
@@ -405,6 +443,21 @@ public class UsersControllerTests
 	}
 
 	[Fact]
+	public async Task DeactivateUser_RotatesSecurityStamp_WhenSuccessful()
+	{
+		SetupUserClaims("admin-1");
+		ApplicationUser user = CreateTestUser("user-123");
+		_userManagerMock.Setup(m => m.FindByIdAsync("user-123")).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.UpdateSecurityStampAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+		await _controller.DeactivateUser("user-123");
+
+		// Clearing the refresh token only stops renewal; rotating the stamp kills the live access token too.
+		_userManagerMock.Verify(m => m.UpdateSecurityStampAsync(user), Times.Once);
+	}
+
+	[Fact]
 	public async Task DeactivateUser_ReturnsBadRequest_WhenSelfDeactivate()
 	{
 		SetupUserClaims("user-123");
@@ -456,6 +509,22 @@ public class UsersControllerTests
 		await _controller.AdminResetPassword(user.Id, new AdminResetPasswordRequest { NewPassword = "NewPassword1!" });
 
 		_apiKeyServiceMock.Verify(s => s.RevokeAllForUserAsync(user.Id, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task AdminResetPassword_RotatesSecurityStamp_WhenSuccessful()
+	{
+		ApplicationUser user = CreateTestUser();
+		_userManagerMock.Setup(m => m.FindByIdAsync(user.Id)).ReturnsAsync(user);
+		_userManagerMock.Setup(m => m.RemovePasswordAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.AddPasswordAsync(user, "NewPassword1!")).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+		_userManagerMock.Setup(m => m.UpdateSecurityStampAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+		await _controller.AdminResetPassword(user.Id, new AdminResetPasswordRequest { NewPassword = "NewPassword1!" });
+
+		// Access tokens minted under the old password must die immediately (RECEIPTS-800).
+		_userManagerMock.Verify(m => m.UpdateSecurityStampAsync(user), Times.Once);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

A JWT access token carries baked-in role claims and, by default, is trusted until it expires (~1h). So a token issued **before** a user was deactivated or had their password reset kept working — `DeactivateUser` only cleared the refresh token, which stops *renewal* but leaves the outstanding access token live. API-key auth already re-checks account state on every request (RECEIPTS-757); this brings JWT auth to parity.

The fix is the idiomatic ASP.NET Identity approach: a **security-stamp claim** revalidated per request.

### What changed

1. **Issue the claim.** `TokenService.GenerateAccessToken` now embeds a `security_stamp` claim (constant in `Common.AuthClaimTypes`). `ITokenService.GenerateAccessToken` gained a `string securityStamp` parameter, threaded through all three `AuthController` token-issuing paths (login, refresh, change-password). Legacy accounts with a null `SecurityStamp` are backfilled via `UpdateSecurityStampAsync` before the claim is emitted, so the claim is never empty.

2. **Revalidate per request.** A new `JwtBearerEvents.OnTokenValidated` handler (`JwtSecurityStampValidator`) resolves `UserManager<ApplicationUser>`, reloads the user by the `sub` claim, and calls `context.Fail(...)` when the user is gone, `IsLockedOutAsync` is true, or the token's `security_stamp` no longer matches the user's live stamp. This adds one DB read per authenticated request — the same trade-off already accepted by the API-key handler. The existing `OnMessageReceived`/`OnAuthenticationFailed`/`OnChallenge` handlers are untouched.

3. **Rotate the stamp on state changes.** `UpdateSecurityStampAsync` is now called wherever a session must die immediately:
   - `UsersController.DeactivateUser`
   - the admin disable path in `UsersController.UpdateUser` (`IsDisabled == true`, alongside the API-key revoke)
   - `UsersController.AdminResetPassword`

### Compatibility

Tokens minted before this change carry no `security_stamp` claim. An absent/empty claim is treated as **invalid** (`context.Fail`), so affected users simply log in once after deploy. That's acceptable for this app.

## Tests

- `TokenServiceTests.GenerateAccessToken_EmbedsSecurityStampClaim` — asserts the claim is present in the issued JWT.
- `JwtSecurityStampValidatorTests` (6 cases) — matching stamp accepted; rotated stamp rejected; absent claim rejected (fails closed without a DB hit); missing `sub` rejected; deleted user rejected; locked-out user rejected even when the stamp matches.
- `AuthControllerTests` — login threads the live stamp into the token without rotating it; legacy null-stamp accounts are backfilled.
- `UsersControllerTests` — stamp is rotated on deactivate, on disable-via-update, and on admin reset-password; not rotated when an update is not a disable.

Validation: `dotnet build Receipts.slnx` clean; `Infrastructure.Tests` 678/678 and `Presentation.API.Tests` 1033/1033 pass (`--filter "Category!=Integration"`, coverage collected); `dotnet format --verify-no-changes` clean on all touched files.

Closes RECEIPTS-800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
