### PR TITLE
docs(infrastructure): document deliberate backup exclusion of log and cursor tables

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -4,18 +4,40 @@ The application supports portable SQLite backups for disaster recovery, migratio
 
 ## What gets backed up
 
-All domain entities are included in the export:
+The export (current format `export_version = 4`) includes your domain data plus YNAB
+configuration/state and normalized-description settings:
 
 - Accounts
+- Cards
 - Categories
 - Subcategories
 - Item Templates
-- Receipts
+- Receipts (including image file **paths** — see below)
 - Receipt Items
 - Transactions
 - Adjustments
+- YNAB configuration and state: selected budget, account mappings, category mappings, and
+  sync records (current per-transaction sync state)
+- Normalized descriptions and their settings
 
 Soft-deleted records are **excluded** from exports.
+
+Receipt image **binaries** are stored outside the database and are **not** included — only
+their file paths are backed up. Back the image files up separately.
+
+### Deliberately excluded from backup
+
+The following tables are intentionally left out of the backup. This is a conscious decision
+(RECEIPTS-802), not an oversight — a backup is meant to restore your **data and state**, not
+the history of how it got there or values a service can regenerate:
+
+| Table | Why it is excluded |
+| --- | --- |
+| `AuditLogs`, `AuthAuditLogs` | Append-only audit/activity logs. Re-importing historical log rows onto another instance would misrepresent when actions actually occurred there. |
+| `YnabSyncEvents` | The YNAB sync activity log — the same class of data as the audit logs (an append-only history of push attempts, **not** state). Distinct from `YnabSyncRecords`, the current sync state, which **is** included above. |
+| `YnabServerKnowledge` | The YNAB delta-sync cursor. It is re-fetchable from YNAB on the next sync (regenerable derived data, like the omitted embedding vectors), so restoring a stale value would only risk a bad delta window. |
+| Normalized-description embedding vectors | Large, regenerable derived data whose dimension is a build-time constant; repopulated by the embedding pipeline after restore. |
+| ASP.NET Identity users and authentication settings | Excluded for security reasons. |
 
 ## REST API
 

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -4294,8 +4294,15 @@ paths:
       summary: Export database to a portable SQLite file
       description: >
         Generates a SQLite database containing all domain data (accounts,
-        categories, receipts, items, transactions, adjustments, item templates).
-        Admin-only. Soft-deleted records are excluded.
+        categories, receipts, items, transactions, adjustments, item templates),
+        YNAB configuration and current sync records, and normalized descriptions.
+        Receipt image file paths are included, but the image binaries are stored
+        outside the database and must be backed up separately. User accounts and
+        authentication settings are excluded. Audit logs, the YNAB sync history
+        (YnabSyncEvents), and the re-fetchable YNAB delta cursor
+        (YnabServerKnowledge) are deliberately excluded as activity history or
+        regenerable data rather than restorable state. Admin-only. Soft-deleted
+        records are excluded.
       security:
         - BearerAuth: []
         - ApiKey: []

