### PR TITLE
test(infrastructure): add postgres integration coverage for restrict, reports, api-key, and balance

### DIFF
--- a/src/Infrastructure/Services/TransactionService.cs
+++ b/src/Infrastructure/Services/TransactionService.cs
@@ -164,6 +164,12 @@ public class TransactionService(
 	// receipt block on the row lock, so the second sees the first's committed write and can
 	// reject an over-allocation. Providers without row locks / transactions (InMemory in unit
 	// tests) degrade to a plain read-validate-write in a single context.
+	//
+	// RECEIPTS-805: this lock serializes the balance invariant ONLY against concurrent TRANSACTION
+	// writes (this create/update path). Concurrent edits to a receipt's items, adjustments, or tax
+	// take no receipt-level lock, so a transaction write racing such an edit can still momentarily
+	// leave the receipt out of balance. Extending the FOR UPDATE guard to cover child/adjustment/tax
+	// edits is deferred — that wider scope is a known, accepted limitation, not an oversight here.
 	private async Task<T> ExecuteBalanceGuardedAsync<T>(
 		Guid receiptId,
 		Action<ReceiptBalanceState> validate,

--- a/tests/Infrastructure.IntegrationTests/Fixtures/PostgresFixture.cs
+++ b/tests/Infrastructure.IntegrationTests/Fixtures/PostgresFixture.cs
@@ -52,7 +52,12 @@ public class PostgresFixture : IAsyncLifetime
 		await reloadConnection.ReloadTypesAsync();
 	}
 
-	public ApplicationDbContext CreateDbContext()
+	public ApplicationDbContext CreateDbContext() => new(CreateOptions());
+
+	// Exposes the same Npgsql/pgvector options CreateDbContext() builds, so a test can construct a
+	// custom ApplicationDbContext subclass (e.g. one that injects a mid-transaction failure) against
+	// the fixture's already-type-reloaded data source without standing up a second connection pool.
+	public DbContextOptions<ApplicationDbContext> CreateOptions()
 	{
 		if (_dataSource is null)
 		{
@@ -62,7 +67,7 @@ public class PostgresFixture : IAsyncLifetime
 		DbContextOptionsBuilder<ApplicationDbContext> builder = new();
 		builder.UseNpgsql(_dataSource, b => b.UseVector());
 
-		return new ApplicationDbContext(builder.Options);
+		return builder.Options;
 	}
 
 	public async Task DisposeAsync()

--- a/tests/Infrastructure.IntegrationTests/Services/AccountMergeAtomicityTests.cs
+++ b/tests/Infrastructure.IntegrationTests/Services/AccountMergeAtomicityTests.cs
@@ -1,0 +1,168 @@
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests.Services;
+
+// Postgres-only coverage for the RECEIPTS-801 fix (PR #605): the Transactions.AccountId FK is
+// DeleteBehavior.Restrict, and AccountMergeService runs Phase 1 (repoint) and Phase 2 (delete
+// orphaned source accounts) inside ONE transaction so a Phase-2 failure rolls back Phase 1. The
+// InMemory unit suite cannot prove either — it enforces no FKs and no-ops BeginTransaction.
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class AccountMergeAtomicityTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task HardDeleteAccount_WithReferencingTransaction_IsRejectedByRestrictFk_AndTransactionSurvives()
+	{
+		// Arrange — the account under test is referenced ONLY by a transaction (its card lives on a
+		// different account), so the delete can fail on exactly one constraint: the Transactions
+		// AccountId Restrict FK. AccountEntity is not soft-deletable, so Remove() is a real hard DELETE.
+		Guid accountUnderTestId = Guid.NewGuid();
+		Guid transactionId = Guid.NewGuid();
+		{
+			await using ApplicationDbContext setup = fixture.CreateDbContext();
+
+			AccountEntity accountUnderTest = AccountEntityGenerator.Generate();
+			accountUnderTest.Id = accountUnderTestId;
+
+			AccountEntity cardOwnerAccount = AccountEntityGenerator.Generate();
+			CardEntity card = CardEntityGenerator.Generate();
+			card.AccountId = cardOwnerAccount.Id;
+
+			ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+
+			TransactionEntity transaction = TransactionEntityGenerator.Generate(receipt.Id, accountUnderTestId, card.Id);
+			transaction.Id = transactionId;
+
+			setup.Accounts.AddRange(accountUnderTest, cardOwnerAccount);
+			setup.Cards.Add(card);
+			setup.Receipts.Add(receipt);
+			await setup.SaveChangesAsync();
+
+			setup.Transactions.Add(transaction);
+			await setup.SaveChangesAsync();
+		}
+
+		// Act — hard-delete the referenced account.
+		await using ApplicationDbContext deleteContext = fixture.CreateDbContext();
+		AccountEntity toDelete = await deleteContext.Accounts.FirstAsync(a => a.Id == accountUnderTestId);
+		deleteContext.Accounts.Remove(toDelete);
+
+		Func<Task> act = async () => await deleteContext.SaveChangesAsync();
+
+		// Assert — Postgres rejects the delete with FK violation SQLSTATE 23503 on the transaction FK.
+		DbUpdateException dbEx = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+		PostgresException pg = dbEx.InnerException.Should().BeOfType<PostgresException>().Which;
+		pg.SqlState.Should().Be(PostgresErrorCodes.ForeignKeyViolation); // "23503"
+		pg.ConstraintName.Should().Be("FK_Transactions_Accounts_AccountId");
+
+		// Assert — the transaction was NOT cascade-deleted; both rows still exist.
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+		(await verify.Accounts.AnyAsync(a => a.Id == accountUnderTestId))
+			.Should().BeTrue("the rejected delete must leave the account in place");
+		(await verify.Transactions.IgnoreAutoIncludes().AnyAsync(t => t.Id == transactionId))
+			.Should().BeTrue("Restrict must not cascade-destroy the referencing transaction");
+	}
+
+	[Fact]
+	public async Task MergeCards_WhenPhase2Fails_RollsBackPhase1Repoint_NoHalfAppliedMerge()
+	{
+		// Arrange — two source accounts, each with one card and one transaction, plus a target.
+		// Every transaction references a real receipt so the Transaction->Receipt FK is satisfied.
+		AccountEntity target = AccountEntityGenerator.Generate();
+		AccountEntity source1 = AccountEntityGenerator.Generate();
+		AccountEntity source2 = AccountEntityGenerator.Generate();
+
+		CardEntity card1 = CardEntityGenerator.Generate();
+		card1.AccountId = source1.Id;
+		CardEntity card2 = CardEntityGenerator.Generate();
+		card2.AccountId = source2.Id;
+
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+
+		TransactionEntity tx1 = TransactionEntityGenerator.Generate(receipt.Id, source1.Id, card1.Id);
+		TransactionEntity tx2 = TransactionEntityGenerator.Generate(receipt.Id, source2.Id, card2.Id);
+
+		{
+			await using ApplicationDbContext setup = fixture.CreateDbContext();
+			setup.Accounts.AddRange(target, source1, source2);
+			setup.Cards.AddRange(card1, card2);
+			setup.Receipts.Add(receipt);
+			await setup.SaveChangesAsync();
+
+			setup.Transactions.AddRange(tx1, tx2);
+			await setup.SaveChangesAsync();
+		}
+
+		// Force Phase 2 to fail without touching production code: a context that throws on its SECOND
+		// SaveChangesAsync. LoadStateAsync only reads (0 saves); the merge context saves once in Phase 1
+		// (repoint + audit) and again in Phase 2 (delete orphaned accounts) — so the throw lands exactly
+		// on the Phase-2 delete, inside the service's own transaction.
+		FailOnSecondSaveContextFactory factory = new(fixture);
+		AccountMergeService service = new(factory, new NullCurrentUserAccessor());
+
+		// Act
+		Func<Task> act = async () => await service.MergeCardsAsync(
+			target.Id, [card1.Id, card2.Id], null, CancellationToken.None);
+
+		// Assert — the injected Phase-2 failure surfaced.
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*RECEIPTS-801*");
+
+		// Assert — the whole merge rolled back: nothing was half-applied.
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+
+		CardEntity verifiedCard1 = await verify.Cards.AsNoTracking().FirstAsync(c => c.Id == card1.Id);
+		CardEntity verifiedCard2 = await verify.Cards.AsNoTracking().FirstAsync(c => c.Id == card2.Id);
+		verifiedCard1.AccountId.Should().Be(source1.Id, "Phase-1 card repoint must roll back");
+		verifiedCard2.AccountId.Should().Be(source2.Id, "Phase-1 card repoint must roll back");
+
+		List<TransactionEntity> verifiedTxns = await verify.Transactions
+			.IgnoreAutoIncludes().AsNoTracking()
+			.Where(t => t.Id == tx1.Id || t.Id == tx2.Id)
+			.ToListAsync();
+		verifiedTxns.Single(t => t.Id == tx1.Id).AccountId.Should().Be(source1.Id, "Phase-1 transaction repoint must roll back");
+		verifiedTxns.Single(t => t.Id == tx2.Id).AccountId.Should().Be(source2.Id, "Phase-1 transaction repoint must roll back");
+
+		List<Guid> seededAccountIds = [target.Id, source1.Id, source2.Id];
+		List<Guid> survivingAccounts = await verify.Accounts.AsNoTracking()
+			.Where(a => seededAccountIds.Contains(a.Id))
+			.Select(a => a.Id)
+			.ToListAsync();
+		survivingAccounts.Should().BeEquivalentTo(seededAccountIds, "the Phase-2 account delete must roll back too");
+
+		bool anyMergeAudit = await verify.AuditLogs.AsNoTracking()
+			.AnyAsync(a => a.Action == Infrastructure.Entities.Audit.AuditAction.Merge
+				&& (a.EntityId == source1.Id.ToString()
+					|| a.EntityId == source2.Id.ToString()
+					|| a.EntityId == target.Id.ToString()));
+		anyMergeAudit.Should().BeFalse("Phase-1 merge audit rows must roll back with the transaction");
+	}
+
+	// A real ApplicationDbContext against the fixture's data source that throws on its second
+	// SaveChangesAsync — a tiny, test-only seam to drive AccountMergeService's Phase-2 failure path.
+	private sealed class FailOnSecondSaveContext(DbContextOptions<ApplicationDbContext> options)
+		: ApplicationDbContext(options)
+	{
+		private int _saveCount;
+
+		public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+		{
+			_saveCount++;
+			return _saveCount == 2
+				? throw new InvalidOperationException("Injected Phase-2 failure (RECEIPTS-801 merge-rollback test).")
+				: base.SaveChangesAsync(cancellationToken);
+		}
+	}
+
+	private sealed class FailOnSecondSaveContextFactory(PostgresFixture fixture)
+		: IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => new FailOnSecondSaveContext(fixture.CreateOptions());
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/Services/ApiKeyLastUsedTests.cs
+++ b/tests/Infrastructure.IntegrationTests/Services/ApiKeyLastUsedTests.cs
@@ -1,0 +1,86 @@
+using Application.Interfaces.Services;
+using FluentAssertions;
+using Infrastructure.Entities;
+using Infrastructure.IntegrationTests.Fixtures;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests.Services;
+
+// Postgres-only coverage for RECEIPTS-769 (PR #612): the auth hot path stamps ApiKey.LastUsedAt via
+// ExecuteUpdateAsync — the RELATIONAL branch of GetUserIdByApiKeyAsync. The InMemory unit suite can
+// only reach the tracked-fallback branch (ExecuteUpdate is unsupported there), so the production
+// path — the targeted UPDATE, its in-WHERE throttle, and its audit-bypass — is proven only here.
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class ApiKeyLastUsedTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task GetUserIdByApiKeyAsync_OnRelationalProvider_StampsLastUsedAt_ThrottlesRestamp_AndWritesNoAudit()
+	{
+		// Arrange — a real user (the ApiKey.UserId FK is enforced by Postgres) and a key created by
+		// the service. Suppress auditing on the user seed so only the key path is under observation.
+		string userId = Guid.NewGuid().ToString();
+		{
+			await using ApplicationDbContext setup = fixture.CreateDbContext();
+			setup.AuditingEnabled = false;
+			setup.Users.Add(new ApplicationUser
+			{
+				Id = userId,
+				UserName = $"apikey-{userId}",
+				NormalizedUserName = $"APIKEY-{userId}".ToUpperInvariant(),
+				Email = $"{userId}@test.local",
+				NormalizedEmail = $"{userId}@TEST.LOCAL".ToUpperInvariant(),
+				SecurityStamp = Guid.NewGuid().ToString(),
+			});
+			await setup.SaveChangesAsync();
+		}
+
+		ApiKeyService service = new(new FixtureDbContextFactory(fixture));
+		CreateApiKeyResult created = await service.CreateApiKeyAsync(userId, "integration-key", expiresAt: null);
+
+		// Sanity — a freshly created key has never been used.
+		(await ReadLastUsedAsync(created.Id)).Should().BeNull("CreateApiKeyAsync does not stamp LastUsedAt");
+
+		// Act 1 — the auth hot path stamps LastUsedAt through the relational ExecuteUpdate.
+		ApiKeyValidationResult? first = await service.GetUserIdByApiKeyAsync(created.RawKey);
+
+		// Assert 1 — validated and stamped.
+		first.Should().NotBeNull();
+		first!.UserId.Should().Be(userId);
+		DateTimeOffset? stampedAt = await ReadLastUsedAsync(created.Id);
+		stampedAt.Should().NotBeNull("the relational path must stamp LastUsedAt on first use");
+
+		// Act 2 — a second authentication immediately after, well inside the 1-minute throttle window.
+		ApiKeyValidationResult? second = await service.GetUserIdByApiKeyAsync(created.RawKey);
+
+		// Assert 2 — still validates, but the throttle predicate makes the UPDATE a no-op: LastUsedAt
+		// is unchanged, so sustained traffic on one key does not write on every request.
+		second.Should().NotBeNull();
+		DateTimeOffset? afterSecond = await ReadLastUsedAsync(created.Id);
+		afterSecond.Should().BeCloseTo(stampedAt!.Value, TimeSpan.FromMilliseconds(1),
+			"a second call within the throttle window must not re-stamp LastUsedAt");
+
+		// Assert 3 — a LastUsedAt bump is telemetry, not audit: the ExecuteUpdate bypasses the change
+		// tracker/interceptor, and ApiKeyEntity is excluded from auditing. No ApiKey audit rows exist.
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+		int apiKeyAuditRows = await verify.AuditLogs.AsNoTracking()
+			.CountAsync(a => a.EntityType == "ApiKey");
+		apiKeyAuditRows.Should().Be(0, "the API-key auth path must never write an AuditLogs row");
+	}
+
+	private async Task<DateTimeOffset?> ReadLastUsedAsync(Guid apiKeyId)
+	{
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+		return await context.ApiKeys.AsNoTracking()
+			.Where(k => k.Id == apiKeyId)
+			.Select(k => k.LastUsedAt)
+			.SingleAsync();
+	}
+
+	private sealed class FixtureDbContextFactory(PostgresFixture fixture) : IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => fixture.CreateDbContext();
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/Services/OutOfBalanceReportTests.cs
+++ b/tests/Infrastructure.IntegrationTests/Services/OutOfBalanceReportTests.cs
@@ -1,0 +1,178 @@
+using Application.Models.Reports;
+using FluentAssertions;
+using Infrastructure.Entities.Core;
+using Infrastructure.IntegrationTests.Fixtures;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using SampleData.Entities;
+
+namespace Infrastructure.IntegrationTests.Services;
+
+// Postgres-only coverage for RECEIPTS-791 (PR #612): GetOutOfBalanceAsync must translate its
+// aggregates — including SumAsync(x => Math.Abs(difference)) over correlated `?? 0m` subqueries —
+// fully to SQL, and paginate in SQL. The InMemory unit suite silently client-evaluates all of this,
+// so it can never catch a translation regression; only a real relational provider throws.
+[Collection(PostgresCollection.Name)]
+[Trait("Category", "Integration")]
+public class OutOfBalanceReportTests(PostgresFixture fixture)
+{
+	[Fact]
+	public async Task GetOutOfBalanceAsync_TranslatesAggregatesToSql_AndReturnsCorrectTotals()
+	{
+		// Arrange — three out-of-balance receipts and one balanced (excluded) receipt.
+		Guid accountId = Guid.NewGuid();
+		Guid cardId = Guid.NewGuid();
+		Guid r1 = Guid.NewGuid(); // items 100, tax 10, adj +5, tx 100 => expected 115, diff +15
+		Guid r2 = Guid.NewGuid(); // items 50,  tax 0,  no adj, tx 50  => expected 50,  diff 0 (excluded)
+		Guid r3 = Guid.NewGuid(); // items 30,  tax 0,  no adj, tx 100 => expected 30,  diff -70
+		Guid r4 = Guid.NewGuid(); // items 20,  tax 0,  no adj, no tx  => expected 20,  diff +20
+
+		await SeedAsync(accountId, cardId, seed =>
+		{
+			AddReceipt(seed, r1, new DateOnly(2025, 2, 1), tax: 10m);
+			AddItem(seed, r1, 100m);
+			AddAdjustment(seed, r1, 5m);
+			AddTransaction(seed, r1, accountId, cardId, 100m);
+
+			AddReceipt(seed, r2, new DateOnly(2025, 2, 15), tax: 0m);
+			AddItem(seed, r2, 50m);
+			AddTransaction(seed, r2, accountId, cardId, 50m);
+
+			AddReceipt(seed, r3, new DateOnly(2025, 1, 1), tax: 0m);
+			AddItem(seed, r3, 30m);
+			AddTransaction(seed, r3, accountId, cardId, 100m);
+
+			AddReceipt(seed, r4, new DateOnly(2025, 3, 1), tax: 0m);
+			AddItem(seed, r4, 20m);
+		});
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		// Act — default sort (date asc). If any aggregate/projection failed to translate, EF would
+		// throw here rather than silently evaluate on the client (RECEIPTS-791).
+		OutOfBalanceResult result = await service.GetOutOfBalanceAsync(
+			sortBy: "date", sortDirection: "asc", page: 1, pageSize: 50, CancellationToken.None);
+
+		// Assert — only the three out-of-balance receipts, ordered by date asc.
+		result.TotalCount.Should().Be(3);
+		result.Items.Select(i => i.ReceiptId).Should().Equal(r3, r1, r4);
+
+		// TotalDiscrepancy = SUM(ABS(difference)) computed in SQL = |−70| + |15| + |20| = 105.
+		result.TotalDiscrepancy.Should().Be(105m);
+
+		OutOfBalanceItem item1 = result.Items.Single(i => i.ReceiptId == r1);
+		item1.ItemSubtotal.Should().Be(100m);
+		item1.TaxAmount.Should().Be(10m);
+		item1.AdjustmentTotal.Should().Be(5m);
+		item1.ExpectedTotal.Should().Be(115m);
+		item1.TransactionTotal.Should().Be(100m);
+		item1.Difference.Should().Be(15m);
+
+		result.Items.Single(i => i.ReceiptId == r3).Difference.Should().Be(-70m);
+		result.Items.Single(i => i.ReceiptId == r4).Difference.Should().Be(20m);
+	}
+
+	[Fact]
+	public async Task GetOutOfBalanceAsync_PaginatesInSql_WithStableOrdering()
+	{
+		// Arrange — three out-of-balance receipts with distinct differences for a deterministic sort.
+		Guid accountId = Guid.NewGuid();
+		Guid cardId = Guid.NewGuid();
+		Guid rSmall = Guid.NewGuid();  // diff +10
+		Guid rMedium = Guid.NewGuid(); // diff +20
+		Guid rLarge = Guid.NewGuid();  // diff +30
+
+		await SeedAsync(accountId, cardId, seed =>
+		{
+			AddReceipt(seed, rSmall, new DateOnly(2025, 5, 1), tax: 0m);
+			AddItem(seed, rSmall, 10m);
+
+			AddReceipt(seed, rMedium, new DateOnly(2025, 5, 2), tax: 0m);
+			AddItem(seed, rMedium, 20m);
+
+			AddReceipt(seed, rLarge, new DateOnly(2025, 5, 3), tax: 0m);
+			AddItem(seed, rLarge, 30m);
+		});
+
+		ReportService service = new(new FixtureDbContextFactory(fixture));
+
+		// Act — sort by difference desc, page size 2. Page 1 fetches only 2 rows from the DB even
+		// though TotalCount is 3, proving Skip/Take runs in SQL (not an in-memory slice of all rows).
+		OutOfBalanceResult page1 = await service.GetOutOfBalanceAsync(
+			sortBy: "difference", sortDirection: "desc", page: 1, pageSize: 2, CancellationToken.None);
+		OutOfBalanceResult page2 = await service.GetOutOfBalanceAsync(
+			sortBy: "difference", sortDirection: "desc", page: 2, pageSize: 2, CancellationToken.None);
+
+		// Assert — pagination and ordering.
+		page1.TotalCount.Should().Be(3);
+		page1.Items.Should().HaveCount(2);
+		page1.Items.Select(i => i.ReceiptId).Should().Equal(rLarge, rMedium);
+
+		page2.TotalCount.Should().Be(3);
+		page2.Items.Should().ContainSingle().Which.ReceiptId.Should().Be(rSmall);
+
+		// The full discrepancy is aggregated over the whole set regardless of which page is requested.
+		page1.TotalDiscrepancy.Should().Be(60m);
+		page2.TotalDiscrepancy.Should().Be(60m);
+	}
+
+	private async Task SeedAsync(Guid accountId, Guid cardId, Action<ApplicationDbContext> seed)
+	{
+		await using ApplicationDbContext context = fixture.CreateDbContext();
+
+		// The report reads across ALL receipts globally, so isolate from other tests in the collection.
+		await context.Database.ExecuteSqlRawAsync(
+			"""TRUNCATE "Transactions", "ReceiptItems", "Adjustments", "Receipts" RESTART IDENTITY CASCADE;""");
+
+		// Transactions need valid Account + Card FKs (both Restrict, NOT NULL).
+		AccountEntity account = AccountEntityGenerator.Generate();
+		account.Id = accountId;
+		CardEntity card = CardEntityGenerator.Generate();
+		card.Id = cardId;
+		card.AccountId = accountId;
+		context.Accounts.Add(account);
+		context.Cards.Add(card);
+		await context.SaveChangesAsync();
+
+		seed(context);
+		await context.SaveChangesAsync();
+	}
+
+	private static void AddReceipt(ApplicationDbContext context, Guid receiptId, DateOnly date, decimal tax)
+	{
+		ReceiptEntity receipt = ReceiptEntityGenerator.Generate();
+		receipt.Id = receiptId;
+		receipt.Date = date;
+		receipt.TaxAmount = tax;
+		context.Receipts.Add(receipt);
+	}
+
+	private static void AddItem(ApplicationDbContext context, Guid receiptId, decimal totalAmount)
+	{
+		ReceiptItemEntity item = ReceiptItemEntityGenerator.Generate(receiptId);
+		item.Quantity = 1m;
+		item.UnitPrice = totalAmount;
+		item.TotalAmount = totalAmount;
+		context.ReceiptItems.Add(item);
+	}
+
+	private static void AddAdjustment(ApplicationDbContext context, Guid receiptId, decimal amount)
+	{
+		AdjustmentEntity adjustment = AdjustmentEntityGenerator.Generate();
+		adjustment.ReceiptId = receiptId;
+		adjustment.Amount = amount;
+		context.Adjustments.Add(adjustment);
+	}
+
+	private static void AddTransaction(ApplicationDbContext context, Guid receiptId, Guid accountId, Guid cardId, decimal amount)
+	{
+		TransactionEntity transaction = TransactionEntityGenerator.Generate(receiptId, accountId, cardId);
+		transaction.Amount = amount;
+		context.Transactions.Add(transaction);
+	}
+
+	private sealed class FixtureDbContextFactory(PostgresFixture fixture) : IDbContextFactory<ApplicationDbContext>
+	{
+		public ApplicationDbContext CreateDbContext() => fixture.CreateDbContext();
+	}
+}

--- a/tests/Infrastructure.IntegrationTests/Services/TransactionBalanceValidationTests.cs
+++ b/tests/Infrastructure.IntegrationTests/Services/TransactionBalanceValidationTests.cs
@@ -1,4 +1,5 @@
 using Application.Commands.Transaction.Create;
+using Application.Commands.Transaction.Update;
 using Application.Models;
 using Domain;
 using Domain.Core;
@@ -201,6 +202,66 @@ public class TransactionBalanceValidationTests(PostgresFixture fixture)
 
 		persisted.Should().ContainSingle("the receipt must never be over-allocated");
 		persisted.Sum(t => t.Amount).Should().Be(50m);
+	}
+
+	[Fact]
+	public async Task ConcurrentUpdates_ForSameReceipt_SerializeSoOnlyOneSucceeds()
+	{
+		// RECEIPTS-805: the per-receipt FOR UPDATE lock must serialize the UPDATE balance-validation
+		// path exactly as it does the CREATE path above. Seed a $50 receipt with two $10 transactions
+		// (currently unbalanced at $20). Two concurrent updates each raise a DIFFERENT transaction to
+		// $40: against the pre-state each looks balanced ($40 + the other's stale $10 == $50), but
+		// applying BOTH would total $80. The row lock forces the loser to re-read the winner's
+		// committed write and be rejected by the balance equation. Without the lock, both would read
+		// the stale $10 pre-state and commit, over-allocating the receipt — so this asserts the lock,
+		// not just the happy path. (Amounts are non-zero because the Money domain type forbids zero.)
+		(Guid receiptId, Guid accountId, Guid cardId) = await SeedReceiptAsync(itemTotal: 50m);
+
+		Guid tx1Id = Guid.NewGuid();
+		Guid tx2Id = Guid.NewGuid();
+		await SeedTransactionsAsync(receiptId, accountId, cardId, amount: 10m, tx1Id, tx2Id);
+
+		UpdateTransactionCommandHandler handler = new(BuildService());
+		UpdateTransactionCommand CommandFor(Guid txId) => new([Tx(cardId, 40m, accountId, txId)]);
+
+		// Both requests are in flight before either commits, so they contend on the receipt row lock.
+		Task<Exception?> first = CaptureAsync(handler.Handle(CommandFor(tx1Id), CancellationToken.None).AsTask());
+		Task<Exception?> second = CaptureAsync(handler.Handle(CommandFor(tx2Id), CancellationToken.None).AsTask());
+		Exception?[] outcomes = await Task.WhenAll(first, second);
+
+		outcomes.Count(e => e is null).Should().Be(1, "exactly one concurrent update may satisfy the $50 balance");
+		outcomes.Count(e => e is ValidationException).Should().Be(1, "the losing update must be rejected by the balance equation, not a server error");
+
+		await using ApplicationDbContext verify = fixture.CreateDbContext();
+		List<TransactionEntity> persisted = await verify.Transactions
+			.IgnoreAutoIncludes()
+			.Where(t => t.ReceiptId == receiptId)
+			.ToListAsync();
+
+		persisted.Should().HaveCount(2);
+		persisted.Sum(t => t.Amount).Should().Be(50m, "the receipt must stay balanced at exactly $50 — never over-allocated to $80");
+		persisted.Count(t => t.Amount == 40m).Should().Be(1, "only the winning update may raise its transaction to $40");
+		persisted.Count(t => t.Amount == 10m).Should().Be(1, "the loser's transaction keeps its pre-update $10 value");
+	}
+
+	private async Task SeedTransactionsAsync(Guid receiptId, Guid accountId, Guid cardId, decimal amount, Guid tx1Id, Guid tx2Id)
+	{
+		await using ApplicationDbContext setup = fixture.CreateDbContext();
+		setup.Transactions.AddRange(
+			SeedTransaction(tx1Id, receiptId, accountId, cardId, amount),
+			SeedTransaction(tx2Id, receiptId, accountId, cardId, amount));
+		await setup.SaveChangesAsync();
+
+		static TransactionEntity SeedTransaction(Guid id, Guid receiptId, Guid accountId, Guid cardId, decimal amount) => new()
+		{
+			Id = id,
+			ReceiptId = receiptId,
+			AccountId = accountId,
+			CardId = cardId,
+			Amount = amount,
+			AmountCurrency = Common.Currency.USD,
+			Date = DateOnly.FromDateTime(DateTime.Now),
+		};
 	}
 
 	private static async Task<Exception?> CaptureAsync(Task task)


### PR DESCRIPTION
Adds Postgres integration coverage (all `[Trait("Category","Integration")]`, run locally against Dockerized Postgres — CI still excludes them) for three follow-ups. Each proves something the EF InMemory unit suite structurally cannot: no FK enforcement, no real SQL translation, no-op `BeginTransaction`.

## RECEIPTS-801 — DB-level Restrict + merge rollback
`tests/Infrastructure.IntegrationTests/Services/AccountMergeAtomicityTests.cs`
- **`HardDeleteAccount_WithReferencingTransaction_IsRejectedByRestrictFk_AndTransactionSurvives`** — a referencing `Transaction` makes a hard `DELETE` of its `Account` fail with `DbUpdateException` → `PostgresException` `SqlState == "23503"` on `FK_Transactions_Accounts_AccountId`; asserts the transaction is not cascade-deleted.
- **`MergeCards_WhenPhase2Fails_RollsBackPhase1Repoint_NoHalfAppliedMerge`** — forces a Phase-2 failure via a tiny test-only `ApplicationDbContext` that throws on its 2nd `SaveChangesAsync` (no production change), then asserts the Phase-1 card/transaction repoint, the source-account deletes, and the merge audit rows all roll back.

## RECEIPTS-804 — report SQL translation + api-key ExecuteUpdate
`tests/Infrastructure.IntegrationTests/Services/OutOfBalanceReportTests.cs`
- **`GetOutOfBalanceAsync_TranslatesAggregatesToSql_AndReturnsCorrectTotals`** — runs the real report against Postgres; `SumAsync(x => Math.Abs(x.Difference))` over correlated `?? 0m` subqueries translates fully to SQL (no client-eval throw), with correct filtering, values, and date-asc ordering.
- **`GetOutOfBalanceAsync_PaginatesInSql_WithStableOrdering`** — page size 2 over 3 rows returns 2 then 1 while `TotalCount`/`TotalDiscrepancy` aggregate the whole set, proving `Skip`/`Take` run in SQL.

`tests/Infrastructure.IntegrationTests/Services/ApiKeyLastUsedTests.cs`
- **`GetUserIdByApiKeyAsync_OnRelationalProvider_StampsLastUsedAt_ThrottlesRestamp_AndWritesNoAudit`** — exercises the production relational `ExecuteUpdateAsync` path (not the InMemory tracked fallback): stamps `LastUsedAt` on first use, is a no-op on a second call inside the 1-minute throttle, and writes no `AuditLogs` row.

## RECEIPTS-805 — balance invariant concurrent UPDATE
`tests/Infrastructure.IntegrationTests/Services/TransactionBalanceValidationTests.cs`
- **`ConcurrentUpdates_ForSameReceipt_SerializeSoOnlyOneSucceeds`** — mirrors the existing create-path concurrency test for `UpdateWithBalanceValidationAsync`: two contexts race to raise different transactions on the same receipt; the `SELECT ... FOR UPDATE` row lock serializes them so exactly one commits, the loser gets a `ValidationException`, and the receipt stays balanced.
- Adds a `// RECEIPTS-805:` comment near `ExecuteBalanceGuardedAsync` noting the invariant is serialized only against concurrent transaction writes, not concurrent child/adjustment/tax edits (a known, accepted scope boundary — the larger lock-extension refactor is not implemented here).

## Test run
`dotnet test tests/Infrastructure.IntegrationTests --filter "Category=Integration"` → **59 passed, 0 failed** (6 new + 53 existing). The two concurrency tests and the merge-rollback test were re-run 3× with no flakiness.

Closes RECEIPTS-801, RECEIPTS-804, RECEIPTS-805.