--- a/src/Infrastructure/Services/BackupService.cs
+++ b/src/Infrastructure/Services/BackupService.cs
@@ -26,6 +26,25 @@ public class BackupService(
 
 		try
 		{
+			// The set of exported tables is defined by the CreateSchemaAsync DDL below and the
+			// Export* calls that follow. The following tables are DELIBERATELY EXCLUDED from the
+			// backup (an intentional decision, not an oversight -- see RECEIPTS-802):
+			//
+			//   - AuditLogs / AuthAuditLogs: append-only audit/history logs. A backup captures
+			//     restorable *state*, not the activity trail that produced it. Re-importing
+			//     historical log rows into a target instance would misrepresent when actions
+			//     actually occurred there, so the audit trail is left to each instance.
+			//   - YnabSyncEvents: the YNAB sync activity log -- the SAME class of data as the audit
+			//     logs above (an append-only history of push attempts, not state). NOTE: this is
+			//     distinct from YnabSyncRecords (the current per-transaction sync *state*), which
+			//     IS exported below via ExportYnabSyncRecordsAsync.
+			//   - YnabServerKnowledge: the YNAB delta-sync cursor. It is re-fetchable from YNAB on
+			//     the next sync (regenerable derived data, like the embedding vectors also omitted),
+			//     so restoring a stale cursor would only risk a bad delta window.
+			//   - ASP.NET Identity users and authentication settings: excluded for security.
+			//
+			// Excluding all log/audit and regenerable-cursor tables is the consistent choice: a
+			// backup restores your data, not the history of how it got there.
 			await CreateSchemaAsync(sqlite, cancellationToken);
 			await ExportAccountsAsync(source, sqlite, cancellationToken);
 			await ExportCardsAsync(source, sqlite, cancellationToken);

--- a/src/Presentation/API/Controllers/BackupController.cs
+++ b/src/Presentation/API/Controllers/BackupController.cs
@@ -28,7 +28,7 @@ public class BackupController(
 
 	[HttpPost("export")]
 	[EndpointSummary("Export database to a portable SQLite file")]
-	[EndpointDescription("Generates a SQLite database containing all domain data (accounts, categories, receipts, items, transactions, adjustments, item templates), YNAB configuration (budget selection and account/category mappings and sync records), and normalized descriptions. Receipt image file paths are included, but the image binaries themselves are stored outside the database and must be backed up separately. User accounts and authentication settings are excluded. Admin-only. Soft-deleted records are excluded.")]
+	[EndpointDescription("Generates a SQLite database containing all domain data (accounts, categories, receipts, items, transactions, adjustments, item templates), YNAB configuration (budget selection and account/category mappings and current sync records), and normalized descriptions. Receipt image file paths are included, but the image binaries themselves are stored outside the database and must be backed up separately. User accounts and authentication settings are excluded. Audit logs (AuditLogs/AuthAuditLogs), the YNAB sync history (YnabSyncEvents), and the re-fetchable YNAB delta cursor (YnabServerKnowledge) are deliberately excluded as activity history or regenerable data rather than restorable state. Admin-only. Soft-deleted records are excluded.")]
 	public async Task<Results<FileStreamHttpResult, StatusCodeHttpResult>> Export(CancellationToken cancellationToken)
 	{
 		string? filePath = null;

--- a/src/client/src/generated/api.d.ts
+++ b/src/client/src/generated/api.d.ts
@@ -1924,7 +1924,7 @@ export interface paths {
         put?: never;
         /**
          * Export database to a portable SQLite file
-         * @description Generates a SQLite database containing all domain data (accounts, categories, receipts, items, transactions, adjustments, item templates). Admin-only. Soft-deleted records are excluded.
+         * @description Generates a SQLite database containing all domain data (accounts, categories, receipts, items, transactions, adjustments, item templates), YNAB configuration and current sync records, and normalized descriptions. Receipt image file paths are included, but the image binaries are stored outside the database and must be backed up separately. User accounts and authentication settings are excluded. Audit logs, the YNAB sync history (YnabSyncEvents), and the re-fetchable YNAB delta cursor (YnabServerKnowledge) are deliberately excluded as activity history or regenerable data rather than restorable state. Admin-only. Soft-deleted records are excluded.
          */
         post: operations["ExportBackup"];
         delete?: never;

--- a/src/client/src/pages/BackupRestore.tsx
+++ b/src/client/src/pages/BackupRestore.tsx
@@ -190,7 +190,9 @@ function BackupRestore() {
             descriptions. Receipt image files are stored outside the database:
             their paths are backed up, but the image files themselves must be
             backed up separately. User accounts and authentication settings are
-            excluded for security reasons.
+            excluded for security reasons. Audit logs and YNAB sync history are
+            not included either &mdash; a backup restores your data, not the
+            record of past activity.
           </AlertDescription>
         </Alert>
 

--- a/tests/Infrastructure.Tests/Services/BackupServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/BackupServiceTests.cs
@@ -340,6 +340,38 @@ public class BackupServiceTests : IDisposable
 		tables.Should().Contain("adjustments");
 	}
 
+	[Fact]
+	public async Task CreateSchemaAsync_DoesNotCreateExcludedLogOrCursorTables()
+	{
+		// Documents the deliberate exclusions (RECEIPTS-802): append-only audit/history logs
+		// and the re-fetchable YNAB delta cursor are intentionally NOT part of the backup schema.
+		// Arrange
+		string path = Path.GetTempFileName();
+		_tempFiles.Add(path);
+
+		await using SqliteConnection conn = new($"Data Source={path}");
+		await conn.OpenAsync();
+
+		// Act
+		await BackupService.CreateSchemaAsync(conn, CancellationToken.None);
+
+		// Assert
+		await using SqliteCommand cmd = conn.CreateCommand();
+		cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table'";
+		await using SqliteDataReader reader = await cmd.ExecuteReaderAsync();
+
+		List<string> tables = [];
+		while (await reader.ReadAsync())
+		{
+			tables.Add(reader.GetString(0));
+		}
+
+		tables.Should().NotContain("audit_logs");
+		tables.Should().NotContain("auth_audit_logs");
+		tables.Should().NotContain("ynab_sync_events");
+		tables.Should().NotContain("ynab_server_knowledge");
+	}
+
 	public void Dispose()
 	{
 		foreach (string path in _tempFiles)


### PR DESCRIPTION
## Decision

The SQLite backup/export feature (PR #607 / RECEIPTS-770) intentionally backs up user
domain data plus YNAB configuration, current YNAB **sync state** (`YnabSyncRecords`),
normalized descriptions, and receipt image **paths**. Two YNAB-related tables were still
outside the backup, and this issue asked to make a conscious, documented decision about them.

**Decision (implemented here): do NOT add them to the backup.** Both belong to classes of data
already deliberately excluded:

- `YnabSyncEvents` — an append-only sync **history / activity log**. Same class as `AuditLogs`
  and `AuthAuditLogs`, which are already excluded. It is distinct from `YnabSyncRecords`
  (current per-transaction sync state), which **is** backed up.
- `YnabServerKnowledge` — the YNAB delta-sync **cursor**. Re-fetchable from YNAB on the next
  sync (regenerable derived data, like the omitted embedding vectors).

A backup is meant to restore your **data and state**, not the history of how it got there or
values a service can regenerate. This change makes that exclusion **explicit and documented**
so it reads as deliberate, not an oversight. No backup behavior or schema change.

## What changed (documentation/comments + one test)

- **`BackupService.cs`** — comment at the export orchestration enumerating every intentionally
  excluded table (`AuditLogs`, `AuthAuditLogs`, `YnabSyncEvents`, `YnabServerKnowledge`,
  Identity users/auth) and the rationale for each.
- **Backup export endpoint description** — controller `[EndpointDescription]` and
  `openapi/spec.yaml` now state the exclusions (regenerated `api.d.ts`).
- **Client `Backup & Restore` help text** — concise note that audit logs and YNAB sync history
  are not included.
- **`docs/backup-restore.md`** — corrected the stale "What gets backed up" list and added a
  "Deliberately excluded from backup" section.
- **Test** — `CreateSchemaAsync_DoesNotCreateExcludedLogOrCursorTables` asserts the backup
  schema omits the log/cursor tables.

## Verification of the premise

Confirmed that `AuditLogs` and `AuthAuditLogs` **are** indeed already excluded: all four
(`AuditLogs`, `AuthAuditLogs`, `YnabServerKnowledge`, `YnabSyncEvents`) are `DbSet`s on
`ApplicationDbContext` but none appear in `BackupService`'s export list — so the exclusions are
real, and the documentation reflects actual behavior.

## Validation

- `dotnet build src/Presentation/API/API.csproj` compiles clean (0 errors).
- Backup tests: 25 passed (`FullyQualifiedName~Backup`), including the new test.
- Client tests: `BackupRestore.test.tsx` 27 passed; full pre-commit client suite 2162 passed.
- `npm run lint:spec` clean; `api.d.ts` regenerated (description-only diff).

Closes RECEIPTS-802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
